### PR TITLE
Tweak CSS to avoid wrapping between search input and "?" icon

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -237,6 +237,8 @@ footer {
 
   div {
     &.search {
+      min-width: 350px;
+
       input {
         width: 280px;
         outline: none;

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -238,7 +238,7 @@ footer {
   div {
     &.search {
       input {
-        width: 300px;
+        width: 280px;
         outline: none;
         padding: 10px 7px;
       }
@@ -248,7 +248,6 @@ footer {
       display: flex;
       justify-content: flex-end;
       flex: 1 0 auto;
-      margin-left: $content-padding;
 
       .blue-button {
         background: $chromium-color-dark;


### PR DESCRIPTION
This is intended to resolve the first problem reported in #727.

Demo link: https://2020-01-23-dot-cr-status.appspot.com/features