### PR TITLE
Implement starred feature models and JSON API handler.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -98,6 +98,10 @@ handlers:
   script: notifier.app
   secure: always
 
+- url: /features/star/.*
+  script: notifier.app
+  secure: always
+
 - url: /features/schedule.*
   script: schedule.app
   secure: always

--- a/notifier.py
+++ b/notifier.py
@@ -24,6 +24,7 @@ import webapp2
 from google.appengine.ext import db
 from google.appengine.api import mail
 from google.appengine.api import urlfetch
+from google.appengine.api import users
 from google.appengine.api import taskqueue
 
 from django.utils.html import conditional_escape as escape
@@ -208,6 +209,47 @@ class PushSubscription(models.DictModel):
   subscription_id = db.StringProperty(required=True)
 
 
+class FeatureStar(models.DictModel):
+  """A FeatureStar represent one user's interest in one feature."""
+  email = db.EmailProperty(required=True)
+  feature_id = db.IntegerProperty(required=True)
+  # This is so that we do not sync a bell to a star that the user has removed.
+  starred = db.BooleanProperty(default=True)
+
+  @classmethod
+  def get_star(self, email, feature_id):
+    """If that user starred that feature, return the model or None."""
+    q = FeatureStar.all()
+    q.filter('email =', email)
+    q.filter('feature_id =', feature_id)
+    return q.get()
+
+  @classmethod
+  def set_star(self, email, feature_id, starred=True):
+    """Set/clear a star for the specified user and feature."""
+    feature_star = self.get_star(email, feature_id)
+    if not feature_star:
+      feature_star = FeatureStar(email=email, feature_id=feature_id)
+    feature_star.starred = starred
+    feature_star.put()
+
+    feature = models.Feature.get_by_id(feature_id)
+    feature.star_count += 1 if starred else -1
+    feature.put(notify=False)
+
+  @classmethod
+  def get_user_stars(self, email):
+    """Return a list of feature_ids of all features that the user starred."""
+    q = FeatureStar.all()
+    q.filter('email =', email)
+    q.filter('starred =', True)
+    feature_stars = q.fetch(None)
+    logging.info('found %d stars for %r', len(feature_stars), email)
+    feature_ids = [fs.feature_id for fs in feature_stars]
+    logging.info('returning %r', feature_ids)
+    return feature_ids
+
+
 class EmailHandler(webapp2.RequestHandler):
 
   def post(self):
@@ -237,6 +279,53 @@ class NotificationNewSubscriptionHandler(webapp2.RequestHandler):
     if found_token is None:
       subscription = PushSubscription(subscription_id=subscription_id)
       subscription.put()
+
+
+class SetStarHandler(webapp2.RequestHandler):
+  """Handle JSON API requests to set/clear a star."""
+
+  def post(self):
+    """Stars or unstars a feature for the signed in user."""
+    json_body = json.loads(self.request.body)
+    feature_id = json_body.get('featureId')
+    starred = json_body.get('starred', True)
+
+    if type(feature_id) != int:
+      logging.info('Invalid feature_id: %r', feature_id)
+      self.abort(400)
+
+    feature = models.Feature.get_feature(feature_id)
+    if not feature:
+      logging.info('feature not found: %r', feature_id)
+      self.abort(404)
+
+    user = users.get_current_user()
+    if not user:
+      logging.info('User must be signed in before starring')
+      self.abort(400)
+
+    FeatureStar.set_star(user.email(), feature_id, starred)
+
+
+class GetUserStarsHandler(webapp2.RequestHandler):
+  """Handle JSON API requests list all stars for current user."""
+
+  def post(self):
+    """Returns a list of starred feature_ids for the signed in user."""
+    # Note: the post body is not used.
+
+    user = users.get_current_user()
+    if user:
+      feature_ids = FeatureStar.get_user_stars(user.email())
+    else:
+      feature_ids = []  # Anon users cannot star features.
+
+    data = {
+        'featureIds': feature_ids,
+        }
+    self.response.headers['Content-Type'] = 'application/json;charset=utf-8'
+    result = self.response.write(json.dumps(data, separators=(',',':')))
+
 
 
 class NotificationSubscribeHandler(webapp2.RequestHandler):
@@ -352,4 +441,11 @@ app = webapp2.WSGIApplication([
   ('/features/push/new', NotificationNewSubscriptionHandler),
   ('/features/push/info', NotificationSubscriptionInfoHandler),
   ('/features/push/subscribe/([0-9]*)', NotificationSubscribeHandler),
+  ('/features/star/set', SetStarHandler),
+  ('/features/star/list', GetUserStarsHandler),
 ], debug=settings.DEBUG)
+
+app.error_handlers[404] = common.handle_404
+
+if settings.PROD and not settings.DEBUG:
+  app.error_handlers[500] = common.handle_500

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "deps": "pip install -t lib -r requirements.txt",
-    "test": "python -m unittest discover -p *_test.py -s tests",
+    "test": "python -m unittest discover -p *_test.py -s tests -b",
     "lint": "gulp lint-fix && lit-analyzer \"static/elements/chromedash-!(featurelist)*.js\"",
     "build": "gulp",
     "watch": "gulp watch",

--- a/tests/notifier_test.py
+++ b/tests/notifier_test.py
@@ -14,11 +14,176 @@
 
 import unittest
 import testing_config  # Must be imported before the module under test.
+import webapp2
+from webob import exc
 
+import models
 import notifier
 
 
-class NotifierFunctionTests(unittest.TestCase):
 
-  def test_list_diff_empty(self):
+class NotifierFunctionsTest(unittest.TestCase):
+
+  def test_list_diff__empty(self):
     self.assertEqual([], notifier.list_diff([], []))
+
+
+class FeatureStarTest(unittest.TestCase):
+
+  def setUp(self):
+    self.feature_1 = models.Feature(
+        name='feature one', summary='sum', category=1, visibility=1,
+        standardization=1, web_dev_views=1, impl_status_chrome=1)
+    self.feature_1.put()
+    self.feature_2 = models.Feature(
+        name='feature two', summary='sum', category=1, visibility=1,
+        standardization=1, web_dev_views=1, impl_status_chrome=1)
+    self.feature_2.put()
+
+  def test_get_star__no_existing(self):
+    """User has never starred the given feature."""
+    email = 'user1@example.com'
+    feature_id = self.feature_1.key().id()
+    actual = notifier.FeatureStar.get_star(email, feature_id)
+    self.assertEqual(None, actual)
+
+  def test_get_and_set_star(self):
+    """User can star and unstar a feature."""
+    email = 'user2@example.com'
+    feature_id = self.feature_1.key().id()
+    notifier.FeatureStar.set_star(email, feature_id)
+    actual = notifier.FeatureStar.get_star(email, feature_id)
+    self.assertEqual(email, actual.email)
+    self.assertEqual(feature_id, actual.feature_id)
+    self.assertTrue(actual.starred)
+    updated_feature = models.Feature.get_by_id(feature_id)
+    self.assertEqual(1, updated_feature.star_count)
+
+    notifier.FeatureStar.set_star(email, feature_id, starred=False)
+    actual = notifier.FeatureStar.get_star(email, feature_id)
+    self.assertEqual(email, actual.email)
+    self.assertEqual(feature_id, actual.feature_id)
+    self.assertFalse(actual.starred)
+    updated_feature = models.Feature.get_by_id(feature_id)
+    self.assertEqual(0, updated_feature.star_count)
+
+  def test_get_user_star__no_stars(self):
+    """User has never starred any features."""
+    email = 'user4@example.com'
+    actual = notifier.FeatureStar.get_user_stars(email)
+    self.assertEqual([], actual)
+
+  def test_get_user_star(self):
+    """User has starred two features."""
+    email = 'user5@example.com'
+    feature_1_id = self.feature_1.key().id()
+    feature_2_id = self.feature_2.key().id()
+    notifier.FeatureStar.set_star(email, feature_1_id)
+    notifier.FeatureStar.set_star(email, feature_2_id)
+
+    actual = notifier.FeatureStar.get_user_stars(email)
+    self.assertItemsEqual(
+        [feature_1_id, feature_2_id],
+        actual)
+
+
+class SetStarHandlerTest(unittest.TestCase):
+
+  def setUp(self):
+    self.feature_1 = models.Feature(
+        name='feature one', summary='sum', category=1, visibility=1,
+        standardization=1, web_dev_views=1, impl_status_chrome=1)
+    self.feature_1.put()
+    self.handler = notifier.SetStarHandler()
+    self.handler.request = webapp2.Request.blank('/features/star/set')
+    self.handler.response = webapp2.Response()
+
+  def test_post__invalid_feature_id(self):
+    """We reject star requests that don't have an int featureId."""
+    self.handler.request.body = '{}'
+    with self.assertRaises(exc.HTTPClientError):
+      self.handler.post()
+
+    self.handler.request.body = '{"featureId":"not an int"}'
+    with self.assertRaises(exc.HTTPClientError):
+      self.handler.post()
+
+  def test_post__feature_id_not_found(self):
+    """We reject star requests for features that don't exist."""
+    self.handler.request.body = '{"featureId": 999}'
+    with self.assertRaises(exc.HTTPClientError):
+      self.handler.post()
+
+  def test_post__anon(self):
+    """We reject anon star requests."""
+    feature_id = self.feature_1.key().id()
+    self.handler.request.body = '{"featureId": %d}' % feature_id
+    testing_config.ourTestbed.setup_env(
+            user_email='', user_id='', overwrite=True)
+    with self.assertRaises(exc.HTTPClientError):
+      self.handler.post()
+
+  def test_post__normal(self):
+    """User can star and unstar."""
+    testing_config.ourTestbed.setup_env(
+            user_email='user6@example.com',
+            user_id='123567890',
+            overwrite=True)
+
+    feature_id = self.feature_1.key().id()
+    self.handler.request.body = '{"featureId": %d}' % feature_id
+    self.handler.post()
+    updated_feature = models.Feature.get_by_id(feature_id)
+    self.assertEqual(1, updated_feature.star_count)
+
+    self.handler.request.body = (
+        '{"featureId": %d, "starred": false}' % feature_id)
+    self.handler.post()
+    updated_feature = models.Feature.get_by_id(feature_id)
+    self.assertEqual(0, updated_feature.star_count)
+
+
+class GetUserStarsHandlerTest(unittest.TestCase):
+
+  def setUp(self):
+    self.feature_1 = models.Feature(
+        name='feature one', summary='sum', category=1, visibility=1,
+        standardization=1, web_dev_views=1, impl_status_chrome=1)
+    self.feature_1.put()
+    self.handler = notifier.GetUserStarsHandler()
+    self.handler.request = webapp2.Request.blank('/features/star/list')
+    self.handler.response = webapp2.Response()
+
+  def test_post__anon(self):
+    """Anon should always have an empty list of stars."""
+    testing_config.ourTestbed.setup_env(
+            user_email='', user_id='', overwrite=True)
+    self.handler.post()
+    self.assertEqual(
+        '{"featureIds":[]}',
+        self.handler.response.body)
+
+  def test_post__no_stars(self):
+    """User has not starred any features."""
+    testing_config.ourTestbed.setup_env(
+            user_email='user7@example.com',
+            user_id='123567890',
+            overwrite=True)
+    self.handler.post()
+    self.assertEqual(
+        '{"featureIds":[]}',
+        self.handler.response.body)
+
+  def test_post__some_stars(self):
+    """User has not starred any features."""
+    email = 'user8@example.com'
+    feature_1_id = self.feature_1.key().id()
+    testing_config.ourTestbed.setup_env(
+            user_email=email,
+            user_id='123567890',
+            overwrite=True)
+    notifier.FeatureStar.set_star(email, feature_1_id)
+    self.handler.post()
+    self.assertEqual(
+        '{"featureIds":[%d]}' % feature_1_id,
+        self.handler.response.body)

--- a/tests/testing_config.py
+++ b/tests/testing_config.py
@@ -44,8 +44,9 @@ os.environ['SERVER_SOFTWARE'] = 'test ' + os.environ.get('SERVER_SOFTWARE', '')
 os.environ['CURRENT_VERSION_ID'] = 'test.123'
 
 
+ourTestbed = testbed.Testbed()
+
 def setUpOurTestbed():
-  ourTestbed = testbed.Testbed()
   # needed because endpoints expects a . in this value
   ourTestbed.setup_env(current_version_id='testbed.version')
   ourTestbed.activate()


### PR DESCRIPTION
ChromeStatus currently has a push notifications that pop up a small window whenever someone edits a feature that the user has clicked the bell icon for.  We want to phase that out and instead offer star icons that trigger notification emails.  See design doc at go/chromestatus-notification-emails.

In this CL:
+ Implement feature star datastore entity model classes with methods to star, unstar, and list.
+ Implement JSON request handlers to star, unstar, and list starred features.
+ Some tweaks to unit test set-up because these are the first significant user tests.