### PR TITLE
Fixes #487 - http -> https for link rel alternate urls

### DIFF
--- a/templates/feature.html
+++ b/templates/feature.html
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block rss %}
-<link rel="alternate" type="application/rss+xml" href="http://www.chromestatus.com/features.xml" title="All features" />
+<link rel="alternate" type="application/rss+xml" href="https://www.chromestatus.com/features.xml" title="All features" />
 {% endblock %}
 
 {% block html_imports %}

--- a/templates/features.html
+++ b/templates/features.html
@@ -20,11 +20,11 @@
 {% endblock %}
 
 {% block rss %}
-<link rel="alternate" type="application/rss+xml" href="http://www.chromestatus.com/features.xml" title="All features" />
+<link rel="alternate" type="application/rss+xml" href="https://www.chromestatus.com/features.xml" title="All features" />
 {% cache TEMPLATE_CACHE_TIME rssfeed %}
   {% for k,v in categories %}
   <link rel="alternate" type="application/rss+xml"
-        href="http://www.chromestatus.com/features.xml?category={{v}}" title='"{{k}}" features'>
+        href="https://www.chromestatus.com/features.xml?category={{v}}" title='"{{k}}" features'>
   {% endfor %}
 {% endcache %}
 


### PR DESCRIPTION
This fix changes the URL that the link rel=alternate points to to be https.... selfishly I needed it so I could build Chromestatus deck.... but I think it would be good.

Question: It doesn't auto redirect existing requests to https, should it?