### PR TITLE
Don't offer to set stage to a stage the feature is already on.

### DIFF
--- a/guide.py
+++ b/guide.py
@@ -242,6 +242,7 @@ class FeatureEditStage(common.ContentHandler):
         'feature': f,
         'feature_id': f.key().id,
         'feature_form': detail_form_class(f.format_for_edit()),
+        'already_on_this_stage': stage_id == f.intent_stage,
     })
 
     self._add_common_template_values(template_data)

--- a/templates/guide/stage.html
+++ b/templates/guide/stage.html
@@ -25,18 +25,21 @@
       <tr>
         <th>Process stage:</th>
         <td>
-          <!-- TODO(jrobbins): Auto-check based on conditions. -->
-          <input type="checkbox" name="set_stage"
-                 id="set_stage">
-          <label for="set_stage">
-            Set to: <b>{{ stage_name }}</b>
-            <br>
-            <span class="helptext">
-              Check this box to move this feature to this
-              phase in the process. Leave it unchecked if you are adding
-              draft information or revising a previous stage.
-            </span>
-          </label>
+          {% if already_on_this_stage %}
+            This feature is already in stage <b>{{ stage_name }}</b>.
+          {% else %}
+            <input type="checkbox" name="set_stage"
+                   id="set_stage">
+            <label for="set_stage">
+              Set to: <b>{{ stage_name }}</b>
+              <br>
+              <span class="helptext">
+                Check this box to move this feature to this
+                phase in the process. Leave it unchecked if you are adding
+                draft information or revising a previous stage.
+              </span>
+            </label>
+          {% endif %}
         </td>
       </tr>
       <tr>

--- a/tests/guide_test.py
+++ b/tests/guide_test.py
@@ -249,6 +249,29 @@ class FeatureEditStageTest(unittest.TestCase):
     self.assertTrue('feature' in template_data)
     self.assertTrue('feature_id' in template_data)
     self.assertTrue('feature_form' in template_data)
+    self.assertTrue('already_on_this_stage' in template_data)
+
+  @mock.patch('guide.FeatureEditStage.render')
+  def test_get__not_on_this_stage(self, mock_render):
+    """When feature is no on the stage for the current form, offer checkbox."""
+    testing_config.sign_in('user1@google.com', 1234567890)
+    self.handler.get('/guide/stage', self.feature_1.key().id(), self.stage)
+    self.assertEqual('200 OK', self.handler.response.status)
+    mock_render.assert_called_once()
+    template_data = mock_render.call_args.kwargs['data']
+    self.assertFalse(template_data['already_on_this_stage'])
+
+  @mock.patch('guide.FeatureEditStage.render')
+  def test_get__already_on_this_stage(self, mock_render):
+    """When feature is already on the stage for the current form, say that."""
+    self.feature_1.intent_stage = self.stage
+    self.feature_1.put()
+    testing_config.sign_in('user1@google.com', 1234567890)
+    self.handler.get('/guide/stage', self.feature_1.key().id(), self.stage)
+    self.assertEqual('200 OK', self.handler.response.status)
+    mock_render.assert_called_once()
+    template_data = mock_render.call_args.kwargs['data']
+    self.assertTrue(template_data['already_on_this_stage'])
 
   def test_post__anon(self):
     """Anon cannot edit features, gets a 401."""


### PR DESCRIPTION
This should resolve issue #980.

Now, when a feature is in stage X and the user visits the stage for for stage X, the location that would normally have a checkbox to set the stage will have a message instead.