### PR TITLE
Callout elements for on-page help

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -119,6 +119,11 @@ handlers:
   script: schedule.app
   secure: always
 
+- url: /cues.*
+  script: cues.app
+  login: required # non-admin
+  secure: always
+
 # Everything else
 - url: /.*
   script: server.app

--- a/common.py
+++ b/common.py
@@ -170,12 +170,14 @@ class ContentHandler(BaseHandler):
 
     user = users.get_current_user()
     if user:
+      user_pref = models.UserPref.get_signed_in_user_pref()
       template_data['login'] = (
           'Logout', users.create_logout_url(dest_url=self.request.path))
       template_data['user'] = {
         'can_edit': self.user_can_edit(user),
         'is_admin': users.is_current_user_admin(),
         'email': user.email(),
+        'dismissed_cues': json.dumps(user_pref.dismissed_cues),
       }
     else:
       template_data['user'] = None

--- a/cues.py
+++ b/cues.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import json
+import webapp2
+
+from google.appengine.ext import db
+from google.appengine.api import users
+
+from django.template.loader import render_to_string
+
+import common
+import models
+import settings
+
+
+# We only accept known cue name strings.
+ALLOWED_CUES = ['progress-checkmarks']
+
+
+class DismissCueHandler(webapp2.RequestHandler):
+  """Handle JSON API requests to dismiss an on-page help cue card."""
+
+  def post(self):
+    """Dismisses a cue card for the signed in user."""
+    json_body = json.loads(self.request.body)
+    cue = json_body.get('cue')
+    if cue not in ALLOWED_CUES:
+      logging.info('Unexpected cue: %r', cue)
+      self.abort(400)
+
+    user = users.get_current_user()
+    if not user:
+      logging.info('User must be signed in before dismissing cues')
+      self.abort(400)
+
+    models.UserPref.dismiss_cue(cue)
+    data = {}
+    self.response.headers['Content-Type'] = 'application/json;charset=utf-8'
+    result = self.response.write(json.dumps(data, separators=(',',':')))
+
+
+app = webapp2.WSGIApplication([
+  ('/cues/dismiss', DismissCueHandler),
+], debug=settings.DEBUG)

--- a/models.py
+++ b/models.py
@@ -1452,6 +1452,10 @@ class UserPref(DictModel):
   # and it bounced.  We will not send to that address again.
   bounced = db.BooleanProperty(default=False)
 
+  # A list of strings identifying on-page help cue cards that the user
+  # has dismissed (clicked "X" or "GOT IT").
+  dismissed_cues = db.StringListProperty()
+
   @classmethod
   def get_signed_in_user_pref(cls):
     """Return a UserPref for the signed in user or None if anon."""
@@ -1466,6 +1470,17 @@ class UserPref(DictModel):
     else:
       user_pref = UserPref(email=signed_in_user.email())
     return user_pref
+
+  @classmethod
+  def dismiss_cue(cls, cue):
+    """Add cue to the signed in user's dismissed_cues."""
+    user_pref = cls.get_signed_in_user_pref()
+    if not user_pref:
+      return  # Anon users cannot store dismissed cue names.
+
+    if cue not in user_pref.dismissed_cues:
+      user_pref.dismissed_cues.append(cue)
+      user_pref.put()
 
   @classmethod
   def get_prefs_for_emails(cls, emails):

--- a/static/components.js
+++ b/static/components.js
@@ -12,6 +12,7 @@ import '@polymer/paper-styles/color.js';
 
 // chromedash components
 import './elements/icons';
+import './elements/chromedash-callout';
 import './elements/chromedash-color-status';
 import './elements/chromedash-feature';
 import './elements/chromedash-featurelist';

--- a/static/elements/chromedash-callout.js
+++ b/static/elements/chromedash-callout.js
@@ -1,0 +1,81 @@
+import {LitElement, css, html} from 'lit-element';
+
+class ChromedashCallout extends LitElement {
+  static get properties() {
+    return {
+      targetEl: {type: Element},
+      // TODO(jrobbins): Support sides other than "south".
+      side: {type: String}, // "north", "south", "east", or "west"
+      hidden: {type: Boolean},
+    };
+  }
+
+  constructor() {
+    super();
+    this.side = 'south';
+    this.hidden = false;
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        /* TODO(jrobins): Put this into a global theme.css file. */
+        --blue-900: #174EA6;
+
+        --callout-bg-color: var(--blue-900);
+        --callout-text-color: white;
+      }
+      #bubble {
+        position: relative;
+        display: inline-block;
+        background: var(--callout-bg-color);
+        border-radius: 8px;
+        padding: 8px;
+        max-width: 24em;
+        color: var(--callout-text-color);
+        font-weight: bold;
+      }
+      #bubble[hidden] {
+        display: none;
+      }
+      #bubble:after {
+        content: '';
+        position: absolute;
+        border: 20px solid transparent;
+      }
+      /* Bubble will be located on the south side of targetEl. */
+      #bubble.south:after {
+        top: 0;
+        left: 50%;
+        width: 0;
+        height: 0;
+        border-bottom-color: var(--callout-bg-color);
+        border-top: 0;
+        margin-left: -20px;
+        margin-top: -20px;
+     }
+     #closebox {
+       float: right;
+       margin-left: 8px;
+     }
+    `;
+  }
+
+  close() {
+    this.hidden = true;
+  }
+
+  render() {
+    return html`
+      <div id="bubble" class="${this.side}" ?hidden=${this.hidden}>
+        <iron-icon id="closebox"
+          icon="chromestatus:close" @click=${this.close}></iron-icon>
+        <div style="margin: 4px">
+          <slot></slot>
+        </div>
+      </div>
+    `;
+  }
+}
+
+customElements.define('chromedash-callout', ChromedashCallout);

--- a/static/elements/chromedash-callout.js
+++ b/static/elements/chromedash-callout.js
@@ -11,7 +11,7 @@ class ChromedashCallout extends LitElement {
       top: {type: Number},
       left: {type: Number},
       cue: {type: String}, // String to send to the server when dismissed.
-      dismissedCues: {attribute: false, type: Array},
+      dismissedCues: {attribute: false, type: Object},
     };
   }
 
@@ -22,7 +22,7 @@ class ChromedashCallout extends LitElement {
     this.top = 0;
     this.left = 0;
     this.signedIn = false;
-    this.dismissedCues = [];
+    this.dismissedCues = {};
   }
 
   connectedCallback() {

--- a/static/elements/chromedash-callout.js
+++ b/static/elements/chromedash-callout.js
@@ -11,7 +11,7 @@ class ChromedashCallout extends LitElement {
       top: {type: Number},
       left: {type: Number},
       cue: {type: String}, // String to send to the server when dismissed.
-      dismissedCues: {attribute: false},
+      dismissedCues: {attribute: false, type: Array},
     };
   }
 

--- a/static/elements/chromedash-process-overview.js
+++ b/static/elements/chromedash-process-overview.js
@@ -14,7 +14,7 @@ class ChromedashProcessOverview extends LitElement {
       feature: {type: Object},
       process: {type: Array},
       progress: {type: Object},
-      dismissedCues: {type: Object},
+      dismissedCues: {type: Array},
     };
   }
 
@@ -23,7 +23,7 @@ class ChromedashProcessOverview extends LitElement {
     this.feature = {};
     this.process = [];
     this.progress = {};
-    this.dismissedCues = {};
+    this.dismissedCues = [];
   }
 
   inFinalStage(stage) {

--- a/static/elements/chromedash-process-overview.js
+++ b/static/elements/chromedash-process-overview.js
@@ -14,7 +14,7 @@ class ChromedashProcessOverview extends LitElement {
       feature: {type: Object},
       process: {type: Array},
       progress: {type: Object},
-      dismissedCues: {type: Array},
+      dismissedCues: {type: Object},
     };
   }
 
@@ -23,7 +23,7 @@ class ChromedashProcessOverview extends LitElement {
     this.feature = {};
     this.process = [];
     this.progress = {};
-    this.dismissedCues = [];
+    this.dismissedCues = {};
   }
 
   inFinalStage(stage) {
@@ -97,6 +97,7 @@ class ChromedashProcessOverview extends LitElement {
 
     return html`<div class="done">${item}</div>`;
   }
+
 
   render() {
     let featureId = this.feature.id;

--- a/static/elements/chromedash-process-overview.js
+++ b/static/elements/chromedash-process-overview.js
@@ -145,7 +145,7 @@ class ChromedashProcessOverview extends LitElement {
 
     ${Object.keys(this.progress).length ? html`
       <chromedash-callout
-        cue="progress-checkmarks" targetid="progress-header" signedin="true"
+        cue="progress-checkmarks" targetid="progress-header" signedin
         .dismissedCues=${this.dismissedCues}>
           Progress checkmarks appear in this column as you fill in
           fields of the feature entry.  However, you may start the next

--- a/static/elements/chromedash-process-overview.js
+++ b/static/elements/chromedash-process-overview.js
@@ -1,6 +1,7 @@
 import {LitElement, html} from 'lit-element';
 import {nothing} from 'lit-html';
 import '@polymer/iron-icon';
+import './chromedash-callout';
 import './chromedash-color-status';
 
 import style from '../css/elements/chromedash-process-overview.css';
@@ -13,6 +14,7 @@ class ChromedashProcessOverview extends LitElement {
       feature: {type: Object},
       process: {type: Array},
       progress: {type: Object},
+      dismissedcues: {type: Object},
     };
   }
 
@@ -21,6 +23,7 @@ class ChromedashProcessOverview extends LitElement {
     this.feature = {};
     this.process = [];
     this.progress = {};
+    this.dismissedcues = {};
   }
 
   inFinalStage(stage) {
@@ -98,10 +101,11 @@ class ChromedashProcessOverview extends LitElement {
   render() {
     let featureId = this.feature.id;
     return html`
+     <div style="position: relative">
      <table>
        <tr>
          <th style="width: 30em;">Stage</th>
-         <th style="width: 25em">Progress</th>
+         <th style="width: 25em" id="progress-header">Progress</th>
          <th style="width: 12em"></th>
        </tr>
 
@@ -138,6 +142,18 @@ class ChromedashProcessOverview extends LitElement {
          </tr>
        `)}
      </table>
+
+    ${Object.keys(this.progress).length ? html`
+      <chromedash-callout
+        cue="progress-checkmarks" targetid="progress-header" signedin
+        .dismissedcues=${this.dismissedcues}>
+          Progress checkmarks appear in this column as you fill in
+          fields of the feature entry.  However, you may start the next
+          stage regardless of checkmarks.
+      </chromedash-callout>` :
+      nothing }
+
+    </div>
     `;
   }
 }

--- a/static/elements/chromedash-process-overview.js
+++ b/static/elements/chromedash-process-overview.js
@@ -14,7 +14,7 @@ class ChromedashProcessOverview extends LitElement {
       feature: {type: Object},
       process: {type: Array},
       progress: {type: Object},
-      dismissedcues: {type: Object},
+      dismissedCues: {type: Object},
     };
   }
 
@@ -23,7 +23,7 @@ class ChromedashProcessOverview extends LitElement {
     this.feature = {};
     this.process = [];
     this.progress = {};
-    this.dismissedcues = {};
+    this.dismissedCues = {};
   }
 
   inFinalStage(stage) {
@@ -145,8 +145,8 @@ class ChromedashProcessOverview extends LitElement {
 
     ${Object.keys(this.progress).length ? html`
       <chromedash-callout
-        cue="progress-checkmarks" targetid="progress-header" signedin
-        .dismissedcues=${this.dismissedcues}>
+        cue="progress-checkmarks" targetid="progress-header" signedin="true"
+        .dismissedCues=${this.dismissedCues}>
           Progress checkmarks appear in this column as you fill in
           fields of the feature entry.  However, you may start the next
           stage regardless of checkmarks.

--- a/static/js-src/cues.js
+++ b/static/js-src/cues.js
@@ -1,0 +1,22 @@
+(function(exports) {
+'use strict';
+
+
+class CuesService {
+  static dismissCue(cue) {
+    const url = location.hostname == 'localhost' ?
+      'https://www.chromestatus.com/cues/dismiss' :
+      '/cues/dismiss';
+    return fetch(url, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({cue: cue}),
+    })
+      .then((res) => res.json);
+    // TODO: catch((error) => { display message }
+  }
+}
+
+
+exports.CuesService = CuesService;
+})(window);

--- a/templates/guide/edit.html
+++ b/templates/guide/edit.html
@@ -25,7 +25,8 @@
     title='Blink Process'
     feature='{{ feature_json }}'
     process='{{ process_json }}'
-    progress='{{ progress_so_far }}'>
+    progress='{{ progress_so_far }}'
+    dismissedcues='{{ user.dismissed_cues }}'>
   </chromedash-process-overview>
 </section>
 
@@ -40,4 +41,5 @@
 
 {% block js %}
 <script src="/static/js/admin/process_overview_form.min.js"></script>
+<script src="/static/js/cues.min.js"></script>
 {% endblock %}

--- a/tests/cues_test.py
+++ b/tests/cues_test.py
@@ -1,0 +1,65 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import testing_config  # Must be imported before the module under test.
+
+import mock
+import webapp2
+from webob import exc
+
+from google.appengine.ext import db
+from google.appengine.api import mail
+from google.appengine.api import users
+
+import cues
+import models
+import settings
+
+
+class DismissCueHandlerTest(unittest.TestCase):
+
+  def setUp(self):
+    self.user_pref_1 = models.UserPref(
+        email='one@example.com',
+        notify_as_starrer=False)
+    self.user_pref_1.put()
+    self.handler = cues.DismissCueHandler()
+    self.handler.request = webapp2.Request.blank('/features/star/set')
+    self.handler.response = webapp2.Response()
+
+  def tearDown(self):
+    self.user_pref_1.delete()
+
+  def test_post__valid(self):
+    """User wants to dismiss a valid cue card ID."""
+    testing_config.sign_in('one@example.com', 123567890)
+
+    self.handler.request.body = '{"cue": "progress-checkmarks"}'
+    self.handler.post()
+
+    revised_user_pref = models.UserPref.get_signed_in_user_pref()
+    self.assertEqual(['progress-checkmarks'], revised_user_pref.dismissed_cues)
+
+  def test_post__invalid(self):
+    """User wants to dismiss an invalid cue card ID."""
+    testing_config.sign_in('one@example.com', 123567890)
+
+    self.handler.request.body = '{"cue": "xyz"}'
+    with self.assertRaises(exc.HTTPClientError):
+        self.handler.post()
+
+    # The invalid string should not be added.
+    revised_user_pref = models.UserPref.get_signed_in_user_pref()
+    self.assertEqual([], revised_user_pref.dismissed_cues)


### PR DESCRIPTION
This should resolve issue #978.

This implements a simple on-page help UI functionality that displays a message in a word-bubble near a UI element on a page.  The message has an "X" icon to dismiss the message, and it will not appear for that user again.  This feature is called "cue cards" because that is the name of a similar feature in Monorail.

The first use of a callout cue card in ChromeStatus is one that tells users the meaning of progress checkmarks.