### PR TITLE
Truncate day percentage numbers for non whitelisted users

### DIFF
--- a/common.py
+++ b/common.py
@@ -43,20 +43,6 @@ class BaseHandler(webapp2.RequestHandler):
     # Settings can't be global in python 2.7 env.
     logging.getLogger().setLevel(logging.DEBUG)
 
-
-class JSONHandler(BaseHandler):
-
-  def get(self, data, formatted=False):
-    self.response.headers['Content-Type'] = 'application/json;charset=utf-8'
-    if formatted:
-      return self.response.write(json.dumps(data, separators=(',',':')))
-    else:
-      data = [entity.to_dict() for entity in data]
-      return self.response.write(json.dumps(data, separators=(',',':')))
-
-
-class ContentHandler(BaseHandler):
-
   def _is_user_whitelisted(self, user):
     if not user:
       return False
@@ -76,6 +62,33 @@ class ContentHandler(BaseHandler):
         is_whitelisted = True
 
     return is_whitelisted
+
+
+class JSONHandler(BaseHandler):
+
+  def _clean_data(self, data):
+
+    def truncate_day_percentage(data):
+      data.day_percentage = round(data.day_percentage, 4)
+      return data
+
+    user = users.get_current_user()
+    # Show raw day percentage numbers if user is whitelisted.
+    if not self._is_user_whitelisted(user):
+      data = map(truncate_day_percentage, data)
+
+    return data
+
+  def get(self, data, formatted=False):
+    self.response.headers['Content-Type'] = 'application/json;charset=utf-8'
+    if formatted:
+      return self.response.write(json.dumps(data, separators=(',',':')))
+    else:
+      data = [entity.to_dict() for entity in data]
+      return self.response.write(json.dumps(data, separators=(',',':')))
+
+
+class ContentHandler(BaseHandler):
 
   def _add_common_template_values(self, d):
     """Mixin common values for templates into d."""

--- a/metrics.py
+++ b/metrics.py
@@ -58,6 +58,7 @@ class TimelineHandler(common.JSONHandler):
 
       memcache.set(KEY, data, time=CACHE_AGE)
 
+    data = self._clean_data(data)
     super(TimelineHandler, self).get(data)
 
 
@@ -115,6 +116,7 @@ class FeatureHandler(common.JSONHandler):
 
         memcache.set(self.MEMCACHE_KEY, properties, time=CACHE_AGE)
 
+    properties = self._clean_data(properties)
     super(FeatureHandler, self).get(properties)
 
 


### PR DESCRIPTION
Based on our previous discussion, here's something that could suit our needs to do usage stat rounding server side.

Following same patterns for edit rights, if user is whitelisted, he'll have access to raw data for JSON endpoints while it will still show 4 decimals for UI. 
If user is not, all JSON endpoints will always truncate day percentage stats.

What do you think @ebidel @dstockwell?

BUG=#123