### PR TITLE
Don't default new feature owner to the wrong address.

### DIFF
--- a/guide.py
+++ b/guide.py
@@ -97,8 +97,10 @@ class FeatureNew(common.ContentHandler):
       common.handle_401(self.request, self.response, Exception)
       return
 
+    new_feature_form = guideforms.NewFeatureForm(
+        initial={'owner': user.email()})
     template_data = {
-        'overview_form': guideforms.NewFeatureForm(),
+        'overview_form': new_feature_form,
         }
 
     self._add_common_template_values(template_data)

--- a/guideforms.py
+++ b/guideforms.py
@@ -488,9 +488,8 @@ class NewFeatureForm(forms.Form):
   name = ALL_FIELDS['name']
   summary = ALL_FIELDS['summary']
   unlisted = ALL_FIELDS['unlisted']
-  current_user_email = users.get_current_user().email if users.get_current_user() else None
   owner = forms.EmailField(
-      initial=current_user_email, required=True, label='Contact emails',
+      required=True, label='Contact emails',
       widget=forms.EmailInput(
           attrs={'multiple': True, 'placeholder': 'email, email'}),
       help_text=('Comma separated list of full email addresses. '
@@ -541,7 +540,6 @@ class NewFeature_Incubate(forms.Form):
   motivation = ALL_FIELDS['motivation']
   initial_public_proposal_url = ALL_FIELDS['initial_public_proposal_url']
   explainer_links = ALL_FIELDS['explainer_links']
-  current_user_email = users.get_current_user().email if users.get_current_user() else None
   footprint = ALL_FIELDS['footprint']
   bug_url = ALL_FIELDS['bug_url']
   launch_bug_url = ALL_FIELDS['launch_bug_url']
@@ -709,9 +707,8 @@ class Any_Identify(forms.Form):
   field_order = (
       'owner', 'blink_components', 'motivation', 'explainer_links',
       'footprint', 'bug_url', 'launch_bug_url', 'comments')
-  current_user_email = users.get_current_user().email if users.get_current_user() else None
   owner = forms.EmailField(
-      initial=current_user_email, required=True, label='Contact emails',
+      required=True, label='Contact emails',
       widget=forms.EmailInput(
           attrs={'multiple': True, 'placeholder': 'email, email'}),
       help_text=('Comma separated list of full email addresses. '

--- a/models.py
+++ b/models.py
@@ -1130,9 +1130,8 @@ class FeatureForm(forms.Form):
                  'on the public feature list. Anyone with the link will be able to '
                  'view the feature on the detail page.'))
 
-  current_user_email = users.get_current_user().email if users.get_current_user() else None
   owner = forms.EmailField(
-      initial=current_user_email, required=True, label='Contact emails',
+      required=True, label='Contact emails',
       widget=forms.EmailInput(
           attrs={'multiple': True, 'placeholder': 'email, email'}),
       help_text='Comma separated list of full email addresses. Prefer @chromium.org.')

--- a/templates/guide/new.html
+++ b/templates/guide/new.html
@@ -91,5 +91,9 @@
 {% endblock %}
 
 {% block js %}
-<script src="/static/js/admin/process_overview_form.min.js"></script>
+<script>
+  var currentUserEmail = "{{user.email}}";
+</script>
+
+<script src="/static/js/guide/new.min.js"></script>
 {% endblock %}

--- a/templates/guide/new.html
+++ b/templates/guide/new.html
@@ -91,9 +91,5 @@
 {% endblock %}
 
 {% block js %}
-<script>
-  var currentUserEmail = "{{user.email}}";
-</script>
-
-<script src="/static/js/guide/new.min.js"></script>
+<script src="/static/js/admin/process_overview_form.min.js"></script>
 {% endblock %}

--- a/tests/guild_test.py
+++ b/tests/guild_test.py
@@ -60,6 +60,11 @@ class FeatureNewTest(unittest.TestCase):
     mock_render.assert_called_once()
     template_data = mock_render.call_args.kwargs['data']
     self.assertTrue('overview_form' in template_data)
+    form = template_data['overview_form']
+    field = form.fields['owner']
+    self.assertEqual(
+        'user1@google.com',
+        form.get_initial_for_field(field, 'owner'))
 
   def test_post__anon(self):
     """Anon cannot create features, gets a 401."""


### PR DESCRIPTION
This problem was previously reported by aglaforge.

The existing code initialized a class variable with the user who was signed in at the time that that python code was first loaded in that GAE server instance.  So, for example, if jrobbins tested the app after deploying it, the feature owner would always default to jrobbins until that GAE instance was shut down.

The new code provides no default in the form field definition, but it provides an initial value when the form instance is created.  Only the new UI has this logic.  The old UI will have that field blank. 