### PR TITLE
Status filter for the RSS feed

### DIFF
--- a/server.py
+++ b/server.py
@@ -112,8 +112,7 @@ class MainHandler(common.ContentHandler, common.JSONHandler):
       elif path.endswith('.xml'): # Atom feed request.
         status = self.request.get('status', None)
         if status:
-          statuses = status.split(',')
-          feature_list = models.Feature.get_all_with_statuses(statuses)
+          feature_list = models.Feature.get_all_with_statuses(status.split(','))
         else:
           filterby = None
 

--- a/server.py
+++ b/server.py
@@ -110,29 +110,34 @@ class MainHandler(common.ContentHandler, common.JSONHandler):
         feature_list = self.__get_feature_list()
         return common.JSONHandler.get(self, feature_list, formatted=True)
       elif path.endswith('.xml'): # Atom feed request.
-        filterby = None
+        status = self.request.get('status', None)
+        if status:
+          statuses = status.split(',')
+          feature_list = models.Feature.get_all_with_statuses(statuses)
+        else:
+          filterby = None
 
-        category = self.request.get('category', None)
+          category = self.request.get('category', None)
 
-        # Support setting larger-than-default Atom feed sizes so that web
-        # crawlers can treat use this as a full site feed.
-        try:
-          max_items = int(self.request.get('max-items',
-                                           settings.RSS_FEED_LIMIT))
-        except TypeError:
-          max_items = settings.RSS_FEED_LIMIT
+          # Support setting larger-than-default Atom feed sizes so that web
+          # crawlers can treat use this as a full site feed.
+          try:
+            max_items = int(self.request.get('max-items',
+                                             settings.RSS_FEED_LIMIT))
+          except TypeError:
+            max_items = settings.RSS_FEED_LIMIT
 
-        if category is not None:
-          for k,v in models.FEATURE_CATEGORIES.iteritems():
-            normalized = normalized_name(v)
-            if category == normalized:
-              filterby = ('category =', k)
-              break
+          if category is not None:
+            for k,v in models.FEATURE_CATEGORIES.iteritems():
+              normalized = normalized_name(v)
+              if category == normalized:
+                filterby = ('category =', k)
+                break
 
-        feature_list = models.Feature.get_all( # Memcached
-            limit=max_items,
-            filterby=filterby,
-            order='-updated')
+          feature_list = models.Feature.get_all( # Memcached
+              limit=max_items,
+              filterby=filterby,
+              order='-updated')
 
         return self.render_atom_feed('Features', feature_list)
       else:


### PR DESCRIPTION
@ebidel @beaufortfrancois

This exposes a new RSS feed, https://www.chromestatus.com/features?status=Deprecated,Removed (or any other comma-separated list of `impl_status_chrome ` values). It's a little hacky since I don't believe App Engine's datastore allows for `OR`s in its queries. I'm also only doing this for the `impl_status_chrome` field—it could be made more generic, but I'm not sure if there's value in that.

This together with the existing https://www.chromestatus.com/features#deprecated|removed may be sufficient to close #101 