### PR TITLE
Fixed features search issue

### DIFF
--- a/static/elements/chromedash-featurelist.html
+++ b/static/elements/chromedash-featurelist.html
@@ -185,7 +185,7 @@
           if (val.indexOf('=') == 0) {
             val = val.substring(1);
           }
-          var regex = new RegExp(val, 'ig');
+          var regex = new RegExp(val, 'i');
           this.filtered = this.features.filter(function(feature, idx, array) {
             return regex.test(feature.name) || regex.test(feature.category) ||
                    regex.test(feature.summary) ||


### PR DESCRIPTION
This one character change seems simple but figuring it out wasn't actually ;)

When setting the `global` attribute on the `RegExp` Object, it keeps track of the `lastIndex` where a match occurred, so on subsequent matches it will start from the last used index, instead of 0, and thus causing the issue with "ES6" search for instance.

BUG=#128,#132

![image](https://cloud.githubusercontent.com/assets/634478/3552313/26ebdae8-08f5-11e4-9610-b3b894d48d55.png)
