### PR TITLE
Fixed Delete feature behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "grunt": "*",
     "grunt-appengine": "^0.1.5",
-    "grunt-vulcanize": "*",
+    "grunt-vulcanize": "0.6.4",
     "load-grunt-tasks": "*"
   }
 }

--- a/static/elements/delete-link.html
+++ b/static/elements/delete-link.html
@@ -1,13 +1,13 @@
 <link rel="import" href="../bower_components/polymer/polymer.html">
 <link rel="import" href="../bower_components/core-ajax/core-xhr.html">
 
-<polymer-element name="delete-link" extends="a" on-tap="{{onTap}}">
+<polymer-element name="delete-link" extends="a" on-click="{{onClick}}">
 <template>
   <content></content>
 </template>
 <script>
   Polymer({
-    onTap: function(e, details, sender) {
+    onClick: function(e, details, sender) {
       e.preventDefault();
 
       var msg = this.getAttribute('message') || 'Remove?';

--- a/templates/admin/features/edit.html
+++ b/templates/admin/features/edit.html
@@ -17,7 +17,7 @@ a[is="delete-link"] {
 <div id="subheader">
   <h2>Edit a feature</h2>
   {% if user.is_admin %}
-     <a is="delete-link" href="/admin/features/delete/{{feature.id}}" message="Delete features?">Delete</a>
+     <a is="delete-link" href="/admin/features/delete/{{feature.id}}" message="Delete feature?">Delete</a>
   {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Hello @ebidel 

This patch addresses the grunt error below:
`Fatal error: This version of vulcanize is not compatible with Polymer < 0.8. Please use vulcanize 0.7.x. File: static/elements/delete-link.html`

Moreover the `onTap` event wasn't properly prevented so I switched to `onClick` which works great now on mobile as well.

BUG=https://github.com/GoogleChrome/chromium-dashboard/issues/214