### PR TITLE
Remove date from email body

### DIFF
--- a/templates/new-feature-email.html
+++ b/templates/new-feature-email.html
@@ -15,7 +15,7 @@
 
 <p><b><a href="https://www.chromestatus.com/feature/{{id}}"
          >{{feature.name}}</a></b>
-  (added {{feature.created|date}})</p>
+</p>
 <p><b>Milestone</b>: {{milestone}}</p>
 <p><b>Implementation status</b>: {{status}}</p>
 

--- a/templates/update-feature-email.html
+++ b/templates/update-feature-email.html
@@ -14,7 +14,7 @@
 
 <p>
   <b><a href="https://www.chromestatus.com/feature/{id}">{{feature.name}}</a></b>
-  (updated {{feature.updated|date}})</p>
+</p>
 
 <p><b>Milestone</b>: {{milestone}}</p>
 <p><b>Implementation status</b>: {{status}}</p>


### PR DESCRIPTION
Dates are tricky because of timezones.  The current date generation is actually done in GMT, which means that it shows tomorrow's date starting at 4 or 5pm Pacific time.  We don't know what timezone any particular user is in at any particular moment.

Email messages have a Date: header that should be displayed by the email client using the preferred timezone for that user.  So, we can just rely on that instead of putting the date in the email body.  

There is a lag between the feature record being changed and the email being sent, but it should only be seconds or minutes, not enough to make the date look wrong.