### PR TITLE
Switch to new release info URL and show dates again.

### DIFF
--- a/schedule.py
+++ b/schedule.py
@@ -39,11 +39,25 @@ def fetch_chrome_release_info(version):
            'mstone=%s' % version)
     result = urlfetch.fetch(url, deadline=60)
     if result.status_code == 200:
-      data = json.loads(result.content)['mstones'][0]
-      del data['owners']
-      del data['feature_freeze']
-      del data['ldaps']
-      memcache.set(key, data)
+      try:
+        data = json.loads(result.content)['mstones'][0]
+        del data['owners']
+        del data['feature_freeze']
+        del data['ldaps']
+        memcache.set(key, data)
+      except ValueError:
+        pass  # Handled by next statement
+
+    if not data:
+      data = {
+          'stable_date': None,
+          'earliest_beta': None,
+          'latest_beta': None,
+          'mstone': version,
+          'version': version,
+      }
+      # Note: we don't put placeholder data into memcache.
+
   return data
 
 def construct_chrome_channels_details():

--- a/schedule.py
+++ b/schedule.py
@@ -35,7 +35,8 @@ def fetch_chrome_release_info(version):
 
   data = memcache.get(key)
   if data is None:
-    url = 'https://chromepmo.appspot.com/schedule/mstone/json?mstone=%s' % version
+    url = ('https://chromiumdash.appspot.com/fetch_milestone_schedule?'
+           'mstone=%s' % version)
     result = urlfetch.fetch(url, deadline=60)
     if result.status_code == 200:
       data = json.loads(result.content)['mstones'][0]
@@ -75,7 +76,8 @@ class ScheduleHandler(common.ContentHandler):
   def get(self, path):
     data = {
       'features': json.dumps(models.Feature.get_chronological()),
-      'channels': json.dumps(construct_chrome_channels_details())
+      'channels': json.dumps(construct_chrome_channels_details(),
+                             indent=4)
     }
 
     self.render(data, template_path=os.path.join('schedule.html'))
@@ -84,4 +86,3 @@ class ScheduleHandler(common.ContentHandler):
 app = webapp2.WSGIApplication([
   ('(.*)', ScheduleHandler),
 ], debug=settings.DEBUG)
-

--- a/static/elements/chromedash-schedule.js
+++ b/static/elements/chromedash-schedule.js
@@ -113,7 +113,7 @@ class ChromedashSchedule extends LitElement {
                  target="_blank">Chrome ${this.channels[type].version}</a>
             </h1>
           </div>
-          ${SHOW_DATES ? html`
+          ${SHOW_DATES && this.channels[type].earliest_beta ? html`
             <div class="milestone_info layout horizontal center-center">
               <h3>
                 <span class="channel_label">Beta</span> ${TEMPLATE_CONTENT[type].dateText}

--- a/static/elements/chromedash-schedule.js
+++ b/static/elements/chromedash-schedule.js
@@ -32,7 +32,7 @@ const TEMPLATE_CONTENT = {
 
 const REMOVED_STATUS = ['Removed'];
 const DEPRECATED_STATUS = ['Deprecated', 'No longer pursuing'];
-const SHOW_DATES = false;
+const SHOW_DATES = true;
 
 class ChromedashSchedule extends LitElement {
   static styles = style;


### PR DESCRIPTION
The new backend for schedule info accepts the same query string parameters as the old backend, so the change here is minimal.

I also added pretty-printing to the JSON to aid debugging.  It increases the size of the HTML page a small amount but whitespace compresses well so I think it is worth it.