### PR TITLE
Define all stage-specific forms and their fields.

### DIFF
--- a/common.py
+++ b/common.py
@@ -19,10 +19,12 @@ __author__ = 'ericbidelman@chromium.org (Eric Bidelman)'
 import datetime
 import json
 import logging
+import re
 import webapp2
 
 # App Engine imports.
 from google.appengine.api import users
+from google.appengine.ext import db
 
 import settings
 import models
@@ -133,6 +135,27 @@ class JSONHandler(BaseHandler):
 
 
 class ContentHandler(BaseHandler):
+
+  def split_input(self, field_name, delim='\\r?\\n'):
+    """Split the input lines, strip whitespace, and skip blank lines."""
+    input_text = self.request.get(field_name) or ''
+    return filter(bool, [
+        x.strip() for x in re.split(delim, input_text)])
+
+  def parse_link(self, param_name):
+    link = self.request.get(param_name) or None
+    if link:
+      if not link.startswith('http'):
+        link = db.Link('http://' + link)
+      else:
+        link = db.Link(link)
+    return link
+
+  def parse_int(self, param_name):
+    param = self.request.get(param_name) or None
+    if param:
+      param = int(param)
+    return param
 
   def _add_common_template_values(self, d):
     """Mixin common values for templates into d."""

--- a/guide.py
+++ b/guide.py
@@ -41,27 +41,39 @@ import settings
 
 
 # Forms to be used for each stage of each process.
+# { feature_type_id: { stage_id: stage_specific_form} }
 STAGE_FORMS = {
-    (models.FEATURE_TYPE_INCUBATE_ID, models.INTENT_NONE):
-    guideforms.Incubate,
-    (models.FEATURE_TYPE_INCUBATE_ID, models.INTENT_IMPLEMENT):
-    guideforms.Prototype,
-    (models.FEATURE_TYPE_INCUBATE_ID, models.INTENT_EXPERIMENT):
-    guideforms.DevTrial,
-    (models.FEATURE_TYPE_INCUBATE_ID, models.INTENT_EXTEND_TRIAL):
-    guideforms.OriginTrial,
+    models.FEATURE_TYPE_INCUBATE_ID: {
+        models.INTENT_INCUBATE: guideforms.NewFeature_Incubate,
+        models.INTENT_IMPLEMENT: guideforms.NewFeature_Prototype,
+        models.INTENT_EXPERIMENT: guideforms.NewFeature_DevTrial,
+        models.INTENT_IMPLEMENT_SHIP: guideforms.NewFeature_EvalReadinessToShip,
+        models.INTENT_EXTEND_TRIAL: guideforms.NewFeature_OriginTrial,
+        models.INTENT_SHIP: guideforms.NewFeature_PrepareToShip,
+        },
 
-    (models.FEATURE_TYPE_EXISTING_ID, models.INTENT_NONE):
-    guideforms.Incubate,
-    (models.FEATURE_TYPE_EXISTING_ID, models.INTENT_IMPLEMENT_SHIP):
-    guideforms.Prototype,
-    (models.FEATURE_TYPE_EXISTING_ID, models.INTENT_SHIP):
-    guideforms.DevTrial,
-    (models.FEATURE_TYPE_EXISTING_ID, models.INTENT_EXTEND_TRIAL):
-    guideforms.OriginTrial,
+    models.FEATURE_TYPE_EXISTING_ID: {
+        models.INTENT_INCUBATE: guideforms.Existing_Identify,
+        models.INTENT_IMPLEMENT: guideforms.Existing_Implement,
+        models.INTENT_EXPERIMENT: guideforms.Existing_DevTrial,
+        models.INTENT_EXTEND_TRIAL: guideforms.Existing_OriginTrial,
+        models.INTENT_SHIP: guideforms.Existing_PrepareToShip,
+        },
 
-    (models.FEATURE_TYPE_CODE_CHANGE_ID, models.INTENT_NONE):
-    guideforms.Incubate,
+    models.FEATURE_TYPE_CODE_CHANGE_ID: {
+        models.INTENT_INCUBATE: guideforms.CodeChange_Identify,
+        models.INTENT_IMPLEMENT: guideforms.CodeChange_Implement,
+        models.INTENT_EXPERIMENT: guideforms.CodeChange_DevTrial,
+        models.INTENT_SHIP: guideforms.CodeChange_PrepareToShip,
+        },
+
+    models.FEATURE_TYPE_DEPRECATION_ID: {
+        models.INTENT_INCUBATE: guideforms.Deprecation_Identify,
+        models.INTENT_IMPLEMENT: guideforms.Deprecation_Implement,
+        models.INTENT_EXPERIMENT: guideforms.Deprecation_DevTrial,
+        models.INTENT_REMOVE: guideforms.Deprecation_PrepareToUnship,
+        models.INTENT_EXTEND_TRIAL: guideforms.Deprecation_ReverseOriginTrial,
+        },
 }
 
 
@@ -235,8 +247,7 @@ class FeatureEditStage(common.ContentHandler):
         }
 
     # TODO(jrobbins): show useful error if stage not found.
-    detail_form_class = STAGE_FORMS.get(
-        (f.feature_type, stage_id), models.FeatureForm)
+    detail_form_class = STAGE_FORMS[f.feature_type][stage_id]
 
     # Provide new or populated form to template.
     template_data.update({

--- a/guide.py
+++ b/guide.py
@@ -107,10 +107,12 @@ class FeatureNew(common.ContentHandler):
       common.handle_401(self.request, self.response, Exception)
       return
 
-    owner_addrs = self.request.get('owner') or ''
-    owner_addrs = filter(bool, [
-        x.strip() for x in re.split(',', owner_addrs)])
+    owner_addrs = self.split_input('owner', delim=',')
     owners = [db.Email(addr) for addr in owner_addrs]
+
+    blink_components = (
+        self.split_input('blink_components', delim=',') or
+        [models.BlinkComponent.DEFAULT_COMPONENT])
 
     # TODO(jrobbins): Validate input, even though it is done on client.
 
@@ -125,7 +127,8 @@ class FeatureNew(common.ContentHandler):
         visibility=models.WARRANTS_ARTICLE,
         standardization=models.EDITORS_DRAFT,
         unlisted=self.request.get('unlisted') == 'on',
-        web_dev_views=models.DEV_NO_SIGNALS)
+        web_dev_views=models.DEV_NO_SIGNALS,
+        blink_components=blink_components)
     key = feature.put()
 
     # TODO(jrobbins): enumerate and remove only the relevant keys.
@@ -195,27 +198,6 @@ class FeatureEditStage(common.ContentHandler):
       return True
     return param_name in self.request.POST
 
-  def split_input(self, field_name, delim='\\r?\\n'):
-    """Split the input lines, strip whitespace, and skip blank lines."""
-    input_text = self.request.get(field_name) or ''
-    return filter(bool, [
-        x.strip() for x in re.split(delim, input_text)])
-
-  def __FullQualifyLink(self, param_name):
-    link = self.request.get(param_name) or None
-    if link:
-      if not link.startswith('http'):
-        link = db.Link('http://' + link)
-      else:
-        link = db.Link(link)
-    return link
-
-  def __ToInt(self, param_name):
-    param = self.request.get(param_name) or None
-    if param:
-      param = int(param)
-    return param
-
   def get_blink_component_from_bug(self, blink_components, bug_url):
     # TODO(jrobbins): Use monorail API instead of scrapping.
     return []
@@ -244,6 +226,7 @@ class FeatureEditStage(common.ContentHandler):
 
     template_data = {
         'stage_name': stage_name,
+        'stage_id': stage_id,
         }
 
     # TODO(jrobbins): show useful error if stage not found.
@@ -275,47 +258,48 @@ class FeatureEditStage(common.ContentHandler):
       feature = models.Feature.get_by_id(long(feature_id))
       if feature is None:
         self.abort(404)
+    stage_id = int(stage_id)
 
     logging.info('POST is %r', self.request.POST)
 
     if self.touched('spec_link'):
-      feature.spec_link = self.__FullQualifyLink('spec_link')
+      feature.spec_link = self.parse_link('spec_link')
 
     if self.touched('explainer_links'):
       feature.explainer_links = self.split_input('explainer_links')
 
     if self.touched('bug_url'):
-      feature.bug_url = self.__FullQualifyLink('bug_url')
+      feature.bug_url = self.parse_link('bug_url')
 
     if self.touched('intent_to_implement_url'):
-      feature.intent_to_implement_url = self.__FullQualifyLink(
+      feature.intent_to_implement_url = self.parse_link(
           'intent_to_implement_url')
 
     if self.touched('origin_trial_feedback_url'):
-      feature.origin_trial_feedback_url = self.__FullQualifyLink(
+      feature.origin_trial_feedback_url = self.parse_link(
           'origin_trial_feedback_url')
 
     # Cast incoming milestones to ints.
     # TODO(jrobbins): Consider supporting milestones that are not ints.
     if self.touched('shipped_milestone = self'):
-      feature.shipped_milestone = self.__ToInt('shipped_milestone')
+      feature.shipped_milestone = self.parse_int('shipped_milestone')
 
     if self.touched('shipped_android_milestone'):
-      feature.shipped_android_milestone = self.__ToInt(
+      feature.shipped_android_milestone = self.parse_int(
           'shipped_android_milestone')
 
     if self.touched('shipped_ios_milestone'):
-      feature.shipped_ios_milestone = self.__ToInt('shipped_ios_milestone')
+      feature.shipped_ios_milestone = self.parse_int('shipped_ios_milestone')
 
     if self.touched('shipped_webview_milestone'):
-      feature.shipped_webview_milestone = self.__ToInt(
+      feature.shipped_webview_milestone = self.parse_int(
           'shipped_webview_milestone')
 
     if self.touched('shipped_opera_milestone'):
-      feature.shipped_opera_milestone = self.__ToInt('shipped_opera_milestone')
+      feature.shipped_opera_milestone = self.parse_int('shipped_opera_milestone')
 
     if self.touched('shipped_opera_android'):
-      feature.shipped_opera_android_milestone = self.__ToInt(
+      feature.shipped_opera_android_milestone = self.parse_int(
           'shipped_opera_android_milestone')
 
     if self.touched('owner'):
@@ -334,7 +318,7 @@ class FeatureEditStage(common.ContentHandler):
     if self.touched('blink_components'):
       feature.blink_components = (
           self.split_input('blink_components', delim=',') or
-          models.BlinkComponent.DEFAULT_COMPONENT)
+          [models.BlinkComponent.DEFAULT_COMPONENT])
 
     if self.touched('devrel'):
       devrel_addrs = self.split_input('devrel', delim=',')
@@ -342,8 +326,11 @@ class FeatureEditStage(common.ContentHandler):
 
     if self.touched('feature_type'):
       feature.feature_type = int(self.request.get('feature_type'))
+
     if self.touched('intent_stage'):
       feature.intent_stage = int(self.request.get('intent_stage'))
+    elif self.request.get('set_stage') == 'on':
+      feature.intent_stage = stage_id
 
     if self.touched('category'):
       feature.category = int(self.request.get('category'))
@@ -380,25 +367,25 @@ class FeatureEditStage(common.ContentHandler):
     if self.touched('ff_views'):
       feature.ff_views = int(self.request.get('ff_views'))
     if self.touched('ff_views_link'):
-      feature.ff_views_link = self.__FullQualifyLink('ff_views_link')
+      feature.ff_views_link = self.parse_link('ff_views_link')
     if self.touched('ff_views_notes'):
       feature.ff_views_notes = self.request.get('ff_views_notes')
     if self.touched('ie_views'):
       feature.ie_views = int(self.request.get('ie_views'))
     if self.touched('ie_views_link'):
-      feature.ie_views_link = self.__FullQualifyLink('ie_views_link')
+      feature.ie_views_link = self.parse_link('ie_views_link')
     if self.touched('ie_views_notes'):
       feature.ie_views_notes = self.request.get('ie_views_notes')
     if self.touched('safari_views'):
       feature.safari_views = int(self.request.get('safari_views'))
     if self.touched('safari_views_link'):
-      feature.safari_views_link = self.__FullQualifyLink('safari_views_link')
+      feature.safari_views_link = self.parse_link('safari_views_link')
     if self.touched('safari_views_notes'):
       feature.safari_views_notes = self.request.get('safari_views_notes')
     if self.touched('web_dev_views'):
       feature.web_dev_views = int(self.request.get('web_dev_views'))
     if self.touched('web_dev_views'):
-      feature.web_dev_views_link = self.__FullQualifyLink('web_dev_views_link')
+      feature.web_dev_views_link = self.parse_link('web_dev_views_link')
     if self.touched('web_dev_views_notes'):
       feature.web_dev_views_notes = self.request.get('web_dev_views_notes')
     if self.touched('prefixed'):
@@ -428,7 +415,6 @@ class FeatureEditStage(common.ContentHandler):
       params.append(self.LAUNCH_PARAM)
     if self.request.get('intent_to_implement') == 'on':
       params.append(self.INTENT_PARAM)
-
       feature.intent_template_use_count += 1
 
     key = feature.put()

--- a/guideforms.py
+++ b/guideforms.py
@@ -326,7 +326,7 @@ ALL_FIELDS = {
         required=False, label='Tracking bug URL',
         help_text=
         ('Tracking bug url (https://bugs.chromium.org/...). This bug '
-         'should have "Type=Feature" set and be world readable.'
+         'should have "Type=Feature" set and be world readable. '
          'Note: This field only accepts one URL.')),
 
     'blink_components': forms.ChoiceField(

--- a/guideforms.py
+++ b/guideforms.py
@@ -293,7 +293,7 @@ ALL_FIELDS = {
         label='Platform Support Explanation', required=False,
         widget=forms.Textarea(attrs={'rows': 2, 'cols': 50, 'maxlength': 2000}),
         help_text=
-        ('Explanation for why this feature is, or is not, '
+        ('Explain why this feature is, or is not, '
          'supported on all platforms.')),
 
     'wpt': forms.BooleanField(

--- a/guideforms.py
+++ b/guideforms.py
@@ -28,8 +28,8 @@ SHIPPED_HELP_TXT = (
     'First milestone to ship with this status. Applies to: Enabled by '
     'default, Behind a flag, Origin trial, Browser Intervention, and '
     'Deprecated. If the flag is \'test\' rather than \'experimental\' set '
-    'status to In development. If the flag is for an origin trial set status'
-    ' to Origin trial.)
+    'status to In development. If the flag is for an origin trial set status '
+    'to Origin trial.')
 
 # We define all form fields here so that they can be include in one or more
 # stage-specific fields without repeating the details and help text.

--- a/guideforms.py
+++ b/guideforms.py
@@ -280,7 +280,7 @@ ALL_FIELDS = {
          'google-chrome-developer-tools</a> list for additional help. '
          'For new language features in V8 specifically, refer to the '
          'debugger support checklist. If your feature doesn\'t require '
-         'changes to DevTools in order to provide a good debugging '
+         'changes to DevTools to provide a good debugging '
          'experience, feel free to leave this section empty.')),
 
     'all_platforms': forms.BooleanField(

--- a/guideforms.py
+++ b/guideforms.py
@@ -306,7 +306,7 @@ ALL_FIELDS = {
         help_text=
         ('Please link to the <a href="https://wpt.fyi/results">results on '
          'wpt.fyi</a>. If any part of the feature is not tested by '
-         'web-platform-tests, please include links to issues, e.g. a '
+         'web-platform-tests. Please include links to issues, e.g. a '
          'web-platform-tests issue with the "infra" label explaining why a '
          'certain thing cannot be tested (<a '
          'href="https://github.com/w3c/web-platform-tests/issues/3867">'

--- a/guideforms.py
+++ b/guideforms.py
@@ -28,7 +28,8 @@ SHIPPED_HELP_TXT = (
     'First milestone to ship with this status. Applies to: Enabled by '
     'default, Behind a flag, Origin trial, Browser Intervention, and '
     'Deprecated. If the flag is \'test\' rather than \'experimental\' set '
-    'status to In development.')
+    'status to In development. If the flag is for an origin trial set status'
+    ' to Origin trial.)
 
 # We define all form fields here so that they can be include in one or more
 # stage-specific fields without repeating the details and help text.

--- a/guideforms.py
+++ b/guideforms.py
@@ -326,7 +326,8 @@ ALL_FIELDS = {
         required=False, label='Tracking bug URL',
         help_text=
         ('Tracking bug url (https://bugs.chromium.org/...). This bug '
-         'should have "Type=Feature" set and be world readable.')),
+         'should have "Type=Feature" set and be world readable.'
+         'Note: This field only accepts one URL.')),
 
     'blink_components': forms.ChoiceField(
       required=True,

--- a/guideforms.py
+++ b/guideforms.py
@@ -24,6 +24,12 @@ import models
 import processes
 
 
+SHIPPED_HELP_TXT = (
+    'First milestone to ship with this status. Applies to: Enabled by '
+    'default, Behind a flag, Origin trial, Browser Intervention, and '
+    'Deprecated. If the flag is \'test\' rather than \'experimental\' set '
+    'status to In development.')
+
 # We define all form fields here so that they can be include in one or more
 # stage-specific fields without repeating the details and help text.
 ALL_FIELDS = {
@@ -256,25 +262,147 @@ ALL_FIELDS = {
          'features which require or assume a specific architecture. '
          'For most features, the answer here is "None."')),
 
-    # TODO(jrobbins): Make sure that every field in the old form is
-    # included here and used in at least one of the detailed forms below.
+    'origin_trial_feedback_url': forms.URLField(
+        required=False, label='Origin Trial feedback summary',
+        help_text=
+        ('If your feature was available as an Origin Trial, link to a summary '
+         'of usage and developer feedback. If not, leave this empty.')),
+
+    'debuggability': forms.CharField(
+        label='Debuggability', required=False,
+        widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
+        help_text=
+        ('Description of the desired DevTools debugging support for your '
+         'feature. Consider emailing the '
+         '<a href="https://groups.google.com/forum/?'
+         'fromgroups#!forum/google-chrome-developer-tools">'
+         'google-chrome-developer-tools</a> list for additional help. '
+         'For new language features in V8 specifically, refer to the '
+         'debugger support checklist. If your feature doesn\'t require '
+         'changes to DevTools in order to provide a good debugging '
+         'experience, feel free to leave this section empty.')),
+
+    'all_platforms': forms.BooleanField(
+        required=False, initial=False, label='Supported on all platforms?',
+        help_text=
+        ('Will this feature be supported on all six Blink platforms '
+         '(Windows, Mac, Linux, Chrome OS, Android, and Android WebView)?')),
+
+    'all_platforms_descr': forms.CharField(
+        label='Platform Support Explanation', required=False,
+        widget=forms.Textarea(attrs={'rows': 2, 'cols': 50, 'maxlength': 2000}),
+        help_text=
+        ('Explanation for why this feature is, or is not, '
+         'supported on all platforms.')),
+
+    'wpt': forms.BooleanField(
+        required=False, initial=False, label='Web Platform Tests',
+        help_text='Is this feature fully tested in Web Platform Tests?'),
+
+    'wpt_descr': forms.CharField(
+        label='Web Platform Tests Description', required=True,
+        widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
+        help_text=
+        ('Please link to the <a href="https://wpt.fyi/results">results on '
+         'wpt.fyi</a>. If any part of the feature is not tested by '
+         'web-platform-tests, please include links to issues, e.g. a '
+         'web-platform-tests issue with the "infra" label explaining why a '
+         'certain thing cannot be tested (<a '
+         'href="https://github.com/w3c/web-platform-tests/issues/3867">'
+         'example</a>), a spec issue for some change that would make it '
+         'possible to test. (<a href="'
+         'https://github.com/whatwg/fullscreen/issues/70">example</a>), or '
+         'a Chromium issue to upstream some existing tests (<a href="'
+         'https://bugs.chromium.org/p/chromium/issues/detail?id=695486">'
+         'example</a>).')),
+
+    'sample_links': forms.CharField(
+        label='Samples links', required=False,
+        widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 500}),
+        help_text='Links to samples (one URL per line).'),
+
+    'bug_url': forms.URLField(
+        required=False, label='Tracking bug URL',
+        help_text=
+        ('Tracking bug url (https://bugs.chromium.org/...). This bug '
+         'should have "Type=Feature" set and be world readable.')),
+
+    'blink_components': forms.ChoiceField(
+      required=True,
+      label='Blink component',
+      help_text=
+      ('Select the most specific component. If unsure, leave as "%s".' %
+       models.BlinkComponent.DEFAULT_COMPONENT),
+      choices=[(x, x) for x in models.BlinkComponent.fetch_all_components()],
+      initial=[models.BlinkComponent.DEFAULT_COMPONENT]),
+
+    'devrel': forms.CharField(
+        required=False, label='Developer relations emails',
+        help_text='Comma separated list of full email addresses.'),
+
+    'impl_status_chrome': forms.ChoiceField(
+        required=True, label='Status in Chromium',
+        choices=models.IMPLEMENTATION_STATUS.items()),
+
+    'shipped_milestone': forms.IntegerField(
+        required=False, label='',
+        help_text='Desktop:<br/>' + SHIPPED_HELP_TXT),
+
+    'shipped_android_milestone': forms.IntegerField(
+        required=False, label='',
+        help_text='Chrome for Android:</br/>' + SHIPPED_HELP_TXT),
+
+    'shipped_ios_milestone': forms.IntegerField(
+        required=False, label='',
+        help_text='Chrome for iOS (RARE):<br/>' + SHIPPED_HELP_TXT),
+
+    'shipped_webview_milestone': forms.IntegerField(
+        required=False, label='',
+        help_text='Android WebView:<br/>' + SHIPPED_HELP_TXT),
+
+    'prefixed': forms.BooleanField(
+        required=False, initial=False, label='Prefixed?'),
+
+    'footprint': forms.ChoiceField(
+        label='Technical footprint',
+        choices=models.FOOTPRINT_CHOICES.items(),
+        initial=models.MAJOR_MINOR_NEW_API),
+
+    'visibility': forms.ChoiceField(
+      label='Developer visibility',
+      choices=models.VISIBILITY_CHOICES.items(),
+      initial=models.WARRANTS_ARTICLE,
+      help_text=('How much press / media / web developer buzz will this '
+                 'feature generate?')),
+
+    'search_tags': forms.CharField(
+        label='Search tags', required=False,
+        help_text='Comma separated keywords used only in search'),
+
+    'comments': forms.CharField(
+        label='Comments', required=False,
+        widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
+        help_text='Additional comments, caveats, info...'),
+
     }
 
 
 class NewFeatureForm(forms.Form):
 
   field_order = (
-      'name', 'summary', 'category', 'owner', 'feature_type')
+      'name', 'summary', 'category', 'unlisted', 'owner', 'feature_type',
+      'blink_components')
   name = ALL_FIELDS['name']
   summary = ALL_FIELDS['summary']
   category = ALL_FIELDS['category']
-  current_user_email = users.get_current_user().email if users.get_current_user() else None
   unlisted = ALL_FIELDS['unlisted']
+  current_user_email = users.get_current_user().email if users.get_current_user() else None
   owner = forms.CharField(
       initial=current_user_email, required=True, label='Contact emails',
       help_text=('Comma separated list of full email addresses. '
                  'Prefer @chromium.org.'))
   # Note: feature_type is done with custom HTML
+  blink_components = ALL_FIELDS['blink_components']
 
 
 class MetadataForm(forms.Form):
@@ -296,34 +424,43 @@ class MetadataForm(forms.Form):
       help_text='Select the appropriate process stage.',
       initial=models.INTENT_IMPLEMENT,
       choices=models.INTENT_STAGES.items())
+  blink_components = ALL_FIELDS['blink_components']
+  bug_url = ALL_FIELDS['bug_url']
+  impl_status_chrome = ALL_FIELDS['impl_status_chrome']
+  search_tags = ALL_FIELDS['search_tags']
 
 
-
-class Incubate(forms.Form):
+class NewFeature_Incubate(forms.Form):
 
   current_user_email = users.get_current_user().email if users.get_current_user() else None
   owner = forms.CharField(
       initial=current_user_email, required=True, label='Contact emails',
       help_text=('Comma separated list of full email addresses. '
                  'Prefer @chromium.org.'))
+  blink_components = ALL_FIELDS['blink_components']
 
   motivation = ALL_FIELDS['motivation']
+  explainer_links = ALL_FIELDS['explainer_links']
+  footprint = ALL_FIELDS['footprint']
+  # TODO(jrobbins): public proposal URL, optional
+
+
+class NewFeature_Prototype(forms.Form):
+
+  # TODO(jrobbins): public proposal URL, required
+  # TODO(jrobbins): advise user to request a tag review
+  spec_link = ALL_FIELDS['spec_link']
+  # TODO(jrobbins): action to generate Intent to Prototype email
+
+
+class NewFeature_DevTrial(forms.Form):
+
+  bug_url = ALL_FIELDS['bug_url']
   doc_links = ALL_FIELDS['doc_links']
-  standardization = ALL_FIELDS['standardization']
+  # TODO(jrobbins): api overview link
   spec_link = ALL_FIELDS['spec_link']
 
-
-class Prototype(forms.Form):
-
-  doc_links = ALL_FIELDS['doc_links']
-  standardization = ALL_FIELDS['standardization']
-  spec_link = ALL_FIELDS['spec_link']
-  tag_review = ALL_FIELDS['tag_review']
   intent_to_implement_url = ALL_FIELDS['intent_to_implement_url']
-
-
-class DevTrial(forms.Form):
-
   interop_compat_risks = ALL_FIELDS['interop_compat_risks']
 
   safari_views = ALL_FIELDS['safari_views']
@@ -344,12 +481,297 @@ class DevTrial(forms.Form):
   ergonomics_risks = ALL_FIELDS['ergonomics_risks']
   activation_risks = ALL_FIELDS['activation_risks']
   security_risks = ALL_FIELDS['security_risks']
+  # TODO(jrobbins): request security and privacy reviews
+  debuggability = ALL_FIELDS['debuggability']
+  all_platforms = ALL_FIELDS['all_platforms']
+  all_platforms_descr = ALL_FIELDS['all_platforms_descr']
+  wpt = ALL_FIELDS['wpt']
+  wpt_descr = ALL_FIELDS['wpt_descr']
+  sample_links = ALL_FIELDS['sample_links']
+  # TODO(jrobbins): generate ready for trial email
 
 
-class OriginTrial(forms.Form):
+class NewFeature_EvalReadinessToShip(forms.Form):
+
+  doc_links = ALL_FIELDS['doc_links']
+  tag_review = ALL_FIELDS['tag_review']
+  spec_link = ALL_FIELDS['spec_link']
+
+  interop_compat_risks = ALL_FIELDS['interop_compat_risks']
+
+  safari_views = ALL_FIELDS['safari_views']
+  safari_views_link = ALL_FIELDS['safari_views_link']
+  safari_views_notes = ALL_FIELDS['safari_views_notes']
+
+  ff_views = ALL_FIELDS['ff_views']
+  ff_views_link = ALL_FIELDS['ff_views_link']
+  ff_views_notes = ALL_FIELDS['ff_views_notes']
+
+  ie_views = ALL_FIELDS['ie_views']
+  ie_views_link = ALL_FIELDS['ie_views_link']
+  ie_views_notes = ALL_FIELDS['ie_views_notes']
+
+  web_dev_views = ALL_FIELDS['web_dev_views']
+  web_dev_views_link = ALL_FIELDS['web_dev_views_link']
+
+  # TODO(jrobbins): ready to ship email URL
+  shipped_milestone = ALL_FIELDS['shipped_milestone']
+  shipped_android_milestone = ALL_FIELDS['shipped_android_milestone']
+  shipped_ios_milestone = ALL_FIELDS['shipped_ios_milestone']
+  shipped_webview_milestone = ALL_FIELDS['shipped_webview_milestone']
+  prefixed = ALL_FIELDS['prefixed']
+  visibility = ALL_FIELDS['visibility']
+
+
+class NewFeature_OriginTrial(forms.Form):
 
   experiment_goals = ALL_FIELDS['experiment_goals']
   experiment_timeline = ALL_FIELDS['experiment_timeline']
   experiment_risks = ALL_FIELDS['experiment_risks']
   experiment_extension_reason = ALL_FIELDS['experiment_extension_reason']
   ongoing_constraints = ALL_FIELDS['ongoing_constraints']
+  origin_trial_feedback_url = ALL_FIELDS['origin_trial_feedback_url'] # optional
+  # TODO(jrobbins): action to generate intent to experiement email
+
+
+class NewFeature_PrepareToShip(forms.Form):
+
+  impl_status_chrome = ALL_FIELDS['impl_status_chrome']
+  footprint = ALL_FIELDS['footprint']
+  tag_review = ALL_FIELDS['tag_review']
+  intent_to_implement_url = ALL_FIELDS['intent_to_implement_url']
+  origin_trial_feedback_url = ALL_FIELDS['origin_trial_feedback_url'] # optional
+
+
+class Existing_Identify(forms.Form):
+
+  current_user_email = users.get_current_user().email if users.get_current_user() else None
+  owner = forms.CharField(
+      initial=current_user_email, required=True, label='Contact emails',
+      help_text=('Comma separated list of full email addresses. '
+                 'Prefer @chromium.org.'))
+  blink_components = ALL_FIELDS['blink_components']
+
+  motivation = ALL_FIELDS['motivation']
+  explainer_links = ALL_FIELDS['explainer_links']
+  footprint = ALL_FIELDS['footprint']
+  # TODO(jrobbins): public proposal URL, optional
+
+
+class Existing_Implement(forms.Form):
+
+  # TODO(jrobbins): public proposal URL, required
+  # TODO(jrobbins): advise user to request a tag review
+  spec_link = ALL_FIELDS['spec_link']
+  # TODO(jrobbins): action to generate Intent to Prototype email
+
+
+class Existing_DevTrial(forms.Form):
+
+  bug_url = ALL_FIELDS['bug_url']
+  doc_links = ALL_FIELDS['doc_links']
+  # TODO(jrobbins): api overview link
+  spec_link = ALL_FIELDS['spec_link']
+
+  intent_to_implement_url = ALL_FIELDS['intent_to_implement_url']
+  interop_compat_risks = ALL_FIELDS['interop_compat_risks']
+
+  safari_views = ALL_FIELDS['safari_views']
+  safari_views_link = ALL_FIELDS['safari_views_link']
+  safari_views_notes = ALL_FIELDS['safari_views_notes']
+
+  ff_views = ALL_FIELDS['ff_views']
+  ff_views_link = ALL_FIELDS['ff_views_link']
+  ff_views_notes = ALL_FIELDS['ff_views_notes']
+
+  ie_views = ALL_FIELDS['ie_views']
+  ie_views_link = ALL_FIELDS['ie_views_link']
+  ie_views_notes = ALL_FIELDS['ie_views_notes']
+
+  web_dev_views = ALL_FIELDS['web_dev_views']
+  web_dev_views_link = ALL_FIELDS['web_dev_views_link']
+
+  ergonomics_risks = ALL_FIELDS['ergonomics_risks']
+  activation_risks = ALL_FIELDS['activation_risks']
+  security_risks = ALL_FIELDS['security_risks']
+  # TODO(jrobbins): request security and privacy reviews
+  debuggability = ALL_FIELDS['debuggability']
+  all_platforms = ALL_FIELDS['all_platforms']
+  all_platforms_descr = ALL_FIELDS['all_platforms_descr']
+  wpt = ALL_FIELDS['wpt']
+  wpt_descr = ALL_FIELDS['wpt_descr']
+  sample_links = ALL_FIELDS['sample_links']
+  # TODO(jrobbins): generate ready for trial email
+
+
+class Existing_OriginTrial(forms.Form):
+
+  experiment_goals = ALL_FIELDS['experiment_goals']
+  experiment_timeline = ALL_FIELDS['experiment_timeline']
+  experiment_risks = ALL_FIELDS['experiment_risks']
+  experiment_extension_reason = ALL_FIELDS['experiment_extension_reason']
+  ongoing_constraints = ALL_FIELDS['ongoing_constraints']
+  origin_trial_feedback_url = ALL_FIELDS['origin_trial_feedback_url'] # optional
+  # TODO(jrobbins): action to generate intent to experiement email
+
+
+class Existing_PrepareToShip(forms.Form):
+
+  impl_status_chrome = ALL_FIELDS['impl_status_chrome']
+  footprint = ALL_FIELDS['footprint']
+  tag_review = ALL_FIELDS['tag_review']
+  intent_to_implement_url = ALL_FIELDS['intent_to_implement_url']
+  origin_trial_feedback_url = ALL_FIELDS['origin_trial_feedback_url'] # optional
+
+
+class CodeChange_Identify(forms.Form):
+
+  current_user_email = users.get_current_user().email if users.get_current_user() else None
+  owner = forms.CharField(
+      initial=current_user_email, required=True, label='Contact emails',
+      help_text=('Comma separated list of full email addresses. '
+                 'Prefer @chromium.org.'))
+  blink_components = ALL_FIELDS['blink_components']
+
+  motivation = ALL_FIELDS['motivation']
+  explainer_links = ALL_FIELDS['explainer_links']
+  footprint = ALL_FIELDS['footprint']
+  # TODO(jrobbins): public proposal URL, optional
+
+
+class CodeChange_Implement(forms.Form):
+
+  # TODO(jrobbins): public proposal URL, required
+  # TODO(jrobbins): advise user to request a tag review
+  spec_link = ALL_FIELDS['spec_link']
+  # TODO(jrobbins): action to generate Intent to Prototype email
+
+
+class CodeChange_DevTrial(forms.Form):
+
+  bug_url = ALL_FIELDS['bug_url']
+  doc_links = ALL_FIELDS['doc_links']
+  # TODO(jrobbins): api overview link
+  spec_link = ALL_FIELDS['spec_link']
+
+  intent_to_implement_url = ALL_FIELDS['intent_to_implement_url']
+  interop_compat_risks = ALL_FIELDS['interop_compat_risks']
+
+  safari_views = ALL_FIELDS['safari_views']
+  safari_views_link = ALL_FIELDS['safari_views_link']
+  safari_views_notes = ALL_FIELDS['safari_views_notes']
+
+  ff_views = ALL_FIELDS['ff_views']
+  ff_views_link = ALL_FIELDS['ff_views_link']
+  ff_views_notes = ALL_FIELDS['ff_views_notes']
+
+  ie_views = ALL_FIELDS['ie_views']
+  ie_views_link = ALL_FIELDS['ie_views_link']
+  ie_views_notes = ALL_FIELDS['ie_views_notes']
+
+  web_dev_views = ALL_FIELDS['web_dev_views']
+  web_dev_views_link = ALL_FIELDS['web_dev_views_link']
+
+  ergonomics_risks = ALL_FIELDS['ergonomics_risks']
+  activation_risks = ALL_FIELDS['activation_risks']
+  security_risks = ALL_FIELDS['security_risks']
+  # TODO(jrobbins): request security and privacy reviews
+  debuggability = ALL_FIELDS['debuggability']
+  all_platforms = ALL_FIELDS['all_platforms']
+  all_platforms_descr = ALL_FIELDS['all_platforms_descr']
+  wpt = ALL_FIELDS['wpt']
+  wpt_descr = ALL_FIELDS['wpt_descr']
+  sample_links = ALL_FIELDS['sample_links']
+  # TODO(jrobbins): generate ready for trial email
+
+
+class CodeChange_PrepareToShip(forms.Form):
+
+  impl_status_chrome = ALL_FIELDS['impl_status_chrome']
+  footprint = ALL_FIELDS['footprint']
+  tag_review = ALL_FIELDS['tag_review']
+  intent_to_implement_url = ALL_FIELDS['intent_to_implement_url']
+  origin_trial_feedback_url = ALL_FIELDS['origin_trial_feedback_url'] # optional
+
+
+
+
+class Deprecation_Identify(forms.Form):
+
+  current_user_email = users.get_current_user().email if users.get_current_user() else None
+  owner = forms.CharField(
+      initial=current_user_email, required=True, label='Contact emails',
+      help_text=('Comma separated list of full email addresses. '
+                 'Prefer @chromium.org.'))
+  blink_components = ALL_FIELDS['blink_components']
+
+  motivation = ALL_FIELDS['motivation']
+  explainer_links = ALL_FIELDS['explainer_links']
+  footprint = ALL_FIELDS['footprint']
+  # TODO(jrobbins): public proposal URL, optional
+
+
+class Deprecation_Implement(forms.Form):
+
+  # TODO(jrobbins): public proposal URL, required
+  # TODO(jrobbins): advise user to request a tag review
+  spec_link = ALL_FIELDS['spec_link']
+  # TODO(jrobbins): action to generate Intent to Prototype email
+
+
+class Deprecation_DevTrial(forms.Form):
+
+  bug_url = ALL_FIELDS['bug_url']
+  doc_links = ALL_FIELDS['doc_links']
+  # TODO(jrobbins): api overview link
+  spec_link = ALL_FIELDS['spec_link']
+
+  intent_to_implement_url = ALL_FIELDS['intent_to_implement_url']
+  interop_compat_risks = ALL_FIELDS['interop_compat_risks']
+
+  safari_views = ALL_FIELDS['safari_views']
+  safari_views_link = ALL_FIELDS['safari_views_link']
+  safari_views_notes = ALL_FIELDS['safari_views_notes']
+
+  ff_views = ALL_FIELDS['ff_views']
+  ff_views_link = ALL_FIELDS['ff_views_link']
+  ff_views_notes = ALL_FIELDS['ff_views_notes']
+
+  ie_views = ALL_FIELDS['ie_views']
+  ie_views_link = ALL_FIELDS['ie_views_link']
+  ie_views_notes = ALL_FIELDS['ie_views_notes']
+
+  web_dev_views = ALL_FIELDS['web_dev_views']
+  web_dev_views_link = ALL_FIELDS['web_dev_views_link']
+
+  ergonomics_risks = ALL_FIELDS['ergonomics_risks']
+  activation_risks = ALL_FIELDS['activation_risks']
+  security_risks = ALL_FIELDS['security_risks']
+  # TODO(jrobbins): request security and privacy reviews
+  debuggability = ALL_FIELDS['debuggability']
+  all_platforms = ALL_FIELDS['all_platforms']
+  all_platforms_descr = ALL_FIELDS['all_platforms_descr']
+  wpt = ALL_FIELDS['wpt']
+  wpt_descr = ALL_FIELDS['wpt_descr']
+  sample_links = ALL_FIELDS['sample_links']
+  # TODO(jrobbins): generate ready for trial email
+
+
+class Deprecation_PrepareToUnship(forms.Form):
+
+  impl_status_chrome = ALL_FIELDS['impl_status_chrome']
+  footprint = ALL_FIELDS['footprint']
+  tag_review = ALL_FIELDS['tag_review']
+  intent_to_implement_url = ALL_FIELDS['intent_to_implement_url']
+  origin_trial_feedback_url = ALL_FIELDS['origin_trial_feedback_url'] # optional
+
+
+class Deprecation_ReverseOriginTrial(forms.Form):
+
+  experiment_goals = ALL_FIELDS['experiment_goals']
+  experiment_timeline = ALL_FIELDS['experiment_timeline']
+  experiment_risks = ALL_FIELDS['experiment_risks']
+  experiment_extension_reason = ALL_FIELDS['experiment_extension_reason']
+  ongoing_constraints = ALL_FIELDS['ongoing_constraints']
+  origin_trial_feedback_url = ALL_FIELDS['origin_trial_feedback_url'] # optional
+  # TODO(jrobbins): action to generate intent to experiement email

--- a/models.py
+++ b/models.py
@@ -1,3 +1,23 @@
+from __future__ import division
+from __future__ import print_function
+
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import collections
 import datetime
 import json
 import logging
@@ -88,22 +108,25 @@ FEATURE_TYPES = {
 
 # Intent stages and mapping from stage to stage name.
 INTENT_NONE = 0
-INTENT_IMPLEMENT = 1
-INTENT_EXPERIMENT = 2
-INTENT_EXTEND_TRIAL = 3
-INTENT_IMPLEMENT_SHIP = 4
-INTENT_SHIP = 5
+INTENT_INCUBATE = 7  # Start incubating
+INTENT_IMPLEMENT = 1  # Start prototyping
+INTENT_EXPERIMENT = 2  # Dev trials
+INTENT_IMPLEMENT_SHIP = 4  # Eval readiness to ship
+INTENT_EXTEND_TRIAL = 3  # Origin trials
+INTENT_SHIP = 5  # Prepare to ship
 INTENT_REMOVE = 6
 
-INTENT_STAGES = {
-  INTENT_NONE: 'None',
-  INTENT_IMPLEMENT: 'Prototype',
-  INTENT_EXPERIMENT: 'Experiment',
-  INTENT_EXTEND_TRIAL: 'Extend Origin Trial',
-  INTENT_IMPLEMENT_SHIP: 'Implement and Ship',
-  INTENT_SHIP: 'Ship',
-  INTENT_REMOVE: 'Remove',
-}
+INTENT_STAGES = collections.OrderedDict([
+  (INTENT_NONE, 'None'),
+  (INTENT_INCUBATE, 'Start incubating'),
+  (INTENT_IMPLEMENT, 'Start prototyping'),
+  (INTENT_EXPERIMENT, 'Dev trials'),
+  (INTENT_IMPLEMENT_SHIP, 'Evaluate readiness to ship'),
+  (INTENT_EXTEND_TRIAL, 'Origin trials'),
+  (INTENT_SHIP, 'Prepare to ship'),
+  (INTENT_REMOVE, 'Remove'),
+])
+
 
 NO_ACTIVE_DEV = 1
 PROPOSED = 2
@@ -1049,7 +1072,8 @@ class FeatureForm(forms.Form):
       initial=MISC,
       choices=sorted(FEATURE_CATEGORIES.items(), key=lambda x: x[1]))
 
-  intent_stage = forms.ChoiceField(required=True, label='Intent stage', help_text='Select the appropriate intent stage.',
+  intent_stage = forms.ChoiceField(
+      required=True, label='Intent stage', help_text='Select the appropriate intent stage.',
       initial=INTENT_IMPLEMENT,
       choices=INTENT_STAGES.items())
 

--- a/models.py
+++ b/models.py
@@ -115,6 +115,7 @@ INTENT_IMPLEMENT_SHIP = 4  # Eval readiness to ship
 INTENT_EXTEND_TRIAL = 3  # Origin trials
 INTENT_SHIP = 5  # Prepare to ship
 INTENT_REMOVE = 6
+INTENT_SHIPPED = 8
 
 INTENT_STAGES = collections.OrderedDict([
   (INTENT_NONE, 'None'),
@@ -125,6 +126,7 @@ INTENT_STAGES = collections.OrderedDict([
   (INTENT_EXTEND_TRIAL, 'Origin trials'),
   (INTENT_SHIP, 'Prepare to ship'),
   (INTENT_REMOVE, 'Remove'),
+  (INTENT_SHIPPED, 'Shipped'),
 ])
 
 

--- a/processes.py
+++ b/processes.py
@@ -94,8 +94,8 @@ BLINK_PROCESS_STAGES = [
       models.INTENT_EXPERIMENT, models.INTENT_IMPLEMENT_SHIP),
 
   ProcessStage(
-      '(Optional) Origin Trial',
-      'Set up and run an origin trial. '
+      'Origin Trial',
+      '(Optional) Set up and run an origin trial. '
       'Act on feedback from partners and web developers.',
       ['OT request',
        'OT available',
@@ -154,8 +154,8 @@ BLINK_FAST_TRACK_STAGES = [
       models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
   ProcessStage(
-      '(Optional) Origin Trial',
-      'Set up and run an origin trial. '
+      'Origin Trial',
+      '(Optional) Set up and run an origin trial. '
       'Act on feedback from partners and web developers.',
       ['OT request',
        'OT available',
@@ -261,8 +261,8 @@ DEPRECATION_STAGES = [
       models.INTENT_EXPERIMENT, models.INTENT_REMOVE),
 
   ProcessStage(
-      '(Optional) Reverse Origin Trial',
-      'Set up and run a reverse origin trial. ',
+      'Reverse Origin Trial',
+      '(Optional) Set up and run a reverse origin trial. ',
       ['ROT request',
        'ROT available',
        'Removal of ROT',

--- a/processes.py
+++ b/processes.py
@@ -54,7 +54,7 @@ BLINK_PROCESS_STAGES = [
       ['WICG discourse post',
        'Spec repo',
       ],
-      models.INTENT_NONE, models.INTENT_IMPLEMENT),
+      models.INTENT_NONE, models.INTENT_INCUBATE),
 
   ProcessStage(
       'Start prototyping',
@@ -68,7 +68,7 @@ BLINK_PROCESS_STAGES = [
        'Intent to Prototype email',
        'Spec reviewer',
       ],
-      models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
+      models.INTENT_INCUBATE, models.INTENT_IMPLEMENT),
 
   ProcessStage(
       'Dev trials and iterate on design',
@@ -81,7 +81,7 @@ BLINK_PROCESS_STAGES = [
        'External reviews',
        'Ready for Trial email',
       ],
-      models.INTENT_EXPERIMENT, models.INTENT_IMPLEMENT_SHIP),
+      models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
   ProcessStage(
       'Evaluate readiness to ship',
@@ -91,7 +91,7 @@ BLINK_PROCESS_STAGES = [
        'Documentation signoff',
        'Estimated target milestone',
       ],
-      models.INTENT_IMPLEMENT_SHIP, models.INTENT_SHIP),
+      models.INTENT_EXPERIMENT, models.INTENT_IMPLEMENT_SHIP),
 
   ProcessStage(
       '(Optional) Origin Trial',
@@ -101,7 +101,7 @@ BLINK_PROCESS_STAGES = [
        'OT available',
        'OT results',
       ],
-      models.INTENT_EXTEND_TRIAL, models.INTENT_EXTEND_TRIAL),
+      models.INTENT_IMPLEMENT_SHIP, models.INTENT_EXTEND_TRIAL),
 
   ProcessStage(
       'Prepare to ship',
@@ -114,7 +114,7 @@ BLINK_PROCESS_STAGES = [
        'Updated vendor signals',
        'Finalized target milestone',
       ],
-      models.INTENT_SHIP, models.INTENT_REMOVE),
+      models.INTENT_IMPLEMENT_SHIP, models.INTENT_SHIP),
   ]
 
 
@@ -132,14 +132,14 @@ BLINK_FAST_TRACK_STAGES = [
       'of an existing specification or combinaton of specifications.',
       ['Spec links',
       ],
-      models.INTENT_NONE, models.INTENT_IMPLEMENT_SHIP),
+      models.INTENT_NONE, models.INTENT_INCUBATE),
 
   ProcessStage(
       'Implement',
       'Check code into Chromium under a flag.',
       ['Code in Chromium',
       ],
-      models.INTENT_IMPLEMENT_SHIP, models.INTENT_SHIP),
+      models.INTENT_INCUBATE, models.INTENT_IMPLEMENT),
 
   ProcessStage(
       'Dev trials and iterate on implementation',
@@ -151,7 +151,7 @@ BLINK_FAST_TRACK_STAGES = [
        'Ready for Trial email',
        'Estimated target milestone',
       ],
-      models.INTENT_EXTEND_TRIAL, models.INTENT_EXTEND_TRIAL),
+      models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
   ProcessStage(
       '(Optional) Origin Trial',
@@ -161,7 +161,7 @@ BLINK_FAST_TRACK_STAGES = [
        'OT available',
        'OT results',
       ],
-      models.INTENT_EXTEND_TRIAL, models.INTENT_EXTEND_TRIAL),
+      models.INTENT_EXPERIMENT, models.INTENT_EXTEND_TRIAL),
 
   ProcessStage(
       'Prepare to ship',
@@ -172,7 +172,7 @@ BLINK_FAST_TRACK_STAGES = [
        'Documentation signoff',
        'Finalized target milestone',
       ],
-      models.INTENT_SHIP, models.INTENT_REMOVE),
+      models.INTENT_EXPERIMENT, models.INTENT_SHIP),
   ]
 
 
@@ -190,14 +190,14 @@ PSA_ONLY_STAGES = [
       'facing change to existing code.',
       ['Spec links',
       ],
-      models.INTENT_NONE, models.INTENT_IMPLEMENT_SHIP),
+      models.INTENT_NONE, models.INTENT_INCUBATE),
 
   ProcessStage(
       'Implement',
       'Check code into Chromium under a flag.',
       ['Code in Chromium',
       ],
-      models.INTENT_IMPLEMENT_SHIP, models.INTENT_SHIP),
+      models.INTENT_INCUBATE, models.INTENT_IMPLEMENT),
 
   ProcessStage(
       'Dev trials and iterate on implementation',
@@ -206,7 +206,7 @@ PSA_ONLY_STAGES = [
       ['Ready for Trial email',
        'Estimated target milestone',
       ],
-      models.INTENT_EXTEND_TRIAL, models.INTENT_EXTEND_TRIAL),
+      models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
   ProcessStage(
       'Prepare to ship',
@@ -215,7 +215,7 @@ PSA_ONLY_STAGES = [
        'One LGTM',
        'Finalize target Milestone',
       ],
-      models.INTENT_SHIP, models.INTENT_REMOVE),
+      models.INTENT_EXPERIMENT, models.INTENT_SHIP),
   ]
 
 PSA_ONLY_PROCESS = Process(
@@ -232,14 +232,14 @@ DEPRECATION_STAGES = [
       'an existing feature stating impact.',
       ['Link to existing feature',
       ],
-      models.INTENT_NONE, models.INTENT_IMPLEMENT_SHIP),
+      models.INTENT_NONE, models.INTENT_INCUBATE),
 
   ProcessStage(
       'Implement',
       'Move existing Chromium code under a flag.',
       ['Code in Chromium',
       ],
-      models.INTENT_IMPLEMENT_SHIP, models.INTENT_SHIP),
+      models.INTENT_INCUBATE, models.INTENT_IMPLEMENT),
 
   # TODO(cwilso): Work out additional steps for flag defaulting to disabled.
   ProcessStage(
@@ -248,7 +248,7 @@ DEPRECATION_STAGES = [
       ['Ready for Trial email',
        'Estimated target milestone',
       ],
-      models.INTENT_EXTEND_TRIAL, models.INTENT_EXTEND_TRIAL),
+      models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
   ProcessStage(
       'Prepare to unship',
@@ -258,7 +258,7 @@ DEPRECATION_STAGES = [
        'Three LGTMs',
        'Finalized target milestone',
       ],
-      models.INTENT_SHIP, models.INTENT_REMOVE),
+      models.INTENT_EXPERIMENT, models.INTENT_REMOVE),
 
   ProcessStage(
       '(Optional) Reverse Origin Trial',
@@ -268,7 +268,7 @@ DEPRECATION_STAGES = [
        'Removal of ROT',
        'Removal of implementation code',
       ],
-      models.INTENT_EXTEND_TRIAL, models.INTENT_EXTEND_TRIAL),
+      models.INTENT_EXPERIMENT, models.INTENT_EXTEND_TRIAL),
   ]
 
 

--- a/processes.py
+++ b/processes.py
@@ -32,7 +32,8 @@ Process = collections.namedtuple(
 
 ProcessStage = collections.namedtuple(
     'ProcessStage',
-    'name, description, progress_items, incoming_stage, outgoing_stage')
+    'name, description, progress_items, actions, '
+    'incoming_stage, outgoing_stage')
 
 
 def process_to_dict(process):
@@ -46,6 +47,12 @@ def process_to_dict(process):
   return process_dict
 
 
+# This page generates a preview of an email that can be sent
+# to a mailing list to announce an intent.
+# The parameter "{feature_id}" is filled in by JS code.
+INTENT_EMAIL_URL = '/admin/features/launch/{feature_id}?intent'
+
+
 BLINK_PROCESS_STAGES = [
   ProcessStage(
       'Start incubation',
@@ -54,6 +61,7 @@ BLINK_PROCESS_STAGES = [
       ['WICG discourse post',
        'Spec repo',
       ],
+      [],
       models.INTENT_NONE, models.INTENT_INCUBATE),
 
   ProcessStage(
@@ -68,6 +76,7 @@ BLINK_PROCESS_STAGES = [
        'Intent to Prototype email',
        'Spec reviewer',
       ],
+      [('Draft Intent to Prototype email', INTENT_EMAIL_URL)],
       models.INTENT_INCUBATE, models.INTENT_IMPLEMENT),
 
   ProcessStage(
@@ -81,6 +90,7 @@ BLINK_PROCESS_STAGES = [
        'External reviews',
        'Ready for Trial email',
       ],
+      [('Draft Ready for Trial email', INTENT_EMAIL_URL)],
       models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
   ProcessStage(
@@ -91,6 +101,7 @@ BLINK_PROCESS_STAGES = [
        'Documentation signoff',
        'Estimated target milestone',
       ],
+      [],
       models.INTENT_EXPERIMENT, models.INTENT_IMPLEMENT_SHIP),
 
   ProcessStage(
@@ -101,6 +112,7 @@ BLINK_PROCESS_STAGES = [
        'OT available',
        'OT results',
       ],
+      [('Draft Intent to Experiment email', INTENT_EMAIL_URL)],
       models.INTENT_IMPLEMENT_SHIP, models.INTENT_EXTEND_TRIAL),
 
   ProcessStage(
@@ -114,6 +126,7 @@ BLINK_PROCESS_STAGES = [
        'Updated vendor signals',
        'Finalized target milestone',
       ],
+      [('Draft Intent to Ship email', INTENT_EMAIL_URL)],
       models.INTENT_IMPLEMENT_SHIP, models.INTENT_SHIP),
   ]
 
@@ -132,6 +145,7 @@ BLINK_FAST_TRACK_STAGES = [
       'of an existing specification or combinaton of specifications.',
       ['Spec links',
       ],
+      [],
       models.INTENT_NONE, models.INTENT_INCUBATE),
 
   ProcessStage(
@@ -139,6 +153,7 @@ BLINK_FAST_TRACK_STAGES = [
       'Check code into Chromium under a flag.',
       ['Code in Chromium',
       ],
+      [],
       models.INTENT_INCUBATE, models.INTENT_IMPLEMENT),
 
   ProcessStage(
@@ -151,6 +166,7 @@ BLINK_FAST_TRACK_STAGES = [
        'Ready for Trial email',
        'Estimated target milestone',
       ],
+      [('Draft Ready for Trial email', INTENT_EMAIL_URL)],
       models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
   ProcessStage(
@@ -161,6 +177,7 @@ BLINK_FAST_TRACK_STAGES = [
        'OT available',
        'OT results',
       ],
+      [('Draft Intent to Experiment email', INTENT_EMAIL_URL)],
       models.INTENT_EXPERIMENT, models.INTENT_EXTEND_TRIAL),
 
   ProcessStage(
@@ -172,6 +189,7 @@ BLINK_FAST_TRACK_STAGES = [
        'Documentation signoff',
        'Finalized target milestone',
       ],
+      [('Draft Intent to Ship email', INTENT_EMAIL_URL)],
       models.INTENT_EXPERIMENT, models.INTENT_SHIP),
   ]
 
@@ -190,6 +208,7 @@ PSA_ONLY_STAGES = [
       'facing change to existing code.',
       ['Spec links',
       ],
+      [],
       models.INTENT_NONE, models.INTENT_INCUBATE),
 
   ProcessStage(
@@ -197,6 +216,7 @@ PSA_ONLY_STAGES = [
       'Check code into Chromium under a flag.',
       ['Code in Chromium',
       ],
+      [],
       models.INTENT_INCUBATE, models.INTENT_IMPLEMENT),
 
   ProcessStage(
@@ -206,6 +226,7 @@ PSA_ONLY_STAGES = [
       ['Ready for Trial email',
        'Estimated target milestone',
       ],
+      [('Draft Ready for Trial email', INTENT_EMAIL_URL)],
       models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
   ProcessStage(
@@ -215,6 +236,7 @@ PSA_ONLY_STAGES = [
        'One LGTM',
        'Finalize target Milestone',
       ],
+      [('Draft Intent to Ship email', INTENT_EMAIL_URL)],
       models.INTENT_EXPERIMENT, models.INTENT_SHIP),
   ]
 
@@ -232,6 +254,7 @@ DEPRECATION_STAGES = [
       'an existing feature stating impact.',
       ['Link to existing feature',
       ],
+      [],
       models.INTENT_NONE, models.INTENT_INCUBATE),
 
   ProcessStage(
@@ -239,6 +262,7 @@ DEPRECATION_STAGES = [
       'Move existing Chromium code under a flag.',
       ['Code in Chromium',
       ],
+      [],
       models.INTENT_INCUBATE, models.INTENT_IMPLEMENT),
 
   # TODO(cwilso): Work out additional steps for flag defaulting to disabled.
@@ -248,6 +272,7 @@ DEPRECATION_STAGES = [
       ['Ready for Trial email',
        'Estimated target milestone',
       ],
+      [],
       models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
   ProcessStage(
@@ -258,6 +283,7 @@ DEPRECATION_STAGES = [
        'Three LGTMs',
        'Finalized target milestone',
       ],
+      [('Draft Intent to Ship email', INTENT_EMAIL_URL)],
       models.INTENT_EXPERIMENT, models.INTENT_REMOVE),
 
   ProcessStage(
@@ -268,6 +294,7 @@ DEPRECATION_STAGES = [
        'Removal of ROT',
        'Removal of implementation code',
       ],
+      [('Draft Ready for Trial email', INTENT_EMAIL_URL)],
       models.INTENT_EXPERIMENT, models.INTENT_EXTEND_TRIAL),
   ]
 

--- a/static/elements/chromedash-process-overview.js
+++ b/static/elements/chromedash-process-overview.js
@@ -52,14 +52,27 @@ class ChromedashProcessOverview extends LitElement {
     return (viewedIncomingStageIndex > featureStageIndex);
   }
 
+  renderAction(action) {
+    const label = action[0];
+    const url = action[1].replace('{feature_id}', this.feature.id);
+    return html`
+      <li>
+        <a href=${url} target="_blank">${label}</a>
+      </li>`;
+  }
+
+  renderActions(stage) {
+    return stage.actions.map(act => this.renderAction(act));
+  }
+
   render() {
     let featureId = this.feature.id;
     return html`
      <table>
        <tr>
-         <th style="width: 100px;">Stage</th>
-         <th style="width: 200px">Progress</th>
-         <th style="width: 80px"></th>
+         <th style="width: 30em;">Stage</th>
+         <th style="width: 25em">Progress</th>
+         <th style="width: 12em"></th>
        </tr>
 
        ${this.process.stages.map(stage => html`
@@ -79,7 +92,7 @@ class ChromedashProcessOverview extends LitElement {
               html`<div><a
                      href="/guide/stage/${featureId}/${stage.outgoing_stage}"
                      class="button primary">Update</a></div>
-                   <!-- TODO(jrobbins): Preview email and other actions -->` :
+                   <ol>${this.renderActions(stage)}</ol>` :
               nothing }
             ${this.isPriorStage(stage) ?
               html`<a href="/guide/stage/${featureId}/${stage.outgoing_stage}"

--- a/static/elements/chromedash-process-overview.js
+++ b/static/elements/chromedash-process-overview.js
@@ -26,6 +26,9 @@ class ChromedashProcessOverview extends LitElement {
   /* A stage is "prior" if it would set a intent_stage that this feature
      has already passed. */
   isPriorStage(stage) {
+    if (this.feature.intent_stage == 'Shipped') {
+      return true;
+    }
     let stageOrder = this.process.stages.map(s => s.outgoing_stage);
     let viewedOutgoingStageIndex = stageOrder.indexOf(stage.outgoing_stage);
     let featureStageIndex = stageOrder.indexOf(this.feature.intent_stage_int);
@@ -36,6 +39,9 @@ class ChromedashProcessOverview extends LitElement {
      feature is on or has already passed, but its outgoing stage has
      not alrady been passed. */
   isStartableStage(stage) {
+    if (this.feature.intent_stage == 'Shipped') {
+      return false;
+    }
     let stageOrder = this.process.stages.map(s => s.outgoing_stage);
     let viewedIncomingStageIndex = stageOrder.indexOf(stage.incoming_stage);
     let viewedOutgoingStageIndex = stageOrder.indexOf(stage.outgoing_stage);
@@ -46,6 +52,9 @@ class ChromedashProcessOverview extends LitElement {
 
   /* A stage is "future" if the feature has not yet reached its incoming stage. */
   isFutureStage(stage) {
+    if (this.feature.intent_stage == 'Shipped') {
+      return false;
+    }
     let stageOrder = this.process.stages.map(s => s.outgoing_stage);
     let viewedIncomingStageIndex = stageOrder.indexOf(stage.incoming_stage);
     let featureStageIndex = stageOrder.indexOf(this.feature.intent_stage_int);

--- a/static/sass/elements/chromedash-process-overview.scss
+++ b/static/sass/elements/chromedash-process-overview.scss
@@ -32,7 +32,7 @@ th {
 
 td {
   color: #222;
-  padding: 8px 8px 16px 8px;
+  padding: 8px 16px 16px 8px;
   vertical-align: top;
   border-bottom: 1px solid #ddd;
   background: white;
@@ -60,6 +60,10 @@ td div.pending:before {
 
 td div.done, td div.pending {
   margin-left: 1em;
+}
+
+ol li {
+  margin-top: .5em;
 }
 
 [hidden] {

--- a/static/sass/elements/chromedash-process-overview.scss
+++ b/static/sass/elements/chromedash-process-overview.scss
@@ -19,6 +19,7 @@
 
 table {
   border-spacing: 0;
+  width: 100%;
 }
 
 th {

--- a/static/sass/forms.scss
+++ b/static/sass/forms.scss
@@ -9,11 +9,13 @@ table {
 
   th {
     max-width: 200px;
+    padding: 12px 10px 10px 0;
+    vertical-align: top;
   }
 
-  th, td {
+  td {
     padding: 10px;
-    vertical-align: baseline;
+    vertical-align: top;
   }
   .choices label {
     font-weight: bold;
@@ -75,4 +77,17 @@ form[name="feature_form"] {
   input[type="submit"] {
     margin-top: $content-padding;
   }
+}
+
+#metadata {
+  color: #222;
+  background: white;
+  max-width: 67em;
+  border: 1px solid #ccc;
+  padding: 1em;
+  box-shadow: rgba(0, 0, 0, 0.067) 1px 1px 4px;
+}
+
+#metadata-readonly div + div {
+  margin-top: 4px;
 }

--- a/static/sass/forms.scss
+++ b/static/sass/forms.scss
@@ -9,7 +9,6 @@ table {
 
   th {
     max-width: 200px;
-    white-space: nowrap;
   }
 
   th, td {

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -291,7 +291,7 @@ footer {
 }
 
 #content {
-  margin: $content-padding;
+  margin: $content-padding 6px;
   position: relative;
   height: 100%;
 }

--- a/templates/admin/features/launch.html
+++ b/templates/admin/features/launch.html
@@ -27,7 +27,7 @@
 
 {% if intent %}
 <section>
-<h3>Copy and send this text for your "Intent to {{feature.intent_stage}}" email</h3>
+<h3>Copy and send this text for your "Intent to ..." email</h3>
 {% include "blink/intent_to_implement.html" %}
 </section>
 {% endif %}

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -1,6 +1,17 @@
 <p>Subject</p>
 <div class="subject">
-Intent to {{feature.intent_stage}}: {{feature.name}}
+  {% if feature.intent_stage_int == 1 %}
+    Intent to Prototype:
+  {% elif feature.intent_stage_int == 2 %}
+    Ready for Trial:
+  {% elif feature.intent_stage_int == 3 %}
+    Intent to Experiment:
+  {% elif feature.intent_stage_int == 5 %}
+    Intent to Ship:
+  {% else %}
+    Intent stage "{{feature.intent_stage}}":
+  {% endif %}
+  {{feature.name}}
 </div>
 
 <p>Body</p>

--- a/templates/guide/edit.html
+++ b/templates/guide/edit.html
@@ -19,7 +19,7 @@
 
 {% include "guide/metadata.html" %}
 
-<section style='margin: 1em 0 8em 0'>
+<section style='margin: 1em 0 8em 0; max-width: 67em'>
   <chromedash-process-overview
     title='Blink Process'
     feature='{{ feature_json }}'

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -1,15 +1,17 @@
-<section style="max-width:67em; border: 1px solid #ccc; padding: 1em; color: #222; box-shadow: rgba(0, 0, 0, 0.067) 1px 1px 4px;">
+<section id="metadata">
 
   <div id="metadata-readonly">
-    <div style="max-height: 3em; overflow: hidden">
-      {% if user.is_admin %}
-        <button id="delete-feature"
-                data-id="{{ feature_id }}"
-                class="delete-button"
-                style="float: right">Delete</button>
-      {% endif %}
-      <button id="open-metadata" style="float: right">Edit</button>
-      {{ feature.summary }}
+    <div style="margin-bottom: 1em">
+        <div style="float: right">
+          <button id="open-metadata" style="float: right">Edit</button>
+          {% if user.is_admin %}
+            <div><button id="delete-feature"
+                    data-id="{{ feature_id }}"
+                    class="delete-button"
+                    >Delete</button></div>
+          {% endif %}
+        </div>
+      <div style="width:60em">{{ feature.summary }}</div>
     </div>
     <div>Category: {{ feature.category }}</div>
     {% if feature.unlisted %}
@@ -24,7 +26,13 @@
     <div>Feature type: {{ feature.feature_type }}</div>
     <div>Feature stage: {{ feature.intent_stage }}</div>
     <div>Blink components: {{ feature.blink_components | join:', ' }}</div>
-    <div>Tracking bug: <a href="{{ feature.bug_url }}">{{ feature.bug_url }}</a></div>
+    <div>Tracking bug:
+      {% if feature.bug_url %}
+        <a href="{{ feature.bug_url }}">{{ feature.bug_url }}</a>
+      {% else %}
+        None
+      {% endif %}
+    </div>
     <div>Status in Chromium: {{ feature.impl_status_chrome }}</div>
     <div>Search tags: {{ feature.search_tags | join:', ' }}</div>
   </div>

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -1,4 +1,4 @@
-<section style="max-width:67em; border: 1px solid #ccc; padding: 1em; color: #222">
+<section style="max-width:67em; border: 1px solid #ccc; padding: 1em; color: #222; box-shadow: rgba(0, 0, 0, 0.067) 1px 1px 4px;">
 
   <div id="metadata-readonly">
     <div style="max-height: 3em; overflow: hidden">
@@ -20,9 +20,13 @@
       {% for owner in feature.owner %}
         <a href="mailto:{{ owner }}">{{ owner }}</a>
       {% endfor %}
+    </div>
     <div>Feature type: {{ feature.feature_type }}</div>
     <div>Feature stage: {{ feature.intent_stage }}</div>
-    </div>
+    <div>Blink components: {{ feature.blink_components | join:', ' }}</div>
+    <div>Tracking bug: <a href="{{ feature.bug_url }}">{{ feature.bug_url }}</a></div>
+    <div>Status in Chromium: {{ feature.impl_status_chrome }}</div>
+    <div>Search tags: {{ feature.search_tags | join:', ' }}</div>
   </div>
 
   <div id="metadata-editing" style="display:none">

--- a/templates/guide/stage.html
+++ b/templates/guide/stage.html
@@ -23,11 +23,11 @@
       {{ feature_form }}
 
       <tr>
-        <th>Set process stage</th>
+        <th></th>
         <td>
           <!-- TODO(jrobbins): Auto-check based on conditions. -->
           <input type="checkbox" name="set_stage"
-                 id="set_stage" checked="checked">
+                 id="set_stage">
           <label for="set_stage">
             Set the process stage to: {{ stage_name }}
           </label>

--- a/templates/guide/stage.html
+++ b/templates/guide/stage.html
@@ -25,10 +25,12 @@
       <tr>
         <th>Set process stage</th>
         <td>
-          <!-- TODO(jrobbins): redo this to be driven by process definition. -->
+          <!-- TODO(jrobbins): Auto-check based on conditions. -->
           <input type="checkbox" name="set_stage"
                  id="set_stage" checked="checked">
-          <label for="set_stage">Advance the intent stage to Prototype</label>
+          <label for="set_stage">
+            Set the process stage to: {{ stage_name }}
+          </label>
         </td>
       </tr>
     </table>

--- a/tests/guild_test.py
+++ b/tests/guild_test.py
@@ -157,7 +157,7 @@ class FeatureEditStageTest(unittest.TestCase):
         name='feature one', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_1.put()
-    self.stage = models.INTENT_NONE  # Shows incubate form
+    self.stage = models.INTENT_INCUBATE  # Shows first form
 
     request = webapp2.Request.blank(
         '/guide/stage/%d/%d' % (self.feature_1.key().id(), self.stage))

--- a/tests/processes_test.py
+++ b/tests/processes_test.py
@@ -31,11 +31,13 @@ class HelperFunctionsTest(unittest.TestCase):
             'Make dough',
             'Mix it and kneed',
             ['Cold dough'],
+            [('Share kneeding video', 'https://example.com')],
             0, 1),
          processes.ProcessStage(
              'Bake it',
              'Heat at 375 for 40 minutes',
              ['A loaf', 'A dirty pan'],
+             [],
              1, 2),
          ])
     expected = {
@@ -46,11 +48,13 @@ class HelperFunctionsTest(unittest.TestCase):
             {'name': 'Make dough',
              'description': 'Mix it and kneed',
              'progress_items': ['Cold dough'],
+             'actions': [('Share kneeding video', 'https://example.com')],
              'incoming_stage': 0,
              'outgoing_stage': 1},
             {'name': 'Bake it',
              'description': 'Heat at 375 for 40 minutes',
              'progress_items': ['A loaf', 'A dirty pan'],
+             'actions': [],
              'incoming_stage': 1,
              'outgoing_stage': 2},
         ]


### PR DESCRIPTION
In this CL:
+ Define Django form fields for all remaining Feature attributes in the old UI.
+ Define forms for each stage of each process, and put fields into them
+ Change the way that the Django form is looked up to make it more clear
+ Change the logic to decide which stage gets the "Revisit", "Start", and "Preview" options.

Discussed today but not in this CL: 
+ Making the same field optional on one stage-specific form and then required on a later stage-specific form.
+ Actions and advice
+ New feature fields, e.g., initial public proposal URL.