### PR TITLE
Make 'Motivation' into a heading.

### DIFF
--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -302,7 +302,7 @@ class ChromedashFeature extends LitElement {
           <p><span>${this.feature.summary}</span></p>
         </summary>
         ${this.feature.motivation ?
-          html`<p><label>Motivation</label></p>
+          html`<p><h3>Motivation</h3></p>
           <p><span>${this.feature.motivation}</span></p>`
           : nothing }
       </section>


### PR DESCRIPTION
When I added the 'Motivation' header last week, I used a `<label>` tag because it was used elsewhere in the interface. It appears that the styling for that element is not in scope where I used it. (See the image below.) This PR replaces `<label>` with `<h3>` which is styled. It's also semantically and structurally correct for this location in the card.

![image](https://user-images.githubusercontent.com/8204171/92166724-f1eb8e80-eded-11ea-95b1-c6ddd3dd93e4.png)
