### PR TITLE
Clarified the compatibility risk title

### DIFF
--- a/static/elements/chromedash-feature.html
+++ b/static/elements/chromedash-feature.html
@@ -36,7 +36,7 @@
 <link rel="stylesheet" href="../css/elements/chromedash-feature.css">
 <div on-click="{{toggle}}"><div class="topcorner pull-right"><span hidden?="{{!deprecated}}" class="tooltip" title="Deprecated feature"><i class="icon-warning-sign" data-tooltip></i></span><span hidden?="{{!needsflag}}" class="tooltip" title="Experimental feature behind a flag."><i class="icon-beaker" data-tooltip></i></span><content select=".edit"></content></div>
   <hgroup>
-    <chromedash-color-status class="tooltip corner" value="{{compatRisk}}" max="{{MAX_RISK}}"></chromedash-color-status>
+    <chromedash-color-status class="tooltip corner" title="Compatibility risk: perceived interest from browser vendors and web developers" value="{{compatRisk}}" max="{{MAX_RISK}}"></chromedash-color-status>
     <h2>{{feature.name}}</h2>
     <label class="category" on-click="{{categoryFilter}}">{{feature.category}}</label>
   </hgroup>


### PR DESCRIPTION
The title attribute of the compatibility risk color has a static text that does not reflect the state of the world. It looks like it only really matches the green color (which means overall acceptance of the feature).
I am not sure what the text should be for each color, but the lesser evil is to not lie.
