### PR TITLE
Update polymer $ shortcut to querySelector().

### DIFF
--- a/static/elements/chromedash-metrics.js
+++ b/static/elements/chromedash-metrics.js
@@ -65,7 +65,7 @@ class ChromedashMetrics extends LitElement {
     if (location.hash) {
       const hash = decodeURIComponent(location.hash);
       if (hash) {
-        const el = this.$['stack-rank-list'].querySelector(hash);
+        const el = this.shadowRoot.querySelector('#stack-rank-list ' + hash);
         el.scrollIntoView(true, {behavior: 'smooth'});
       }
     }


### PR DESCRIPTION
I think this is the last occurrence of the old polymer $ shortcut. 