### PR TITLE
Handle clicks on sorting arrow icons.

### DIFF
--- a/static/elements/chromedash-metrics.js
+++ b/static/elements/chromedash-metrics.js
@@ -74,7 +74,7 @@ class ChromedashMetrics extends LitElement {
   sort(e) {
     e.preventDefault();
 
-    const order = e.target.dataset.order || e.target.parentNode.dataset.order;
+    const order = e.currentTarget.dataset.order;
     sortBy_(order, this.viewList);
     switch (order) {
       case 'percentage':

--- a/static/elements/chromedash-metrics.js
+++ b/static/elements/chromedash-metrics.js
@@ -74,7 +74,7 @@ class ChromedashMetrics extends LitElement {
   sort(e) {
     e.preventDefault();
 
-    const order = e.target.dataset.order;
+    const order = e.target.dataset.order || e.target.parentNode.dataset.order;
     sortBy_(order, this.viewList);
     switch (order) {
       case 'percentage':


### PR DESCRIPTION
This avoids a JS error when the user clicks on the sort triangle icons in the headers of the metrics pages.  The data-order attribute is defined on the <span> but if the user clicks on the icon, e.target will be the icon which has no dataset.order.