### PR TITLE
Use more memcache chunks to stay under 1M size limit.

### DIFF
--- a/models.py
+++ b/models.py
@@ -366,7 +366,7 @@ class Feature(DictModel):
   """Container for a feature."""
 
   DEFAULT_MEMCACHE_KEY = '%s|features' % (settings.MEMCACHE_KEY_PREFIX)
-  MAX_CHUNK_SIZE = 500 # max num features to save for each memcache chunk.
+  MAX_CHUNK_SIZE = 300 # max num features to save for each memcache chunk.
 
   @classmethod
   def get_feature_chunk_memcache_keys(self, key_prefix):


### PR DESCRIPTION
There was existing logic to split the list of feature objects into chunks in memcache to stay under a 1MB per item size limit.  However, apparently 500 features can add up to more than 1MB, so I reduced it to 300.

This is already live on the site because the problem was causing 500s.  See:
https://pantheon.corp.google.com/errors/CJaB2c2LzZLPeA?time=PT1H&project=cr-status&organizationId=433637338589