### PR TITLE
Scroll/reveal header for mobile

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
 application: cr-status
-version: 2016-10-10-swfastest
+version: 2016-10-16
 runtime: python27
 threadsafe: true
 api_version: 1

--- a/static/elements/chromedash-featurelist.html
+++ b/static/elements/chromedash-featurelist.html
@@ -75,6 +75,9 @@
         }
       },
 
+      // True when the user has physically scrolled the list fo rthe first time.
+      _hasScrolledList: false,
+
       listeners: {
         'keyup': '_onKeyUp',
         'feature-toggled': '_onFeatureToggled'
@@ -327,6 +330,10 @@
       _onScrollList: function(e, detail) {
         if (this._firstLoad) {
           return;
+        }
+        if (!this._hasScrolledList) {
+          this._hasScrolledList = true;
+          this.fire('has-scroll-list');
         }
         var feature = this.features[this.$.ironlist.firstVisibleIndex];
         this.metadata.selectMilestone(feature);

--- a/static/elements/common.html
+++ b/static/elements/common.html
@@ -2,4 +2,5 @@
 <link rel="import" href="../bower_components/app-layout/app-drawer/app-drawer.html">
 <link rel="import" href="../bower_components/app-layout/app-scroll-effects/effects/waterfall.html">
 <link rel="import" href="../bower_components/app-layout/app-header/app-header.html">
+<link rel="import" href="../bower_components/app-layout/app-header-layout/app-header-layout.html">
 <link rel="import" href="chromedash-toast.html">

--- a/static/sass/_vars.scss
+++ b/static/sass/_vars.scss
@@ -22,7 +22,6 @@ $default-border-radius: 3px;
 
 $app-drawer-width: 200px;
 $header-height: 135px;
-$banner-height: 67px;
 $max-content-width: 768px;
 /* ----- */
 

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -277,6 +277,9 @@ footer {
       max-width: $max-content-width;
     }
   }
+  footer {
+    padding-left: $app-drawer-width;
+  }
 }
 
 @media only screen and (max-width: 700px) {

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -262,7 +262,7 @@ footer {
   margin: $content-padding;
   position: relative;
   height: 100%;
-  margin-top: $header-height;
+  // margin-top: $header-height;
 }
 
 #panels {
@@ -276,14 +276,6 @@ footer {
     .toolbar-content {
       max-width: $max-content-width;
     }
-  }
-  app-drawer {
-    .drawer-content-wrapper {
-      margin-top: $header-height;
-    }
-  }
-  app-header {
-    padding-left: $app-drawer-width;
   }
 }
 

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -241,16 +241,6 @@ footer {
   }
 }
 
-// #banner {
-//   display: flex;
-//   margin: $content-padding 0;
-//   max-width: $max-content-width;
-//   background: #fff3e0;
-//   font-weight: 500;
-//   padding: $content-padding $content-padding / 2;
-// }
-
-
 #container {
   display: flex;
   flex-direction: column;
@@ -262,7 +252,6 @@ footer {
   margin: $content-padding;
   position: relative;
   height: 100%;
-  // margin-top: $header-height;
 }
 
 #panels {

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -26,7 +26,7 @@ body {
   align-items: center;
   justify-content: center;
   position: fixed;
-  height: calc(100% - 54px - $header-height - $banner-height); // 100% - height of footer - banner + header.
+  height: calc(100% - 54px - $header-height); // 100% - height of footer + header.
   max-width: $max-content-width;
   width: 100%;
 }
@@ -241,14 +241,14 @@ footer {
   }
 }
 
-#banner {
-  display: flex;
-  margin: $content-padding 0;
-  max-width: $max-content-width;
-  background: #fff3e0;
-  font-weight: 500;
-  padding: $content-padding $content-padding / 2;
-}
+// #banner {
+//   display: flex;
+//   margin: $content-padding 0;
+//   max-width: $max-content-width;
+//   background: #fff3e0;
+//   font-weight: 500;
+//   padding: $content-padding $content-padding / 2;
+// }
 
 
 #container {
@@ -262,7 +262,7 @@ footer {
   margin: $content-padding;
   position: relative;
   height: 100%;
-  margin-top: $header-height + $banner-height;
+  margin-top: $header-height;
 }
 
 #panels {
@@ -279,7 +279,7 @@ footer {
   }
   app-drawer {
     .drawer-content-wrapper {
-      margin-top: $header-height + $banner-height;
+      margin-top: $header-height;
     }
   }
   app-header {

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -280,6 +280,12 @@ footer {
   footer {
     padding-left: $app-drawer-width;
   }
+  // Overrides styles set by app-header-layout so there's no visual
+  // layout FOUC/jump as the drawer panel upgrades.
+  app-header {
+    padding-left: $app-drawer-width;
+    left: 0 !important;
+  }
 }
 
 @media only screen and (max-width: 700px) {

--- a/static/sass/shared.scss
+++ b/static/sass/shared.scss
@@ -2,6 +2,11 @@
 
 @import "vars";
 
+* {
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  outline: 0;
+}
+
 h1, h2, h3, h4 {
   font-weight: 300;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -99,13 +99,6 @@ var $$ = function(selector) {
     <div class="main-toolbar">
       <div class="toolbar-content">
         {% include "header.html" %}
-        {% block banner %}
-        <div id="banner">
-          <p>
-            Help us improve this site by filling out this very short <a href="https://docs.google.com/a/google.com/forms/d/e/1FAIpQLSd5lL2cRXOnxYZF8qaPykLsU6-1_p4M_1PatwGaIwL3eVcOMA/viewform?c=0&w=1" target="_blank">survey</a>.
-          </p>
-        </div>
-        {% endblock %}
         {% block subheader %}{% endblock %}
       </div>
     </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -95,21 +95,27 @@ var $$ = function(selector) {
       {% block drawer %}{% endblock %}
     </div>
   </app-drawer>
-  <app-header fixed effects="waterfall">
-    <div class="main-toolbar">
-      <div class="toolbar-content">
-        {% include "header.html" %}
-        {% block subheader %}{% endblock %}
+  <app-header-layout>
+    <app-header reveals fixed effects="waterfall">
+      <div class="main-toolbar">
+        <div class="toolbar-content">
+          {% include "header.html" %}
+          {% block subheader %}{% endblock %}
+        </div>
       </div>
+    </app-header>
+
+    <div id="content">
+      <div id="spinner"><img src="/static/img/ring.svg"></div>
+      {% block content %}{% endblock %}
     </div>
-  </app-header>
 
-  <div id="content">
-    <div id="spinner"><img src="/static/img/ring.svg"></div>
-    {% block content %}{% endblock %}
-  </div>
+    {% include "footer.html" %}
+    <!-- <app-header fixed effects="waterfall">
+      {% include "footer.html" %}
+    </app-header> -->
+  </app-header-layout>
 
-  {% include "footer.html" %}
 </app-drawer-layout>
 
 <chromedash-toast msg="Welcome to chromestatus.com!"></chromedash-toast>

--- a/templates/features.html
+++ b/templates/features.html
@@ -77,7 +77,7 @@
 {% endblock %}
 
 {% block overlay %}
-<chromedash-legend>
+<chromedash-legend hidden>
   <p class="description">What you're looking at is a mostly comprehensive list of
   web platform features that have landed in Chromium, ordered chronologically by the milestone
   in which they were added. Features marked "No active development" are being
@@ -138,6 +138,13 @@ featureList.addEventListener('app-ready', function() {
   registerServiceWorker();
 });
 
+featureList.addEventListener('has-scroll-list', function(e) {
+  var header = document.querySelector('app-header-layout app-header');
+  if (header) {
+    header.fixed = false;
+  }
+});
+
 featureList.addEventListener('filter-category', function(e) {
   search.value = 'category: ' + e.detail.val;
   featureList.filter(search.value);
@@ -177,6 +184,7 @@ var helpOverlayLoadPromise = function(overlay) {
         webdevs: {{WEB_DEV_VIEWS|safe}}, // set from server
         standards: {{STANDARDS_VALS|safe}} // set from server
       };
+      overlay.hidden = false;
       resolve();
     }, function(e) {
       reject(new Error('Error loading:' + url));

--- a/templates/metrics/css/animated.html
+++ b/templates/metrics/css/animated.html
@@ -38,7 +38,7 @@
 
 {% block js %}
 <script>
-document.addEventListener('app-ready', function(e) {
+document.addEventListener('WebComponentsReady', function(e) {
   document.body.classList.remove('loading');
 });
 </script>

--- a/templates/metrics/css/popularity.html
+++ b/templates/metrics/css/popularity.html
@@ -38,7 +38,7 @@
 
 {% block js %}
 <script>
-document.addEventListener('app-ready', function(e) {
+document.addEventListener('WebComponentsReady', function(e) {
   document.body.classList.remove('loading');
 });
 </script>


### PR DESCRIPTION
R: @jeffposnick @beaufortfrancois @GoogleChrome/chromium-dashboard 

We currently have a lot of wasted space. The main content area is the most important thing, and since the last UI refresh, the header takes up much more space than it should. This PR moves the drawer content to the top left corner and makes the header scroll away and reveal itself again on scroll. For mobile, this creates a lot more space to view the features, samples, and other content. 

update: the footer text has been centered, so ignore that in the new screenshots.

BEFORE:

![screen shot 2016-10-16 at 11 09 23 am](https://cloud.githubusercontent.com/assets/238208/19416769/0288c296-9391-11e6-967c-3dc98ce0e342.png)

AFTER:
![screen shot 2016-10-16 at 11 08 38 am](https://cloud.githubusercontent.com/assets/238208/19416766/f7c86fbe-9390-11e6-9463-bc9cd8ff17a7.png)

![screen shot 2016-10-16 at 11 36 34 am](https://cloud.githubusercontent.com/assets/238208/19416887/d0a3fde6-9394-11e6-93d7-7165c7f1476c.png)
