### PR TITLE
Replace bell icon with stars on schedule page.

### DIFF
--- a/schedule.py
+++ b/schedule.py
@@ -40,11 +40,14 @@ def fetch_chrome_release_info(version):
     result = urlfetch.fetch(url, deadline=60)
     if result.status_code == 200:
       try:
-        data = json.loads(result.content)['mstones'][0]
-        del data['owners']
-        del data['feature_freeze']
-        del data['ldaps']
-        memcache.set(key, data)
+        logging.info('result.content is:\n%s', result.content)
+        result_json = json.loads(result.content)
+        if 'mstones' in result_json:
+          data = result_json['mstones'][0]
+          del data['owners']
+          del data['feature_freeze']
+          del data['ldaps']
+          memcache.set(key, data)
       except ValueError:
         pass  # Handled by next statement
 

--- a/static/js-src/schedule-page.js
+++ b/static/js-src/schedule-page.js
@@ -30,6 +30,9 @@ async function init() {
   if (window.PushNotifier && PushNotifier.SUPPORTS_NOTIFICATIONS) {
     initNotifications(features);
   }
+  StarService.getStars().then((starredFeatureIds) => {
+    scheduleEl.starredFeatures = new Set(starredFeatureIds);
+  });
 }
 
 function mapFeaturesToComponents(features) {

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -21,7 +21,9 @@
 
 {% block content %}
   <section id="releases-section">
-    <chromedash-schedule></chromedash-schedule>
+    <chromedash-schedule
+      {% if user %}signedin{% endif %}
+    ></chromedash-schedule>
   </section>
 {% endblock %}
 


### PR DESCRIPTION
This replaces the bell icons on the schedule page with stars.

It also makes the call to chromiumdash robustly handle the case where it gives a warning message instead of a response for mstone 82.