### PR TITLE
Show unlisted features to users who could edit them

### DIFF
--- a/models.py
+++ b/models.py
@@ -708,7 +708,8 @@ class Feature(DictModel):
     return feature
 
   @classmethod
-  def get_chronological(self, limit=None, update_cache=False, version=None):
+  def get_chronological(
+      self, limit=None, update_cache=False, version=None, show_unlisted=False):
     KEY = '%s|%s|%s|%s' % (Feature.DEFAULT_MEMCACHE_KEY,
                            'cronorder', limit, version)
 
@@ -769,8 +770,7 @@ class Feature(DictModel):
       pre_release.extend(shipping_features)
       pre_release.extend(no_longer_pursuing_features)
 
-      feature_list = [f.format_for_template(version) for f in pre_release
-                      if not f.unlisted]
+      feature_list = [f.format_for_template(version) for f in pre_release]
 
       self._annotate_first_of_milestones(feature_list, version=version)
 
@@ -784,7 +784,11 @@ class Feature(DictModel):
         temp_feature_list.extend(feature_list[key])
       feature_list = temp_feature_list
 
-    return feature_list
+    allowed_feature_list = [
+        f for f in feature_list
+        if show_unlisted or not f['unlisted']]
+
+    return allowed_feature_list
 
   @classmethod
   def get_shipping_samples(self, limit=None, update_cache=False):

--- a/schedule.py
+++ b/schedule.py
@@ -91,8 +91,11 @@ class ScheduleHandler(common.ContentHandler):
 
   @common.strip_trailing_slash
   def get(self, path):
+    user = users.get_current_user()
+    features = models.Feature.get_chronological(
+        show_unlisted=self._is_user_whitelisted(user))
     data = {
-      'features': json.dumps(models.Feature.get_chronological()),
+      'features': json.dumps(features),
       'channels': json.dumps(construct_chrome_channels_details(),
                              indent=4)
     }

--- a/server.py
+++ b/server.py
@@ -25,6 +25,8 @@ import common
 import models
 import util
 
+from google.appengine.api import users
+
 import http2push.http2push as http2push
 
 
@@ -153,9 +155,14 @@ class FeaturesAPIHandler(common.JSONHandler):
     else:
       version = int(version)
 
-    feature_list = models.Feature.get_chronological(version=version) # Memcached
-
-    return common.JSONHandler.get(self, feature_list, formatted=True)
+    user = users.get_current_user()
+    feature_list = models.Feature.get_chronological(
+        version=version, show_unlisted=self._is_user_whitelisted(user))
+    logging.info('user is %r', user)
+    logging.info('show_unlisted is %r', self._is_user_whitelisted(user))
+    logging.info('feature: %r', [f['name'] for f in feature_list])
+    return common.JSONHandler.get(
+        self, feature_list, formatted=True, public=False)
 
 
 class SamplesHandler(common.ContentHandler, common.JSONHandler):

--- a/server.py
+++ b/server.py
@@ -158,9 +158,6 @@ class FeaturesAPIHandler(common.JSONHandler):
     user = users.get_current_user()
     feature_list = models.Feature.get_chronological(
         version=version, show_unlisted=self._is_user_whitelisted(user))
-    logging.info('user is %r', user)
-    logging.info('show_unlisted is %r', self._is_user_whitelisted(user))
-    logging.info('feature: %r', [f['name'] for f in feature_list])
     return common.JSONHandler.get(
         self, feature_list, formatted=True, public=False)
 

--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -295,6 +295,10 @@ class ChromedashFeature extends LitElement {
       </hgroup>
       <section class="desc" @click="${this._togglePanelExpansion}">
         <summary>
+          ${this.feature.unlisted ?
+             html`<p><b>This feature is only shown in the feature list
+                        to users who could edit it.</b></p>
+             `: nothing }
           <p><span>${this.feature.summary}</span></p>
           <p><span>${this.feature.motivation}</span></p>
         </summary>

--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -297,7 +297,7 @@ class ChromedashFeature extends LitElement {
         <summary>
           ${this.feature.unlisted ?
              html`<p><b>This feature is only shown in the feature list
-                        to users who could edit it.</b></p>
+                        to users with edit access.</b></p>
              `: nothing }
           <p><span>${this.feature.summary}</span></p>
           <p><span>${this.feature.motivation}</span></p>

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -78,7 +78,8 @@
 
     {% if feature.unlisted %}
     <section id="access">
-      <p><b>Not shown in feature list</b></p>
+      <p><b>This feature is only shown in the feature list to users who
+          could edit it.</b></p>
     </section>
     {% endif %}
 

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -78,8 +78,8 @@
 
     {% if feature.unlisted %}
     <section id="access">
-      <p><b>This feature is only shown in the feature list to users who
-          could edit it.</b></p>
+      <p><b>This feature is only shown in the feature list to users with
+          edit access.</b></p>
     </section>
     {% endif %}
 

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -14,7 +14,7 @@
     <div>Category: {{ feature.category }}</div>
     {% if feature.unlisted %}
     <div>This feature is only shown in the feature list
-         to users who could edit it.</div>
+         to users who with edit access.</div>
     {% endif %}
     <div>Owners: 
       {% for owner in feature.owner %}

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -13,7 +13,8 @@
     </div>
     <div>Category: {{ feature.category }}</div>
     {% if feature.unlisted %}
-      <div>Not shown in feature list</div>
+    <div>This feature is only shown in the feature list
+         to users who could edit it.</div>
     {% endif %}
     <div>Owners: 
       {% for owner in feature.owner %}

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -119,7 +119,7 @@ class FeatureTest(unittest.TestCase):
         names)
 
   def test_get_chronological__unlisted_shown(self):
-    """Unlisted features are still included for users allowed to edit."""
+    """Unlisted features are included for users with edit access."""
     self.feature_2.unlisted = True
     self.feature_2.put()
     actual = models.Feature.get_chronological(show_unlisted=True)

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -118,6 +118,16 @@ class FeatureTest(unittest.TestCase):
         ['feature one'],
         names)
 
+  def test_get_chronological__unlisted_shown(self):
+    """Unlisted features are still included for users allowed to edit."""
+    self.feature_2.unlisted = True
+    self.feature_2.put()
+    actual = models.Feature.get_chronological(show_unlisted=True)
+    names = [f['name'] for f in actual]
+    self.assertEqual(
+        ['feature one', 'feature two'],
+        names)
+
 
 class UserPrefTest(unittest.TestCase):
 


### PR DESCRIPTION
As discussed today, this CL allows any user who is qualified to edit features to also see unlisted features.  Otherwise, it would be possible for user to lose the URL for a feature and not be able to get back to it.

In this CL:
+ Pass a show_unlisted parameter to get_chronological() to include unlisted features.  That parameter is determined by _is_user_whitelisted().
+ Move _is_user_whitelisted() into the base class so that it can be called from either a page handler or a JSON handler.
+ Make these feeds private so that one user does not see a feed cached for another user
+ Add indication that an unlisted feature is being shown.