### PR TITLE
Upgrade to Django 1.11.29 to avoid a github security alert.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django==1.11.28
+Django==1.11.29
 beautifulsoup4
 mock


### PR DESCRIPTION
Security alert is here:
https://github.com/GoogleChrome/chromium-dashboard/network/alert/requirements.txt/django/open

Django 1.11.29 release notes consist of only the relevant security fix:
https://docs.djangoproject.com/en/3.0/releases/1.11.29/