### PR TITLE
Set up staging server, and send staging email to archive.

### DIFF
--- a/notifier.py
+++ b/notifier.py
@@ -228,8 +228,12 @@ class OutboundEmailHandler(webapp2.RequestHandler):
     subject = json_body['subject']
     email_html = json_body['html']
 
+    if settings.SEND_ALL_EMAIL_TO:
+      to_user, to_domain = to.split('@')
+      to = settings.SEND_ALL_EMAIL_TO % {'user': to_user, 'domain': to_domain}
+
     message = mail.EmailMessage(
-        sender='Chromestatus <admin@cr-status.appspotmail.com>',
+        sender='Chromestatus <admin@%s.appspotmail.com>' % settings.APP_ID,
         to=to, subject=subject, html=email_html)
     message.check_initialized()
 
@@ -239,6 +243,9 @@ class OutboundEmailHandler(webapp2.RequestHandler):
     logging.info('Body:\n%s', message.html)
     if settings.SEND_EMAIL:
       message.send()
+      logging.info('Email sent')
+    else:
+      logging.info('Email not sent because of settings.SEND_EMAIL')
 
 
 class NotificationNewSubscriptionHandler(webapp2.RequestHandler):

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "gulp",
     "watch": "gulp watch",
     "deploy": "npm run build && ./scripts/deploy_site.sh `date +%Y-%m-%d`",
+    "staging": "npm run build && ./scripts/deploy_site.sh `date +%Y-%m-%d` cr-status-staging",
     "start": "npm run build && ./scripts/start_server.sh"
   },
   "repository": {

--- a/scripts/deploy_site.sh
+++ b/scripts/deploy_site.sh
@@ -9,6 +9,7 @@
 
 
 deployVersion=$1
+appName=${2:-cr-status}
 usage="Usage: deploy.sh `date +%Y-%m-%d`"
 
 if [ -z "$deployVersion" ]
@@ -28,7 +29,7 @@ gulp
 
 $BASEDIR/oauthtoken.sh deploy
 gcloud app deploy \
-  --project cr-status \
+  --project $appName \
   --version $deployVersion \
   --no-promote \
   $BASEDIR/../app.yaml $BASEDIR/../notifier.yaml


### PR DESCRIPTION
On prod, email should continue to be delivered directly to the users who are subscribed.  But, on cr-status-staging, all outbound email will go to a mailing list archive where googlers can view it to verify that it worked.