### PR TITLE
Add support for Experimental Framework

### DIFF
--- a/models.py
+++ b/models.py
@@ -56,6 +56,7 @@ BEHIND_A_FLAG = 4
 ENABLED_BY_DEFAULT = 5
 DEPRECATED = 6
 REMOVED = 7
+EXPERIMENTAL_FRAMEWORK = 8
 NO_LONGER_PURSUING = 1000 # insure bottom of list
 
 IMPLEMENTATION_STATUS = {
@@ -66,6 +67,7 @@ IMPLEMENTATION_STATUS = {
   ENABLED_BY_DEFAULT: 'Enabled by default',
   DEPRECATED: 'Deprecated',
   REMOVED: 'Removed',
+  EXPERIMENTAL_FRAMEWORK: 'In experimental framework',
   NO_LONGER_PURSUING: 'No longer pursuing',
   }
 
@@ -223,6 +225,7 @@ class Feature(DictModel):
     d['visibility'] = VISIBILITY_CHOICES[self.visibility]
     d['impl_status_chrome'] = IMPLEMENTATION_STATUS[self.impl_status_chrome]
     d['meta'] = {
+      'experimentalframework': self.impl_status_chrome == EXPERIMENTAL_FRAMEWORK,
       'needsflag': self.impl_status_chrome == BEHIND_A_FLAG,
       'milestone_str': self.shipped_milestone or d['impl_status_chrome']
       }

--- a/static/elements/chromedash-feature.html
+++ b/static/elements/chromedash-feature.html
@@ -84,6 +84,11 @@
             <iron-icon icon="icons:extension" class="experimental"></iron-icon>
           </span>
         </template>
+        <template is="dom-if" if="{{feature.meta.experimentalframework}}">
+          <span class="tooltip" title="Feature in experimental framework">
+            <iron-icon icon="icons:extension" class="experimental"></iron-icon>
+          </span>
+        </template>
         <template is="dom-if" if="{{whitelisted}}">
           <span class="tooltip" title="Edit this feature">
             <a href$="{{_computeEditLinkHidden(feature)}}" class="editfeature" data-tooltip>

--- a/static/elements/chromedash-legend.html
+++ b/static/elements/chromedash-legend.html
@@ -52,10 +52,11 @@
         <li><span>"&lt;30"</span>features that landed before 30</li>
         <li><span>"&lt;=30"</span>features in 30</li>
         <li><span>"=30"</span>features that landed in 30</li>
-        <li><span>"&gt;28"</span>features since 28
-        </li><li><span>"behind a flag"</span>all experimental features
+        <li><span>"&gt;28"</span>features since 28</li>
+        <li><span>"behind a flag"</span>all experimental features</li>
+        <li><span>"in experimental framework"</span>in experimental framework</li>
         <!-- <li><span>"category: CSS"</span>features in the category CSS</li> -->
-        </li><li><span>"owner: user@example.org"</span>features owned by user@example.org</li>
+        <li><span>"owner: user@example.org"</span>features owned by user@example.org</li>
       </ul>
     </section>
     <div class="content-wrapper"><content></content></div>

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -70,10 +70,12 @@
     <h3>Implementation Status</h3>
     <p>
       {% if feature.shipped_milestone %}
-        {% if feature.meta.needsflag %}
-          Behind a flag
+        {% if feature.meta.experimentalframework %}
+          In experimental framework
         {% else %}
-          {% if feature.impl_status_chrome == "Deprecated" or feature.impl_status_chrome == "No longer pursuing" %}
+          {% if feature.meta.needsflag %}
+            Behind a flag
+          {% elif feature.impl_status_chrome == "Deprecated" or feature.impl_status_chrome == "No longer pursuing" %}
             Deprecated
           {% elif feature.impl_status_chrome == "Removed" %}
             Removed

--- a/templates/features.html
+++ b/templates/features.html
@@ -58,6 +58,7 @@
         "ENABLED_BY_DEFAULT": 5,
         "DEPRECATED": 6,
         "REMOVED": 7,
+        "IN_EXPERIMENTAL_FRAMEWORK": 8,
         "NO_LONGER_PURSUING": 1000
       }'></chromedash-metadata>
 </nav>

--- a/templates/samples.html
+++ b/templates/samples.html
@@ -40,8 +40,8 @@ paper-input {
 </div>
 <div class="subheader layout vertical start">
   <p class="description">Features are ordered by Chrome release version, latest first. Features
-  enabled by default always come first, followed by features that are behind a flag
-  or are still in the development.</p>
+  enabled by default always come first, followed by features that are in experimental framework,
+  behind a flag or still in the development.</p>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
This PR add support for the Experimental Framework coming soon.
See https://github.com/jpchase/ExperimentalFramework/blob/master/explainer.md for some background.

![screenshot 2016-02-03 at 10 41 01 am](https://cloud.githubusercontent.com/assets/634478/12778468/1d430698-ca63-11e5-9981-9657ee60ed32.png)