### PR TITLE
Fix release/impl status links

### DIFF
--- a/templates/features.html
+++ b/templates/features.html
@@ -117,9 +117,10 @@ var featuresUnveilMetric = new Metric('features_unveil');
 var featuresFetchMetric = new Metric('features_loaded');
 
 chromeMetadata.addEventListener('query-changed', function(e) {
-  var propertyName = e.detail.version.match(/^[0-9]+$/) ? 'milestone' :
-      'impl_status_chrome';
-  search.value = propertyName + '=' + e.detail.version;
+  var value = e.detail.version;
+  var isMilestone = value.match(/^[0-9]+$/);
+  search.value = isMilestone ? 'milestone=' + value :
+      'impl_status_chrome:"' + value + '"';
   featureList.filter(search.value);
 });
 

--- a/templates/features.html
+++ b/templates/features.html
@@ -117,7 +117,9 @@ var featuresUnveilMetric = new Metric('features_unveil');
 var featuresFetchMetric = new Metric('features_loaded');
 
 chromeMetadata.addEventListener('query-changed', function(e) {
-  search.value = '=' + e.detail.version;
+  var propertyName = e.detail.version.match(/^[0-9]+$/) ? 'milestone' :
+      'impl_status_chrome';
+  search.value = propertyName + '=' + e.detail.version;
   featureList.filter(search.value);
 });
 
@@ -222,6 +224,11 @@ window.asyncImportsLoadPromise = new Promise(function(resolve, reject) {
     resolve();
 
     featuresPromise.then(function(features) {
+      features.map(function(feature) {
+      feature.milestone = feature.shipped_milestone || feature.shipped_android_milestone ||
+          feature.shipped_webview_milestone || feature.shipped_ios_milestone ||
+          Infinity;
+      });
       featureList.features = features;
       featureList.filter(search.value);
       search.disabled = false;

--- a/templates/features.html
+++ b/templates/features.html
@@ -226,9 +226,11 @@ window.asyncImportsLoadPromise = new Promise(function(resolve, reject) {
 
     featuresPromise.then(function(features) {
       features.map(function(feature) {
-      feature.milestone = feature.shipped_milestone || feature.shipped_android_milestone ||
-          feature.shipped_webview_milestone || feature.shipped_ios_milestone ||
-          Infinity;
+        feature.milestone = feature.shipped_milestone ||
+            feature.shipped_android_milestone ||
+            feature.shipped_webview_milestone ||
+            feature.shipped_ios_milestone ||
+            Infinity;
       });
       featureList.features = features;
       featureList.filter(search.value);


### PR DESCRIPTION
Fix the format of the query injected when clicking sidebar links associated with release numbers and `impl_status_chrome`. Fixes #409.