### PR TITLE
Distinguished Chrome for iOS from other versions

### DIFF
--- a/models.py
+++ b/models.py
@@ -641,6 +641,9 @@ class FeatureForm(forms.Form):
                       '(either enabled by default, origin trial, intervention, '
                       'or deprecated)')
 
+  SHIPPED_IOS_HELP_TXT = ('Fill this only in case this feature is relevant to Chrome for iOS '
+                         '(most are not)!' + SHIPPED_HELP_TXT)
+
   #name = PlaceholderCharField(required=True, placeholder='Feature name')
   name = forms.CharField(required=True, label='Feature')
 
@@ -677,11 +680,11 @@ class FeatureForm(forms.Form):
   shipped_android_milestone = forms.IntegerField(required=False, label='',
       help_text='Chrome for Android: ' + SHIPPED_HELP_TXT)
 
-  shipped_ios_milestone = forms.IntegerField(required=False, label='',
-      help_text='Chrome for iOS: ' + SHIPPED_HELP_TXT)
-
   shipped_webview_milestone = forms.IntegerField(required=False, label='',
       help_text='Chrome for Android web view: ' + SHIPPED_HELP_TXT)
+
+  shipped_ios_milestone = forms.IntegerField(required=False, label='',
+      help_text='Chrome for iOS: ' + SHIPPED_IOS_HELP_TXT)
 
   shipped_opera_milestone = forms.IntegerField(required=False, label='',
       help_text='Opera for desktop: ' + SHIPPED_HELP_TXT)


### PR DESCRIPTION
Some entries creep in that mention that a feature is supported on Chrome for iOS when it does not. Instead of removing it completely, since a few features are apparently polyfilled by Chrome for iOS, the fields were re-ordered a bit to have it as the last Chrome-related field (right behind the Opera section) and the help text was prepended with some wording to make it more noticable that it is Chrome for iOS and that it usually does not include those features.