### PR TITLE
Make all_platforms_descr a multi-line fileld, and add logging.

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -363,6 +363,17 @@ class FeatureHandler(common.ContentHandler):
     if blink_components:
       blink_components = filter(bool, [x.strip() for x in blink_components.split(',')])
 
+    try:
+      intent_stage = int(self.request.get('intent_stage'))
+    except:
+      logging.error('Invalid intent_stage \'{}\'' \
+                    .format(self.request.get('intent_stage')))
+
+      # Default the intent stage to 1 (Implement) if we failed to get a valid
+      # intent stage from the request. This should be removed once we
+      # understand what causes this.
+      intent_stage = 1
+
     if feature_id: # /admin/edit/1234
       feature = models.Feature.get_by_id(long(feature_id))
 
@@ -377,7 +388,7 @@ class FeatureHandler(common.ContentHandler):
       # Update properties of existing feature.
       feature.category = int(self.request.get('category'))
       feature.name = self.request.get('name')
-      feature.intent_stage = int(self.request.get('intent_stage'))
+      feature.intent_stage = intent_stage
       feature.summary = self.request.get('summary')
       feature.intent_to_implement_url = intent_to_implement_url
       feature.origin_trial_feedback_url = origin_trial_feedback_url
@@ -440,7 +451,7 @@ class FeatureHandler(common.ContentHandler):
       feature = models.Feature(
           category=int(self.request.get('category')),
           name=self.request.get('name'),
-          intent_stage=int(self.request.get('intent_stage')),
+          intent_stage=intent_stage,
           summary=self.request.get('summary'),
           intent_to_implement_url=intent_to_implement_url,
           origin_trial_feedback_url=origin_trial_feedback_url,

--- a/models.py
+++ b/models.py
@@ -853,7 +853,7 @@ class Feature(DictModel):
   security_risks = db.StringProperty(multiline=True)
   debuggability = db.StringProperty(multiline=True)
   all_platforms = db.BooleanProperty()
-  all_platforms_descr = db.StringProperty()
+  all_platforms_descr = db.StringProperty(multiline=True)
   wpt = db.BooleanProperty()
   wpt_descr = db.StringProperty(multiline=True)
 


### PR DESCRIPTION
This PR changes the all_platforms_descr form field to be a multiline
form field. This fixes some reported 500 errors (#641), and also adds
logging for catching a yet to be understood error with intent_stage not
being an integer string.