### PR TITLE
Allow inputs to have defaul outline when focused.

### DIFF
--- a/static/sass/forms.scss
+++ b/static/sass/forms.scss
@@ -61,7 +61,6 @@ table {
 }
 
 input, textarea {
-  outline: none;
   padding: 7px;
 }
 

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -241,7 +241,6 @@ footer {
 
       input {
         width: 280px;
-        outline: none;
         padding: 10px 7px;
       }
     }

--- a/templates/guide/new.html
+++ b/templates/guide/new.html
@@ -88,10 +88,6 @@
   </form>
 </section>
 
-
-<section style="margin-top: 4em">
-  <a href="/admin/features/new">Use old UI</a>
-</section>
 {% endblock %}
 
 {% block js %}


### PR DESCRIPTION
This should resolve issue #873. 

For some reason, the existing CSS had outline:none for all inputs.  That disabled the focus indicator that is normally provided by the browser.  Doing that is discouraged, so I removed it.
https://developer.mozilla.org/en-US/docs/Web/CSS/outline#Accessibility_concerns

Screenshots:
Radio button with focus:
https://screenshot.googleplex.com/gZcBjQJU696.png

Text field with focus:
https://screenshot.googleplex.com/WBtvEhKHgTJ.png