### PR TITLE
Removed nested scroll bars from the timeline view

### DIFF
--- a/static/sass/metrics/metrics.scss
+++ b/static/sass/metrics/metrics.scss
@@ -8,7 +8,6 @@
 
 .data-panel {
   max-width: $max-content-width;
-  overflow: auto;
 
   .description {
     margin-bottom: 1em;


### PR DESCRIPTION
There were unnecessary, the main scroll bars work just fine when needed.
Fixed https://github.com/GoogleChrome/chromium-dashboard/issues/390 by removing `overflow: auto` that apparently has no useful purpose.
