### PR TITLE
Add prop Blink Components

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -335,7 +335,7 @@ class FeatureHandler(common.ContentHandler):
     if search_tags:
       search_tags = filter(bool, [x.strip() for x in search_tags.split(',')])
 
-    blink_components = self.request.get('blink_components') or [models.DEFAULT_BUG_COMPONENT]
+    blink_components = self.request.get('blink_components') or models.DEFAULT_BUG_COMPONENT
     if blink_components:
       blink_components = [x.strip() for x in blink_components.split(',')]
 
@@ -357,7 +357,6 @@ class FeatureHandler(common.ContentHandler):
       feature.summary = self.request.get('summary')
       feature.owner = owners
       feature.bug_url = bug_url
-      feature.bug_component = self.request.get('bug_component')
       feature.blink_components = blink_components
       feature.impl_status_chrome = int(self.request.get('impl_status_chrome'))
       feature.shipped_milestone = shipped_milestone
@@ -389,7 +388,6 @@ class FeatureHandler(common.ContentHandler):
           summary=self.request.get('summary'),
           owner=owners,
           bug_url=bug_url,
-          bug_component=self.request.get('bug_component'),
           blink_components=blink_components,
           impl_status_chrome=int(self.request.get('impl_status_chrome')),
           shipped_milestone=shipped_milestone,

--- a/admin.py
+++ b/admin.py
@@ -335,6 +335,10 @@ class FeatureHandler(common.ContentHandler):
     if search_tags:
       search_tags = filter(bool, [x.strip() for x in search_tags.split(',')])
 
+    blink_components = self.request.get('blink_components') or [models.DEFAULT_BUG_COMPONENT]
+    if blink_components:
+      blink_components = [x.strip() for x in blink_components.split(',')]
+
     # Update/delete existing feature.
     if feature_id: # /admin/edit/1234
       feature = models.Feature.get_by_id(long(feature_id))
@@ -354,6 +358,7 @@ class FeatureHandler(common.ContentHandler):
       feature.owner = owners
       feature.bug_url = bug_url
       feature.bug_component = self.request.get('bug_component')
+      feature.blink_components = blink_components
       feature.impl_status_chrome = int(self.request.get('impl_status_chrome'))
       feature.shipped_milestone = shipped_milestone
       feature.shipped_android_milestone = shipped_android_milestone
@@ -385,6 +390,7 @@ class FeatureHandler(common.ContentHandler):
           owner=owners,
           bug_url=bug_url,
           bug_component=self.request.get('bug_component'),
+          blink_components=blink_components,
           impl_status_chrome=int(self.request.get('impl_status_chrome')),
           shipped_milestone=shipped_milestone,
           shipped_android_milestone=shipped_android_milestone,

--- a/admin.py
+++ b/admin.py
@@ -337,7 +337,7 @@ class FeatureHandler(common.ContentHandler):
 
     blink_components = self.request.get('blink_components') or models.DEFAULT_BUG_COMPONENT
     if blink_components:
-      blink_components = [x.strip() for x in blink_components.split(',')]
+      blink_components = filter(bool, [x.strip() for x in blink_components.split(',')])
 
     # Update/delete existing feature.
     if feature_id: # /admin/edit/1234

--- a/common.py
+++ b/common.py
@@ -142,8 +142,9 @@ class ContentHandler(BaseHandler):
 
     try:
       self.response.out.write(render_to_string(template_path, data))
-    except Exception:
-      handle_404(self.request, self.response, Exception)
+    except Exception as e:
+      logging.error(e)
+      handle_404(self.request, self.response, e)
 
   def render_atom_feed(self, title, data):
     features_url = '%s://%s%s' % (self.request.scheme,

--- a/models.py
+++ b/models.py
@@ -372,7 +372,7 @@ class Feature(DictModel):
       d['browsers'] = {
         'chrome': {
           'bug': d.pop('bug_url', None),
-          'blink_components': d.pop('blink_components', None),
+          'blink_components': d.pop('blink_components', []),
           'owners': d.pop('owner', []),
           'origintrial': self.impl_status_chrome == ORIGIN_TRIAL,
           'intervention': self.impl_status_chrome == INTERVENTION,

--- a/models.py
+++ b/models.py
@@ -372,7 +372,6 @@ class Feature(DictModel):
       d['browsers'] = {
         'chrome': {
           'bug': d.pop('bug_url', None),
-          'crbug_component': d.pop('bug_component', None),
           'blink_components': d.pop('blink_components', None),
           'owners': d.pop('owner', []),
           'origintrial': self.impl_status_chrome == ORIGIN_TRIAL,
@@ -654,7 +653,7 @@ class Feature(DictModel):
 
   def new_crbug_url(self):
     url = 'https://bugs.chromium.org/p/chromium/issues/entry'
-    params = ['components=' + self.bug_component or DEFAULT_BUG_COMPONENT]
+    params = ['components=' + self.blink_components[0] or DEFAULT_BUG_COMPONENT]
     crbug_number = self.crbug_number()
     if crbug_number and self.impl_status_chrome in (
         NO_ACTIVE_DEV,
@@ -681,7 +680,6 @@ class Feature(DictModel):
 
   # Chromium details.
   bug_url = db.LinkProperty()
-  bug_component = db.StringProperty(required=False, default=DEFAULT_BUG_COMPONENT)
   blink_components = db.StringListProperty(required=True, default=[DEFAULT_BUG_COMPONENT])
 
   impl_status_chrome = db.IntegerProperty(required=True)
@@ -778,9 +776,6 @@ class FeatureForm(forms.Form):
 
   bug_url = forms.URLField(required=False, label='Bug URL',
       help_text='OWP Launch Tracking, crbug, etc.')
-
-  bug_component = forms.CharField(required=False, label='Bug Component',
-      help_text='"%s" will be used if not specified.' % DEFAULT_BUG_COMPONENT)
 
   blink_components = forms.ChoiceField(
       required=True,

--- a/models.py
+++ b/models.py
@@ -1,9 +1,11 @@
 import datetime
+import json
 import logging
 import re
 import time
 
 from google.appengine.api import memcache
+from google.appengine.api import urlfetch
 from google.appengine.api import users
 from google.appengine.ext import db
 #from google.appengine.ext.db import djangoforms
@@ -162,7 +164,7 @@ WEB_DEV_VIEWS = {
   }
 
 DEFAULT_BUG_COMPONENT = 'Blink'
-
+BLINK_COMPONENTS_URL = 'https://blinkcomponents-b48b5.firebaseapp.com/blinkcomponents'
 
 def del_none(d):
   """
@@ -179,6 +181,19 @@ def list_to_chunks(l, n):
   """Yield successive n-sized chunk lists from l."""
   for i in xrange(0, len(l), n):
     yield l[i:i + n]
+
+def fetch_blink_components():
+  key = '%s|blinkcomponents' % (settings.MEMCACHE_KEY_PREFIX)
+
+  components = memcache.get(key)
+  if components is None:
+    components = []
+
+    result = urlfetch.fetch(BLINK_COMPONENTS_URL)
+    if result.status_code == 200:
+      components = sorted(json.loads(result.content))
+      memcache.set(key, components)
+  return [(x, x) for x in components]
 
 
 class DictModel(db.Model):
@@ -358,6 +373,7 @@ class Feature(DictModel):
         'chrome': {
           'bug': d.pop('bug_url', None),
           'crbug_component': d.pop('bug_component', None),
+          'blink_components': d.pop('blink_components', None),
           'owners': d.pop('owner', []),
           'origintrial': self.impl_status_chrome == ORIGIN_TRIAL,
           'intervention': self.impl_status_chrome == INTERVENTION,
@@ -453,6 +469,7 @@ class Feature(DictModel):
     d['doc_links'] = '\r\n'.join(self.doc_links)
     d['sample_links'] = '\r\n'.join(self.sample_links)
     d['search_tags'] = ', '.join(self.search_tags)
+    d['blink_components'] = ', '.join(self.blink_components)
     return d
 
   @classmethod
@@ -636,8 +653,8 @@ class Feature(DictModel):
       return m.group(1)
 
   def new_crbug_url(self):
-    url = 'https://bugs.chromium.org/p/chromium/issues/entry';
-    params = ['components=' + self.bug_component or DEFAULT_BUG_COMPONENT];
+    url = 'https://bugs.chromium.org/p/chromium/issues/entry'
+    params = ['components=' + self.bug_component or DEFAULT_BUG_COMPONENT]
     crbug_number = self.crbug_number()
     if crbug_number and self.impl_status_chrome in (
         NO_ACTIVE_DEV,
@@ -665,6 +682,8 @@ class Feature(DictModel):
   # Chromium details.
   bug_url = db.LinkProperty()
   bug_component = db.StringProperty(required=False, default=DEFAULT_BUG_COMPONENT)
+  blink_components = db.StringListProperty(required=True, default=[DEFAULT_BUG_COMPONENT])
+
   impl_status_chrome = db.IntegerProperty(required=True)
   shipped_milestone = db.IntegerProperty()
   shipped_android_milestone = db.IntegerProperty()
@@ -751,22 +770,27 @@ class FeatureForm(forms.Form):
   #     help_text='Comma separated list of full email addresses (@chromium.org preferred).')
 
   category = forms.ChoiceField(required=True,
-                               choices=sorted(FEATURE_CATEGORIES.items(), key=lambda x: x[1]))
+      choices=sorted(FEATURE_CATEGORIES.items(), key=lambda x: x[1]))
 
-  owner = forms.CharField(
-      required=False, label='Owner(s) email',
+  owner = forms.CharField(required=False, label='Owner(s) email',
       help_text='Comma separated list of full email addresses. Prefer @chromium.org.')
 
 
   bug_url = forms.URLField(required=False, label='Bug URL',
-                           help_text='OWP Launch Tracking, crbug, etc.')
+      help_text='OWP Launch Tracking, crbug, etc.')
 
   bug_component = forms.CharField(required=False, label='Bug Component',
-                           help_text='"%s" will be used if not specified.' % DEFAULT_BUG_COMPONENT)
+      help_text='"%s" will be used if not specified.' % DEFAULT_BUG_COMPONENT)
+
+  blink_components = forms.ChoiceField(
+      required=True,
+      label='Blink component',
+      help_text='Select the most specific component. If unsure, leave as "%s".' % DEFAULT_BUG_COMPONENT,
+      choices=fetch_blink_components(),
+      initial=[DEFAULT_BUG_COMPONENT])
 
   impl_status_chrome = forms.ChoiceField(required=True,
-                                         label='Status in Chromium',
-                                         choices=IMPLEMENTATION_STATUS.items())
+      label='Status in Chromium', choices=IMPLEMENTATION_STATUS.items())
 
   #shipped_milestone = PlaceholderCharField(required=False,
   #                                         placeholder='First milestone the feature shipped with this status (either enabled by default or experimental)')
@@ -788,8 +812,7 @@ class FeatureForm(forms.Form):
   shipped_opera_android_milestone = forms.IntegerField(required=False, label='',
       help_text='Opera for Android: ' + SHIPPED_HELP_TXT)
 
-  prefixed = forms.BooleanField(
-      required=False, initial=False, label='Prefixed?')
+  prefixed = forms.BooleanField(required=False, initial=False, label='Prefixed?')
 
   standardization = forms.ChoiceField(
       label='Standardization', choices=STANDARDIZATION.items(),
@@ -809,8 +832,7 @@ class FeatureForm(forms.Form):
       help_text='One URL per line')
 
   footprint  = forms.ChoiceField(label='Technical footprint',
-                                 choices=FOOTPRINT_CHOICES.items(),
-                                 initial=MAJOR_MINOR_NEW_API)
+      choices=FOOTPRINT_CHOICES.items(), initial=MAJOR_MINOR_NEW_API)
 
   visibility  = forms.ChoiceField(
       label='Developer visibility',

--- a/static/elements/chromedash-feature.html
+++ b/static/elements/chromedash-feature.html
@@ -438,7 +438,7 @@
       return '/admin/features/edit/' + feature.id;
     },
     _computeBugComponent: function(feature) {
-      return feature.browsers.chrome.crbug_component || 'Blink';
+      return feature.browsers.chrome.blink_components[0] || 'Blink';
     },
     _computeCrbugNumber: function(link) {
       if (!link) {

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -40,7 +40,7 @@
     </span>
     {% endif %}
     <span class="tooltip" title="File a bug against this feature">
-      <a href="{{ feature.new_crbug_url }}" class="newbug" data-tooltip>
+      <a href="{{ feature.new_crbug_url }}" class="newbug" data-tooltip target="_blank">
         <iron-icon icon="chromestatus:bug-report"></iron-icon>
       </a>
     </span>
@@ -93,12 +93,21 @@
   {% if feature.spec_link %}
   <section id="specification">
     <h3>Specification</h3>
-    <p><a href="{{ feature.spec_link }}">{{ feature.standardization.text }}</a></p>
+    <p><a href="{{feature.spec_link}}" target="_blank">{{feature.standardization.text}}</a></p>
   </section>
   {% endif %}
 
   <section id="status">
     <h3>Status in Chromium</h3>
+    {% if feature.blink_components %}
+      <p>
+        <label>Blink components:</label>
+        {% for c in feature.blink_components %}
+          <a><a href="https://bugs.chromium.org/p/chromium/issues/list?q=component:{{c}}" target="_blank">{{c}}</a>
+        {% endfor %}
+      </p>
+    {% endif %}
+    <br>
     <p>
       {% if feature.shipped_milestone or feature.shipped_android_milestone or feature.shipped_ios_milestone or feature.shipped_webview_milestone or feature.shipped_opera_milestone or shipped_opera_android_milestone %}
         <b>
@@ -117,7 +126,7 @@
         {% endif %}
         </b>
         {% if feature.bug_url %}
-        (<a href="{{ feature.bug_url }}">launch bug</a>)
+        (<a href="{{feature.bug_url}}" target="_blank">launch bug</a>)
         {% endif %}
         in:
         <ul>
@@ -145,7 +154,7 @@
       {% else %}
         {{ feature.meta.milestone_str }}
         {% if feature.bug_url %}
-        (<a href="{{ feature.bug_url }}">launch bug</a>)
+        (<a href="{{ feature.bug_url }}" target="_blank">launch bug</a>)
         {% endif %}
       {% endif %}
     </p>


### PR DESCRIPTION
- Adds dropdown list of blink components to new feature form
- Adds `blink_components` property (list) to data model. We're only accepting one component for now.
- Removes old `crbug_component` from data model