### PR TITLE
Rename "Intent to Implement" as "Intent to Prototype"

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -369,7 +369,7 @@ class FeatureHandler(common.ContentHandler):
       logging.error('Invalid intent_stage \'{}\'' \
                     .format(self.request.get('intent_stage')))
 
-      # Default the intent stage to 1 (Implement) if we failed to get a valid
+      # Default the intent stage to 1 (Prototype) if we failed to get a valid
       # intent stage from the request. This should be removed once we
       # understand what causes this.
       intent_stage = 1

--- a/models.py
+++ b/models.py
@@ -76,7 +76,7 @@ INTENT_REMOVE = 6
 
 INTENT_STAGES = {
   INTENT_NONE: 'None',
-  INTENT_IMPLEMENT: 'Implement',
+  INTENT_IMPLEMENT: 'Prototype',
   INTENT_EXPERIMENT: 'Experiment',
   INTENT_EXTEND_TRIAL: 'Extend Origin Trial',
   INTENT_IMPLEMENT_SHIP: 'Implement and Ship',
@@ -979,17 +979,17 @@ class FeatureForm(forms.Form):
 
   explainer_links = forms.CharField(label='Explainer link(s)', required=False,
       widget=forms.Textarea(attrs={'rows': 4, 'cols': 50, 'maxlength': 500}),
-      help_text='Link to explainer(s) (one URL per line). You should have at least an explainer in hand and have shared it on a public forum before sending an intent to implement in order to enable discussion with other browser vendors, standards bodies, or other interested parties.')
+      help_text='Link to explainer(s) (one URL per line). You should have at least an explainer in hand and have shared it on a public forum before sending an Intent to Prototype in order to enable discussion with other browser vendors, standards bodies, or other interested parties.')
 
-  intent_to_implement_url = forms.URLField(required=False, label='Intent to Implement link',
-      help_text='Link to the "Intent to Implement" discussion thread.')
+  intent_to_implement_url = forms.URLField(required=False, label='Intent to Prototype link',
+      help_text='Link to the "Intent to Prototype" discussion thread.')
 
   origin_trial_feedback_url = forms.URLField(required=False, label='Origin Trial feedback summary',
       help_text='If your feature was available as an Origin Trial, link to a summary of usage and developer feedback. If not, leave this empty.')
 
   doc_links = forms.CharField(label='Doc link(s)', required=False,
       widget=forms.Textarea(attrs={'rows': 4, 'cols': 50, 'maxlength': 500}),
-      help_text='Links to design doc(s) (one URL per line), if and when available. [This is not required to send out an Intent to Implement. Please update the intent thread with the design doc when ready]. An explainer and/or design doc is sufficient to start this process. [Note: Please include links and data, where possible, to support any claims.]')
+      help_text='Links to design doc(s) (one URL per line), if and when available. [This is not required to send out an Intent to Prototype. Please update the intent thread with the design doc when ready]. An explainer and/or design doc is sufficient to start this process. [Note: Please include links and data, where possible, to support any claims.]')
 
   standardization = forms.ChoiceField(
       label='Standardization', choices=STANDARDIZATION.items(),

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -23,10 +23,10 @@ Specification: <a href="{{feature.spec_link}}">{{feature.spec_link}}</a>
 
 <label>Summary</label>
 {{feature.summary}}
-{% if feature.intent_stage == "Implement" or feature.intent_stage == "Ship" or feature.intent_stage == "Implement and Ship" %}
-{% if feature.intent_stage == "Implement" or feature.intent_stage == "Implement and Ship" %}<label>Motivation</label>
+{% if feature.intent_stage == "Prototype" or feature.intent_stage == "Ship" or feature.intent_stage == "Implement and Ship" %}
+{% if feature.intent_stage == "Prototype" or feature.intent_stage == "Implement and Ship" %}<label>Motivation</label>
 {{feature.motivation|urlize}}
-{% endif %}{% if feature.intent_stage == "Ship" or feature.intent_stage == "Experiment" or feature.intent_stage == "Extend Origin Trial" %}<label>Link to “Intent to Implement” blink-dev discussion</label>
+{% endif %}{% if feature.intent_stage == "Ship" or feature.intent_stage == "Experiment" or feature.intent_stage == "Extend Origin Trial" %}<label>Link to “Intent to Prototype” blink-dev discussion</label>
 {{feature.intent_to_implement_url}}
 {% if feature.origin_trial_feedback_url %}
 <label>Link to Origin Trial feedback summary</label>

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -231,8 +231,8 @@
 
   {% if feature.intent_to_implement_url %}
   <section id="intent_to_implement_url">
-    <h3>Intent to Implement url</h3>
-    <a href="{{ feature.intent_to_implement_url }}">Intent to Implement thread</a>
+    <h3>Intent to Prototype url</h3>
+    <a href="{{ feature.intent_to_implement_url }}">Intent to Prototype thread</a>
     </ul>
   </section>
   {% endif %}


### PR DESCRIPTION
This PR renames the labels and sets up the proper naming for the generated intent template, but does not rename the internal definitions or macros.