### PR TITLE
Allow generation of any intent email at any time.

### DIFF
--- a/processes.py
+++ b/processes.py
@@ -49,11 +49,13 @@ def process_to_dict(process):
 
 # This page generates a preview of an email that can be sent
 # to a mailing list to announce an intent.
-# The parameter "{feature_id}" is filled in by JS code.
+# {feature_id} and {outgoing_stage} are filled in by JS code.
 # The param "intent" adds clauses the template to include details
 # needed for an intent email.  The param "launch" causes those
 # details to be omitted and a link to create a launch bug shown instead.
-INTENT_EMAIL_URL = '/admin/features/launch/{feature_id}?intent'
+INTENT_EMAIL_URL = ('/admin/features/launch/{feature_id}'
+                    '/{outgoing_stage}'
+                    '?intent')
 LAUNCH_BUG_TEMPLATE_URL = '/admin/features/launch/{feature_id}?launch'
 # TODO(jrobbins): Creation of the launch bug has been a TODO for 5 years.
 

--- a/static/elements/chromedash-process-overview.js
+++ b/static/elements/chromedash-process-overview.js
@@ -70,9 +70,10 @@ class ChromedashProcessOverview extends LitElement {
     return (viewedIncomingStageIndex > featureStageIndex);
   }
 
-  renderAction(action) {
+  renderAction(action, stage) {
     const label = action[0];
-    const url = action[1].replace('{feature_id}', this.feature.id);
+    const url = (action[1].replace('{feature_id}', this.feature.id)
+      .replace('{outgoing_stage}', stage.outgoing_stage));
     return html`
       <li>
         <a href=${url} target="_blank">${label}</a>
@@ -80,7 +81,14 @@ class ChromedashProcessOverview extends LitElement {
   }
 
   renderActions(stage) {
-    return stage.actions.map(act => this.renderAction(act));
+    if (stage.actions) {
+      return html`
+        <ol>
+         ${stage.actions.map(act => this.renderAction(act, stage))}
+        </ol>`;
+    } else {
+      return nothing;
+    }
   }
 
   renderProgressItem(item) {
@@ -124,8 +132,7 @@ class ChromedashProcessOverview extends LitElement {
             ${this.feature.intent_stage_int == stage.outgoing_stage ?
               html`<div><a
                      href="/guide/stage/${featureId}/${stage.outgoing_stage}"
-                     class="button primary">Update</a></div>
-                   <ol>${this.renderActions(stage)}</ol>` :
+                     class="button primary">Update</a></div>` :
               nothing }
             ${this.isPriorStage(stage) ?
               html`<a href="/guide/stage/${featureId}/${stage.outgoing_stage}"
@@ -139,6 +146,8 @@ class ChromedashProcessOverview extends LitElement {
               html`<a href="/guide/stage/${featureId}/${stage.outgoing_stage}"
                    >Preview</a>` :
               nothing }
+
+            ${this.renderActions(stage)}
            </td>
          </tr>
        `)}


### PR DESCRIPTION
Previously, intent email generation was always done based on the current state of the feature entry.  That meant that, e.g., a user could not preview the Intent to Ship email before the feature reached that stage, and users could not go back to look at the Intent to Prototype email template after the feature had progressed.  Now we allow viewing of any intent email for a selected stage at any time.

In this CL:
+ Add the stage_id placeholder to the URLs for the actions that link to intent email templates
+ JS code to insert the appropriate stage_id value into the action URL
+ Add stage_id as an optional parameter to the intent email template handler
+ Add logic to use the supplied stage_id, or default to feature.intent_stage for users following old URLs
+ Updated unit tests