### PR TITLE
Use CamelCase names for CSS property metrics.

### DIFF
--- a/static/elements/chromedash-timeline.js
+++ b/static/elements/chromedash-timeline.js
@@ -181,7 +181,10 @@ class ChromedashTimeline extends LitElement {
 
     const feature = this.props.find((el) => el[0] === parseInt(this.selectedBucketId));
     if (feature) {
-      const featureName = feature[1];
+      let featureName = feature[1];
+      if (this.type == 'css') {
+        featureName = convertToCamelCaseFeatureName(featureName);
+      }
       const REPORT_ID = '1M8kXOqPkwYNKjJhtag_nvDNJCpvmw_ri';
       const dsEmbedUrl = `https://datastudio.google.com/embed/reporting/${REPORT_ID}/page/tc5b?config=%7B"df3":"include%25EE%2580%25800%25EE%2580%2580IN%25EE%2580%2580${featureName}"%7D`;
       const hadEl = this.shadowRoot.getElementById('httparchivedata');
@@ -227,5 +230,19 @@ ORDER BY yyyymmdd DESC, client`;
     `;
   }
 }
+
+
+// Capitalizes the first letter of a word.
+function capitalize(word) {
+  let letters = word.split('');
+  letters[0] = letters[0].toUpperCase();
+  return letters.join('');
+}
+
+// Converts 'background-image' to 'CSSPropertyBackgroundImage'.
+function convertToCamelCaseFeatureName(property) {
+  return 'CSSProperty' + property.split('-').map(capitalize).join('');
+}
+
 
 customElements.define('chromedash-timeline', ChromedashTimeline);


### PR DESCRIPTION
This is rviscomi's suggested fix from issue #784. 

I went ahead and made it live on the site because the staging site is not currently showing any metrics and because this chart is broken for these CSS properties in the previously live version. So, demo is at, e.g., 
https://chromestatus.com/metrics/css/timeline/popularity/516