### PR TITLE
Add Bug Component property to Feature

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -409,6 +409,7 @@ class FeatureHandler(common.ContentHandler):
         feature.summary = self.request.get('summary')
         feature.owner = owners
         feature.bug_url = bug_url
+        feature.bug_component = self.request.get('bug_component')
         feature.impl_status_chrome = int(self.request.get('impl_status_chrome'))
         feature.shipped_milestone = shipped_milestone
         feature.shipped_android_milestone = shipped_android_milestone
@@ -439,6 +440,7 @@ class FeatureHandler(common.ContentHandler):
           summary=self.request.get('summary'),
           owner=owners,
           bug_url=bug_url,
+          bug_component=self.request.get('bug_component'),
           impl_status_chrome=int(self.request.get('impl_status_chrome')),
           shipped_milestone=shipped_milestone,
           shipped_android_milestone=shipped_android_milestone,

--- a/models.py
+++ b/models.py
@@ -394,8 +394,7 @@ class Feature(DictModel):
 
   def new_crbug_url(self):
     url = 'https://bugs.chromium.org/p/chromium/issues/entry';
-    params = [];
-    params.append('components=' + self.bug_component or DEFAULT_BUG_COMPONENT);
+    params = ['components=' + self.bug_component or DEFAULT_BUG_COMPONENT];
     crbug_number = self.crbug_number()
     if crbug_number and self.impl_status_chrome in (
         NO_ACTIVE_DEV,
@@ -518,7 +517,7 @@ class FeatureForm(forms.Form):
                            help_text='OWP Launch Tracking, crbug, etc.')
 
   bug_component = forms.CharField(required=False, label='Bug Component',
-                           help_text='"%s" will be used if not speficied.' % DEFAULT_BUG_COMPONENT)
+                           help_text='"%s" will be used if not specified.' % DEFAULT_BUG_COMPONENT)
 
   impl_status_chrome = forms.ChoiceField(required=True,
                                          label='Status in Chromium',

--- a/models.py
+++ b/models.py
@@ -158,6 +158,8 @@ WEB_DEV_VIEWS = {
   DEV_STRONG_NEGATIVE: 'Strongly negative',
   }
 
+DEFAULT_BUG_COMPONENT = 'Blink'
+
 
 class DictModel(db.Model):
   # def to_dict(self):
@@ -392,7 +394,8 @@ class Feature(DictModel):
 
   def new_crbug_url(self):
     url = 'https://bugs.chromium.org/p/chromium/issues/entry';
-    params = ['components=Blink'];
+    params = [];
+    params.append('components=' + self.bug_component or DEFAULT_BUG_COMPONENT);
     crbug_number = self.crbug_number()
     if crbug_number and self.impl_status_chrome in (
         NO_ACTIVE_DEV,
@@ -418,6 +421,7 @@ class Feature(DictModel):
 
   # Chromium details.
   bug_url = db.LinkProperty()
+  bug_component = db.StringProperty(required=False, default=DEFAULT_BUG_COMPONENT)
   impl_status_chrome = db.IntegerProperty(required=True)
   shipped_milestone = db.IntegerProperty()
   shipped_android_milestone = db.IntegerProperty()
@@ -512,6 +516,9 @@ class FeatureForm(forms.Form):
 
   bug_url = forms.URLField(required=False, label='Bug URL',
                            help_text='OWP Launch Tracking, crbug, etc.')
+
+  bug_component = forms.CharField(required=False, label='Bug Component',
+                           help_text='"%s" will be used if not speficied.' % DEFAULT_BUG_COMPONENT)
 
   impl_status_chrome = forms.ChoiceField(required=True,
                                          label='Status in Chromium',

--- a/static/elements/chromedash-feature.html
+++ b/static/elements/chromedash-feature.html
@@ -415,6 +415,9 @@
     _computeEditLinkHidden: function(feature) {
       return '/admin/features/edit/' + feature.id;
     },
+    _computeBugComponent: function(feature) {
+      return feature.bug_component || 'Blink';
+    },
     _computeCrbugNumber: function(link) {
       if (!link) {
         return;
@@ -433,7 +436,8 @@
     },
     _computeNewBugUrl: function(feature) {
       var url = 'https://bugs.chromium.org/p/chromium/issues/entry';
-      var params = ['components=Blink'];
+      var params = [];
+      params.push('components=' + this._computeBugComponent(feature));
       var crbugNumber = this._computeCrbugNumber(feature.bug_url);
       if (crbugNumber && this._computePreLaunch(feature.impl_status_chrome)) {
         params.push('blocking=' + crbugNumber);

--- a/static/elements/chromedash-feature.html
+++ b/static/elements/chromedash-feature.html
@@ -436,8 +436,7 @@
     },
     _computeNewBugUrl: function(feature) {
       var url = 'https://bugs.chromium.org/p/chromium/issues/entry';
-      var params = [];
-      params.push('components=' + this._computeBugComponent(feature));
+      var params = ['components=' + this._computeBugComponent(feature)];
       var crbugNumber = this._computeCrbugNumber(feature.bug_url);
       if (crbugNumber && this._computePreLaunch(feature.impl_status_chrome)) {
         params.push('blocking=' + crbugNumber);


### PR DESCRIPTION
https://www.chromestatus.com/feature/5264933985976320 new bug URL points to https://bugs.chromium.org/p/chromium/issues/entry?components=Blink&blocking=419413&cc=jyasskin@chromium.org,scheib@chromium.org which is not quite accurate and could be better if `components` was `Blink-Bluetooth`.

This patch adds support for Bug Component Feature property and always fallbacks to `Blink` if not specified.

![screenshot 2016-08-23 at 1 41 39 pm](https://cloud.githubusercontent.com/assets/634478/17890604/58874b06-6937-11e6-8fed-d9635a43bd87.png)


R: @ebidel 