### PR TITLE
Added shareable searches

### DIFF
--- a/static/elements/chromedash-feature.html
+++ b/static/elements/chromedash-feature.html
@@ -164,7 +164,7 @@
                             '/features/' + this.feature.id + location.hash);
         } else {
           history.replaceState({id: null}, this.feature.name,
-                            '/features' + location.hash);
+                               '/features' + location.hash);
         }
       }
     },

--- a/static/elements/chromedash-featurelist.html
+++ b/static/elements/chromedash-featurelist.html
@@ -143,10 +143,11 @@
     filter: function(val) {
       // Clear filter if there's no search or if called directly.
       if (!val) {
-        if (history && history.replaceState)
+        if (history && history.replaceState) {
           history.replaceState('', document.title, location.pathname + location.search);
-        else
+        } else {
           location.hash = '';
+        }
         this.filtered = this.features;
       } else {
         val = val.trim();

--- a/templates/features.html
+++ b/templates/features.html
@@ -136,8 +136,9 @@ document.addEventListener('polymer-ready', function(e) {
     }
   });
 
-  if (location.hash)
+  if (location.hash) {
     search.value = location.hash.substr(1);
+  }
 
   overlay.views = {
     vendors: {{VENDOR_VIEWS|safe}}, // set from server


### PR DESCRIPTION
Each search is now saved in the `location.hash` so that it doesn't interfere with the feature Id URLs. Hopefully, you'll like it.

TEST=
http://localhost:8080/features/#>=36
http://localhost:8080/features#owner:kenji
http://localhost:8080/features#proposed
http://localhost:8080/features/5298357018820608#proposed

BUG=#80
![image](https://cloud.githubusercontent.com/assets/634478/3610879/fa4257f4-0d92-11e4-801d-2fec4947be10.png)
