### PR TITLE
Refactor current email notification code to use django template and add tests

### DIFF
--- a/notifier.py
+++ b/notifier.py
@@ -78,9 +78,6 @@ def format_email_body(is_update, feature, component, changes):
   moz_link_urls = [link for link in feature.doc_links
                    if 'developer.mozilla.org' in link]
 
-  created_on = datetime.datetime.strptime(str(feature.created), "%Y-%m-%d %H:%M:%S.%f").date()
-  updated_on = datetime.datetime.strptime(str(feature.updated), "%Y-%m-%d %H:%M:%S.%f").date()
-
   formatted_changes = ''
   for prop in changes:
     prop_name = prop['prop_name']
@@ -100,8 +97,6 @@ def format_email_body(is_update, feature, component, changes):
   body_data = {
       'feature': feature,
       'id': feature.key().id(),
-      'created': created_on,
-      'updated': updated_on,
       'owners': ', '.join([o.name for o in component.owners]),
       'milestone': milestone_str,
       'status': models.IMPLEMENTATION_STATUS[feature.impl_status_chrome],

--- a/templates/new-feature-email.html
+++ b/templates/new-feature-email.html
@@ -15,7 +15,7 @@
 
 <p><b><a href="https://www.chromestatus.com/feature/{{id}}"
          >{{feature.name}}</a></b>
-  (added {{created}})</p>
+  (added {{feature.created|date}})</p>
 <p><b>Milestone</b>: {{milestone}}</p>
 <p><b>Implementation status</b>: {{status}}</p>
 

--- a/templates/new-feature-email.html
+++ b/templates/new-feature-email.html
@@ -4,10 +4,10 @@
 <p>
   {% if owners %}
     You are listed as an owner for web platform features under
-    "{{component_name}}".
+    "{{component.name}}".
   {% else %}
-    Just letting you know that there\'s a new feature under
-    "{{component_name}}".
+    Just letting you know that there's a new feature under
+    "{{component.name}}".
   {% endif %}
   {{feature.created_by}} added a new feature to this component:
 </p>
@@ -40,7 +40,7 @@
 </ul>
 
 <p>If you're CCd on this email, you expressed interest in helping with
-features under "{{component_name}}". Feel free to reply-all if you can
+features under "{{component.name}}". Feel free to reply-all if you can
 help with these tasks!</p>
 
 </body></html>

--- a/templates/new-feature-email.html
+++ b/templates/new-feature-email.html
@@ -1,0 +1,46 @@
+<html><body>
+<p>Hi <b>{{owners}}</b>,</p>
+
+<p>
+  {% if owners %}
+    You are listed as an owner for web platform features under
+    "{{component_name}}".
+  {% else %}
+    Just letting you know that there\'s a new feature under
+    "{{component_name}}".
+  {% endif %}
+  {{feature.created_by}} added a new feature to this component:
+</p>
+<hr>
+
+<p><b><a href="https://www.chromestatus.com/feature/{{id}}"
+         >{{feature.name}}</a></b>
+  (added {{created}})</p>
+<p><b>Milestone</b>: {{milestone}}</p>
+<p><b>Implementation status</b>: {{status}}</p>
+
+<hr>
+<p>Next steps:</p>
+<ul>
+  <li>Try the API, write a sample, provide early feedback to eng.</li>
+  <li>Consider authoring a new article/update for /web.</li>
+  <li>Write a
+    <a href="https://github.com/GoogleChrome/lighthouse/tree/master/docs/recipes/custom-audit"
+       >new Lighthouse audit</a>. This can help drive adoption of an API
+    over time.
+  </li>
+  <li>Add a sample to https://github.com/GoogleChrome/samples (see
+    <a href="https://github.com/GoogleChrome/samples#contributing-samples"
+       >contributing</a>).
+  </li>
+  <li>Don't forget add your demo link to the
+    <a href="https://www.chromestatus.com/admin/features/edit/{{id}}"
+       >chromestatus feature entry</a>.
+  </li>
+</ul>
+
+<p>If you're CCd on this email, you expressed interest in helping with
+features under "{{component_name}}". Feel free to reply-all if you can
+help with these tasks!</p>
+
+</body></html>

--- a/templates/update-feature-email.html
+++ b/templates/update-feature-email.html
@@ -1,0 +1,45 @@
+<html><body>
+<p>Hi <b>{{owners}}</b>,</p>
+
+<p>
+  {% if owners %}
+    You are listed as an owner for web platform features under
+    "{{component_name}}".
+  {% else %}
+    Just letting you know that a feature under "{{component_name}}" has changed.
+  {% endif %}
+  {{feature.updated_by}} updated this feature:
+</p>
+<hr>
+
+<p>
+  <b><a href="https://www.chromestatus.com/feature/{id}">{{feature.name}}</a></b>
+  (updated {{updated}})</p>
+
+<p><b>Milestone</b>: {{milestone}}</p>
+<p><b>Implementation status</b>: {{status}}</p>
+
+<p>Changes:</p>
+<ul>
+{{formatted_changes}}
+</ul>
+
+<hr>
+
+<p>Next steps:</p>
+<ul>
+  <li>Check existing
+    <a href="https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-core/audits"
+       >Lighthouse audits</a> for correctness.</li>
+<li>Check existing /web content for correctness. Non-exhaustive list:
+  <ul>{{wf_content}}</ul>
+</li>
+{{moz_links}}
+</ul>
+
+<p>
+  If you're CCd on this email, you expressed interest in helping with features
+  under "{{component_name}}". Feel free to reply-all if you can help!
+</p>
+
+</body></html>

--- a/templates/update-feature-email.html
+++ b/templates/update-feature-email.html
@@ -4,9 +4,9 @@
 <p>
   {% if owners %}
     You are listed as an owner for web platform features under
-    "{{component_name}}".
+    "{{component.name}}".
   {% else %}
-    Just letting you know that a feature under "{{component_name}}" has changed.
+    Just letting you know that a feature under "{{component.name}}" has changed.
   {% endif %}
   {{feature.updated_by}} updated this feature:
 </p>
@@ -21,7 +21,7 @@
 
 <p>Changes:</p>
 <ul>
-{{formatted_changes}}
+{{formatted_changes|safe}}
 </ul>
 
 <hr>
@@ -32,14 +32,26 @@
     <a href="https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-core/audits"
        >Lighthouse audits</a> for correctness.</li>
 <li>Check existing /web content for correctness. Non-exhaustive list:
-  <ul>{{wf_content}}</ul>
+  <ul>{{wf_content|safe}}</ul>
 </li>
-{{moz_links}}
+
+{% if moz_link_urls %}
+  <li>Review the following MDN pages and
+    <a href="https://docs.google.com/document/d/10jDTZeW914ahqWfxwm9_WXJWvyAKT6EcDIlbI3w0BKY/edit#heading=h.frumfipthu7"
+       >subscribe to updates</a> for them.
+    <ul>
+      {% for url in moz_link_urls %}
+        <li>{{url}}</li>
+      {% endfor %}
+    </ul>
+  </li>
+{% endif %}
+
 </ul>
 
 <p>
   If you're CCd on this email, you expressed interest in helping with features
-  under "{{component_name}}". Feel free to reply-all if you can help!
+  under "{{component.name}}". Feel free to reply-all if you can help!
 </p>
 
 </body></html>

--- a/templates/update-feature-email.html
+++ b/templates/update-feature-email.html
@@ -14,7 +14,7 @@
 
 <p>
   <b><a href="https://www.chromestatus.com/feature/{id}">{{feature.name}}</a></b>
-  (updated {{updated}})</p>
+  (updated {{feature.updated|date}})</p>
 
 <p><b>Milestone</b>: {{milestone}}</p>
 <p><b>Implementation status</b>: {{status}}</p>


### PR DESCRIPTION
This is the existing email notification functionality, just implemented with more readable and testable code.

I believe I also fixed at least one defect, where new feature emails had the text "{component_name}" in the intro instead of the component name being inserted.