### PR TITLE
Hide Chrome Desktop tooltip if no milestone version

### DIFF
--- a/static/elements/chromedash-feature.html
+++ b/static/elements/chromedash-feature.html
@@ -45,7 +45,12 @@
     <section>
       <h3>Implementation Status</h3>
       <div class="impl_status">
-        <span class="chrome_desktop tooltip" title="Chrome desktop"><label>{{feature.impl_status_chrome}}</label>{{feature.shipped_milestone}}</span>
+        <template if="{{feature.shipped_milestone}}">
+          <span class="chrome_desktop tooltip" title="Chrome desktop"><label>{{feature.impl_status_chrome}}</label>{{feature.shipped_milestone}}</span>
+        </template>
+        <template if="{{!feature.shipped_milestone}}">
+          <span class="chrome_desktop"><label>{{feature.impl_status_chrome}}</label></span>
+        </template>
         <template if="{{feature.shipped_android_milestone}}">
           <span class="chrome_android tooltip" title="Chrome for Android"><label><i class="icon-android"></i></label>{{feature.shipped_android_milestone}}</span>
         </template>


### PR DESCRIPTION
As requested first by @maxh, tooltip for "Chrome should be hidden when no dekstop milestone version is set.

BUG=#122

![image](https://cloud.githubusercontent.com/assets/634478/3539642/76fae38a-083c-11e4-9e5e-e1b69cf1bd0c.png)

![screenshot from 2014-07-10 16 14 53](https://cloud.githubusercontent.com/assets/634478/3539685/b7420590-083c-11e4-8d42-2867b70774c8.png)
