### PR TITLE
Use sw-toolbox "fastest" for all endpoints to combat liefi

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
 application: cr-status
-version: 2016-10-10
+version: 2016-10-10-swfastest
 runtime: python27
 threadsafe: true
 api_version: 1

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -219,19 +219,23 @@ gulp.task('generate-service-worker', () => {
         }
       }
     }, {
-      // For dynamic data (json), try the network first to get the most recent
-      // values.
+      // For dynamic data (json), use "fastest" so liefi scenarios are fast.
+      // "fastest" also makes a network request to update the cached copy.
+      // The worst case is that the user with an active SW gets stale content
+      // and never refreshes the page.
+      // TODO: use sw-toolbox notifyOnCacheUpdate when it's ready
+      // https://github.com/GoogleChrome/sw-toolbox/pull/174/
       urlPattern: /\/data\//,
-      handler: 'networkFirst'
+      handler: 'fastest'
     }, {
       urlPattern: /\/features.json$/,
-      handler: 'networkFirst'
+      handler: 'fastest'
     }, {
       urlPattern: /\/samples.json$/,
-      handler: 'networkFirst'
+      handler: 'fastest'
     }, {
       urlPattern: /\/omaha_data$/,
-      handler: 'networkFirst'
+      handler: 'fastest'
     }]
   });
 });


### PR DESCRIPTION
R: @jeffposnick 

This brings [FP down to 1.9s](https://www.webpagetest.org/video/compare.php?tests=161011_11_18EK-r:2-c:0,161011_11_18EK-r:1-c:1) on Nexus5 3G with an active sw (repeat view). Before, using `networkFirst` for features.json, the same scenario was 500ms worse!

We should dogfood https://github.com/GoogleChrome/sw-toolbox/pull/174/ when you have it ready. With this update, users will get stale content and not know it. Instead, we can notify them with a toast message that the cached copy was updated.