### PR TITLE
Add DevRel field to Feature

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -363,6 +363,10 @@ class FeatureHandler(common.ContentHandler):
     if blink_components:
       blink_components = filter(bool, [x.strip() for x in blink_components.split(',')])
 
+    devrel = self.request.get('devrel') or []
+    if devrel:
+      devrel = [db.Email(x.strip()) for x in devrel.split(',')]
+
     try:
       intent_stage = int(self.request.get('intent_stage'))
     except:
@@ -397,6 +401,7 @@ class FeatureHandler(common.ContentHandler):
       feature.owner = owners
       feature.bug_url = bug_url
       feature.blink_components = blink_components
+      feature.devrel = devrel
       feature.impl_status_chrome = int(self.request.get('impl_status_chrome'))
       feature.shipped_milestone = shipped_milestone
       feature.shipped_android_milestone = shipped_android_milestone
@@ -460,6 +465,7 @@ class FeatureHandler(common.ContentHandler):
           owner=owners,
           bug_url=bug_url,
           blink_components=blink_components,
+          devrel=devrel,
           impl_status_chrome=int(self.request.get('impl_status_chrome')),
           shipped_milestone=shipped_milestone,
           shipped_android_milestone=shipped_android_milestone,

--- a/models.py
+++ b/models.py
@@ -474,6 +474,7 @@ class Feature(DictModel):
         'chrome': {
           'bug': d.pop('bug_url', None),
           'blink_components': d.pop('blink_components', []),
+          'devrel': d.pop('devrel', []),
           'owners': d.pop('owner', []),
           'origintrial': self.impl_status_chrome == ORIGIN_TRIAL,
           'intervention': self.impl_status_chrome == INTERVENTION,
@@ -576,6 +577,7 @@ class Feature(DictModel):
     d['sample_links'] = '\r\n'.join(self.sample_links)
     d['search_tags'] = ', '.join(self.search_tags)
     d['blink_components'] = self.blink_components[0] #TODO: support more than one component.
+    d['devrel'] = ', '.join(self.devrel)
     return d
 
   @classmethod
@@ -843,6 +845,7 @@ class Feature(DictModel):
   # Chromium details.
   bug_url = db.LinkProperty()
   blink_components = db.StringListProperty(required=True, default=[BlinkComponent.DEFAULT_COMPONENT])
+  devrel = db.ListProperty(db.Email)
 
   impl_status_chrome = db.IntegerProperty(required=True)
   shipped_milestone = db.IntegerProperty()
@@ -1106,6 +1109,9 @@ class FeatureForm(forms.Form):
       help_text='Select the most specific component. If unsure, leave as "%s".' % BlinkComponent.DEFAULT_COMPONENT,
       choices=[(x, x) for x in BlinkComponent.fetch_all_components()],
       initial=[BlinkComponent.DEFAULT_COMPONENT])
+
+  devrel = forms.CharField(required=False, label='Developer relations emails',
+      help_text='Comma separated list of full email addresses.')
 
   impl_status_chrome = forms.ChoiceField(required=True,
       label='Status in Chromium', choices=IMPLEMENTATION_STATUS.items())


### PR DESCRIPTION
This PR simply adds a DevRel field (Developer relations emails) to the Feature table so that web developers can query through ChromeStatus API the appropriate DevRel folks for each feature.

```js
const response = await fetch('https://chromestatus.com/features_v2.json');
const features = await response.json();
features.forEach(feature => {
  const devrel = feature.browsers.chrome.devrel;
  const featureName = feature.name;
  console.log(`Web Dev POC for "${featureName}": ${devrel}`);
});
``` 

FYI @petele @jeffposnick @tomayac @jpmedley 