### PR TITLE
Fix swapped created 'by' and 'when' fields when formatting a Feature

### DIFF
--- a/models.py
+++ b/models.py
@@ -419,8 +419,8 @@ class Feature(DictModel):
         d['id'] = None
       d['category'] = FEATURE_CATEGORIES[self.category]
       d['created'] = {
-        'by': d.pop('created', None),
-        'when': d.pop('created_by', None),
+        'by': d.pop('created_by', None),
+        'when': d.pop('created', None),
       }
       d['updated'] = {
         'by': d.pop('updated_by', None),


### PR DESCRIPTION
I noticed this while working on a bigger change. This appears to affect nothing, as in no code appears to use this object where the two fields are swapped, but should IMO be fixed nonetheless. @ebidel please have a look and let me know if you agree with this change.