### PR TITLE
Removed One Time Peaks in timeline

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -48,6 +48,14 @@ class TimelineHandler(common.JSONHandler):
       # Remove outliers if percentage is not between 0-1.
       data = filter(lambda x: 0 <= x.day_percentage <= 1, data)
 
+      # Remove one time peaks where delta is more than 10%.
+      threshold = 0.1
+      last_percentage = None
+      for x in list(data):
+        if last_percentage and (abs(x.day_percentage - last_percentage) > threshold):
+          data.remove(x)
+        last_percentage = x.day_percentage
+
       memcache.set(KEY, data, time=CACHE_AGE)
 
     super(TimelineHandler, self).get(data)


### PR DESCRIPTION
I've arbitrarily set the threshold to 10%. Please let me know if you think it should be smaller.

Here are some old and new screenshots for `mask` CSS property:
![image](https://cloud.githubusercontent.com/assets/634478/3554710/7cace1f6-090f-11e4-9d8b-0cde53dd6488.png)
![image](https://cloud.githubusercontent.com/assets/634478/3554704/6c496942-090f-11e4-9b6f-1b53ac9f9ce6.png)

BUG=#126
