### PR TITLE
Use Gulp for build instead of Grunt

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": ["es2015"],
+  // Remove the line below to enable ES2015 support.
+  "only": "gulpfile.babel.js",
+  "retainLines": true
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,93 +3,6 @@ module.exports = function(grunt) {
   grunt.initConfig({
     // pkg: grunt.file.readJSON('package.json'),
 
-    vulcanize: {
-      options: {
-        // excludes: {
-        //   imports: [
-        //     "polymer.html$"
-        //   ]
-        // },
-        stripComments: true,
-        inlineScripts: true,
-        inlineCss: true
-      },
-      buildall: {
-        options: {
-          csp: 'elements.vulcanize.js'
-        },
-        files: {
-          'static/elements/elements.vulcanize.html': 'static/elements/elements.html'
-        },
-      },
-      build1: {
-        options: {
-          csp: 'metrics-imports.vulcanize.js'
-        },
-        files: {
-          'static/elements/metrics-imports.vulcanize.html': 'static/elements/metrics-imports.html'
-        }
-      },
-      build2: {
-        options: {
-          csp: 'features-imports.vulcanize.js'
-        },
-        files: {
-          'static/elements/features-imports.vulcanize.html': 'static/elements/features-imports.html'
-        }
-      },
-      build3: {
-        options: {
-          csp: 'admin-imports.vulcanize.js'
-        },
-        files: {
-          'static/elements/admin-imports.vulcanize.html': 'static/elements/admin-imports.html'
-        }
-      },
-      build4: {
-        options: {
-          csp: 'samples-imports.vulcanize.js'
-        },
-        files: {
-          'static/elements/samples-imports.vulcanize.html': 'static/elements/samples-imports.html'
-        }
-      }
-    },
-
-    minified : {
-      files: {
-        src: [
-          'static/elements/*.vulcanize.js'
-        ],
-        dest: 'static'
-      },
-      options : {
-        sourcemap: false,
-        mirrorSource: {
-          path: 'static/'
-        },
-        ext: '.js'
-      }
-    },
-
-    sass: {
-      options: {
-        sourceMap: false,
-        outputStyle: 'compressed'
-      },
-      dist: {
-        expand: true,
-        cwd: 'static/sass',
-        src: ['**/*.scss'],
-        dest: 'static/css',
-        ext: '.css'
-      }
-    },
-
-    clean: {
-      default: ['static/elements/*.vulcanize.{html,js}']
-    },
-
     watch: {
       elements: {
         files: ['components/*.html'],
@@ -123,6 +36,5 @@ module.exports = function(grunt) {
   // Plugin and grunt tasks.
   require('load-grunt-tasks')(grunt);
 
-  grunt.registerTask('default', ['sass', 'vulcanize', 'minified']);
   grunt.registerTask('serve', ['appengine:run:frontend']);
 };

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You'll also need node/npm. Next, install `bower` and the npm deps:
     npm install -g bower
     npm install
 
-This will also pull down bower_components and run `grunt` to build the site.
+This will also pull down bower_components and run `gulp` to build the site.
 
 ### Developing
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -79,26 +79,15 @@ gulp.task('styles', () => {
 // Concatenate and minify JavaScript. Optionally transpiles ES2015 code to ES5.
 // to enable ES2015 support remove the line `"only": "gulpfile.babel.js",` in the
 // `.babelrc` file.
-gulp.task('scripts', () =>
-    gulp.src([
-      // Note: Since we are not using useref in the scripts build pipeline,
-      //       you need to explicitly list your scripts here in the right order
-      //       to be correctly concatenated
-      './app/scripts/main.js'
-      // Other scripts
-    ])
-      .pipe($.newer('.tmp/scripts'))
-      .pipe($.sourcemaps.init())
-      .pipe($.babel())
-      .pipe($.sourcemaps.write())
-      .pipe(gulp.dest('.tmp/scripts'))
-      .pipe($.concat('main.min.js'))
-      .pipe($.uglify({preserveComments: 'some'}))
-      // Output files
-      .pipe($.size({title: 'scripts'}))
-      .pipe($.sourcemaps.write('.'))
-      .pipe(gulp.dest('dist/scripts'))
-);
+gulp.task('scripts', () => {
+  // Minify the vulcanized script files (overwriting in place)
+  //  - The 'base' option is used to retain the relative path of each file
+  return gulp.src(
+    'static/elements/*.vulcanize.js', {base: 'static'}
+  )
+    .pipe($.uglify())
+    .pipe(gulp.dest('static'));
+});
 
 // Scan your HTML for assets & optimize them
 gulp.task('html', () => {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,0 +1,238 @@
+'use strict';
+
+// This gulpfile makes use of new JavaScript features.
+// Babel handles this without us having to do anything. It just works.
+// You can read more about the new JavaScript features here:
+// https://babeljs.io/docs/learn-es2015/
+
+import path from 'path';
+import gulp from 'gulp';
+import del from 'del';
+// import runSequence from 'run-sequence';
+// import browserSync from 'browser-sync';
+// import swPrecache from 'sw-precache';
+// import gulpLoadPlugins from 'gulp-load-plugins';
+// import {output as pagespeed} from 'psi';
+// import pkg from './package.json';
+
+// const $ = gulpLoadPlugins();
+// const reload = browserSync.reload;
+
+// Lint JavaScript
+gulp.task('lint', () =>
+  gulp.src('app/scripts/**/*.js')
+    .pipe($.eslint())
+    .pipe($.eslint.format())
+    .pipe($.if(!browserSync.active, $.eslint.failOnError()))
+);
+
+// Optimize images
+gulp.task('images', () =>
+  gulp.src('app/images/**/*')
+    .pipe($.cache($.imagemin({
+      progressive: true,
+      interlaced: true
+    })))
+    .pipe(gulp.dest('dist/images'))
+    .pipe($.size({title: 'images'}))
+);
+
+// Copy all files at the root level (app)
+gulp.task('copy', () =>
+  gulp.src([
+    'app/*',
+    '!app/*.html',
+    'node_modules/apache-server-configs/dist/.htaccess'
+  ], {
+    dot: true
+  }).pipe(gulp.dest('dist'))
+    .pipe($.size({title: 'copy'}))
+);
+
+// Compile and automatically prefix stylesheets
+gulp.task('styles', () => {
+  const AUTOPREFIXER_BROWSERS = [
+    'ie >= 10',
+    'ie_mob >= 10',
+    'ff >= 30',
+    'chrome >= 34',
+    'safari >= 7',
+    'opera >= 23',
+    'ios >= 7',
+    'android >= 4.4',
+    'bb >= 10'
+  ];
+
+  // For best performance, don't add Sass partials to `gulp.src`
+  return gulp.src([
+    'app/styles/**/*.scss',
+    'app/styles/**/*.css'
+  ])
+    .pipe($.newer('.tmp/styles'))
+    .pipe($.sourcemaps.init())
+    .pipe($.sass({
+      precision: 10
+    }).on('error', $.sass.logError))
+    .pipe($.autoprefixer(AUTOPREFIXER_BROWSERS))
+    .pipe(gulp.dest('.tmp/styles'))
+    // Concatenate and minify styles
+    .pipe($.if('*.css', $.cssnano()))
+    .pipe($.size({title: 'styles'}))
+    .pipe($.sourcemaps.write('./'))
+    .pipe(gulp.dest('dist/styles'));
+});
+
+// Concatenate and minify JavaScript. Optionally transpiles ES2015 code to ES5.
+// to enable ES2015 support remove the line `"only": "gulpfile.babel.js",` in the
+// `.babelrc` file.
+gulp.task('scripts', () =>
+    gulp.src([
+      // Note: Since we are not using useref in the scripts build pipeline,
+      //       you need to explicitly list your scripts here in the right order
+      //       to be correctly concatenated
+      './app/scripts/main.js'
+      // Other scripts
+    ])
+      .pipe($.newer('.tmp/scripts'))
+      .pipe($.sourcemaps.init())
+      .pipe($.babel())
+      .pipe($.sourcemaps.write())
+      .pipe(gulp.dest('.tmp/scripts'))
+      .pipe($.concat('main.min.js'))
+      .pipe($.uglify({preserveComments: 'some'}))
+      // Output files
+      .pipe($.size({title: 'scripts'}))
+      .pipe($.sourcemaps.write('.'))
+      .pipe(gulp.dest('dist/scripts'))
+);
+
+// Scan your HTML for assets & optimize them
+gulp.task('html', () => {
+  return gulp.src('app/**/*.html')
+    .pipe($.useref({
+      searchPath: '{.tmp,app}',
+      noAssets: true
+    }))
+
+    // Minify any HTML
+    .pipe($.if('*.html', $.htmlmin({
+      removeComments: true,
+      collapseWhitespace: true,
+      collapseBooleanAttributes: true,
+      removeAttributeQuotes: true,
+      removeRedundantAttributes: true,
+      removeEmptyAttributes: true,
+      removeScriptTypeAttributes: true,
+      removeStyleLinkTypeAttributes: true,
+      removeOptionalTags: true
+    })))
+    // Output files
+    .pipe($.if('*.html', $.size({title: 'html', showFiles: true})))
+    .pipe(gulp.dest('dist'));
+});
+
+// Clean output directory
+gulp.task('clean', () => del(['static/elements/*.vulcanize.{html,js}'], {dot: true}));
+
+// Watch files for changes & reload
+gulp.task('serve', ['scripts', 'styles'], () => {
+  browserSync({
+    notify: false,
+    // Customize the Browsersync console logging prefix
+    logPrefix: 'WSK',
+    // Allow scroll syncing across breakpoints
+    scrollElementMapping: ['main', '.mdl-layout'],
+    // Run as an https by uncommenting 'https: true'
+    // Note: this uses an unsigned certificate which on first access
+    //       will present a certificate warning in the browser.
+    // https: true,
+    server: ['.tmp', 'app'],
+    port: 3000
+  });
+
+  gulp.watch(['app/**/*.html'], reload);
+  gulp.watch(['app/styles/**/*.{scss,css}'], ['styles', reload]);
+  gulp.watch(['app/scripts/**/*.js'], ['lint', 'scripts', reload]);
+  gulp.watch(['app/images/**/*'], reload);
+});
+
+// Build and serve the output from the dist build
+gulp.task('serve:dist', ['default'], () =>
+  browserSync({
+    notify: false,
+    logPrefix: 'WSK',
+    // Allow scroll syncing across breakpoints
+    scrollElementMapping: ['main', '.mdl-layout'],
+    // Run as an https by uncommenting 'https: true'
+    // Note: this uses an unsigned certificate which on first access
+    //       will present a certificate warning in the browser.
+    // https: true,
+    server: 'dist',
+    port: 3001
+  })
+);
+
+// Build production files, the default task
+gulp.task('default', ['clean'], cb =>
+  cb
+/*
+  runSequence(
+    'styles',
+    ['lint', 'html', 'scripts', 'images', 'copy'],
+    'generate-service-worker',
+    cb
+  )
+*/
+);
+
+// Run PageSpeed Insights
+gulp.task('pagespeed', cb =>
+  // Update the below URL to the public URL of your site
+  pagespeed('example.com', {
+    strategy: 'mobile'
+    // By default we use the PageSpeed Insights free (no API key) tier.
+    // Use a Google Developer API key if you have one: http://goo.gl/RkN0vE
+    // key: 'YOUR_API_KEY'
+  }, cb)
+);
+
+// Copy over the scripts that are used in importScripts as part of the generate-service-worker task.
+gulp.task('copy-sw-scripts', () => {
+  return gulp.src(['node_modules/sw-toolbox/sw-toolbox.js', 'app/scripts/sw/runtime-caching.js'])
+    .pipe(gulp.dest('dist/scripts/sw'));
+});
+
+// See http://www.html5rocks.com/en/tutorials/service-worker/introduction/ for
+// an in-depth explanation of what service workers are and why you should care.
+// Generate a service worker file that will provide offline functionality for
+// local resources. This should only be done for the 'dist' directory, to allow
+// live reload to work as expected when serving from the 'app' directory.
+gulp.task('generate-service-worker', ['copy-sw-scripts'], () => {
+  const rootDir = 'dist';
+  const filepath = path.join(rootDir, 'service-worker.js');
+
+  return swPrecache.write(filepath, {
+    // Used to avoid cache conflicts when serving on localhost.
+    cacheId: pkg.name || 'web-starter-kit',
+    // sw-toolbox.js needs to be listed first. It sets up methods used in runtime-caching.js.
+    importScripts: [
+      'scripts/sw/sw-toolbox.js',
+      'scripts/sw/runtime-caching.js'
+    ],
+    staticFileGlobs: [
+      // Add/remove glob patterns to match your directory setup.
+      `${rootDir}/images/**/*`,
+      `${rootDir}/scripts/**/*.js`,
+      `${rootDir}/styles/**/*.css`,
+      `${rootDir}/*.{html,json}`
+    ],
+    // Translates a static file path to the relative URL that it's served from.
+    // This is '/' rather than path.sep because the paths returned from
+    // glob always use '/'.
+    stripPrefix: rootDir + '/'
+  });
+});
+
+// Load custom tasks from the `tasks` directory
+// Run: `npm install --save-dev require-dir` from the command-line
+// try { require('require-dir')('tasks'); } catch (err) { console.error(err); }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -74,13 +74,15 @@ gulp.task('vulcanize', () => {
     }))
     // Create an external script file to satisfy CSP
     .pipe($.crisper({
-      scriptInHead: false
+      scriptInHead: true
     }))
     .pipe(gulp.dest('static'));
 });
 
 // Clean output directory
-gulp.task('clean', () => del(['static/elements/*.vulcanize.{html,js}'], {dot: true}));
+gulp.task('clean', () => {
+  del(['static/elements/*.vulcanize.{html,js}'], {dot: true});
+});
 
 // Build production files, the default task
 gulp.task('default', ['clean'], cb =>

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -11,11 +11,11 @@ import del from 'del';
 // import runSequence from 'run-sequence';
 // import browserSync from 'browser-sync';
 // import swPrecache from 'sw-precache';
-// import gulpLoadPlugins from 'gulp-load-plugins';
+import gulpLoadPlugins from 'gulp-load-plugins';
 // import {output as pagespeed} from 'psi';
 // import pkg from './package.json';
 
-// const $ = gulpLoadPlugins();
+const $ = gulpLoadPlugins();
 // const reload = browserSync.reload;
 
 // Lint JavaScript
@@ -65,21 +65,14 @@ gulp.task('styles', () => {
 
   // For best performance, don't add Sass partials to `gulp.src`
   return gulp.src([
-    'app/styles/**/*.scss',
-    'app/styles/**/*.css'
+    'static/sass/**/*.scss'
   ])
-    .pipe($.newer('.tmp/styles'))
-    .pipe($.sourcemaps.init())
     .pipe($.sass({
+      outputStyle: 'compressed',
       precision: 10
     }).on('error', $.sass.logError))
-    .pipe($.autoprefixer(AUTOPREFIXER_BROWSERS))
-    .pipe(gulp.dest('.tmp/styles'))
-    // Concatenate and minify styles
-    .pipe($.if('*.css', $.cssnano()))
-    .pipe($.size({title: 'styles'}))
-    .pipe($.sourcemaps.write('./'))
-    .pipe(gulp.dest('dist/styles'));
+//    .pipe($.autoprefixer(AUTOPREFIXER_BROWSERS))
+    .pipe(gulp.dest('static/css'));
 });
 
 // Concatenate and minify JavaScript. Optionally transpiles ES2015 code to ES5.

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -14,6 +14,7 @@ import del from 'del';
 import gulpLoadPlugins from 'gulp-load-plugins';
 // import {output as pagespeed} from 'psi';
 // import pkg from './package.json';
+import merge from 'merge-stream';
 
 const $ = gulpLoadPlugins();
 // const reload = browserSync.reload;
@@ -122,6 +123,55 @@ gulp.task('html', () => {
     // Output files
     .pipe($.if('*.html', $.size({title: 'html', showFiles: true})))
     .pipe(gulp.dest('dist'));
+});
+
+gulp.task('vulcanize', () => {
+  var targets = [
+    {
+      input: 'static/elements/elements.html',
+      outputDir: 'static/elements',
+      outputFile: 'elements.vulcanize.html',
+    },
+    {
+      input: 'static/elements/metrics-imports.html',
+      outputDir: 'static/elements',
+      outputFile: 'metrics-imports.vulcanize.html',
+    },
+    {
+      input: 'static/elements/features-imports.html',
+      outputDir: 'static/elements',
+      outputFile: 'features-imports.vulcanize.html',
+    },
+    {
+      input: 'static/elements/admin-imports.html',
+      outputDir: 'static/elements',
+      outputFile: 'admin-imports.vulcanize.html',
+    },
+    {
+      input: 'static/elements/samples-imports.html',
+      outputDir: 'static/elements',
+      outputFile: 'samples-imports.vulcanize.html',
+    },
+  ];
+
+  // Vulcanize does not allow the name of the output file to be changed, so
+  // must manually rename the file first.
+  var tasks = targets.map(target => {
+    return gulp.src(target.input)
+      .pipe($.rename(target.outputFile))
+      .pipe(gulp.dest(target.outputDir))
+      .pipe($.vulcanize({
+        stripComments: true,
+        inlineScripts: true,
+        inlineCss: true
+      }))
+      .pipe($.crisper({
+        scriptInHead: false
+      }))
+      .pipe(gulp.dest(target.outputDir));
+  });
+
+  return merge(tasks);
 });
 
 // Clean output directory

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -9,46 +9,12 @@ import path from 'path';
 import gulp from 'gulp';
 import del from 'del';
 import runSequence from 'run-sequence';
-// import browserSync from 'browser-sync';
 // import swPrecache from 'sw-precache';
 import gulpLoadPlugins from 'gulp-load-plugins';
-// import {output as pagespeed} from 'psi';
 // import pkg from './package.json';
 import merge from 'merge-stream';
 
 const $ = gulpLoadPlugins();
-// const reload = browserSync.reload;
-
-// Lint JavaScript
-gulp.task('lint', () =>
-  gulp.src('app/scripts/**/*.js')
-    .pipe($.eslint())
-    .pipe($.eslint.format())
-    .pipe($.if(!browserSync.active, $.eslint.failOnError()))
-);
-
-// Optimize images
-gulp.task('images', () =>
-  gulp.src('app/images/**/*')
-    .pipe($.cache($.imagemin({
-      progressive: true,
-      interlaced: true
-    })))
-    .pipe(gulp.dest('dist/images'))
-    .pipe($.size({title: 'images'}))
-);
-
-// Copy all files at the root level (app)
-gulp.task('copy', () =>
-  gulp.src([
-    'app/*',
-    '!app/*.html',
-    'node_modules/apache-server-configs/dist/.htaccess'
-  ], {
-    dot: true
-  }).pipe(gulp.dest('dist'))
-    .pipe($.size({title: 'copy'}))
-);
 
 // Compile and automatically prefix stylesheets
 gulp.task('styles', () => {
@@ -76,9 +42,6 @@ gulp.task('styles', () => {
     .pipe(gulp.dest('static/css'));
 });
 
-// Concatenate and minify JavaScript. Optionally transpiles ES2015 code to ES5.
-// to enable ES2015 support remove the line `"only": "gulpfile.babel.js",` in the
-// `.babelrc` file.
 gulp.task('scripts', () => {
   // Minify the vulcanized script files (overwriting in place)
   //  - The 'base' option is used to retain the relative path of each file
@@ -87,31 +50,6 @@ gulp.task('scripts', () => {
   )
     .pipe($.uglify())
     .pipe(gulp.dest('static'));
-});
-
-// Scan your HTML for assets & optimize them
-gulp.task('html', () => {
-  return gulp.src('app/**/*.html')
-    .pipe($.useref({
-      searchPath: '{.tmp,app}',
-      noAssets: true
-    }))
-
-    // Minify any HTML
-    .pipe($.if('*.html', $.htmlmin({
-      removeComments: true,
-      collapseWhitespace: true,
-      collapseBooleanAttributes: true,
-      removeAttributeQuotes: true,
-      removeRedundantAttributes: true,
-      removeEmptyAttributes: true,
-      removeScriptTypeAttributes: true,
-      removeStyleLinkTypeAttributes: true,
-      removeOptionalTags: true
-    })))
-    // Output files
-    .pipe($.if('*.html', $.size({title: 'html', showFiles: true})))
-    .pipe(gulp.dest('dist'));
 });
 
 gulp.task('vulcanize', () => {
@@ -144,44 +82,6 @@ gulp.task('vulcanize', () => {
 // Clean output directory
 gulp.task('clean', () => del(['static/elements/*.vulcanize.{html,js}'], {dot: true}));
 
-// Watch files for changes & reload
-gulp.task('serve', ['scripts', 'styles'], () => {
-  browserSync({
-    notify: false,
-    // Customize the Browsersync console logging prefix
-    logPrefix: 'WSK',
-    // Allow scroll syncing across breakpoints
-    scrollElementMapping: ['main', '.mdl-layout'],
-    // Run as an https by uncommenting 'https: true'
-    // Note: this uses an unsigned certificate which on first access
-    //       will present a certificate warning in the browser.
-    // https: true,
-    server: ['.tmp', 'app'],
-    port: 3000
-  });
-
-  gulp.watch(['app/**/*.html'], reload);
-  gulp.watch(['app/styles/**/*.{scss,css}'], ['styles', reload]);
-  gulp.watch(['app/scripts/**/*.js'], ['lint', 'scripts', reload]);
-  gulp.watch(['app/images/**/*'], reload);
-});
-
-// Build and serve the output from the dist build
-gulp.task('serve:dist', ['default'], () =>
-  browserSync({
-    notify: false,
-    logPrefix: 'WSK',
-    // Allow scroll syncing across breakpoints
-    scrollElementMapping: ['main', '.mdl-layout'],
-    // Run as an https by uncommenting 'https: true'
-    // Note: this uses an unsigned certificate which on first access
-    //       will present a certificate warning in the browser.
-    // https: true,
-    server: 'dist',
-    port: 3001
-  })
-);
-
 // Build production files, the default task
 gulp.task('default', ['clean'], cb =>
   runSequence(
@@ -191,17 +91,6 @@ gulp.task('default', ['clean'], cb =>
 //    'generate-service-worker',
     cb
   )
-);
-
-// Run PageSpeed Insights
-gulp.task('pagespeed', cb =>
-  // Update the below URL to the public URL of your site
-  pagespeed('example.com', {
-    strategy: 'mobile'
-    // By default we use the PageSpeed Insights free (no API key) tier.
-    // Use a Google Developer API key if you have one: http://goo.gl/RkN0vE
-    // key: 'YOUR_API_KEY'
-  }, cb)
 );
 
 // Copy over the scripts that are used in importScripts as part of the generate-service-worker task.

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -115,52 +115,30 @@ gulp.task('html', () => {
 });
 
 gulp.task('vulcanize', () => {
-  var targets = [
-    {
-      input: 'static/elements/elements.html',
-      outputDir: 'static/elements',
-      outputFile: 'elements.vulcanize.html',
-    },
-    {
-      input: 'static/elements/metrics-imports.html',
-      outputDir: 'static/elements',
-      outputFile: 'metrics-imports.vulcanize.html',
-    },
-    {
-      input: 'static/elements/features-imports.html',
-      outputDir: 'static/elements',
-      outputFile: 'features-imports.vulcanize.html',
-    },
-    {
-      input: 'static/elements/admin-imports.html',
-      outputDir: 'static/elements',
-      outputFile: 'admin-imports.vulcanize.html',
-    },
-    {
-      input: 'static/elements/samples-imports.html',
-      outputDir: 'static/elements',
-      outputFile: 'samples-imports.vulcanize.html',
-    },
-  ];
-
-  // Vulcanize does not allow the name of the output file to be changed, so
-  // must manually rename the file first.
-  var tasks = targets.map(target => {
-    return gulp.src(target.input)
-      .pipe($.rename(target.outputFile))
-      .pipe(gulp.dest(target.outputDir))
-      .pipe($.vulcanize({
-        stripComments: true,
-        inlineScripts: true,
-        inlineCss: true
-      }))
-      .pipe($.crisper({
-        scriptInHead: false
-      }))
-      .pipe(gulp.dest(target.outputDir));
-  });
-
-  return merge(tasks);
+  // Vulcanize the Polymer imports, creating *.vulcanize.* files beside the
+  // original input files.
+  return gulp.src([
+      'static/elements/elements.html',
+      'static/elements/metrics-imports.html',
+      'static/elements/features-imports.html',
+      'static/elements/admin-imports.html',
+      'static/elements/samples-imports.html',
+    ], {base: 'static'}
+  )
+    // Vulcanize does not allow the name of the output file to be changed, so
+    // must manually rename the file first.
+    .pipe($.rename({suffix: '.vulcanize'}))
+    .pipe(gulp.dest('static'))
+    .pipe($.vulcanize({
+      stripComments: true,
+      inlineScripts: true,
+      inlineCss: true
+    }))
+    // Create an external script file to satisfy CSP
+    .pipe($.crisper({
+      scriptInHead: false
+    }))
+    .pipe(gulp.dest('static'));
 });
 
 // Clean output directory

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -8,7 +8,7 @@
 import path from 'path';
 import gulp from 'gulp';
 import del from 'del';
-// import runSequence from 'run-sequence';
+import runSequence from 'run-sequence';
 // import browserSync from 'browser-sync';
 // import swPrecache from 'sw-precache';
 import gulpLoadPlugins from 'gulp-load-plugins';
@@ -184,15 +184,13 @@ gulp.task('serve:dist', ['default'], () =>
 
 // Build production files, the default task
 gulp.task('default', ['clean'], cb =>
-  cb
-/*
   runSequence(
     'styles',
-    ['lint', 'html', 'scripts', 'images', 'copy'],
-    'generate-service-worker',
+    'vulcanize',
+    'scripts',
+//    'generate-service-worker',
     cb
   )
-*/
 );
 
 // Run PageSpeed Insights

--- a/package.json
+++ b/package.json
@@ -20,12 +20,16 @@
     "url": "https://github.com/GoogleChrome/chromium-dashboard/issues"
   },
   "devDependencies": {
+    "babel-core": "^6.10.4",
+    "babel-preset-es2015": "^6.9.0",
+    "del": "^2.2.1",
     "grunt": "^0.4.5",
     "grunt-appengine": "^0.1.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-minified": "0.0.6",
     "grunt-sass": "^1.2.0",
     "grunt-vulcanize": "^1.0.0",
+    "gulp": "^3.9.1",
     "http2-push-manifest": "^1.0.0",
     "load-grunt-tasks": "^3.4.1"
   }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gulp-load-plugins": "^1.2.4",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.3.2",
+    "gulp-uglify": "^1.5.4",
     "gulp-vulcanize": "^6.1.0",
     "http2-push-manifest": "^1.0.0",
     "load-grunt-tasks": "^3.4.1"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "grunt-sass": "^1.2.0",
     "grunt-vulcanize": "^1.0.0",
     "gulp": "^3.9.1",
+    "gulp-load-plugins": "^1.2.4",
+    "gulp-sass": "^2.3.2",
     "http2-push-manifest": "^1.0.0",
     "load-grunt-tasks": "^3.4.1"
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "grunt": "^0.4.5",
     "grunt-appengine": "^0.1.5",
     "gulp": "^3.9.1",
+    "gulp-autoprefixer": "^3.1.0",
     "gulp-crisper": "^1.1.0",
     "gulp-if": "^2.0.1",
     "gulp-load-plugins": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,12 @@
     "grunt-sass": "^1.2.0",
     "grunt-vulcanize": "^1.0.0",
     "gulp": "^3.9.1",
+    "gulp-crisper": "^1.1.0",
+    "gulp-if": "^2.0.1",
     "gulp-load-plugins": "^1.2.4",
+    "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.3.2",
+    "gulp-vulcanize": "^6.1.0",
     "http2-push-manifest": "^1.0.0",
     "load-grunt-tasks": "^3.4.1"
   }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "gulp-uglify": "^1.5.4",
     "gulp-vulcanize": "^6.1.0",
     "http2-push-manifest": "^1.0.0",
-    "load-grunt-tasks": "^3.4.1"
+    "load-grunt-tasks": "^3.4.1",
+    "run-sequence": "^1.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "postinstall": "npm run deps; npm run build",
     "deps": "rm -rf static/bower_components; bower install",
-    "build": "grunt",
+    "build": "gulp",
     "deploy": "./scripts/deploy_site.sh"
   },
   "repository": {
@@ -25,10 +25,6 @@
     "del": "^2.2.1",
     "grunt": "^0.4.5",
     "grunt-appengine": "^0.1.5",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-minified": "0.0.6",
-    "grunt-sass": "^1.2.0",
-    "grunt-vulcanize": "^1.0.0",
     "gulp": "^3.9.1",
     "gulp-crisper": "^1.1.0",
     "gulp-if": "^2.0.1",


### PR DESCRIPTION
For #290, change to use Gulp for builds instead of Grunt:
- Sass, vulcanize and js minify now use Gulp tasks
- Post npm install invokes the default Gulp task
- Works with Gulp installed either as a global or local npm package

The serve task is still implemented in Grunt for now. Will address that next.

@ebidel, please take a look.