### PR TITLE
Update intent to implement to include a tag review

### DIFF
--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -9,7 +9,7 @@ Intent to Implement: {{feature.name}}
 
 <label>Spec</label>
 {% if feature.spec_link %}<a href="{{feature.spec_link}}">{{feature.spec_link}}</a>{% else %}None{% endif %}
-<span class="help">You should have at least an unofficial spec in hand and/or have discussed the API with other browser vendors or standards bodies before sending an intent to implement. If your change is not yet at this stage of maturity, feel free to solicit feedback informally on blink-dev instead.</span>
+<span class="help">You should have at least an unofficial spec in hand and/or have discussed the API with other browser vendors or standards bodies before sending an intent to implement. If your change is not yet at this stage of maturity, feel free to solicit feedback informally on blink-dev instead. If this is an intent to ship, include a link to a <a href="https://github.com/w3ctag/spec-reviews/issues">tag review</a> or a description about why the tag review process is being skipped.</span>
 
 <label>Summary</label>
 {{feature.summary}}


### PR DESCRIPTION
Tag, you're it! We're asking intenters to include a tag review now, or a reason why they are skipping that process.