### PR TITLE
Help text improvements.

### DIFF
--- a/guideforms.py
+++ b/guideforms.py
@@ -280,9 +280,7 @@ ALL_FIELDS = {
     'experiment_timeline': forms.CharField(
         label='Experiment Timeline', required=False,
         widget=forms.Textarea(attrs={'rows': 2, 'cols': 50, 'maxlength': 1480}),
-        help_text=(
-            'For developer trials and origin trials state which versions of '
-            'Chrome will support the trial.')),
+        help_text='State which versions of Chrome will support the origin trial.'),
 
     'experiment_risks': forms.CharField(
         label='Experiment Risks', required=False,
@@ -411,8 +409,10 @@ ALL_FIELDS = {
         widget=forms.EmailInput(
             attrs={'multiple': True, 'placeholder': 'email, email'}),
         help_text=(
-            'If you are working with members of Developer relations, add a '
-            'comma separated list of their email addresses.')),
+            'If Developer Relations staff are actively supporting this feature, '
+            'provide a comma separated list of their email addresses. To request '
+            'support from Developer Relations, send an email to '
+            'web-devrel-chrome-team@google.com')),
 
     'impl_status_chrome': forms.ChoiceField(
         required=False, label='Status in Chromium',

--- a/guideforms.py
+++ b/guideforms.py
@@ -280,7 +280,9 @@ ALL_FIELDS = {
     'experiment_timeline': forms.CharField(
         label='Experiment Timeline', required=False,
         widget=forms.Textarea(attrs={'rows': 2, 'cols': 50, 'maxlength': 1480}),
-        help_text='When does the experiment start and expire?'),
+        help_text=(
+            'For developer trials and origin trials state which versions of '
+            'will support the trial.')),
 
     'experiment_risks': forms.CharField(
         label='Experiment Risks', required=False,
@@ -338,8 +340,7 @@ ALL_FIELDS = {
         label='Platform Support Explanation', required=False,
         widget=forms.Textarea(attrs={'rows': 2, 'cols': 50, 'maxlength': 2000}),
         help_text=
-        ('Explain why this feature is, or is not, '
-         'supported on all platforms.')),
+        ('If this feature is not supported on all platforms, explain why.')),
 
     'wpt': forms.BooleanField(
         required=False, initial=False, label='Web Platform Tests',
@@ -409,7 +410,9 @@ ALL_FIELDS = {
         required=False, label='Developer relations emails',
         widget=forms.EmailInput(
             attrs={'multiple': True, 'placeholder': 'email, email'}),
-        help_text='Comma separated list of full email addresses.'),
+        help_text=(
+            'If you are working with members of Developer relations, add a '
+            'comma separated list of their email addresses.')),
 
     'impl_status_chrome': forms.ChoiceField(
         required=False, label='Status in Chromium',
@@ -436,7 +439,7 @@ ALL_FIELDS = {
         help_text='Android WebView:<br/>' + SHIPPED_WEBVIEW_HELP_TXT),
 
     'prefixed': forms.BooleanField(
-        required=False, initial=False, label='Prefixed?'),
+        required=False, initial=False, label='WebKit prefixed?'),
 
     'footprint': forms.ChoiceField(
         required=False,

--- a/guideforms.py
+++ b/guideforms.py
@@ -282,7 +282,7 @@ ALL_FIELDS = {
         widget=forms.Textarea(attrs={'rows': 2, 'cols': 50, 'maxlength': 1480}),
         help_text=(
             'For developer trials and origin trials state which versions of '
-            'will support the trial.')),
+            'Chrome will support the trial.')),
 
     'experiment_risks': forms.CharField(
         label='Experiment Risks', required=False,

--- a/models.py
+++ b/models.py
@@ -1258,7 +1258,7 @@ class FeatureForm(forms.Form):
       widget=forms.Textarea(attrs={'rows': 2, 'cols': 50, 'maxlength': 1480}),
       help_text=(
             'For developer trials and origin trials state which versions of '
-            'will support the trial.')),
+            'Chrome will support the trial.')),
 
   experiment_risks = forms.CharField(label='Experiment Risks', required=False,
       widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),

--- a/models.py
+++ b/models.py
@@ -1256,9 +1256,7 @@ class FeatureForm(forms.Form):
 
   experiment_timeline = forms.CharField(label='Experiment Timeline', required=False,
       widget=forms.Textarea(attrs={'rows': 2, 'cols': 50, 'maxlength': 1480}),
-      help_text=(
-            'For developer trials and origin trials state which versions of '
-            'Chrome will support the trial.')),
+      help_text='State which versions of Chrome will support the origin trial.'),
 
   experiment_risks = forms.CharField(label='Experiment Risks', required=False,
       widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
@@ -1329,8 +1327,10 @@ class FeatureForm(forms.Form):
       widget=forms.EmailInput(
           attrs={'multiple': True, 'placeholder': 'email, email'}),
       help_text=(
-          'If you are working with members of Developer relations, add a '
-          'comma separated list of their email addresses.'))
+            'If Developer Relations staff are actively supporting this feature, '
+            'provide a comma separated list of their email addresses. To request '
+            'support from Developer Relations, send an email to '
+            'web-devrel-chrome-team@google.com'))
 
   impl_status_chrome = forms.ChoiceField(
       required=False,

--- a/models.py
+++ b/models.py
@@ -1256,7 +1256,9 @@ class FeatureForm(forms.Form):
 
   experiment_timeline = forms.CharField(label='Experiment Timeline', required=False,
       widget=forms.Textarea(attrs={'rows': 2, 'cols': 50, 'maxlength': 1480}),
-      help_text='When does the experiment start and expire?')
+      help_text=(
+            'For developer trials and origin trials state which versions of '
+            'will support the trial.')),
 
   experiment_risks = forms.CharField(label='Experiment Risks', required=False,
       widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
@@ -1279,7 +1281,7 @@ class FeatureForm(forms.Form):
 
   all_platforms_descr = forms.CharField(label='Platform Support Explanation', required=False,
       widget=forms.Textarea(attrs={'rows': 2, 'cols': 50, 'maxlength': 2000}),
-      help_text='Explanation for why this feature is, or is not, supported on all platforms.')
+      help_text='If this feature is not supported on all platforms, explain why.')
 
   wpt = forms.BooleanField(required=False, initial=False, label='Web Platform Tests', help_text='Is this feature fully tested in Web Platform Tests?')
 
@@ -1326,7 +1328,9 @@ class FeatureForm(forms.Form):
       required=False, label='Developer relations emails',
       widget=forms.EmailInput(
           attrs={'multiple': True, 'placeholder': 'email, email'}),
-      help_text='Comma separated list of full email addresses.')
+      help_text=(
+          'If you are working with members of Developer relations, add a '
+          'comma separated list of their email addresses.'))
 
   impl_status_chrome = forms.ChoiceField(
       required=False,
@@ -1354,7 +1358,7 @@ class FeatureForm(forms.Form):
       widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
       help_text='Android WebView:<br/>' + SHIPPED_WEBVIEW_HELP_TXT)
 
-  prefixed = forms.BooleanField(required=False, initial=False, label='Prefixed?')
+  prefixed = forms.BooleanField(required=False, initial=False, label='WebKit prefixed?')
 
   footprint  = forms.ChoiceField(
       required=False, label='Technical footprint',


### PR DESCRIPTION
Gang,

Here's the changes I've made based on today's usability session. 

One issue I was not able to cover was what do do about the description of web platform tests. My impression is that this is tied to a very definite set of criteria, but I am not versed in them. This will ultimately be a job for our help text. In the meantime, it seems like we need something more descriptive than 'Is this feature fully tested in Web Platform Tests?'