### PR TITLE
Refactor chromedash-feature subscribed attribute.

### DIFF
--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -29,7 +29,6 @@ class ChromedashFeature extends LitElement {
       _commentHtml: {attribute: false},
       _crBugNumber: {attribute: false},
       _newBugUrl: {attribute: false},
-      _receivePush: {attribute: false},
     };
   }
 

--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -20,6 +20,7 @@ class ChromedashFeature extends LitElement {
       feature: {type: Object},
       whitelisted: {type: Boolean},
       open: {type: Boolean, reflect: true}, // Attribute used in the parent for styling
+      subscribed: {type: Boolean},
       // Values used in the template
       _interopRisk: {attribute: false},
       _isDeprecated: {attribute: false},
@@ -49,7 +50,6 @@ class ChromedashFeature extends LitElement {
   }
 
   _initializeValues() {
-    this._receivePush = this.feature.receivePush;
     this._crBugNumber = this._getCrBugNumber();
     this._newBugUrl = this._getNewBugUrl();
     this._interopRisk = this._getInteropRisk();
@@ -188,13 +188,21 @@ class ChromedashFeature extends LitElement {
       return;
     }
 
-    this._receivePush = !this._receivePush;
+    // We toggle the subscribed state by sending an event, which causes a new
+    // ChromedashFeature object to be created with the new state.
+    const newSubscribed = !this.subscribed;
 
-    if (this._receivePush) {
+    if (newSubscribed) {
       window.PushNotifications.subscribeToFeature(featureId);
     } else {
       window.PushNotifications.unsubscribeFromFeature(featureId);
     }
+
+    // Handled in `chromedash-featurelist`
+    this._fireEvent('subscribed-toggled', {
+      feature: this.feature,
+      subscribed: newSubscribed,
+    });
   }
 
   render() {
@@ -259,7 +267,7 @@ class ChromedashFeature extends LitElement {
               <span class="tooltip"
                     title="Receive a push notification when there are updates">
                 <a href="#" @click="${this.subscribeToFeature}" data-tooltip>
-                  <iron-icon icon="${this._receivePush ?
+                  <iron-icon icon="${this.subscribed ?
                                 'chromestatus:notifications' :
                                 'chromestatus:notifications-off'}"
                              class="pushicon ${window.PushNotifier && window.PushNotifier.GRANTED_ACCESS ?

--- a/static/js-src/features-page.js
+++ b/static/js-src/features-page.js
@@ -85,13 +85,7 @@ featureListEl.addEventListener('app-ready', () => {
           iconEl.icon = 'chromestatus:notifications-off';
         }
 
-        featureListEl.features.forEach((f, i) => {
-          if (subscribedFeatures.includes(String(f.id))) {
-            f.receivePush = true;
-            featureListEl.notifyPath(['features', i, 'receivePush'], true);
-            featureListEl.notifyPath(['filtered', i, 'receivePush'], true);
-          }
-        });
+        featureListEl.subscribedFeatures = new Set(subscribedFeatures);
       });
     }
   });


### PR DESCRIPTION
I don't think that there is something like notifyPath([]) in lit-element.  So, to make the subscription bell icons show the current state of subscriptions, I refactored that UI state data into a separate property that will trigger a re-render when it is modified.  This makes is similar to the way that open/closed features are managed.