### PR TITLE
Avoid autofill on feature name.

### DIFF
--- a/guideforms.py
+++ b/guideforms.py
@@ -42,7 +42,9 @@ SHIPPED_WEBVIEW_HELP_TXT = (
 ALL_FIELDS = {
     'name': forms.CharField(
         required=True, label='Feature',
-        widget=forms.TextInput(attrs={'autocomplete': 'off'}),
+        # Use a specific autocomplete value to avoid "name" autofill.
+        # https://bugs.chromium.org/p/chromium/issues/detail?id=468153#c164
+        widget=forms.TextInput(attrs={'autocomplete': 'feature-name'}),
         help_text=
         ('Capitalize only the first letter and the beginnings of '
          'proper nouns. '

--- a/models.py
+++ b/models.py
@@ -1109,7 +1109,9 @@ class FeatureForm(forms.Form):
   #name = PlaceholderCharField(required=True, placeholder='Feature name')
   name = forms.CharField(
       required=True, label='Feature',
-      widget=forms.TextInput(attrs={'autocomplete': 'off'}),
+      # Use a specific autocomplete value to avoid "name" autofill.
+      # https://bugs.chromium.org/p/chromium/issues/detail?id=468153#c164
+      widget=forms.TextInput(attrs={'autocomplete': 'feature-name'}),
       help_text='Capitalize only the first letter and the beginnings of proper nouns.')
 
   summary = forms.CharField(label='Summary', required=True,


### PR DESCRIPTION
This should resolve the problem that you chatted to me about today.

Chrome offers autofill on form fields that have names that match names commonly used in shipping addresses.  In this case, the feature name field is called "name".  As I understand it, Chrome ignores autocomplete="off" for those cases because too many existing websites have autocomplete="off" specified in too many places.  The spec says that the autocomplete attribute actually indicates the type of data that should be autocompleted.  The recommended way to control it is to specify a semantic value that describes the type of content in the field and simply does not match any shipping address related type listed in the spec.