### PR TITLE
Added support for new lines for link lists split

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -23,6 +23,7 @@ import datetime
 import json
 import logging
 import os
+import re
 import sys
 import webapp2
 
@@ -320,11 +321,11 @@ class FeatureHandler(common.ContentHandler):
 
     doc_links = self.request.get('doc_links') or []
     if doc_links:
-      doc_links = [x.strip() for x in doc_links.split(',')]
+      doc_links = [x.strip() for x in re.split(',|\\r?\\n', doc_links)]
 
     sample_links = self.request.get('sample_links') or []
     if sample_links:
-      sample_links = [x.strip() for x in sample_links.split(',')]
+      sample_links = [x.strip() for x in re.split(',|\\r?\\n', sample_links)]
 
     search_tags = self.request.get('search_tags') or []
     if search_tags:


### PR DESCRIPTION
The fields for link lists (documentation and sample links) are text areas and not single line fields. While there is a note below the field that directs the editor to use commas to separate the links, this is confusing and nonsensical in text areas or links (there will never be new lines within URLs) and makes it error prone, as evident in https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/BdAbzHMdjh8 - and so support for new lines as well as commas was added (I prefer to just use new lines, though).
