### PR TITLE
Remove gradients and improve text contrast.

### DIFF
--- a/static/sass/_vars.scss
+++ b/static/sass/_vars.scss
@@ -1,4 +1,6 @@
-$default-font-color: #666666;
+$default-font-color: #222;
+$page-background: #fafafa;
+
 $light-grey: #eee;
 
 $gray-1: #e6e6e6;
@@ -6,9 +8,10 @@ $gray-2: #a9a9a9;
 $gray-3: #797979;
 $gray-4: #515151;
 
+$nav-link-color: #444;
+
 $bar-shadow-color: rgba(0, 0, 0, .065);
 $bar-border-color: #D4D4D4;
-$bar-gradient: linear-gradient(to bottom, white, #F2F2F2);
 
 $chromium-color-dark: #366597;
 $chromium-color-medium: #85b4df;
@@ -17,6 +20,9 @@ $chromium-color-center: #4580c0;
 
 $material-primary-button: #58f;
 
+$card-background: white;
+$card-border: 1px solid #ddd;
+$card-box-shadow: rgba(0, 0, 0, 0.067) 1px 1px 4px;
 
 $md-yellow-100: #FFF9C4;
 $md-yellow-200: #FFF59D;
@@ -30,13 +36,6 @@ $app-drawer-width: 200px;
 $header-height: 135px;
 $max-content-width: 760px;
 /* ----- */
-
-@mixin gradient-bar-bg() {
-  background-color: #FAFAFA;
-  background: $bar-gradient;
-  padding: 0.75em 0.5em;
-  box-shadow: 1px 1px 4px $bar-shadow-color;
-}
 
 // @mixin width-max-content() {
 //   width: -webkit-max-content;

--- a/static/sass/elements/_element.scss
+++ b/static/sass/elements/_element.scss
@@ -15,7 +15,6 @@ $feature-min-height: 75px;
 @mixin tooltip {
   content: attr(title) ""; // force to be a string for FF/Safari.
   position: absolute;
-  @include gradient-bar-bg();
   box-shadow: 2px 2px 4px $gray-2;
   border: 1px solid $gray-1;
   z-index: 100;

--- a/static/sass/elements/chromedash-feature.scss
+++ b/static/sass/elements/chromedash-feature.scss
@@ -1,10 +1,12 @@
 @import "element";
 
 :host {
-  @include gradient-bar-bg();
   display: block;
   position: relative;
+  background: $card-background;
   border-radius: $default-border-radius;
+  border: $card-border;
+  box-shadow: $card-box-shadow;
   padding: 10px 10px 10px 20px !important;
   list-style: none;
   box-sizing: border-box;

--- a/static/sass/elements/chromedash-featurelist.scss
+++ b/static/sass/elements/chromedash-featurelist.scss
@@ -11,11 +11,8 @@
 
 .milestone-marker {
   $milestone-label-size: 18px;
-  text-align: right;
-  text-transform: uppercase;
   margin: 32px 0 8px 0;
   font-size: $milestone-label-size;
-  color: $chromium-color-dark;
   -webkit-font-smoothing: initial;
 }
 

--- a/static/sass/elements/chromedash-process-overview.scss
+++ b/static/sass/elements/chromedash-process-overview.scss
@@ -1,7 +1,6 @@
 @import "element";
 
 :host {
-  @include gradient-bar-bg();
   display: block;
   position: relative;
   border-radius: $default-border-radius;

--- a/static/sass/elements/chromedash-schedule.scss
+++ b/static/sass/elements/chromedash-schedule.scss
@@ -156,7 +156,6 @@ iron-icon {
 @mixin tooltip {
   content: attr(title) ""; // force to be a string for FF/Safari.
   position: absolute;
-  @include gradient-bar-bg();
   box-shadow: 2px 2px 4px $gray-2;
   border: 1px solid $gray-1;
   z-index: 100;

--- a/static/sass/features/feature.scss
+++ b/static/sass/features/feature.scss
@@ -1,8 +1,11 @@
 @import "../vars";
 
 #feature {
-  @include gradient-bar-bg;
+  background: $card-background;
   border-radius: $default-border-radius;
+  border: $card-border;
+  box-shadow: $card-box-shadow;
+
   box-sizing: border-box;
   word-wrap: break-word;
   margin-bottom: $content-padding + 100; // padding + height of footer.

--- a/static/sass/features/launch.scss
+++ b/static/sass/features/launch.scss
@@ -12,13 +12,15 @@
     margin-bottom: 15px;
 
     > div {
-      background: rgba(255,255,255,0.8);
-      border-radius: $default-border-radius;
-      margin-top: 5px;
+      background: $card-background;
+      border: $card-border;
+      box-shadow: $card-box-shadow;
+      padding: 12px;
+      margin: 8px 0 16px 0;
     }
 
     > p {
-      color: #666;
+      color: #444;
     }
   }
 

--- a/static/sass/features/launch.scss
+++ b/static/sass/features/launch.scss
@@ -12,7 +12,6 @@
     margin-bottom: 15px;
 
     > div {
-      @include gradient-bar-bg;
       background: rgba(255,255,255,0.8);
       border-radius: $default-border-radius;
       margin-top: 5px;

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -213,7 +213,7 @@ footer {
   div {
     margin-top: $content-padding / 4;
 
-    a + a, a + b, b + a {
+    > * + * {
       margin-left: 1em;
       padding-left: 1em;
     }

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -133,8 +133,8 @@ header {
       white-space: nowrap;
 
       &:hover {
-	color: black;
-	background: $light-grey;
+        color: black;
+        background: $light-grey;
       }
 
       &.disabled {

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -9,7 +9,7 @@ body {
   font: 14px "Roboto", sans-serif;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
-  background-color: $light-grey;
+  background: $page-background;
 
   &.loading {
     #spinner {
@@ -67,6 +67,7 @@ app-drawer {
     height: 100%;
     overflow: auto;
     padding: $content-padding;
+    background: $page-background;
   }
 
   paper-listbox {
@@ -79,7 +80,6 @@ app-drawer {
 
   h3 {
     margin-bottom: $content-padding;
-    text-transform: uppercase;
     font-weight: 500;
     font-size: 14px;
     color: inherit;
@@ -87,7 +87,6 @@ app-drawer {
 }
 
 app-header {
-  background-color: $light-grey;
   right: 0;
   top: 0;
   left: 0;
@@ -107,11 +106,13 @@ app-header {
 header, footer {
   display: flex;
   align-items: center;
-  text-shadow: 0 1px 0 white;
 }
 
 header {
   user-select: none;
+  background: $card-background;
+  border-bottom: $card-border;
+  box-shadow: $card-box-shadow;
 
   a {
     text-decoration: none !important;
@@ -120,24 +121,20 @@ header {
   nav {
     display: flex;
     align-items: center;
-    margin-left: $content-padding;
+    margin: 0 $content-padding;
     -webkit-font-smoothing: initial;
 
     a {
-      @include gradient-bar-bg;
       cursor: pointer;
       font-size: 16px;
       text-align: center;
-      border-radius: $default-border-radius;
-      border-bottom: 1px solid $bar-border-color;
-      border-right: 1px solid $bar-border-color;
+      padding: 8px 16px;
+      color: $nav-link-color;
       white-space: nowrap;
 
-      &:active {
-        position: relative;
-        top: 1px;
-        left: 1px;
-        box-shadow: 3px 3px 4px $bar-shadow-color;
+      &:hover {
+	color: black;
+	background: $light-grey;
       }
 
       &.disabled {
@@ -156,9 +153,13 @@ header {
         left: 0;
         list-style: none;
         z-index: 1;
+        background: $card-background;
+        border-bottom: $card-border;
+        box-shadow: $card-box-shadow;
       }
 
       a {
+	text-align: left;
         display: block;
       }
 
@@ -172,16 +173,9 @@ header {
   aside {
     $logoSize: 32px;
 
-    @include gradient-bar-bg;
-    border-bottom-left-radius: 5px;
-    border-bottom-right-radius: 5px;
-    border-bottom: 1px solid $bar-border-color;
-    border-right: 1px solid $bar-border-color;
-
     background: url(/static/img/chrome_logo.svg) no-repeat $content-padding 50%;
     background-size: $logoSize;
-    background-color: #fafafa;
-    padding: 0.75em 1em;
+    padding: 0.75em 2em;
     padding-left: $logoSize + $content-padding  + $content-padding / 2;
 
     hgroup {
@@ -202,14 +196,15 @@ header {
 }
 
 footer {
-  @include gradient-bar-bg;
   font-size: 12px;
+  background: $card-background;
   box-shadow: 0 -2px 5px $bar-shadow-color;
   display: flex;
   flex-direction: column;
   justify-content: center;
   text-align: center;
   position: fixed;
+  padding: 8px;
   bottom: 0;
   left: 0;
   right: 0;
@@ -217,6 +212,11 @@ footer {
 
   div {
     margin-top: $content-padding / 4;
+
+    a + a, a + b, b + a {
+      margin-left: 1em;
+      padding-left: 1em;
+    }
   }
 }
 

--- a/static/sass/samples.scss
+++ b/static/sass/samples.scss
@@ -1,5 +1,9 @@
 @import "vars";
 
+paper-listbox {
+   background: inherit;
+ }
+
 paper-item {
   display: block;
   padding: 12px 16px;

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,16 +1,17 @@
 <footer>
-  <p>Except as otherwise noted, the content of this page under <a href="https://creativecommons.org/licenses/by/2.5/">CC Attribution 2.5</a> license. Code examples are <a href="https://github.com/GoogleChrome/samples/blob/gh-pages/LICENSE">Apache-2.0</a>.</p>
   <div>
-    <a href="https://groups.google.com/a/chromium.org/forum/#!newtopic/blink-dev"
-       >File content issue</a> |
-    <a href="https://github.com/GoogleChrome/chromium-dashboard/issues"
-       >File an issue</a> |
+     <a href="https://groups.google.com/a/chromium.org/forum/#!newtopic/blink-dev"
+        >Discuss</a>
+     <a href="https://github.com/GoogleChrome/chromium-dashboard/issues"
+       >File an issue</a>
+     <a href="https://www.google.com/policies/privacy/"
+        >Privacy</a>
     <a href="https://docs.google.com/document/d/1jrSlM4Yhae7XCJ8BuasWx71CvDEMMbSKbXwx7hoh1Co/edit?pli=1"
        target="_blank"
-       >About</a> |
+       >About</a>
     {% if user %}
     <a href="/settings"
-       >Settings</a> |
+       >Settings</a>
       <b>{{user.email}}</b>
     {% endif %}  <a href="{{login.1}}">{{login.0}}</a>
   </div>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,18 +1,20 @@
 <footer>
   <div>
      <a href="https://groups.google.com/a/chromium.org/forum/#!newtopic/blink-dev"
+        target="_blank"
         >Discuss</a>
      <a href="https://github.com/GoogleChrome/chromium-dashboard/issues"
+        target="_blank"
        >File an issue</a>
      <a href="https://www.google.com/policies/privacy/"
+        target="_blank"
         >Privacy</a>
     <a href="https://docs.google.com/document/d/1jrSlM4Yhae7XCJ8BuasWx71CvDEMMbSKbXwx7hoh1Co/edit?pli=1"
        target="_blank"
        >About</a>
     {% if user %}
-    <a href="/settings"
-       >Settings</a>
-      <b>{{user.email}}</b>
+    <a href="/settings">Settings</a>
+    <b>{{user.email}}</b>
     {% endif %}  <a href="{{login.1}}">{{login.0}}</a>
   </div>
 </footer>


### PR DESCRIPTION
This is the second of three CLs to refresh the look of chromestatus.

In this CL:
+ Remove gradient backgrounds, and instead use white or very light grey.
+ Use a darker font color for better contrast.
+ Simplify the footer (it will be further simplified when I move login info into the header in my next CL)
+ Stop using all uppercase for milestone markers