### PR TITLE
Remove the 0.03% "at risk" cut-off

### DIFF
--- a/static/elements/x-meter.html
+++ b/static/elements/x-meter.html
@@ -4,8 +4,8 @@
 <dom-module id="x-meter">
 <link rel="import" type="css" href="../css/elements/x-meter.css">
 <template>
-  <div class$="{{_computeClass('meter', value)}}" id="meter">
-    <div style$="[[_computeStyle(value)]]"><span>{{valueFormmatted}}</span></div>
+  <div class="meter" id="meter">
+    <div style$="[[_computeStyle(value)]]"><span>{{valueFormatted}}</span></div>
   </div>
 </template>
 <script>
@@ -13,35 +13,19 @@
     is: 'x-meter',
 
     properties: {
-      MIN_FOR_AT_RISK: {
-        type: Number,
-        value: 0.03,
-        readOnly: true
-      },
       value: {
         type: Number,
         value: 0,
         notify: true
       },
-      valueFormmatted: {
+      valueFormatted: {
         type: Number,
         computed: '_computeFormattedValue(value)'
       }
     },
 
     _computeFormattedValue: function(value) {
-      var atRiskMsg = 'This feature may be at risk for removal. Usage is <= ' +
-                       this.MIN_FOR_AT_RISK + '%.';
-      var num = value <= 0.0001 ? '<=0.0001%' : Number(value).toFixed(4) + '%';
-
-      if (value <= this.MIN_FOR_AT_RISK) {
-        num += ' ' + atRiskMsg
-      }
-
-      return num;
-    },
-    _computeClass: function(defaultClasses, value) {
-      return defaultClasses + ' ' + (value <= this.MIN_FOR_AT_RISK ? 'atrisk' : '');
+      return value <= 0.0001 ? '<=0.0001%' : Number(value).toFixed(4) + '%';
     },
     _computeStyle: function(value) {
       return 'width:' + value + '%';

--- a/static/sass/elements/x-meter.scss
+++ b/static/sass/elements/x-meter.scss
@@ -12,14 +12,6 @@
   height: 1.7em;
   color: white;
 
-  &.atrisk {
-    background: darkred; //var(--paper-red-500) !important;
-
-    div {
-      background: red; //var(--paper-red-200) !important;
-    }
-  }
-
   div {
     background: $chromium-color-center; //var(--paper-green-500);
     height: 100%;
@@ -28,4 +20,3 @@
     text-indent: 5px;
   }
 }
-


### PR DESCRIPTION
0.03% has never been a hard rule, and over the past few years we
haven't given it much weight at all.

No more red!

Fixes https://github.com/GoogleChrome/chromium-dashboard/issues/439

Drive-by: fix typo formmatted -> formatted