### PR TITLE
Revert "WebComponents v0 origin trial"

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -31,10 +31,7 @@ limitations under the License.
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-<meta http-equiv="origin-trial" 
-      content="AqvuBI0008nAQcVG+APF4fAXKbf/uX+1h0UZFvblbNnS1AWGPAgWncjC7VMkVFKMc4iITTP3rWCAM7o9ktwmYQUAAABseyJvcmlnaW4iOiJodHRwczovL2Nocm9tZXN0YXR1cy5jb206NDQzIiwiZmVhdHVyZSI6IldlYkNvbXBvbmVudHNWMCIsImV4cGlyeSI6MTYwNDcwODQ2OSwiaXNTdWJkb21haW4iOnRydWV9">
 
-  
 <link rel="apple-touch-icon" href="/static/img/crstatus_128.png">
 <link rel="apple-touch-icon-precomposed" href="/static/img/crstatus_128.png">
 <link rel="shortcut icon" href="/static/img/crstatus_128.png">

--- a/templates/blank.html
+++ b/templates/blank.html
@@ -31,9 +31,6 @@ limitations under the License.
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-<meta http-equiv="origin-trial" 
-      content="AqvuBI0008nAQcVG+APF4fAXKbf/uX+1h0UZFvblbNnS1AWGPAgWncjC7VMkVFKMc4iITTP3rWCAM7o9ktwmYQUAAABseyJvcmlnaW4iOiJodHRwczovL2Nocm9tZXN0YXR1cy5jb206NDQzIiwiZmVhdHVyZSI6IldlYkNvbXBvbmVudHNWMCIsImV4cGlyeSI6MTYwNDcwODQ2OSwiaXNTdWJkb21haW4iOnRydWV9">
-
 
 <link rel="apple-touch-icon" href="/static/img/crstatus_128.png">
 <link rel="apple-touch-icon-precomposed" href="/static/img/crstatus_128.png">


### PR DESCRIPTION
Reverts GoogleChrome/chromium-dashboard#692

The polyfill decision logic was overly specific which made it fragile.  Now that Chrome Canary 80 also disabled HTML imports, the polyfill decision logic works.  So, I don't think that we need a reverse origin trial.