### PR TITLE
Upgrade django again and lodash.template to resolve security warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4855,6 +4855,23 @@
           "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
           "dev": true
         },
+        "lodash.template": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+          "dev": true,
+          "requires": {
+            "lodash._basecopy": "3.0.1",
+            "lodash._basetostring": "3.0.1",
+            "lodash._basevalues": "3.0.0",
+            "lodash._isiterateecall": "3.0.9",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.escape": "3.2.0",
+            "lodash.keys": "3.1.2",
+            "lodash.restparam": "3.6.1",
+            "lodash.templatesettings": "3.1.1"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -6140,20 +6157,24 @@
       "dev": true
     },
     "lodash.template": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash._basetostring": "3.0.1",
-        "lodash._basevalues": "3.0.0",
-        "lodash._isiterateecall": "3.0.9",
         "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0",
-        "lodash.keys": "3.1.2",
-        "lodash.restparam": "3.6.1",
-        "lodash.templatesettings": "3.1.1"
+        "lodash.templatesettings": "4.2.0"
+      },
+      "dependencies": {
+        "lodash.templatesettings": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+          "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "3.0.0"
+          }
+        }
       }
     },
     "lodash.templatesettings": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "http2-push-manifest": "^1.0.0",
     "lighthouse-ci": "https://github.com/ebidel/lighthouse-ci",
     "lit-analyzer": "^1.1.9",
+    "lodash.template": ">=4.5.0",
     "regenerator-runtime": "^0.13.3",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django==1.11.27
+Django==1.11.28
 beautifulsoup4
 mock


### PR DESCRIPTION
Github lists two security advisories on our project home page because we need to upgrade the version of these libraries.