### PR TITLE
Use side-by-side striped tables for the feature metadata

### DIFF
--- a/static/sass/guide.scss
+++ b/static/sass/guide.scss
@@ -9,6 +9,18 @@
   margin-top: 20px;
 }
 
+.flex-cols {
+  display: flex;
+  flex-flow: row wrap;
+  align-items: flex-start;
+  align-content: space-between;
+}
+
+table.property-sheet {
+  margin-right: 16px;
+  margin-bottom: 16px;
+}
+
 table.property-sheet tr:nth-of-type(odd) {
   background: #f8f8f8;
 }

--- a/static/sass/guide.scss
+++ b/static/sass/guide.scss
@@ -1,0 +1,23 @@
+/* TODO(jrobbins): Convert metadata.html to a web component and put these
+   style rules inside that component. */
+
+#metadata-buttons {
+  margin-left: 20px;
+}
+
+#metadata-buttons div {
+  margin-top: 20px;
+}
+
+table.property-sheet tr:nth-of-type(odd) {
+  background: #f8f8f8;
+}
+
+
+table.property-sheet th, #metadata-readonly td {
+  padding: 6px 30px 6px 6px;
+}
+
+table.property-sheet th {
+  white-space: nowrap;
+}

--- a/templates/guide/edit.html
+++ b/templates/guide/edit.html
@@ -2,14 +2,7 @@
 
 {% block css %}
 <link rel="stylesheet" href="/static/css/forms.css">
-<style>
-#metadata-buttons {
-  margin-left: 20px;
-}
-#metadata-buttons div {
-  margin-top: 20px;
-}
-</style>
+<link rel="stylesheet" href="/static/css/guide.css">
 {% endblock %}
 
 {% block subheader %}

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -28,16 +28,6 @@
         </td>
       </tr>
 
-      {% if feature.unlisted %}
-      <tr>
-        <th></th>
-        <td>
-           This feature is only shown in the feature list
-           to users who with edit access.
-        </td>
-      </tr>
-      {% endif %}
-      
       <tr>
         <th>Blink components</th>
         <td>{{ feature.blink_components | join:', ' }}</td>
@@ -98,6 +88,14 @@
     </table>
 
     </td></tr></table>
+
+    {% if feature.unlisted %}
+      <div style="padding: 8px">
+        This feature is only shown in the feature list
+        to users who with edit access.
+      </div>
+    {% endif %}
+
   </div>
 
   <div id="metadata-editing" style="display:none">

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -14,9 +14,7 @@
         <div style="width:60em">{{ feature.summary }}</div>
     </div>
 
-    <table>
-      <tr>
-        <td>
+    <div class="flex-cols">
 
     <table class="property-sheet">
       <tr>
@@ -87,7 +85,7 @@
 
     </table>
 
-    </td></tr></table>
+    </div> <!-- flex-cols -->
 
     {% if feature.unlisted %}
       <div style="padding: 8px">

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -11,37 +11,93 @@
                     >Delete</a></div>
           {% endif %}
         </div>
-      <div style="width:60em">{{ feature.summary }}</div>
+        <div style="width:60em">{{ feature.summary }}</div>
     </div>
-    <div>Category: {{ feature.category }}</div>
-    {% if feature.unlisted %}
-    <div>This feature is only shown in the feature list
-         to users who with edit access.</div>
-    {% endif %}
-    <div>Owners: 
-      {% for owner in feature.owner %}
-        <a href="mailto:{{ owner }}">{{ owner }}</a>
-      {% endfor %}
-    </div>
-    <div>Feature type: {{ feature.feature_type }}</div>
-    <div>Feature stage: {{ feature.intent_stage }}</div>
-    <div>Blink components: {{ feature.blink_components | join:', ' }}</div>
-    <div>Tracking bug:
-      {% if feature.bug_url %}
-        <a href="{{ feature.bug_url }}">{{ feature.bug_url }}</a>
-      {% else %}
-        None
+
+    <table>
+      <tr>
+        <td>
+
+    <table class="property-sheet">
+      <tr>
+        <th>Owners</th>
+        <td>
+          {% for owner in feature.owner %}
+            <a href="mailto:{{ owner }}">{{ owner }}</a>
+          {% endfor %}
+        </td>
+      </tr>
+
+      {% if feature.unlisted %}
+      <tr>
+        <th></th>
+        <td>
+           This feature is only shown in the feature list
+           to users who with edit access.
+        </td>
+      </tr>
       {% endif %}
-    </div>
-    <div>Launch bug:
-      {% if feature.launch_bug_url %}
-        <a href="{{ feature.launch_bug_url }}">{{ feature.launch_bug_url }}</a>
-      {% else %}
-        None
-      {% endif %}
-    </div>
-    <div>Status in Chromium: {{ feature.impl_status_chrome }}</div>
-    <div>Search tags: {{ feature.search_tags | join:', ' }}</div>
+      
+      <tr>
+        <th>Blink components</th>
+        <td>{{ feature.blink_components | join:', ' }}</td>
+      </tr>
+
+      <tr>
+        <th>Category</th>
+        <td>{{ feature.category }}</td>
+      </tr>
+
+      <tr>
+        <th>Feature type</th>
+        <td>{{ feature.feature_type }}</td>
+      </tr>
+
+      <tr>
+        <th>Feature stage</th>
+        <td>{{ feature.intent_stage }}</td>
+      </tr>
+    </table>
+
+        </td>
+        <td>
+
+    <table class="property-sheet">
+      <tr>
+        <th>Tracking bug</th>
+        <td>
+          {% if feature.bug_url %}
+            <a href="{{ feature.bug_url }}">{{ feature.bug_url }}</a>
+          {% else %}
+            None
+          {% endif %}
+         </td>
+      </tr>
+
+      <tr>
+        <th>Launch bug</th>
+        <td>
+          {% if feature.launch_bug_url %}
+            <a href="{{ feature.launch_bug_url }}">{{ feature.launch_bug_url }}</a>
+          {% else %}
+            None
+          {% endif %}
+        </td>
+      </tr>
+
+      <tr>
+        <th>Status in Chromium</th>
+        <td>{{ feature.impl_status_chrome }}</td>
+      </tr>
+
+      <tr>
+        <th>Search tags</th>
+        <td>{{ feature.search_tags | join:', ' }}</td>
+      </tr>
+
+    </table>
+
+    </td></tr></table>
   </div>
 
   <div id="metadata-editing" style="display:none">


### PR DESCRIPTION
This addresses one of the items in your "WebStatus - Notes" doc about using a mutli-column layout to make more efficient use of space on the metadata panel in the Guide UX.  Also, the fields are reordered to match the ordering of my other CL that changed the field order.