### PR TITLE
Fix typo in templates/feature.html

### DIFF
--- a/templates/feature.html
+++ b/templates/feature.html
@@ -83,7 +83,7 @@
   <section id="motivation">
     <p>{{ feature.motivation|urlize }}</p>
   </section>
-  {% eindif %}
+  {% endif %}
 
   {% if feature.comments %}
   <section id="comments">


### PR DESCRIPTION
PR #603 had `eindif` instead of `endif` in one of the lines. Addresses #612.