### PR TITLE
Fix #643, always include TAG review in intents.

### DIFF
--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -17,10 +17,10 @@ Intent to {{feature.intent_stage}}: {{feature.name}}
 Specification: <a href="{{feature.spec_link}}">{{feature.spec_link}}</a>
 {% endif %}
 {% for link in feature.doc_links %}<a href="{{link}}">{{link}}</a>{% endfor %}
-
+{% endif %}
 <label>TAG review</label>
 {{feature.tag_review|urlize}}
-{% endif %}
+
 <label>Summary</label>
 {{feature.summary}}
 {% if feature.intent_stage == "Implement" or feature.intent_stage == "Ship" or feature.intent_stage == "Implement and Ship" %}


### PR DESCRIPTION
This change makes is so that all intent email templates include the TAG
review field.