### PR TITLE
Linkify urls in comments on standalone feature page

### DIFF
--- a/templates/feature.html
+++ b/templates/feature.html
@@ -31,9 +31,13 @@
   {% if feature.summary %}
   <section id="summary">
     <p>{{ feature.summary }}</p>
-    {% if feature.comments %}
-    <p class="note">Note: {{ feature.comments }}</p>
-    {% endif %}
+  </section>
+  {% endif %}
+
+  {% if feature.comments %}
+  <section id="comments">
+    <h3>Comments</h3>
+    <p>{{ feature.comments|urlize }}</p>
   </section>
   {% endif %}
 


### PR DESCRIPTION
On the standalone feature.html page, move comments into a separate section (similar to the features page). In this separate section, the comments are now processed to have any urls turned into actual links.

Fixes #222 