### PR TITLE
Added support for search tags

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -316,6 +316,10 @@ class FeatureHandler(common.ContentHandler):
     if sample_links:
       sample_links = [x.strip() for x in sample_links.split(',')]
 
+    search_tags = self.request.get('search_tags') or []
+    if search_tags:
+      search_tags = [x.strip() for x in search_tags.split(',')]
+
     redirect_url = self.DEFAULT_URL
 
     # Update/delete existing feature.
@@ -352,6 +356,7 @@ class FeatureHandler(common.ContentHandler):
         feature.web_dev_views = int(self.request.get('web_dev_views'))
         feature.doc_links = doc_links
         feature.sample_links = sample_links
+        feature.search_tags = search_tags
     else:
       feature = models.Feature(
           category=int(self.request.get('category')),
@@ -381,6 +386,7 @@ class FeatureHandler(common.ContentHandler):
           web_dev_views=int(self.request.get('web_dev_views')),
           doc_links=doc_links,
           sample_links=sample_links,
+          search_tags=search_tags,
           )
 
     if 'delete' in path:

--- a/models.py
+++ b/models.py
@@ -243,6 +243,7 @@ class Feature(DictModel):
     d['owner'] = ', '.join(self.owner)
     d['doc_links'] = ', '.join(self.doc_links)
     d['sample_links'] = ', '.join(self.sample_links)
+    d['search_tags'] = ', '.join(self.search_tags)
     return d
 
   @classmethod
@@ -355,6 +356,8 @@ class Feature(DictModel):
   doc_links = db.StringListProperty()
   sample_links = db.StringListProperty()
   #tests = db.StringProperty()
+
+  search_tags = db.StringListProperty()
 
   comments = db.StringProperty(multiline=True)
 
@@ -495,6 +498,9 @@ class FeatureForm(forms.Form):
                                initial=NO_PUBLIC_SIGNALS)
   ie_views_link = forms.URLField(required=False, label='',
       help_text='Citation link.')
+
+  search_tags = forms.CharField(label='Search tags', required=False,
+      help_text='Comma separated keywords used only in search')
 
   comments = forms.CharField(label='', required=False, widget=forms.Textarea(
       attrs={'cols': 50, 'placeholder': 'Additional comments, caveats, info...'}))

--- a/static/elements/chromedash-featurelist.html
+++ b/static/elements/chromedash-featurelist.html
@@ -189,6 +189,7 @@
           this.filtered = this.features.filter(function(feature, idx, array) {
             return regex.test(feature.name) || regex.test(feature.category) ||
                    regex.test(feature.summary) ||
+                   regex.test(feature.search_tags) ||
                    /*regex.test(feature.shipped_milestone) ||*/
                    regex.test(feature.impl_status_chrome);
           });


### PR DESCRIPTION
Feature owners can now add extra "search tags" so that users can search by them.
Search tags are not shown to the user.

TEST=
- Add search tags such as "css-sizing,max-content" for a feature
- Search for "max-content"
- Feature shows in the results

BUG=#99

![image](https://cloud.githubusercontent.com/assets/634478/3612869/1b30f2fe-0db1-11e4-8979-a0caa0cdded0.png)
