### PR TITLE
Added an edit link to the standalone feature page

### DIFF
--- a/templates/feature.html
+++ b/templates/feature.html
@@ -25,6 +25,7 @@
       {% if feature.impl_status_chrome == "Removed" %} (removed){% endif %}
     </h2>
     <a href="/features#category: {{ feature.category }}" class="category">{{ feature.category }}</a>
+    {% if user.is_whitelisted %}<a href="/admin/features/edit/{{ feature.id }}" class="edit">&#160;edit</a>{% endif %}
   </section>
 
   {% if feature.summary %}


### PR DESCRIPTION
People keep linking to the standalone page and after I sign in, I must either construct the edit link by myself, or go to the list of features and re-search for the feature, which is annoying. The solution - add an edit link in the standalone page.