### PR TITLE
Add note to migrate traffic to both the default and notifier services.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ number. This will build the site and deploy it to GAE.
 
 Lastly, open the [Google Developer
 Console](https://console.cloud.google.com/appengine/versions?project=cr-status&organizationId=433637338589&moduleId=default)
-and flip to the new version by selecting from the list and clicking *MIGRATE TRAFFIC*.
+and flip to the new version by selecting from the list and clicking *MIGRATE TRAFFIC*. Make sure to do this for both the 'default' service as well as for the 'notifier' service.
 
 ### LICENSE
 


### PR DESCRIPTION
Expand on the deployment instructions a bit to clarify that cr-status contains two services, 'default' and 'notifier'.