### PR TITLE
Removed http://caniuse.com link

### DIFF
--- a/static/elements/chromedash-feature.html
+++ b/static/elements/chromedash-feature.html
@@ -108,7 +108,6 @@
           </template>
           <span hidden?="{{feature.spec_link}}">{{feature.standardization.text}}</span>
         </span>
-        <span><a href="http://caniuse.com/#search={{feature.name}}" target="_blank">Browser share %</a></span>
       </div>
     </section>
     <template if="{{feature.doc_links.length || feature.sample_links.length}}">


### PR DESCRIPTION
BUG=#136

Screenshot belows shows the missing "browser share %" next to "Working draft or equivalent" whereas it exists at http://www.chromestatus.com/features/5910974510923776

![image](https://cloud.githubusercontent.com/assets/634478/3541831/16a18e4e-0850-11e4-9af6-d9eeec7f767a.png)
