### PR TITLE
Cache json endpoints

### DIFF
--- a/common.py
+++ b/common.py
@@ -63,8 +63,16 @@ class JSONHandler(BaseHandler):
 
     return data
 
-  def get(self, data, formatted=False):
+  def get(self, data, formatted=False, public=True):
+    cache_type = 'public'
+    if not public:
+      cache_type = 'private'
+
+    # Cache script generated json responses for 10 minutes.
+    self.response.headers['Cache-Control'] = '%s, max-age=%s' % (
+        cache_type, settings.DEFAULT_CACHE_TIME)
     self.response.headers['Content-Type'] = 'application/json;charset=utf-8'
+
     if formatted:
       return self.response.write(json.dumps(data, separators=(',',':')))
     else:

--- a/common.py
+++ b/common.py
@@ -68,7 +68,7 @@ class JSONHandler(BaseHandler):
     if not public:
       cache_type = 'private'
 
-    # Cache script generated json responses for 10 minutes.
+    # Cache script generated json responses.
     self.response.headers['Cache-Control'] = '%s, max-age=%s' % (
         cache_type, settings.DEFAULT_CACHE_TIME)
     self.response.headers['Content-Type'] = 'application/json;charset=utf-8'

--- a/metrics.py
+++ b/metrics.py
@@ -59,7 +59,9 @@ class TimelineHandler(common.JSONHandler):
       memcache.set(KEY, data, time=CACHE_AGE)
 
     data = self._clean_data(data)
-    super(TimelineHandler, self).get(data)
+    # Metrics json shouldn't be cached by intermediary caches because users
+    # see different data when logged in. Set Cache-Control: private.
+    super(TimelineHandler, self).get(data, public=False)
 
 
 class PopularityTimelineHandler(TimelineHandler):
@@ -114,7 +116,9 @@ class FeatureHandler(common.JSONHandler):
       memcache.set(self.MEMCACHE_KEY, properties, time=CACHE_AGE)
 
     properties = self._clean_data(properties)
-    super(FeatureHandler, self).get(properties)
+    # Metrics json shouldn't be cached by intermediary caches because users
+    # see different data when logged in. Set Cache-Control: private.
+    super(FeatureHandler, self).get(properties, public=False)
 
 
 class CSSPopularityHandler(FeatureHandler):

--- a/settings.py
+++ b/settings.py
@@ -30,3 +30,5 @@ MEMCACHE_KEY_PREFIX = APP_VERSION # For memcache busting on new version
 RSS_FEED_LIMIT = 15
 
 VULCANIZE = True #PROD
+
+DEFAULT_CACHE_TIME = 600 # seconds

--- a/static/elements/chromedash-featurelist.html
+++ b/static/elements/chromedash-featurelist.html
@@ -165,10 +165,15 @@
         this.fire('filtered', {count: this.filtered.length});
       },
 
-      filter: function(val) {
-        this.debounce('filtering', function() {
+      filter: function(val, opt_debounce) {
+        var debounce = opt_debounce || false;
+        if (debounce) {
+          this.debounce('filtering', function() {
+            this._filterList(val);
+          }, 200);
+        } else {
           this._filterList(val);
-        }, 200);
+        }
       },
 
       // Returns the index of the first feature of a given milestone string.
@@ -238,7 +243,9 @@
       _deepLinkToFeature: function() {
         this._set_firstLoad(false);
 
-        this.$.ironlist._update(); // force update to list.
+        // TODO(ericbidelman): Originally introduced to fix a bug in ironlist.
+        // Looks fixed now and removing this call helps page load perf!
+        //this.$.ironlist._update(); // force update to list.
 
         document.getElementById('content').classList.add('ready'); // unmask app.
         this.fire('unveiled');

--- a/templates/features.html
+++ b/templates/features.html
@@ -129,7 +129,7 @@ search.addEventListener('search', function(e) {
 });
 
 search.addEventListener('input', function(e) {
-  featureList.filter(e.target.value);
+  featureList.filter(e.target.value, true);
   chromeMetadata.selected = null;
 });
 


### PR DESCRIPTION
R: @RByers @beaufortfrancois @GoogleChrome/chromium-dashboard 

GAE does not set cache headers for script handlers. These resources don't change much
and should be cached. This introduces minimal caching (10min) for the feed resources. The timeline data are marked `private` b/c signed in admins see more granular metric data.