### PR TITLE
Use git hash rather than date for the GAE app version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "lint": "gulp lint-fix && lit-analyzer \"static/elements/chromedash-!(featurelist)*.js\"",
     "build": "gulp",
     "watch": "gulp watch",
-    "deploy": "npm run build && ./scripts/deploy_site.sh `date +%Y-%m-%d`",
-    "staging": "npm run build && ./scripts/deploy_site.sh `date +%Y-%m-%d` cr-status-staging",
+    "deploy": "npm run build && ./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'`",
+    "staging": "npm run build && ./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'` cr-status-staging",
     "start": "npm run build && ./scripts/start_server.sh"
   },
   "repository": {


### PR DESCRIPTION
This will allow us to be more certain about what is in a given deployed app version.  And, we can push two distinct versions on the same calendar day without overwriting.  

The "-tainted" suffix is a convention used in ChOps to indicate that a version is not the head of the main branch or that there were uncommitted changes in the working directory.  Here it just means that there were uncommitted changes because detecting that is simpler.