### PR TITLE
Don't send notifications to addresses that bounced.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -53,6 +53,10 @@ handlers:
   script: notifier.app
   login: admin # Prevents raw access to this handler. Tasks runs as admin.
 
+- url: /_ah/bounce
+  script: notifier.app
+  login: admin # Prevents raw access to this handler.
+
 - url: /admin/gae/.*
   script: google.appengine.ext.admin.application
   login: admin
@@ -114,3 +118,6 @@ handlers:
 includes:
 - skip_files.yaml
 - env_vars.yaml
+
+inbound_services:
+- mail_bounce

--- a/models.py
+++ b/models.py
@@ -1226,6 +1226,10 @@ class UserPref(DictModel):
   # to each feature that the user starred.
   notify_as_starrer = db.BooleanProperty(default=True)
 
+  # True means that we sent an email message to this user in the past
+  # and it bounced.  We will not send to that address again.
+  bounced = db.BooleanProperty(default=False)
+
   @classmethod
   def get_prefs_for_emails(self, emails):
     """Return a list of UserPrefs for each of the given emails."""

--- a/tests/testing_config.py
+++ b/tests/testing_config.py
@@ -71,3 +71,17 @@ def setUpOurTestbed():
 # but we need it to be done before importing any application code because
 # models.py makes GAE API calls to in code that runs during loading.
 setUpOurTestbed()
+
+
+class Blank(object):
+  """Simple class that assigns all named args to attributes.
+  Tip: supply a lambda to define a method.
+  """
+  def __init__(self, **kwargs):
+    vars(self).update(kwargs)
+  def __repr__(self):
+    return '%s(%s)' % (self.__class__.__name__, str(vars(self)))
+  def __eq__(self, other):
+    if other is None:
+      return False
+    return vars(self) == vars(other)


### PR DESCRIPTION
This is mainly cribbed from
https://chromium.googlesource.com/infra/infra/+/master/appengine/monorail/features/inboundemail.py#287

In Monorail, we avoid sending emails to addresses that previously bounced for two reasons:
+ We can warn other users when they try to CC or have already CC'd those bad addresses.
+ We have some clues to investigate if a user complains that email is not reaching them.
+ We are less likely to be put on a bad email sender list which could prevent our good emails from being delivered.

For ChromeStatus, we are doing this mainly for the second two reasons, but it is possible that the first reason might also be relevant in the future.