### PR TITLE
Fix malformed tag in notifier email.

### DIFF
--- a/notifier.py
+++ b/notifier.py
@@ -65,7 +65,7 @@ def format_email_body(is_update, feature, changes):
     old_val = prop['old_val']
 
     formatted_changes += ('<li><b>%s:</b> <br/><b>old:</b> %s <br/>'
-                          '<b>new:</b> %s<br/></li><br/>br/>' %
+                          '<b>new:</b> %s<br/></li><br/>' %
                           (prop_name, escape(old_val), escape(new_val)))
   if not formatted_changes:
     formatted_changes = '<li>None</li>'


### PR DESCRIPTION
This PR fixes this:

![image](https://user-images.githubusercontent.com/8204171/92020722-70243400-ed0d-11ea-9757-1b9760cf22f0.png)
