### PR TITLE
Fix email link to updated feature.

### DIFF
--- a/notifier.py
+++ b/notifier.py
@@ -66,8 +66,8 @@ def format_email_body(is_update, feature, changes):
       new_val = models.FEATURE_CATEGORIES[new_val]
       old_val = models.FEATURE_CATEGORIES[old_val]
 
-    formatted_changes += ('<li>%s: <br/><b>old:</b> %s <br/><br/>'
-                          '<b>new:</b> %s<br/><br/></li>\n' %
+    formatted_changes += ('<li>%s: <br/><b>old:</b> %s <br/>'
+                          '<b>new:</b> %s<br/></li>\n' %
                           (prop_name, escape(old_val), escape(new_val)))
   if not formatted_changes:
     formatted_changes = '<li>None</li>'

--- a/templates/update-feature-email.html
+++ b/templates/update-feature-email.html
@@ -3,7 +3,8 @@
 </p>
 
 <p>
-  <b><a href="https://www.chromestatus.com/feature/{id}">{{feature.name}}</a></b>
+  <b><a href="https://www.chromestatus.com/feature/{{id}}"
+        >{{feature.name}}</a></b>
 </p>
 
 <p><b>Milestone</b>: {{milestone}}</p>

--- a/tests/notifier_test.py
+++ b/tests/notifier_test.py
@@ -57,6 +57,8 @@ class EmailFormattingTest(unittest.TestCase):
         False, self.feature_1, [])
     self.assertIn('Blink', body_html)
     self.assertIn('creator@example.com added', body_html)
+    self.assertIn('www.chromestatus.com/feature/%d' % self.feature_1.key().id(),
+                  body_html)
     self.assertNotIn('watcher_1,', body_html)
 
   def test_format_email_body__update_no_changes(self):
@@ -74,6 +76,8 @@ class EmailFormattingTest(unittest.TestCase):
     body_html = notifier.format_email_body(
         True, self.feature_1, changes)
     self.assertIn('test_prop', body_html)
+    self.assertIn('www.chromestatus.com/feature/%d' % self.feature_1.key().id(),
+                  body_html)
     self.assertIn('test old value', body_html)
     self.assertIn('test new value', body_html)
 


### PR DESCRIPTION
I mistakenly had {id} where {{id}} was needed.   This fixes the problem, and I added a test.  Grepping for '{' shows no other cases of this syntax error.