### PR TITLE
Use one URL per line for docs and samples

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -384,11 +384,11 @@ class FeatureHandler(common.ContentHandler):
 
     doc_links = self.request.get('doc_links') or []
     if doc_links:
-      doc_links = [x.strip() for x in re.split(',|\\r?\\n', doc_links)]
+      doc_links = [x.strip() for x in re.split('\\r?\\n', doc_links)]
 
     sample_links = self.request.get('sample_links') or []
     if sample_links:
-      sample_links = [x.strip() for x in re.split(',|\\r?\\n', sample_links)]
+      sample_links = [x.strip() for x in re.split('\\r?\\n', sample_links)]
 
     search_tags = self.request.get('search_tags') or []
     if search_tags:

--- a/models.py
+++ b/models.py
@@ -246,8 +246,8 @@ class Feature(DictModel):
     d = self.to_dict()
     #d['id'] = self.key().id
     d['owner'] = ', '.join(self.owner)
-    d['doc_links'] = ', '.join(self.doc_links)
-    d['sample_links'] = ', '.join(self.sample_links)
+    d['doc_links'] = '\r\n'.join(self.doc_links)
+    d['sample_links'] = '\r\n'.join(self.sample_links)
     d['search_tags'] = ', '.join(self.search_tags)
     return d
 
@@ -526,12 +526,12 @@ class FeatureForm(forms.Form):
                              help_text="Prefer editor's draft.")
 
   doc_links = forms.CharField(label='Doc links', required=False, max_length=500,
-      widget=forms.Textarea(attrs={'cols': 50, 'placeholder': 'Links to documentation (comma separated)', 'maxlength': 500}),
-      help_text='Comma separated URLs')
+      widget=forms.Textarea(attrs={'cols': 50, 'placeholder': 'Links to documentation (one per line)', 'maxlength': 500}),
+      help_text='One URL per line')
 
   sample_links = forms.CharField(label='Samples links', required=False, max_length=500,
-      widget=forms.Textarea(attrs={'cols': 50, 'placeholder': 'Links to samples (comma separated)', 'maxlength': 500}),
-      help_text='Comma separated URLs')
+      widget=forms.Textarea(attrs={'cols': 50, 'placeholder': 'Links to samples (one per line)', 'maxlength': 500}),
+      help_text='One URL per line')
 
   footprint  = forms.ChoiceField(label='Technical footprint',
                                  choices=FOOTPRINT_CHOICES.items(),


### PR DESCRIPTION
In order to make sure any doc and sample URL (even one with a comma) can be added to a feature, I've simply decided to replace comma-separated URLs with one per line. 

Moreover, this makes it even easier to read.

FIX=#269
R=@ebidel