### PR TITLE
Redirected admin URLs to view URLS for unauthenticated users

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -48,7 +48,6 @@ handlers:
 
 - url: /admin/features/.*
   script: admin.app
-  login: required
 
 - url: /admin/users/.*
   script: users.app


### PR DESCRIPTION
As said in the bug issue, _When unauthenticated users hit admin pages, they get a Google login screen. Instead, they should get rerouted to the view mode for that feature._

BUG=#76

![image](https://cloud.githubusercontent.com/assets/634478/3614147/01225db4-0dbe-11e4-82f1-4f5ecbf865e6.png)
