### PR TITLE
Implement unlisted features

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -394,6 +394,7 @@ class FeatureHandler(common.ContentHandler):
       feature.name = self.request.get('name')
       feature.intent_stage = intent_stage
       feature.summary = self.request.get('summary')
+      feature.unlisted = self.request.get('unlisted') == 'on'
       feature.intent_to_implement_url = intent_to_implement_url
       feature.origin_trial_feedback_url = origin_trial_feedback_url
       feature.motivation = self.request.get('motivation')

--- a/guide.py
+++ b/guide.py
@@ -95,6 +95,7 @@ class FeatureNew(common.ContentHandler):
         impl_status_chrome=models.NO_ACTIVE_DEV,
         visibility=models.WARRANTS_ARTICLE,
         standardization=models.EDITORS_DRAFT,
+        unlisted=self.request.get('unlisted') == 'on',
         web_dev_views=models.DEV_NO_SIGNALS)
     key = feature.put()
 
@@ -158,6 +159,10 @@ class FeatureEditStage(common.ContentHandler):
     # to have been touched.  Later we will add javascript to populate a
     # hidden form field named "touched" that lists the names of all fields
     # actually touched by the user.
+    # For now, checkboxes are always considered "touched", otherwise there
+    # would be no way to uncheck.
+    if param_name in ('unlisted', 'all_platforms', 'wpt', 'prefixed'):
+      return True
     return param_name in self.request.POST
 
   def split_input(self, field_name, delim='\\r?\\n'):
@@ -375,6 +380,8 @@ class FeatureEditStage(common.ContentHandler):
       feature.tag_review = self.request.get('tag_review')
     if self.touched('standardization'):
       feature.standardization = int(self.request.get('standardization'))
+    if self.touched('unlisted'):
+      feature.unlisted = self.request.get('unlisted') == 'on'
     if self.touched('comments'):
       feature.comments = self.request.get('comments')
     if self.touched('experiment_goals'):

--- a/guideforms.py
+++ b/guideforms.py
@@ -73,6 +73,12 @@ ALL_FIELDS = {
         help_text=("The standardization status of the API. In bodies that don't "
                    "use this nomenclature, use the closest equivalent.")),
 
+    'unlisted': forms.BooleanField(
+      required=False, initial=False,
+      help_text=('Check this box for draft features that should not appear '
+                 'in the feature list.  Anyone with the link will be able to '
+                 'view the feature on the detail page.')),
+
     'spec_link': forms.URLField(
         required=False, label='Spec link',
         help_text=('Link to spec, if and when available.  Please update the '
@@ -256,6 +262,7 @@ class NewFeatureForm(forms.Form):
   summary = ALL_FIELDS['summary']
   category = ALL_FIELDS['category']
   current_user_email = users.get_current_user().email if users.get_current_user() else None
+  unlisted = ALL_FIELDS['unlisted']
   owner = forms.CharField(
       initial=current_user_email, required=True, label='Contact emails',
       help_text=('Comma separated list of full email addresses. '
@@ -268,6 +275,7 @@ class MetadataForm(forms.Form):
   name = ALL_FIELDS['name']
   summary = ALL_FIELDS['summary']
   category = ALL_FIELDS['category']
+  unlisted = ALL_FIELDS['unlisted']
   owner = forms.CharField(
       label='Contact emails',
       help_text=('Comma separated list of full email addresses. '

--- a/guideforms.py
+++ b/guideforms.py
@@ -76,7 +76,7 @@ ALL_FIELDS = {
     'unlisted': forms.BooleanField(
       required=False, initial=False,
       help_text=('Check this box for draft features that should not appear '
-                 'in the feature list.  Anyone with the link will be able to '
+                 'in the feature list. Anyone with the link will be able to '
                  'view the feature on the detail page.')),
 
     'spec_link': forms.URLField(

--- a/models.py
+++ b/models.py
@@ -752,7 +752,8 @@ class Feature(DictModel):
       pre_release.extend(shipping_features)
       pre_release.extend(no_longer_pursuing_features)
 
-      feature_list = [f.format_for_template(version) for f in pre_release]
+      feature_list = [f.format_for_template(version) for f in pre_release
+                      if not f.unlisted]
 
       self._annotate_first_of_milestones(feature_list, version=version)
 
@@ -893,6 +894,7 @@ class Feature(DictModel):
   summary = db.StringProperty(required=True, multiline=True)
   intent_to_implement_url = db.LinkProperty()
   origin_trial_feedback_url = db.LinkProperty()
+  unlisted = db.BooleanProperty(default=False)
 
   # A list of intent threads in the format "date|subject|url"
   intent_threads = db.StringListProperty()
@@ -1048,6 +1050,12 @@ class FeatureForm(forms.Form):
 
   origin_trial_feedback_url = forms.URLField(required=False, label='Origin Trial feedback summary',
       help_text='If your feature was available as an Origin Trial, link to a summary of usage and developer feedback. If not, leave this empty.')
+
+  unlisted = forms.BooleanField(
+      required=False, initial=False,
+      help_text=('Check this box for draft features that should not appear '
+                 'in the feature list.  Anyone with the link will be able to '
+                 'view the feature on the detail page.'))
 
   doc_links = forms.CharField(label='Doc link(s)', required=False,
       widget=forms.Textarea(attrs={'rows': 4, 'cols': 50, 'maxlength': 500}),

--- a/models.py
+++ b/models.py
@@ -1054,7 +1054,7 @@ class FeatureForm(forms.Form):
   unlisted = forms.BooleanField(
       required=False, initial=False,
       help_text=('Check this box for draft features that should not appear '
-                 'in the feature list.  Anyone with the link will be able to '
+                 'in the feature list. Anyone with the link will be able to '
                  'view the feature on the detail page.'))
 
   doc_links = forms.CharField(label='Doc link(s)', required=False,

--- a/settings.py
+++ b/settings.py
@@ -61,7 +61,7 @@ RSS_FEED_LIMIT = 15
 
 VULCANIZE = True #PROD
 
-DEFAULT_CACHE_TIME = 600 # seconds
+DEFAULT_CACHE_TIME = 60 # seconds
 
 USE_I18N = False
 

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -76,6 +76,12 @@
       </div>
     </section>
 
+    {% if feature.unlisted %}
+    <section id="access">
+      <p><b>Not shown in feature list</b></p>
+    </section>
+    {% endif %}
+
     {% if feature.summary %}
     <section id="summary">
       <p>{{ feature.summary|urlize }}</p>

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -12,6 +12,9 @@
       {{ feature.summary }}
     </div>
     <div>Category: {{ feature.category }}</div>
+    {% if feature.unlisted %}
+      <div>Not shown in feature list</div>
+    {% endif %}
     <div>Owners: 
       {% for owner in feature.owner %}
         <a href="mailto:{{ owner }}">{{ owner }}</a>

--- a/tests/admin_test.py
+++ b/tests/admin_test.py
@@ -37,6 +37,9 @@ class FeatureHandlerTest(unittest.TestCase):
     response = webapp2.Response()
     self.handler = admin.FeatureHandler(request, response)
 
+  def tearDown(self):
+    self.feature_1.delete()
+
   def test_post__anon(self):
     """Anon cannot edit features, gets a 401."""
     testing_config.sign_out()

--- a/tests/guild_test.py
+++ b/tests/guild_test.py
@@ -94,6 +94,7 @@ class FeatureNewTest(unittest.TestCase):
     self.assertEqual(1, feature.category)
     self.assertEqual('Feature name', feature.name)
     self.assertEqual('Feature summary', feature.summary)
+    feature.delete()
 
 
 class ProcessOverviewTest(unittest.TestCase):
@@ -108,6 +109,9 @@ class ProcessOverviewTest(unittest.TestCase):
         '/guide/edit/%d' % self.feature_1.key().id())
     response = webapp2.Response()
     self.handler = guide.ProcessOverview(request, response)
+
+  def tearDown(self):
+    self.feature_1.delete()
 
   @mock.patch('guide.ProcessOverview.render')
   def test_get__anon(self, mock_render):
@@ -159,6 +163,9 @@ class FeatureEditStageTest(unittest.TestCase):
         '/guide/stage/%d/%d' % (self.feature_1.key().id(), self.stage))
     response = webapp2.Response()
     self.handler = guide.FeatureEditStage(request, response)
+
+  def tearDown(self):
+    self.feature_1.delete()
 
   def test_touched(self):
     """We can tell if the user meant to edit a field."""

--- a/tests/notifier_test.py
+++ b/tests/notifier_test.py
@@ -60,6 +60,10 @@ class EmailFormattingTest(unittest.TestCase):
         blink_components=['Blink'])
     self.feature_2.put()
 
+  def tearDown(self):
+    self.feature_1.delete()
+    self.feature_2.delete()
+
   def test_format_email_body__new(self):
     """We generate an email body for new features."""
     body_html = notifier.format_email_body(
@@ -211,6 +215,10 @@ class FeatureStarTest(unittest.TestCase):
         standardization=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_2.put()
 
+  def tearDown(self):
+    self.feature_1.delete()
+    self.feature_2.delete()
+
   def test_get_star__no_existing(self):
     """User has never starred the given feature."""
     email = 'user1@example.com'
@@ -358,6 +366,9 @@ class SetStarHandlerTest(unittest.TestCase):
     self.handler.request = webapp2.Request.blank('/features/star/set')
     self.handler.response = webapp2.Response()
 
+  def tearDown(self):
+    self.feature_1.delete()
+
   def test_post__invalid_feature_id(self):
     """We reject star requests that don't have an int featureId."""
     self.handler.request.body = '{}'
@@ -444,6 +455,9 @@ class GetUserStarsHandlerTest(unittest.TestCase):
     self.handler = notifier.GetUserStarsHandler()
     self.handler.request = webapp2.Request.blank('/features/star/list')
     self.handler.response = webapp2.Response()
+
+  def tearDown(self):
+    self.feature_1.delete()
 
   def test_post__anon(self):
     """Anon should always have an empty list of stars."""


### PR DESCRIPTION
In this CL:
+ Add a boolean field named unlisted
+ Include that field in the existing editing forms and the new guide forms and form handlers
+ Add a condition to get_chronological to exclude any unlisted features
+ Unit tests
+ Reduce HTTP cache time on JSON feeds 

I believe that a 600 second cache time was previously used because the feature list page was slow to load.  The number of features in the list was capped a few months ago, so that page loads in reasonable time even on a cache miss.  A shorter cache time makes setting the unlisted boolean take effect more quickly.