### PR TITLE
Intent to implement should not include the edit URL.

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -275,6 +275,8 @@ class FeatureHandler(common.ContentHandler):
       template_data.update({
           'feature': f.format_for_template(),
           'feature_form': models.FeatureForm(f.format_for_edit()),
+          'default_url': '%s://%s%s/%s' % (self.request.scheme, self.request.host,
+                                           self.DEFAULT_URL, feature_id)
           'edit_url': '%s://%s%s/%s' % (self.request.scheme, self.request.host,
                                         self.EDIT_URL, feature_id)
           })

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -36,7 +36,7 @@ Chrome OS, and Android)? Yes or no.</label>
 {% if feature.bug_url %}<a href="{{feature.bug_url}}">{{feature.bug_url}}</a>{% else %}None{% endif %}
 
 <label>Entry in {{APP_TITLE}}</label>
-<a href="{{edit_url}}">{{edit_url}}</a>
+<a href="{{default_url}}">{{default_url}}</a>
 
 <label>Requesting approval to ship?</label>
 <span class="help">"No" - you will be implementing your feature behind a runtime flag and sending an Intent to Ship email when you're ready to enable by default.


### PR DESCRIPTION
Unfortunately, the edit URL is not readable by everyone. Non @chromium.org (and whitelisted?) accounts can not read them).
Also, it might make it too easy to override other's people entries because the links are all over the place. For example, the Web Manifest entry got overridden by Network Information API. Likely because they use Web Manifest as an example.
