### PR TITLE
Increase instance size for more RAM.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,7 +1,7 @@
 runtime: python27
 threadsafe: true
 api_version: 1
-instance_class: F2
+instance_class: F4
 
 # default_expiration: "30s"
 


### PR DESCRIPTION
One of our metrics cron jobs has been running out of RAM, so this CL increases it.

We normally only have a handful of instances running, so the increased cost of the new instance size is not signifiant.