### PR TITLE
Make intent template point to a standalone feature page.

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -224,7 +224,7 @@ class HistogramsHandler(webapp2.RequestHandler):
 
 class FeatureHandler(common.ContentHandler):
 
-  DEFAULT_URL = '/features'
+  DEFAULT_URL = '/feature'
   ADD_NEW_URL = '/admin/features/new'
   EDIT_URL = '/admin/features/edit'
   LAUNCH_URL = '/admin/features/launch'


### PR DESCRIPTION
Right now the intent template points to feature entries as part of the
list of all entries. Given the non-trivial length of the list of
features today, it seems it makes more sense to make the intent template
point directly to the feature itself instead of just expanding the feature
in the long list of all features.