### PR TITLE
Upgrade django to resolve another security alert listed on github.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django==1.11.23
+Django==1.11.27
 beautifulsoup4


### PR DESCRIPTION
This change to the django version does not appear to require any app changes on our part.
https://docs.djangoproject.com/en/3.0/releases/1.11.27/

I don't think that the vulnerability applied to chromestatus, but making this change should clear the warning on the GitHub code page.