### PR TITLE
Fix impl_status_in_chrome on feature detail page.

### DIFF
--- a/templates/feature.html
+++ b/templates/feature.html
@@ -143,25 +143,11 @@
       {% endif %}
       <br>
       <p>
-        {% if feature.shipped_milestone or feature.shipped_android_milestone or feature.shipped_ios_milestone or feature.shipped_webview_milestone %}
-          <b>
-          {% if feature.meta.origintrial %}
-            Origin trial
-          {% else %}
-            {% if feature.meta.needsflag %}
-              Behind a flag
-            {% elif feature.impl_status_chrome == "Deprecated" or feature.impl_status_chrome == "No longer pursuing" %}
-              Deprecated
-            {% elif feature.impl_status_chrome == "Removed" %}
-              Removed
-            {% else %}
-              Enabled by default
-            {% endif %}
-          {% endif %}
-          </b>
-          {% if feature.bug_url %}
+        <b>{{ feature.impl_status_chrome }}</b>
+        {% if feature.bug_url %}
           (<a href="{{feature.bug_url}}" target="_blank">tracking bug</a>)
-          {% endif %}
+        {% endif %}
+        {% if feature.shipped_milestone or feature.shipped_android_milestone or feature.shipped_ios_milestone or feature.shipped_webview_milestone %}
           in:
           <ul>
           {% if feature.shipped_milestone %}
@@ -177,11 +163,6 @@
           <li>Android WebView release {{ feature.shipped_webview_milestone }}</li>
           {% endif %}
           </ul>
-        {% else %}
-          {{ feature.meta.milestone_str }}
-          {% if feature.bug_url %}
-          (<a href="{{ feature.bug_url }}" target="_blank">tracking bug</a>)
-          {% endif %}
         {% endif %}
       </p>
     </section>


### PR DESCRIPTION
This should resolve issue #975.

There was some old logic-tree code to display the implementation status of a feature in chrome.  It had not been updated to include all possible status values, so several possible values caused an incorrect default to be displayed instead.  The new code simply displays the status string, since that is available from a value generated in python.