### PR TITLE
Added /robots.txt with a Sitemap: definition.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -27,6 +27,10 @@ handlers:
   static_files: static/img/chromium-128.png
   upload: static/img/chromium-128\.png
 
+- url: /robots\.txt
+  static_files: static/robots.txt
+  upload: static/robots\.txt
+
 - url: /static
   static_dir: static
   #expiration: 30s

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: http://www.chromestatus.com/features.xml?max-items=9999


### PR DESCRIPTION
A simple way to provide a link to a site's feed is via the Sitemap: property in `robots.txt`.

This has the benefit of being discoverable by any search engine, not just Google.
