### PR TITLE
Work around GAE deadline for feature popularity

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -8,3 +8,6 @@ cron:
 - description: update list of Blink components
   url: /cron/update_blink_components
   schedule: every day 04:30
+- description: sort metrics and load into memcache without request time limits
+  url: /data/featurepopularity
+  schedule: every 30 minutes synchronized


### PR DESCRIPTION
This request was never succeeding because it was taking longer than GAE's 60s deadline.

There is no deadline when it is run as a cron, which allows it to succeed and put data into memcache for user requests to access.

This change has already been deployed for about a week.