### PR TITLE
Add shipped milestones to prepare-to-ship form

### DIFF
--- a/guideforms.py
+++ b/guideforms.py
@@ -650,10 +650,16 @@ class NewFeature_OriginTrial(forms.Form):
 class Any_PrepareToShip(forms.Form):
 
   field_order = (
-      'impl_status_chrome', 'footprint', 'tag_review',
+      'impl_status_chrome', 'shipped_milestone', 'shipped_android_milestone',
+      'shipped_ios_milestone', 'shipped_webview_milestone',
+      'footprint', 'tag_review',
       'intent_to_implement_url', 'origin_trial_feedback_url',
       'launch_bug_url', 'comments')
   impl_status_chrome = ALL_FIELDS['impl_status_chrome']
+  shipped_milestone = ALL_FIELDS['shipped_milestone']
+  shipped_android_milestone = ALL_FIELDS['shipped_android_milestone']
+  shipped_ios_milestone = ALL_FIELDS['shipped_ios_milestone']
+  shipped_webview_milestone = ALL_FIELDS['shipped_webview_milestone']
   footprint = ALL_FIELDS['footprint']
   tag_review = ALL_FIELDS['tag_review']
   intent_to_implement_url = ALL_FIELDS['intent_to_implement_url']


### PR DESCRIPTION
This should resolve issue #868.
The problem was that the shipped milestone fields were not part of the "prepare to ship" form.

The JS code that shows or hides them based on the implementation status selector seems to work when those fields are present.  However, that JS code also shows the milestones for implementation statuses of "Browser intervention" and "On hold".  Do I need to hide the milestone fields for those values?
