### PR TITLE
Fix cr bug # regex to account for 'desc='

### DIFF
--- a/static/elements/chromedash-feature.html
+++ b/static/elements/chromedash-feature.html
@@ -469,7 +469,7 @@
       if (!link) {
         return;
       }
-      var m = link.match(/[\/|?id=]([0-9]+)$/); // pull out bug number.
+      var m = link.match(/[\/|?id=]([0-9]+)(?:&desc=\d)?$/); // pull out bug number.
       if (m) {
         return m[1];
       }

--- a/static/elements/chromedash-feature.html
+++ b/static/elements/chromedash-feature.html
@@ -469,7 +469,7 @@
       if (!link) {
         return;
       }
-      var m = link.match(/id=([0-9]+)/); // pull out bug number.
+      var m = link.match(/id=([0-9]+)/g); // pull out bug number.
       if (m) {
         return m[1];
       }

--- a/static/elements/chromedash-feature.html
+++ b/static/elements/chromedash-feature.html
@@ -469,7 +469,7 @@
       if (!link) {
         return;
       }
-      var m = link.match(/[\/|?id=]([0-9]+)(?:&desc=\d)?$/); // pull out bug number.
+      var m = link.match(/id=([0-9]+)/); // pull out bug number.
       if (m) {
         return m[1];
       }


### PR DESCRIPTION
If the cr bug URL contains a `desc` parameter, the current regex returns it's value instead of the `id'. Here are the two cases the new regex is intended to cover.

https://bugs.chromium.org/p/chromium/issues/detail?id=742518&desc=3
https://bugs.chromium.org/p/chromium/issues/detail?id=742518

Here's the entry where I noticed the problem: https://www.chromestatus.com/features/5704730961510400

Here's where I worked out this solution: https://regex101.com/r/c1ZzwZ/1