### PR TITLE
Expose bogus sample 2 item appearing

### DIFF
--- a/templates/feature.html
+++ b/templates/feature.html
@@ -73,10 +73,12 @@
     </div>
   </section>
 
-  {% if feature.summary %}
-  <section id="summary">
-    <p>{{ feature.summary|urlize }}</p>
-  </section>
+  {% for summary in feature.summary %}
+    <section id="summary">
+      <p>{{ feature.summary|urlize }}</p>
+    </section>
+	{% endfor %}
+
   {% endif %}
 
   {% if feature.motivation %}


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/chromium-dashboard/issues/372.

- [x] Iterate over the list
- [x] Use the fields from iterated list and show as per the list