### PR TITLE
Add launch bug URL, add try link at top, style tweaks.

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -327,6 +327,7 @@ class FeatureHandler(common.ContentHandler):
       explainer_links = filter(bool, [x.strip() for x in re.split('\\r?\\n', explainer_links)])
 
     bug_url = self.__FullQualifyLink('bug_url')
+    launch_bug_url = self.__FullQualifyLink('launch_bug_url')
     intent_to_implement_url = self.__FullQualifyLink('intent_to_implement_url')
     origin_trial_feedback_url = self.__FullQualifyLink('origin_trial_feedback_url')
 
@@ -401,6 +402,7 @@ class FeatureHandler(common.ContentHandler):
       feature.explainer_links = explainer_links
       feature.owner = owners
       feature.bug_url = bug_url
+      feature.launch_bug_url = launch_bug_url
       feature.blink_components = blink_components
       feature.devrel = devrel
       feature.impl_status_chrome = int(self.request.get('impl_status_chrome'))

--- a/guide.py
+++ b/guide.py
@@ -270,6 +270,8 @@ class FeatureEditStage(common.ContentHandler):
 
     if self.touched('bug_url'):
       feature.bug_url = self.parse_link('bug_url')
+    if self.touched('launch_bug_url'):
+      feature.launch_bug_url = self.parse_link('launch_bug_url')
 
     if self.touched('intent_to_implement_url'):
       feature.intent_to_implement_url = self.parse_link(

--- a/guideforms.py
+++ b/guideforms.py
@@ -329,6 +329,13 @@ ALL_FIELDS = {
          'should have "Type=Feature" set and be world readable. '
          'Note: This field only accepts one URL.')),
 
+    'launch_bug_url': forms.URLField(
+        required=False, label='Launch bug URL',
+        help_text=(
+            'Launch bug url (https://bugs.chromium.org/...) to track launch '
+            'aprpovals. '
+            'This bug should be created using a "Launch" issue template.')),
+
     'blink_components': forms.ChoiceField(
       required=True,
       label='Blink component',
@@ -410,7 +417,9 @@ class NewFeatureForm(forms.Form):
 class MetadataForm(forms.Form):
 
   field_order = (
-      'name', 'summary', 'category', 'owner', 'feature_type', 'intent_stage')
+      'name', 'summary', 'category', 'unlisted', 'owner', 'feature_type',
+      'intent_stage', 'blink_components', 'bug_url', 'launch_bug_url',
+      'impl_status_chrome', 'search_tags')
   name = ALL_FIELDS['name']
   summary = ALL_FIELDS['summary']
   category = ALL_FIELDS['category']
@@ -428,6 +437,7 @@ class MetadataForm(forms.Form):
       choices=models.INTENT_STAGES.items())
   blink_components = ALL_FIELDS['blink_components']
   bug_url = ALL_FIELDS['bug_url']
+  launch_bug_url = ALL_FIELDS['launch_bug_url']
   impl_status_chrome = ALL_FIELDS['impl_status_chrome']
   search_tags = ALL_FIELDS['search_tags']
 
@@ -444,6 +454,8 @@ class NewFeature_Incubate(forms.Form):
   motivation = ALL_FIELDS['motivation']
   explainer_links = ALL_FIELDS['explainer_links']
   footprint = ALL_FIELDS['footprint']
+  bug_url = ALL_FIELDS['bug_url']
+  launch_bug_url = ALL_FIELDS['launch_bug_url']
   # TODO(jrobbins): public proposal URL, optional
 
 
@@ -543,6 +555,7 @@ class NewFeature_PrepareToShip(forms.Form):
   tag_review = ALL_FIELDS['tag_review']
   intent_to_implement_url = ALL_FIELDS['intent_to_implement_url']
   origin_trial_feedback_url = ALL_FIELDS['origin_trial_feedback_url'] # optional
+  launch_bug_url = ALL_FIELDS['launch_bug_url']
 
 
 class Existing_Identify(forms.Form):
@@ -557,6 +570,8 @@ class Existing_Identify(forms.Form):
   motivation = ALL_FIELDS['motivation']
   explainer_links = ALL_FIELDS['explainer_links']
   footprint = ALL_FIELDS['footprint']
+  bug_url = ALL_FIELDS['bug_url']
+  launch_bug_url = ALL_FIELDS['launch_bug_url']
   # TODO(jrobbins): public proposal URL, optional
 
 
@@ -624,6 +639,7 @@ class Existing_PrepareToShip(forms.Form):
   tag_review = ALL_FIELDS['tag_review']
   intent_to_implement_url = ALL_FIELDS['intent_to_implement_url']
   origin_trial_feedback_url = ALL_FIELDS['origin_trial_feedback_url'] # optional
+  launch_bug_url = ALL_FIELDS['launch_bug_url']
 
 
 class CodeChange_Identify(forms.Form):
@@ -638,6 +654,8 @@ class CodeChange_Identify(forms.Form):
   motivation = ALL_FIELDS['motivation']
   explainer_links = ALL_FIELDS['explainer_links']
   footprint = ALL_FIELDS['footprint']
+  bug_url = ALL_FIELDS['bug_url']
+  launch_bug_url = ALL_FIELDS['launch_bug_url']
   # TODO(jrobbins): public proposal URL, optional
 
 
@@ -694,8 +712,7 @@ class CodeChange_PrepareToShip(forms.Form):
   tag_review = ALL_FIELDS['tag_review']
   intent_to_implement_url = ALL_FIELDS['intent_to_implement_url']
   origin_trial_feedback_url = ALL_FIELDS['origin_trial_feedback_url'] # optional
-
-
+  launch_bug_url = ALL_FIELDS['launch_bug_url']
 
 
 class Deprecation_Identify(forms.Form):
@@ -710,6 +727,8 @@ class Deprecation_Identify(forms.Form):
   motivation = ALL_FIELDS['motivation']
   explainer_links = ALL_FIELDS['explainer_links']
   footprint = ALL_FIELDS['footprint']
+  bug_url = ALL_FIELDS['bug_url']
+  launch_bug_url = ALL_FIELDS['launch_bug_url']
   # TODO(jrobbins): public proposal URL, optional
 
 
@@ -766,6 +785,7 @@ class Deprecation_PrepareToUnship(forms.Form):
   tag_review = ALL_FIELDS['tag_review']
   intent_to_implement_url = ALL_FIELDS['intent_to_implement_url']
   origin_trial_feedback_url = ALL_FIELDS['origin_trial_feedback_url'] # optional
+  launch_bug_url = ALL_FIELDS['launch_bug_url']
 
 
 class Deprecation_ReverseOriginTrial(forms.Form):

--- a/guideforms.py
+++ b/guideforms.py
@@ -329,12 +329,16 @@ ALL_FIELDS = {
          'should have "Type=Feature" set and be world readable. '
          'Note: This field only accepts one URL.')),
 
+    # TODO(jrobbins): Consider a button to file the launch bug automatically,
+    # or a deep link that has some feature details filled in.
     'launch_bug_url': forms.URLField(
         required=False, label='Launch bug URL',
         help_text=(
             'Launch bug url (https://bugs.chromium.org/...) to track launch '
             'aprpovals. '
-            'This bug should be created using a "Launch" issue template.')),
+          '<a href="https://bugs.chromium.org/p/chromium/issues/entry?template=Chrome+Launch+Feature" '
+          'target="_blank" '
+          '>Create launch bug<a>')),
 
     'blink_components': forms.ChoiceField(
       required=True,

--- a/models.py
+++ b/models.py
@@ -951,6 +951,7 @@ class Feature(DictModel):
 
   # Chromium details.
   bug_url = db.LinkProperty()
+  launch_bug_url = db.LinkProperty()
   blink_components = db.StringListProperty(required=True, default=[BlinkComponent.DEFAULT_COMPONENT])
   devrel = db.ListProperty(db.Email)
 
@@ -1219,6 +1220,12 @@ class FeatureForm(forms.Form):
 
   bug_url = forms.URLField(required=False, label='Tracking bug URL',
       help_text='Tracking bug url (https://bugs.chromium.org/...). This bug should have "Type=Feature" set and be world readable.')
+
+  launch_bug_url = forms.URLField(required=False, label='Launch bug URL',
+      help_text=(
+          'Launch bug url (https://bugs.chromium.org/...) to track launch '
+          'aprpovals. '
+          'This bug should be created using a "Launch" issue template.'))
 
   blink_components = forms.ChoiceField(
       required=True,

--- a/models.py
+++ b/models.py
@@ -1225,7 +1225,9 @@ class FeatureForm(forms.Form):
       help_text=(
           'Launch bug url (https://bugs.chromium.org/...) to track launch '
           'aprpovals. '
-          'This bug should be created using a "Launch" issue template.'))
+          '<a href="https://bugs.chromium.org/p/chromium/issues/entry?template=Chrome+Launch+Feature" '
+          'target="_blank" '
+          '>Create launch bug<a>'))
 
   blink_components = forms.ChoiceField(
       required=True,

--- a/static/sass/forms.scss
+++ b/static/sass/forms.scss
@@ -33,6 +33,7 @@ table {
     font-style: italic;
     font-size: smaller;
     max-width: 40em;
+    margin-top: 2px;
   }
   input[type="text"], input[type="url"], input[type="email"], textarea {
     width: 100%;
@@ -79,8 +80,16 @@ form[name="feature_form"] {
   }
 }
 
-#metadata {
-  color: #222;
+#stage_form form[name="feature_form"] {
+  margin-bottom: 1em;
+}
+
+#stage_form {
+  margin-bottom: 6em;
+}
+
+#metadata, #stage_form {
+  color: #444;
   background: white;
   max-width: 67em;
   border: 1px solid #ccc;

--- a/templates/admin/features/edit.html
+++ b/templates/admin/features/edit.html
@@ -14,7 +14,9 @@
   <h2>Edit a feature</h2>
   {% if user.is_admin %}
     <button class="delete-button" data-id="{{feature.id}}">Delete</button>
-  {% endif %}
+    {% endif %}
+    <a style="flex-grow:1; text-align:right"
+     href="/guide/edit/{{ feature.id }}">Try new UI</a>
 </div>
 {% endblock %}
 

--- a/templates/admin/features/new.html
+++ b/templates/admin/features/new.html
@@ -11,6 +11,8 @@
 {% block subheader %}
 <div id="subheader">
   <h2>Add a feature</h2>
+  <a style="flex-grow:1; text-align:right"
+     href="/guide/new">Try new UI</a>
 </div>
 {% endblock %}
 

--- a/templates/guide/edit.html
+++ b/templates/guide/edit.html
@@ -10,7 +10,9 @@
 {% endblock %}
 
 {% block subheader %}
-<div id="subheader">
+<div id="subheader" style="display:block">
+  <a style="float:right"
+     href="/admin/features/edit/{{ feature_id }}">Use old UI</a>
   <h2>Edit feature: {{ feature.name }}</h2>
 </div>
 {% endblock %}
@@ -30,7 +32,6 @@
 
 
 <section style="margin-top: 4em">
-  <a href="/admin/features/edit/{{ feature_id }}">Use old UI</a>
 </section>
 
 {% endblock %}

--- a/templates/guide/edit.html
+++ b/templates/guide/edit.html
@@ -13,6 +13,9 @@
 <div id="subheader" style="display:block">
   <a style="float:right"
      href="/admin/features/edit/{{ feature_id }}">Use old UI</a>
+  <a style="float:right; margin-right: 2em"
+     href="https://github.com/GoogleChrome/chromium-dashboard/issues/new?labels=Feedback&template=process-and-guide-ux-feedback.md"
+     target="_blank">Process and UI feedback</a>
   <h2>Edit feature: {{ feature.name }}</h2>
 </div>
 {% endblock %}

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -33,6 +33,13 @@
         None
       {% endif %}
     </div>
+    <div>Launch bug:
+      {% if feature.launch_bug_url %}
+        <a href="{{ feature.launch_bug_url }}">{{ feature.launch_bug_url }}</a>
+      {% else %}
+        None
+      {% endif %}
+    </div>
     <div>Status in Chromium: {{ feature.impl_status_chrome }}</div>
     <div>Search tags: {{ feature.search_tags | join:', ' }}</div>
   </div>

--- a/templates/guide/new.html
+++ b/templates/guide/new.html
@@ -9,20 +9,25 @@
 {% endblock %}
 
 {% block subheader %}
-<div id="subheader">
+<div id="subheader" style="display:block">
+  <a style="float:right"
+     href="/admin/features/new">Use old UI</a>
+  <a style="float:right; margin-right: 2em"
+     href="https://github.com/GoogleChrome/chromium-dashboard/issues/new?labels=Feedback&template=process-and-guide-ux-feedback.md"
+     target="_blank">Process and UI feedback</a>
   <h2>Add a feature</h2>
 </div>
 {% endblock %}
 
 {% block content %}
 
-<section>
+<section id="stage_form">
   <form name="overview_form" method="POST" action="{{ current_path }}">
     <table style="max-width: 60em">
       {{ overview_form }}
       <tr>
         <th>Feature type:</th>
-        <td class="choices">
+        <td class="choices" style="padding-top:0">
           <div>
             <label for="id_feature_type_0">
               <input id="id_feature_type_0" name="feature_type" type="radio"

--- a/templates/guide/stage.html
+++ b/templates/guide/stage.html
@@ -17,19 +17,25 @@
 {% endblock %}
 
 {% block content %}
-<section>
+<section id="stage_form">
   <form name="feature_form" method="POST" action="{{current_path}}">
     <table>
       {{ feature_form }}
 
       <tr>
-        <th></th>
+        <th>Process stage:</th>
         <td>
           <!-- TODO(jrobbins): Auto-check based on conditions. -->
           <input type="checkbox" name="set_stage"
                  id="set_stage">
           <label for="set_stage">
-            Set the process stage to: {{ stage_name }}
+            Set to: <b>{{ stage_name }}</b>
+            <br>
+            <span class="helptext">
+              Check this box when you are ready to advance this feature to
+              this phase in the process.  Leave unchecked if you are filling
+              in draft information or revising a previous stage.
+            </span>
           </label>
         </td>
       </tr>


### PR DESCRIPTION
In this CL:
+ Add launch bug URL to datastore model and old UI 
+ Add it to new UI metadata display, editing, first stage of each process, and prepare to launch
+ Move "Use old UI" link to top of page, and add "Try new UI" link in same location.
+ Make new stage-specific forms white to match process overview page