### PR TITLE
Reduce h2 push'd resources. Preload instead. Fixes #345

### DIFF
--- a/push_manifest_features.json
+++ b/push_manifest_features.json
@@ -1,28 +1,4 @@
 {
-  "/static/css/main.css": {
-    "type": "style",
-    "weight": 1
-  },
-  "/static/bower_components/webcomponentsjs/webcomponents-lite.min.js": {
-    "type": "script",
-    "weight": 1
-  },
-  "/static/css/features/features.css": {
-    "type": "style",
-    "weight": 1
-  },
-  "/static/elements/features-imports.vulcanize.html": {
-    "type": "document",
-    "weight": 1
-  },
-  "/static/elements/features-imports.vulcanize.js": {
-    "type": "script",
-    "weight": 1
-  },
-  "/features.json": {
-    "type": "script",
-    "weight": 1
-  },
   "/omaha_data": {
     "type": "script",
     "weight": 1

--- a/push_manifest_metrics.json
+++ b/push_manifest_metrics.json
@@ -1,22 +1,3 @@
 {
-  "/static/css/main.css": {
-    "type": "style",
-    "weight": 1
-  },
-  "/static/bower_components/webcomponentsjs/webcomponents-lite.min.js": {
-    "type": "script",
-    "weight": 1
-  },
-  "/static/css/metrics/metrics.css": {
-    "type": "style",
-    "weight": 1
-  },
-  "/static/elements/metrics-imports.vulcanize.html": {
-    "type": "document",
-    "weight": 1
-  },
-  "/static/elements/metrics-imports.vulcanize.js": {
-    "type": "script",
-    "weight": 1
-  }
+
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -54,9 +54,8 @@
 <link rel="stylesheet" href="/static/css/main.css">
 {% block css %}{% endblock %}
 
-<script src="/static/bower_components/webcomponentsjs/webcomponents-lite.min.js" defer></script>
-<!-- <script src="/static/js/smoothscroll/dist/smoothscroll.js"></script> -->
-<!-- <script src="/static/js/bower_components/smoothscroll/smoothscroll.js"></script>  -->
+{% block preload %}{% endblock %}
+
 <script>
 window.Polymer = window.Polymer || {dom: 'shadow', lazyRegister: true};
 
@@ -86,8 +85,33 @@ var $$ = function(selector) {
 
 {% block js %}{% endblock %}
 
-<!-- Google Analytics -->
 <script>
+// https://gist.github.com/ebidel/1d5ede1e35b6f426a2a7
+function lazyLoadWCPolyfillsIfNecessary() {
+  function onload() {
+    // For native Imports, manually fire WCR so user code
+    // can use the same code path for native and polyfill'd imports.
+    if (!('HTMLImports' in window)) {
+      document.body.dispatchEvent(
+          new CustomEvent('WebComponentsReady', {bubbles: true}));
+    }
+  }
+
+  var webComponentsSupported = ('registerElement' in document
+      && 'import' in document.createElement('link')
+      && 'content' in document.createElement('template'));
+  if (!webComponentsSupported) {
+    var script = document.createElement('script');
+    script.async = true;
+    script.src = '/static/bower_components/webcomponentsjs/webcomponents-lite.min.js';
+    script.onload = onload;
+    document.head.appendChild(script);
+  } else {
+    onload();
+  }
+}
+
+// Google Analytics
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -95,8 +119,9 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 
 ga('create', 'UA-39048143-1', 'auto');
 ga('send', 'pageview');
-</script>
-<!-- End Google Analytics -->
+// End Google Analytics
 
+lazyLoadWCPolyfillsIfNecessary();
+</script>
 </body>
 </html>

--- a/templates/features.html
+++ b/templates/features.html
@@ -1,5 +1,14 @@
 {% extends "base.html" %}
 
+{% block preload %}
+{% if VULCANIZE %}
+  <link rel="preload" href="/static/elements/features-imports.vulcanize.js" as="script">
+{% endif %}
+{% if PROD %}
+  <link rel="preload" href="/features.json" as="script">
+{% endif %}
+{% endblock %}
+
 {% block html_imports %}
   <link rel="import" href="/static/elements/features-imports{% if VULCANIZE %}.vulcanize{% endif %}.html">
 {% endblock %}
@@ -178,16 +187,6 @@ function importsLoaded() {
     console.error(e);
   });
 
-  // // Alternative to XHR, we could fill data from server by including it
-  // // directly in the server's page template. However, this increases the weight
-  // // of the page and slows down window.onload, especially as the number of
-  // // features increases over time. For this reason, XHR is preferred.
-  // featureList.features = {{features|safe}};
-  // featureList.metadata = chromeMetadata; // Feature list needs access to the selected milestone.
-  // featureList.search = search;
-  // updateCount(featureList.filter(search.value)); // Set initial # features showing.
-  // search.disabled = false;
-
   overlay.views = {
     vendors: {{VENDOR_VIEWS|safe}}, // set from server
     webdevs: {{WEB_DEV_VIEWS|safe}}, // set from server
@@ -195,14 +194,8 @@ function importsLoaded() {
   };
 }
 
-var importsSupported = ('import' in document.createElement('link'));
-if (importsSupported) {
-  document.addEventListener('HTMLImportsLoaded', importsLoaded);
-} else {
-  // Polyfilled browsers need to wait for the WCR event to in order to set
-  // properties on upgraded elements.
-  document.addEventListener('WebComponentsReady', importsLoaded);
-}
+// Fired after lazy loading the polyfills (if necessary).
+document.addEventListener('WebComponentsReady', importsLoaded);
 
 window.addEventListener('popstate', function(e) {
   if (e.state) {

--- a/templates/metrics/css/animated.html
+++ b/templates/metrics/css/animated.html
@@ -7,6 +7,12 @@
 {% block js %}
 {% endblock %}
 
+{% block preload %}
+  {% if VULCANIZE %}
+    <link rel="preload" href="/static/elements/metrics-imports.vulcanize.js" as="script">
+  {% endif %}
+{% endblock %}
+
 {% block html_imports %}
   <link rel="import" href="/static/elements/metrics-imports{% if VULCANIZE %}.vulcanize{% endif %}.html">
 {% endblock %}

--- a/templates/metrics/css/popularity.html
+++ b/templates/metrics/css/popularity.html
@@ -7,6 +7,12 @@
 {% block js %}
 {% endblock %}
 
+{% block preload %}
+  {% if VULCANIZE %}
+    <link rel="preload" href="/static/elements/metrics-imports.vulcanize.js" as="script">
+  {% endif %}
+{% endblock %}
+
 {% block html_imports %}
   <link rel="import" href="/static/elements/metrics-imports{% if VULCANIZE %}.vulcanize{% endif %}.html">
 {% endblock %}

--- a/templates/metrics/feature/popularity.html
+++ b/templates/metrics/feature/popularity.html
@@ -7,6 +7,12 @@
 {% block js %}
 {% endblock %}
 
+{% block preload %}
+  {% if VULCANIZE %}
+    <link rel="preload" href="/static/elements/metrics-imports.vulcanize.js" as="script">
+  {% endif %}
+{% endblock %}
+
 {% block html_imports %}
   <link rel="import" href="/static/elements/metrics-imports{% if VULCANIZE %}.vulcanize{% endif %}.html">
 {% endblock %}

--- a/templates/metrics/feature/timeline/popularity.html
+++ b/templates/metrics/feature/timeline/popularity.html
@@ -5,6 +5,12 @@
 <link rel="stylesheet" href="/static/css/metrics/metrics.css">
 {% endblock %}
 
+{% block preload %}
+  {% if VULCANIZE %}
+    <link rel="preload" href="/static/elements/metrics-imports.vulcanize.js" as="script">
+  {% endif %}
+{% endblock %}
+
 {% block html_imports %}
   <link rel="import" href="/static/elements/metrics-imports{% if VULCANIZE %}.vulcanize{% endif %}.html">
 {% endblock %}

--- a/templates/samples.html
+++ b/templates/samples.html
@@ -1,6 +1,12 @@
 {% extends "base.html" %}
 {% load verbatim %}
 
+{% block preload %}
+  {% if VULCANIZE %}
+    <link rel="preload" href="/static/elements/samples-imports.vulcanize.js" as="script">
+  {% endif %}
+{% endblock %}
+
 {% block html_imports %}
   <link rel="import" href="/static/elements/samples-imports{% if VULCANIZE %}.vulcanize{% endif %}.html">
 {% endblock %}


### PR DESCRIPTION
R: @RByers @clelland @jeffposnick @GoogleChrome/chromium-dashboard 

This also lazy loads the web component polyfills!