### PR TITLE
Remove lit-virtualizer until it is fully supported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3298,11 +3298,6 @@
         "es5-ext": "0.10.49"
       }
     },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-    },
     "execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -5977,25 +5972,6 @@
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.1.2.tgz",
       "integrity": "sha512-FFlUMKHKi+qG1x1iHNZ1hrtc/zHmfYTyrSvs3/wBTvaNtpZjOZGWzU7efGYVpgp6KvWeKF6ql9/KsCq6Z/mEDA=="
     },
-    "lit-virtualizer": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/lit-virtualizer/-/lit-virtualizer-0.4.1.tgz",
-      "integrity": "sha512-iwQT14XjlD+e9+hiFRpPf66kF6hhKvUN1TcMfVXiPOZ4OvaXq+UVjAeiqYo1G+FNq6qEI5GHVrp3JXSqjWN0Lg==",
-      "requires": {
-        "event-target-shim": "5.0.1",
-        "lit-element": "2.2.0",
-        "lit-html": "1.1.2",
-        "resize-observer-polyfill": "1.5.1",
-        "tslib": "1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
-        }
-      }
-    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -7679,11 +7655,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
-    },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@polymer/paper-ripple": "^3.0.1",
     "@polymer/paper-styles": "^3.0.1",
     "lit-element": "^2.1.0",
-    "lit-html": "^1.1.2",
-    "lit-virtualizer": "^0.4.1"
+    "lit-html": "^1.1.2"
   }
 }

--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -1,6 +1,5 @@
 import {LitElement, html} from 'lit-element';
 // eslint-disable-next-line no-unused-vars
-import {LitVirtualizer} from 'lit-virtualizer';
 import './chromedash-feature';
 import style from '../css/elements/chromedash-featurelist.css';
 
@@ -47,7 +46,7 @@ class ChromedashFeaturelist extends LitElement {
   }
 
   firstUpdated() {
-    this._virtualizerEl = this.shadowRoot.querySelector('lit-virtualizer');
+    // @@@ this._virtualizerEl = this.shadowRoot.querySelector('lit-virtualizer');
   }
 
   async _loadData() {
@@ -335,7 +334,7 @@ class ChromedashFeaturelist extends LitElement {
 
     for (let i = 0, f; f = this.filtered[i]; ++i) {
       if (f.id === targetId) {
-        this._virtualizerEl.scrollToIndex(i);
+        // @@@ this._virtualizerEl.scrollToIndex(i);
         return;
       }
     }
@@ -388,6 +387,7 @@ class ChromedashFeaturelist extends LitElement {
   }
 
   render() {
+    console.log('num features = ' + this.filtered.length);
     const filteredWithState = this.filtered.map((feature) => {
       return {
         feature: feature,
@@ -401,11 +401,7 @@ class ChromedashFeaturelist extends LitElement {
         .item {width: 100%}
       </style>
 
-      <lit-virtualizer
-        .scrollTarget=${window}
-        .items=${filteredWithState}
-        @rangechange=${this._onScrollList}
-        .renderItem=${(item) => html`
+      ${filteredWithState.map((item) => html`
           <div class="item">
             <div ?hidden="${this._computeMilestoneHidden(item.feature, this.features, this.filtered)}"
                  class="milestone-marker">${this._computeMilestoneString(item.feature.browsers.chrome.status.milestone_str)}</div>
@@ -417,8 +413,7 @@ class ChromedashFeaturelist extends LitElement {
                  .feature="${item.feature}"
                  ?whitelisted="${this.whitelisted}"></chromedash-feature>
           </div>
-        `}>
-      </lit-virtualizer>
+        `)}
     `;
   }
 }

--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -333,22 +333,8 @@ class ChromedashFeaturelist extends LitElement {
     const targetEl = this.shadowRoot.querySelector('#id-' + targetId);
     if (targetEl) {
       targetEl.scrollIntoView();
-    }
-  }
-
-  _onScrollList(e) {
-    if (!this._hasInitialized) {
-      return;
-    }
-    if (!this._hasScrolledByUser) {
-      this._hasScrolledByUser = true;
-      this._fireEvent('has-scroll-list'); // Nofity the app to un-fix header.
-    }
-
-    // Note: e.firstVisible is undefined on Safari.
-    const feature = this.features[e.firstVisible];
-    if (feature) {
-      this.metadataEl.selectMilestone(feature);
+      const heightOfHeader = document.querySelector('.main-toolbar').getBoundingClientRect().height;
+      window.scrollBy(0, heightOfHeader * -1);
     }
   }
 
@@ -383,7 +369,7 @@ class ChromedashFeaturelist extends LitElement {
   }
 
   render() {
-    console.log('num features = ' + this.filtered.length);
+    // TODO: Avoid computing values in render().
     let filteredWithState = this.filtered.map((feature) => {
       return {
         feature: feature,

--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -3,6 +3,8 @@ import {LitElement, html} from 'lit-element';
 import './chromedash-feature';
 import style from '../css/elements/chromedash-featurelist.css';
 
+const MAX_FEATURES_SHOWN = 500;
+
 class ChromedashFeaturelist extends LitElement {
   static styles = style;
 
@@ -43,10 +45,6 @@ class ChromedashFeaturelist extends LitElement {
     this._onSubscribedToggledBound = this._onSubscribedToggled.bind(this);
 
     this._loadData();
-  }
-
-  firstUpdated() {
-    // @@@ this._virtualizerEl = this.shadowRoot.querySelector('lit-virtualizer');
   }
 
   async _loadData() {
@@ -332,11 +330,9 @@ class ChromedashFeaturelist extends LitElement {
 
     this._setOpenFeatures(targetId, true);
 
-    for (let i = 0, f; f = this.filtered[i]; ++i) {
-      if (f.id === targetId) {
-        // @@@ this._virtualizerEl.scrollToIndex(i);
-        return;
-      }
+    const targetEl = this.shadowRoot.querySelector('#id-' + targetId);
+    if (targetEl) {
+      targetEl.scrollIntoView();
     }
   }
 
@@ -388,13 +384,18 @@ class ChromedashFeaturelist extends LitElement {
 
   render() {
     console.log('num features = ' + this.filtered.length);
-    const filteredWithState = this.filtered.map((feature) => {
+    let filteredWithState = this.filtered.map((feature) => {
       return {
         feature: feature,
         open: this.openFeatures.has(feature.id),
         subscribed: this.subscribedFeatures.has(String(feature.id)),
       };
     });
+    let numOverLimit = 0;
+    if (filteredWithState.length > MAX_FEATURES_SHOWN) {
+      numOverLimit = filteredWithState.length - MAX_FEATURES_SHOWN;
+      filteredWithState = filteredWithState.slice(0, MAX_FEATURES_SHOWN);
+    }
     return html`
       <link rel="stylesheet" href="/static/css/elements/chromedash-featurelist.css">
       <style>
@@ -414,6 +415,10 @@ class ChromedashFeaturelist extends LitElement {
                  ?whitelisted="${this.whitelisted}"></chromedash-feature>
           </div>
         `)}
+
+      ${numOverLimit > 0 ?
+        html`<p>To see ${numOverLimit} earlier features, please enter a more specific query.</p>` :
+        ''}
     `;
   }
 }

--- a/static/sass/elements/chromedash-featurelist.scss
+++ b/static/sass/elements/chromedash-featurelist.scss
@@ -23,6 +23,10 @@
   width: 100%;
 }
 
+p {
+  margin: 32px;
+}
+
 @media only screen and (max-width: 700px) {
   .milestone-marker {
     font-size: 14px;


### PR DESCRIPTION
While investigating issue #737, I realized that it will be pretty difficult for me to get lit-virtualizer to work perfectly and to debug it.  While anything is possible with enough time and effort, I want to switch gears to work on collaborative functionality.  So, I'd like to try taking lit-virtualizer out until I get a chance to re-implement the feature list view to look more like a Monorail table and/or lit-virtualizer graduates from pre-release status.

This change removes lit-virtualizer and simply renders each feature element.  Rendering 1600 elements takes about 3 seconds, which feels like it is too slow, especially for the search-as-you-type feature.  So, I am capping the number of features shown at 500.   I don't think that many users would scroll down through 500 features.  If they want to get to features in earlier releases, they can click on a release number.