### PR TITLE
Make guide UX the default

### DIFF
--- a/guideforms.py
+++ b/guideforms.py
@@ -691,7 +691,7 @@ Flat_Metadata = define_form_class_using_shared_fields(
 
 Flat_Identify = define_form_class_using_shared_fields(
     'Flat_Identify',
-    ('motivation', 'explainer_links'))
+    ('motivation', 'initial_public_proposal_url', 'explainer_links'))
 
 
 Flat_Implement = define_form_class_using_shared_fields(

--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -214,7 +214,7 @@ class ChromedashFeature extends LitElement {
         <h2>${this.feature.name}
           ${this.canEdit ? html`
             <span class="tooltip" title="Edit this feature">
-              <a href="/admin/features/edit/${this.feature.id}" data-tooltip>
+              <a href="/guide/edit/${this.feature.id}" data-tooltip>
                 <iron-icon icon="chromestatus:create"></iron-icon>
               </a>
             </span>

--- a/static/js-src/admin/feature_form.js
+++ b/static/js-src/admin/feature_form.js
@@ -48,7 +48,7 @@ if (document.querySelector('.delete-button')) {
 
 if (document.querySelector('#cancel-button')) {
   document.querySelector('#cancel-button').addEventListener('click', (e) => {
-    location.href = `/guide/edit/${e.currentTarget.dataset.id}`;
+    window.location.href = `/guide/edit/${e.currentTarget.dataset.id}`;
   });
 }
 

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -67,7 +67,7 @@
       </span>
       {% if user.can_edit %}
       <span class="tooltip" title="Edit this feature">
-        <a href="/admin/features/edit/{{ feature.id }}" class="editfeature" data-tooltip>
+        <a href="/guide/edit/{{ feature.id }}" class="editfeature" data-tooltip>
           <iron-icon icon="chromestatus:create"></iron-icon>
         </a>
       </span>

--- a/templates/features.html
+++ b/templates/features.html
@@ -31,7 +31,7 @@
     <div class="actionlinks">
       <!-- TODO(jrobbins): Re-implement Subscribe button to use emails. -->
       {% if user.can_edit %}
-        <a href="/admin/features/new" class="blue-button" title="Adds a new feature to the site"><iron-icon icon="chromestatus:add-circle-outline"></iron-icon><span>Add new feature</span></a>
+        <a href="/guide/new" class="blue-button" title="Adds a new feature to the site"><iron-icon icon="chromestatus:add-circle-outline"></iron-icon><span>Add new feature</span></a>
       {% endif %}
     </div>
   </div>

--- a/templates/guide/editall.html
+++ b/templates/guide/editall.html
@@ -33,7 +33,8 @@
         <th></th>
         <td>
           <input class="button" type="submit" value="Submit">
-          <button id="cancel-button" data-id="{{ feature_id }}">Cancel</button>
+          <button id="cancel-button" data-id="{{ feature_id }}"
+                  type="reset">Cancel</button>
         </td>
       </tr>
     </table>
@@ -44,6 +45,10 @@
 
 {% block js %}
 <script>
+  document.querySelector('#cancel-button').addEventListener('click', (e) => {
+    window.location.href = `/guide/edit/${e.currentTarget.dataset.id}`;
+  });
+
   document.body.classList.remove('loading');
 </script>
 {% endblock %}

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -105,7 +105,7 @@
           <th></th>
           <td>
             <input class="button" type="submit" value="Submit">
-            <button id="close-metadata">Cancel</button>
+            <button id="close-metadata" type="reset">Cancel</button>
           </td>
         </tr>
       </table>

--- a/templates/guide/stage.html
+++ b/templates/guide/stage.html
@@ -47,7 +47,8 @@
         <th></th>
         <td>
           <input class="button" type="submit" value="Submit">
-          <button id="cancel-button" data-id="{{ feature_id }}">Cancel</button>
+          <button id="cancel-button" data-id="{{ feature_id }}"
+                  type="reset">Cancel</button>
         </td>
       </tr>
     </table>


### PR DESCRIPTION
This should resolve issue #993.

In this CL:
+ Change the new feature and editing icon links from /admin/feature to /guide.
+ Fix: Add the initial_public_proposal field to the edit-all page.
+ Fix: Make the various Cancel buttons actually cancel the edit and reset the form or navigate back to the overview.