### PR TITLE
Increase number of rows in Spreadsheet iframe

### DIFF
--- a/templates/features.html
+++ b/templates/features.html
@@ -17,7 +17,7 @@
 </table>
 {% endverbatim %} -->
 
-<iframe seamless src="//docs.google.com/spreadsheet/pub?key=0AjGgk26K1Cc-dFdfUlRQRWtjUm5XdjB4cmFGWjhTZmc&single=true&gid=0&range=A2:Z109&output=html"></iframe>
+<iframe seamless src="//docs.google.com/spreadsheet/pub?key=0AjGgk26K1Cc-dFdfUlRQRWtjUm5XdjB4cmFGWjhTZmc&single=true&gid=0&range=A2:Z200&output=html"></iframe>
 
 <!-- <div id="viz"></div> -->
 


### PR DESCRIPTION
It seems like we can use a number greater than the number rows. The iframe will just include as many rows as it can.

I think we should set the range to 200 for now.
