### PR TITLE
Several tweaks to field location and order.

### DIFF
--- a/guideforms.py
+++ b/guideforms.py
@@ -225,7 +225,7 @@ ALL_FIELDS = {
                    'maxlength': 1480})),
 
     'ie_views': forms.ChoiceField(
-        required=False, label='Edge',
+        required=False, label='Edge views',
         choices=models.VENDOR_VIEWS_EDGE.items(),
         initial=models.NO_PUBLIC_SIGNALS),
 
@@ -481,13 +481,12 @@ ALL_FIELDS = {
 class NewFeatureForm(forms.Form):
 
   field_order = (
-      'name', 'summary', 'owner',
+      'name', 'summary',
+      'unlisted', 'owner',
       'blink_components', 'category',
-      'unlisted',
       'feature_type')
   name = ALL_FIELDS['name']
   summary = ALL_FIELDS['summary']
-  category = ALL_FIELDS['category']
   unlisted = ALL_FIELDS['unlisted']
   current_user_email = users.get_current_user().email if users.get_current_user() else None
   owner = forms.EmailField(
@@ -496,22 +495,21 @@ class NewFeatureForm(forms.Form):
           attrs={'multiple': True, 'placeholder': 'email, email'}),
       help_text=('Comma separated list of full email addresses. '
                  'Prefer @chromium.org.'))
-  # Note: feature_type is done with custom HTML
   blink_components = ALL_FIELDS['blink_components']
+  category = ALL_FIELDS['category']
+  # Note: feature_type is done with custom HTML
 
 
 class MetadataForm(forms.Form):
 
   field_order = (
-      'name', 'summary', 'owner',
+      'name', 'summary', 'unlisted', 'owner',
       'blink_components', 'category',
-      'unlisted',
       'feature_type', 'intent_stage',
       'bug_url', 'launch_bug_url',
       'impl_status_chrome', 'search_tags')
   name = ALL_FIELDS['name']
   summary = ALL_FIELDS['summary']
-  category = ALL_FIELDS['category']
   unlisted = ALL_FIELDS['unlisted']
   owner = forms.EmailField(
       required=False,
@@ -520,13 +518,14 @@ class MetadataForm(forms.Form):
           attrs={'multiple': True, 'placeholder': 'email, email'}),
       help_text=('Comma separated list of full email addresses. '
                  'Prefer @chromium.org.'))
+  blink_components = ALL_FIELDS['blink_components']
+  category = ALL_FIELDS['category']
   feature_type = ALL_FIELDS['feature_type']
   intent_stage = forms.ChoiceField(
       required=False, label='Feature stage',
       help_text='Select the appropriate process stage.',
       initial=models.INTENT_IMPLEMENT,
       choices=models.INTENT_STAGES.items())
-  blink_components = ALL_FIELDS['blink_components']
   bug_url = ALL_FIELDS['bug_url']
   launch_bug_url = ALL_FIELDS['launch_bug_url']
   impl_status_chrome = ALL_FIELDS['impl_status_chrome']
@@ -537,19 +536,12 @@ class NewFeature_Incubate(forms.Form):
 
   field_order = (
       'motivation', 'initial_public_proposal_url', 'explainer_links',
-      'owner', 'blink_components', 'footprint',
+      'footprint',
       'bug_url', 'launch_bug_url', 'comments')
   motivation = ALL_FIELDS['motivation']
   initial_public_proposal_url = ALL_FIELDS['initial_public_proposal_url']
   explainer_links = ALL_FIELDS['explainer_links']
   current_user_email = users.get_current_user().email if users.get_current_user() else None
-  owner = forms.EmailField(
-      initial=current_user_email, required=True, label='Contact emails',
-      widget=forms.EmailInput(
-          attrs={'multiple': True, 'placeholder': 'email, email'}),
-      help_text=('Comma separated list of full email addresses. '
-                 'Prefer @chromium.org.'))
-  blink_components = ALL_FIELDS['blink_components']
   footprint = ALL_FIELDS['footprint']
   bug_url = ALL_FIELDS['bug_url']
   launch_bug_url = ALL_FIELDS['launch_bug_url']
@@ -559,9 +551,8 @@ class NewFeature_Incubate(forms.Form):
 class NewFeature_Prototype(forms.Form):
 
   field_order = (
-      'initial_public_proposal_url', 'spec_link',
+      'spec_link',
       'intent_to_implement_url', 'comments')
-  initial_public_proposal_url = ALL_FIELDS['initial_public_proposal_url']
   # TODO(jrobbins): advise user to request a tag review
   spec_link = ALL_FIELDS['spec_link']
   intent_to_implement_url = ALL_FIELDS['intent_to_implement_url']
@@ -570,7 +561,7 @@ class NewFeature_Prototype(forms.Form):
 
 class Any_DevTrial(forms.Form):
   field_order = (
-      'bug_url', 'doc_links', 'spec_link',
+      'bug_url', 'doc_links',
       'interop_compat_risks',
       'safari_views', 'safari_views_link', 'safari_views_notes',
       'ff_views', 'ff_views_link', 'ff_views_notes',
@@ -583,7 +574,6 @@ class Any_DevTrial(forms.Form):
   bug_url = ALL_FIELDS['bug_url']
   doc_links = ALL_FIELDS['doc_links']
   # TODO(jrobbins): api overview link
-  spec_link = ALL_FIELDS['spec_link']
 
   interop_compat_risks = ALL_FIELDS['interop_compat_risks']
 

--- a/models.py
+++ b/models.py
@@ -108,7 +108,7 @@ FEATURE_TYPES = {
 
 # Intent stages and mapping from stage to stage name.
 INTENT_NONE = 0
-INTENT_INCUBATE = 7  # Start incubating
+INTENT_INCUBATE = 7  # Start incubation
 INTENT_IMPLEMENT = 1  # Start prototyping
 INTENT_EXPERIMENT = 2  # Dev trials
 INTENT_IMPLEMENT_SHIP = 4  # Eval readiness to ship
@@ -120,11 +120,11 @@ INTENT_PARKED = 9
 
 INTENT_STAGES = collections.OrderedDict([
   (INTENT_NONE, 'None'),
-  (INTENT_INCUBATE, 'Start incubating'),
+  (INTENT_INCUBATE, 'Start incubation'),
   (INTENT_IMPLEMENT, 'Start prototyping'),
   (INTENT_EXPERIMENT, 'Dev trials'),
   (INTENT_IMPLEMENT_SHIP, 'Evaluate readiness to ship'),
-  (INTENT_EXTEND_TRIAL, 'Origin trials'),
+  (INTENT_EXTEND_TRIAL, 'Origin Trial'),
   (INTENT_SHIP, 'Prepare to ship'),
   (INTENT_REMOVED, 'Removed'),
   (INTENT_SHIPPED, 'Shipped'),
@@ -1120,6 +1120,30 @@ class FeatureForm(forms.Form):
       widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 500}),
       help_text='Provide a one sentence description followed by one or two lines explaining how this feature helps web developers.')
 
+  summary = forms.CharField(label='Feature summary', required=True, max_length=500,
+      widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 500}),
+      help_text='Summarize the feature using complete sentences as you would to an external developer using the feature.')
+
+  unlisted = forms.BooleanField(
+      required=False, initial=False,
+      help_text=('Check this box for draft features that should not appear '
+                 'on the public feature list. Anyone with the link will be able to '
+                 'view the feature on the detail page.'))
+
+  current_user_email = users.get_current_user().email if users.get_current_user() else None
+  owner = forms.EmailField(
+      initial=current_user_email, required=True, label='Contact emails',
+      widget=forms.EmailInput(
+          attrs={'multiple': True, 'placeholder': 'email, email'}),
+      help_text='Comma separated list of full email addresses. Prefer @chromium.org.')
+
+  blink_components = forms.ChoiceField(
+      required=False,
+      label='Blink component',
+      help_text='Select the most specific component. If unsure, leave as "%s".' % BlinkComponent.DEFAULT_COMPONENT,
+      choices=[(x, x) for x in BlinkComponent.fetch_all_components()],
+      initial=[BlinkComponent.DEFAULT_COMPONENT])
+
   category = forms.ChoiceField(
       required=False,
       help_text='Select the most specific category. If unsure, leave as "%s".' % FEATURE_CATEGORIES[MISC],
@@ -1131,17 +1155,6 @@ class FeatureForm(forms.Form):
       label='Intent stage', help_text='Select the appropriate intent stage.',
       initial=INTENT_IMPLEMENT,
       choices=INTENT_STAGES.items())
-
-  current_user_email = users.get_current_user().email if users.get_current_user() else None
-  owner = forms.EmailField(
-      initial=current_user_email, required=True, label='Contact emails',
-      widget=forms.EmailInput(
-          attrs={'multiple': True, 'placeholder': 'email, email'}),
-      help_text='Comma separated list of full email addresses. Prefer @chromium.org.')
-
-  summary = forms.CharField(label='Feature summary', required=True, max_length=500,
-      widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 500}),
-      help_text='Summarize the feature using complete sentences as you would to an external developer using the feature.')
 
   motivation = forms.CharField(label='Motivation', required=True,
       widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
@@ -1182,12 +1195,6 @@ class FeatureForm(forms.Form):
       required=False, label='Origin Trial feedback summary',
       widget=forms.URLInput(attrs={'placeholder': 'https://'}),
       help_text='If your feature was available as an Origin Trial, link to a summary of usage and developer feedback. If not, leave this empty.')
-
-  unlisted = forms.BooleanField(
-      required=False, initial=False,
-      help_text=('Check this box for draft features that should not appear '
-                 'on the public feature list. Anyone with the link will be able to '
-                 'view the feature on the detail page.'))
 
   doc_links = forms.CharField(label='Doc link(s)', required=False,
       widget=forms.Textarea(
@@ -1238,7 +1245,7 @@ class FeatureForm(forms.Form):
       widget=forms.Textarea(attrs={'rows': 2, 'cols': 50, 'placeholder': 'Notes', 'maxlength': 1480}))
 
   ie_views = forms.ChoiceField(
-      required=False, label='Edge',
+      required=False, label='Edge views',
       choices=VENDOR_VIEWS_EDGE.items(),
       initial=NO_PUBLIC_SIGNALS)
   ie_views_link = forms.URLField(
@@ -1338,13 +1345,6 @@ class FeatureForm(forms.Form):
       help_text=(
           'Link to the first public proposal to create this feature, e.g., '
           'a WICG discourse post.'))
-
-  blink_components = forms.ChoiceField(
-      required=False,
-      label='Blink component',
-      help_text='Select the most specific component. If unsure, leave as "%s".' % BlinkComponent.DEFAULT_COMPONENT,
-      choices=[(x, x) for x in BlinkComponent.fetch_all_components()],
-      initial=[BlinkComponent.DEFAULT_COMPONENT])
 
   devrel = forms.EmailField(
       required=False, label='Developer relations emails',

--- a/models.py
+++ b/models.py
@@ -108,7 +108,7 @@ FEATURE_TYPES = {
 
 # Intent stages and mapping from stage to stage name.
 INTENT_NONE = 0
-INTENT_INCUBATE = 7  # Start incubation
+INTENT_INCUBATE = 7  # Start incubating
 INTENT_IMPLEMENT = 1  # Start prototyping
 INTENT_EXPERIMENT = 2  # Dev trials
 INTENT_IMPLEMENT_SHIP = 4  # Eval readiness to ship
@@ -120,7 +120,7 @@ INTENT_PARKED = 9
 
 INTENT_STAGES = collections.OrderedDict([
   (INTENT_NONE, 'None'),
-  (INTENT_INCUBATE, 'Start incubation'),
+  (INTENT_INCUBATE, 'Start incubating'),
   (INTENT_IMPLEMENT, 'Start prototyping'),
   (INTENT_EXPERIMENT, 'Dev trials'),
   (INTENT_IMPLEMENT_SHIP, 'Evaluate readiness to ship'),

--- a/processes.py
+++ b/processes.py
@@ -66,6 +66,7 @@ BLINK_PROCESS_STAGES = [
       ['Initial public proposal',
        'Motivation',
        'Spec repo',
+       'Explainer',
       ],
       [],
       models.INTENT_NONE, models.INTENT_INCUBATE),
@@ -74,9 +75,7 @@ BLINK_PROCESS_STAGES = [
       'Start prototyping',
       'Share an explainer doc and API. '
       'Start prototyping code in a public repo.',
-      ['Explainer',
-       'API design',
-       'Code in repo',
+      ['API design',
        'Security review',
        'Privacy review',
        'Intent to Prototype email',

--- a/processes.py
+++ b/processes.py
@@ -60,7 +60,7 @@ LAUNCH_BUG_TEMPLATE_URL = '/admin/features/launch/{feature_id}?launch'
 
 BLINK_PROCESS_STAGES = [
   ProcessStage(
-      'Start incubation',
+      'Start incubating',
       'Create an initial WebStatus feature entry and kick off standards '
       'incubation (WICG) to share ideas.',
       ['Initial public proposal',

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -14,6 +14,13 @@
         <div style="width:60em">{{ feature.summary }}</div>
     </div>
 
+    {% if feature.unlisted %}
+      <div style="padding: 8px">
+        This feature is only shown in the feature list
+        to users who with edit access.
+      </div>
+    {% endif %}
+
     <div class="flex-cols">
 
     <table class="property-sheet">
@@ -86,13 +93,6 @@
     </table>
 
     </div> <!-- flex-cols -->
-
-    {% if feature.unlisted %}
-      <div style="padding: 8px">
-        This feature is only shown in the feature list
-        to users who with edit access.
-      </div>
-    {% endif %}
 
   </div>
 

--- a/tests/admin_test.py
+++ b/tests/admin_test.py
@@ -86,7 +86,7 @@ class IntentEmailPreviewHandlerTest(unittest.TestCase):
 
     self.feature_1.intent_stage = models.INTENT_INCUBATE
     self.assertEqual(
-        'Intent stage "Start incubating"',
+        'Intent stage "Start incubation"',
         self.handler.compute_subject_prefix(self.feature_1))
 
     self.feature_1.intent_stage = models.INTENT_IMPLEMENT

--- a/tests/admin_test.py
+++ b/tests/admin_test.py
@@ -86,7 +86,7 @@ class IntentEmailPreviewHandlerTest(unittest.TestCase):
 
     self.feature_1.intent_stage = models.INTENT_INCUBATE
     self.assertEqual(
-        'Intent stage "Start incubation"',
+        'Intent stage "Start incubating"',
         self.handler.compute_subject_prefix(self.feature_1))
 
     self.feature_1.intent_stage = models.INTENT_IMPLEMENT


### PR DESCRIPTION
This is a bunch of small changes discussed in our meeting this morning.  They are all related to field location, order, and labels.
* Make unlisted first
* Remove contact email and blink component from first stage
* "Edge" -> "Edge Views"
* Delete "Code in repo" progress checkmark
* Initial publication URL should be in incubate stage only
* Explainer checkmark was on a different stage than the explainer field
