### PR TITLE
Fix issue 646, line breaks dropped from motivation.

### DIFF
--- a/static/sass/features/feature.scss
+++ b/static/sass/features/feature.scss
@@ -36,7 +36,7 @@ section {
   }
 }
 
-#summary, #comments {
+#summary, #comments, #motivation {
   p {
     white-space: pre-line;
   }


### PR DESCRIPTION
This ensures we display line breaks in feature motivation fields.