### PR TITLE
Rename permission functions to use inclusive language.

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -272,9 +272,9 @@ class FeatureHandler(common.ContentHandler):
       return self.redirect(self.request.path.rstrip('/'))
 
     # TODO(ericbidelman): This creates a additional call to
-    # _is_user_whitelisted() (also called in common.py), resulting in another
+    # user_can_edit() (also called in common.py), resulting in another
     # db query.
-    if not self._is_user_whitelisted(user):
+    if not self.user_can_edit(user):
       #TODO(ericbidelman): Use render(status=401) instead.
       #self.render(data={}, template_path=os.path.join(path + '.html'), status=401)
       common.handle_401(self.request, self.response, Exception)
@@ -316,7 +316,7 @@ class FeatureHandler(common.ContentHandler):
 
   def post(self, path, feature_id=None):
     user = users.get_current_user()
-    if user is None or (user and not self._is_user_whitelisted(user)):
+    if user is None or (user and not self.user_can_edit(user)):
       common.handle_401(self.request, self.response, Exception)
       return
 

--- a/blink_handler.py
+++ b/blink_handler.py
@@ -55,7 +55,7 @@ class PopulateSubscribersHandler(common.ContentHandler):
       user.put()
     f.close()
 
-  @common.require_whitelisted_user
+  @common.require_edit_permission
   def get(self):
     if settings.PROD:
       return self.response.out.write('Handler not allowed in production.')
@@ -87,7 +87,7 @@ class BlinkHandler(common.ContentHandler):
 
     return True
 
-  @common.require_whitelisted_user
+  @common.require_edit_permission
   @common.strip_trailing_slash
   def get(self, path):
     # key = '%s|blinkcomponentowners' % (settings.MEMCACHE_KEY_PREFIX)
@@ -139,7 +139,7 @@ class BlinkHandler(common.ContentHandler):
 
 class SubscribersHandler(common.ContentHandler):
 
-  @common.require_whitelisted_user
+  @common.require_edit_permission
   # @common.strip_trailing_slash
   def get(self, path):
     users = models.FeatureOwner.all().order('name').fetch(None)
@@ -180,4 +180,3 @@ app = webapp2.WSGIApplication([
   ('/admin/subscribers(.*)', SubscribersHandler),
   ('(.*)', BlinkHandler),
 ], debug=settings.DEBUG)
-

--- a/guide.py
+++ b/guide.py
@@ -90,7 +90,7 @@ class FeatureNew(common.ContentHandler):
     if user is None:
       return self.redirect(users.create_login_url(self.request.uri))
 
-    if not self._is_user_whitelisted(user):
+    if not self.user_can_edit(user):
       common.handle_401(self.request, self.response, Exception)
       return
 
@@ -104,7 +104,7 @@ class FeatureNew(common.ContentHandler):
 
   def post(self, path):
     user = users.get_current_user()
-    if user is None or (user and not self._is_user_whitelisted(user)):
+    if user is None or (user and not self.user_can_edit(user)):
       common.handle_401(self.request, self.response, Exception)
       return
 
@@ -154,7 +154,7 @@ class ProcessOverview(common.ContentHandler):
       # Redirect to public URL for unauthenticated users.
       return self.redirect(format_feature_url(feature_id))
 
-    if not self._is_user_whitelisted(user):
+    if not self.user_can_edit(user):
       common.handle_401(self.request, self.response, Exception)
       return
 
@@ -213,7 +213,7 @@ class FeatureEditStage(common.ContentHandler):
       # Redirect to public URL for unauthenticated users.
       return self.redirect(format_feature_url(feature_id))
 
-    if not self._is_user_whitelisted(user):
+    if not self.user_can_edit(user):
       common.handle_401(self.request, self.response, Exception)
       return
 
@@ -254,7 +254,7 @@ class FeatureEditStage(common.ContentHandler):
 
   def post(self, path, feature_id, stage_id):
     user = users.get_current_user()
-    if user is None or (user and not self._is_user_whitelisted(user)):
+    if user is None or (user and not self.user_can_edit(user)):
       common.handle_401(self.request, self.response, Exception)
       return
 

--- a/models.py
+++ b/models.py
@@ -1419,7 +1419,7 @@ class UserPrefForm(forms.Form):
 
 
 class AppUser(DictModel):
-  """Describes a user for whitelisting."""
+  """Describes a user for permission checking."""
 
   #user = db.UserProperty(required=True, verbose_name='Google Account')
   email = db.EmailProperty(required=True)

--- a/schedule.py
+++ b/schedule.py
@@ -93,7 +93,7 @@ class ScheduleHandler(common.ContentHandler):
   def get(self, path):
     user = users.get_current_user()
     features = models.Feature.get_chronological(
-        show_unlisted=self._is_user_whitelisted(user))
+        show_unlisted=self.user_can_edit(user))
     data = {
       'features': json.dumps(features),
       'channels': json.dumps(construct_chrome_channels_details(),

--- a/server.py
+++ b/server.py
@@ -157,7 +157,7 @@ class FeaturesAPIHandler(common.JSONHandler):
 
     user = users.get_current_user()
     feature_list = models.Feature.get_chronological(
-        version=version, show_unlisted=self._is_user_whitelisted(user))
+        version=version, show_unlisted=self.user_can_edit(user))
     return common.JSONHandler.get(
         self, feature_list, formatted=True, public=False)
 

--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -18,7 +18,7 @@ class ChromedashFeature extends LitElement {
   static get properties() {
     return {
       feature: {type: Object},
-      whitelisted: {type: Boolean},
+      canEdit: {type: Boolean},
       signedin: {type: Boolean},
       loginUrl: {type: String},
       open: {type: Boolean, reflect: true}, // Attribute used in the parent for styling
@@ -212,7 +212,7 @@ class ChromedashFeature extends LitElement {
           .value="${this._interopRisk}"
           .max="${MAX_RISK}"></chromedash-color-status>
         <h2>${this.feature.name}
-          ${this.whitelisted ? html`
+          ${this.canEdit ? html`
             <span class="tooltip" title="Edit this feature">
               <a href="/admin/features/edit/${this.feature.id}" data-tooltip>
                 <iron-icon icon="chromestatus:create"></iron-icon>

--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -10,7 +10,7 @@ class ChromedashFeaturelist extends LitElement {
 
   static get properties() {
     return {
-      whitelisted: {type: Boolean},
+      canEdit: {type: Boolean},
       signedin: {type: Boolean},
       loginUrl: {type: String},
       features: {attribute: false}, // Directly edited and accessed in template/features.html
@@ -28,7 +28,7 @@ class ChromedashFeaturelist extends LitElement {
     this.filtered = [];
     this.metadataEl = document.querySelector('chromedash-metadata');
     this.searchEl = document.querySelector('.search input');
-    this.whitelisted = false;
+    this.canEdit = false;
     this.signedin = false;
     this._hasInitialized = false; // Used to check initialization code.
     this._hasScrolledByUser = false; // Used to set the app header state.
@@ -402,7 +402,7 @@ class ChromedashFeaturelist extends LitElement {
                  @star-toggled="${this._onStarToggledBound}"
                  .feature="${item.feature}"
                  loginurl="${this.loginUrl}"
-                 ?whitelisted="${this.whitelisted}"
+                 ?canedit="${this.canEdit}"
                  ?signedin="${this.signedin}"
           ></chromedash-feature>
           </div>

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -65,7 +65,7 @@
           <iron-icon icon="chromestatus:share" onclick="shareFeature()"></iron-icon>
         </a>
       </span>
-      {% if user.is_whitelisted %}
+      {% if user.can_edit %}
       <span class="tooltip" title="Edit this feature">
         <a href="/admin/features/edit/{{ feature.id }}" class="editfeature" data-tooltip>
           <iron-icon icon="chromestatus:create"></iron-icon>

--- a/templates/features.html
+++ b/templates/features.html
@@ -30,7 +30,7 @@
     </div>
     <div class="actionlinks">
       <a id="features-subscribe-button" class="blue-button no-push-notifications" title="Sends a push notification when new features are added."><iron-icon icon="chromestatus:notifications-off"></iron-icon><span>Subscribe</span></a>
-      {% if user.is_whitelisted %}
+      {% if user.can_edit %}
         <a href="/admin/features/new" class="blue-button" title="Adds a new feature to the site"><iron-icon icon="chromestatus:add-circle-outline"></iron-icon><span>Add new feature</span></a>
       {% endif %}
     </div>
@@ -53,7 +53,7 @@
   <chromedash-featurelist
     {% if user %}signedin{% endif %}
     loginurl="{{login.1}}"
-    {% if user.is_whitelisted %}whitelisted{% endif %}
+    {% if user.can_edit %}canedit{% endif %}
     ></chromedash-featurelist>
 {% endblock %}
 


### PR DESCRIPTION
This relates to https://tools.ietf.org/id/draft-knodel-terminology-00.html and was mentioned in an email from Rachel yesterday

In this CL:
+ Rename functions in python and attributes in JS code
+ Add python tests