### PR TITLE
Simpify app UX layout to be more document-like.

### DIFF
--- a/common.py
+++ b/common.py
@@ -178,7 +178,7 @@ class ContentHandler(BaseHandler):
     if user:
       user_pref = models.UserPref.get_signed_in_user_pref()
       template_data['login'] = (
-          'Logout', users.create_logout_url(dest_url=self.request.path))
+          'Sign out', users.create_logout_url(dest_url=self.request.path))
       template_data['user'] = {
         'can_edit': self.user_can_edit(user),
         'is_admin': users.is_current_user_admin(),
@@ -188,7 +188,7 @@ class ContentHandler(BaseHandler):
     else:
       template_data['user'] = None
       template_data['login'] = (
-          'Login', users.create_login_url(dest_url=self.request.path))
+          'Sign in', users.create_login_url(dest_url=self.request.path))
 
     d.update(template_data)
 

--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -347,11 +347,8 @@ class ChromedashFeaturelist extends LitElement {
     let id;
     if (lastSlash > 0) {
       id = parseInt(location.pathname.substring(lastSlash + 1));
-    } else {
-      const milestone = this.metadataEl.implStatuses[this.metadataEl.status.IN_DEVELOPMENT - 1].val;
-      id = this._firstOfMilestone(milestone);
+      this.scrollToId(id);
     }
-    this.scrollToId(id);
   }
 
   _initialize() {

--- a/static/sass/elements/chromedash-featurelist.scss
+++ b/static/sass/elements/chromedash-featurelist.scss
@@ -18,6 +18,7 @@
 
 .item {
   width: 100%;
+  padding-bottom: 8px;
 }
 
 p {

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -91,16 +91,12 @@ app-header {
   top: 0;
   left: 0;
   z-index: 1;
-
-  &[fixed] {
-    position: fixed;
-  }
 }
 
 .main-toolbar {
   display: flex;
   position: relative;
-  padding: 0 $content-padding;
+  padding: 0;
 }
 
 header, footer {
@@ -120,6 +116,7 @@ header {
 
   nav {
     display: flex;
+    flex: 1;
     align-items: center;
     margin: 0 $content-padding;
     -webkit-font-smoothing: initial;
@@ -196,19 +193,14 @@ header {
 }
 
 footer {
-  font-size: 12px;
-  background: $card-background;
+  // No background: allow footer to blend into page background to de-emphaize it.
   box-shadow: 0 -2px 5px $bar-shadow-color;
   display: flex;
   flex-direction: column;
   justify-content: center;
   text-align: center;
-  position: fixed;
+  margin-top: 6em;
   padding: 8px;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 3;
 
   div {
     margin-top: $content-padding / 4;
@@ -290,9 +282,22 @@ footer {
 }
 
 #content {
-  margin: $content-padding 6px;
+  margin: $content-padding;
   position: relative;
-  height: 100%;
+}
+
+#column-container {
+   display: flex;
+   align-items: stretch;
+ }
+
+#drawer-column {
+  padding: 1em 2em 1em 1em;
+}
+
+#content-column {
+  flex: 1;
+  padding-left: 2em;
 }
 
 #panels {
@@ -311,14 +316,12 @@ footer {
 @media only screen and (min-width: 701px) {
   .main-toolbar {
     .toolbar-content {
-      max-width: $max-content-width;
       width: 100%;
     }
   }
   // Overrides styles set by app-header-layout so there's no visual
   // layout FOUC/jump as the drawer panel upgrades.
   app-header {
-    padding-left: $app-drawer-width;
     left: 0 !important;
   }
 }
@@ -337,10 +340,6 @@ footer {
     .main-toolbar {
       padding: 0;
       display: block;
-
-      iron-icon {
-        width: 24px;
-      }
     }
   }
 
@@ -353,6 +352,14 @@ footer {
     margin-right: 0;
   }
 
+
+  #drawer-column {
+    display: none;
+  }
+  #content-column {
+    padding-left: 8px;
+  }
+
   header {
     $logoSize: 24px;
 
@@ -362,22 +369,15 @@ footer {
       display: flex;
       padding: $content-padding / 2;
       border-radius: 0;
-      background-size: $logoSize;
-      background-position: $content-padding + 8 + $logoSize 50%;
+      background: inherit;  // no logo
 
-      hgroup {
-        padding-left: $content-padding + 8 + $logoSize;
-        span {
-          display: none;
-        }
-      }
     }
     nav {
       margin: 0;
       justify-content: center;
       flex-wrap: wrap;
       a {
-        padding: 5px 10px;
+        padding: 8px 16px;
         margin: 0;
         border-radius: 0;
         flex: 1 0 auto;

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -26,7 +26,7 @@ body {
   align-items: center;
   justify-content: center;
   position: fixed;
-  height: calc(100% - 54px - $header-height); // 100% - height of footer + header.
+  height: 60%; // Centered, half that.
   max-width: $max-content-width;
   width: 100%;
 }
@@ -92,6 +92,11 @@ app-header {
   left: 0;
   z-index: 1;
 }
+
+app-header-layout {
+  flex: 1;
+}
+
 
 .main-toolbar {
   display: flex;
@@ -199,7 +204,7 @@ footer {
   flex-direction: column;
   justify-content: center;
   text-align: center;
-  margin-top: 6em;
+  margin-top: 2em;
   padding: 8px;
 
   div {
@@ -279,6 +284,13 @@ footer {
   flex-direction: column;
   height: 100%;
   width: 100%;
+}
+
+
+#app-content-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 #content {

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -77,7 +77,7 @@ limitations under the License.
   {% comment %}
   {% endcomment %}
 
-  <app-drawer-layout fullbleed>
+  <div id="app-content-container">
     <app-header-layout>
       <app-header slot="header">
         <div class="main-toolbar">
@@ -101,7 +101,7 @@ limitations under the License.
     </app-header-layout>
 
     {% include "footer.html" %}
-  </app-drawer-layout>
+  </div>
 
   <chromedash-toast msg="Welcome to chromestatus.com!"></chromedash-toast>
 

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -78,24 +78,24 @@ limitations under the License.
   {% endcomment %}
 
   <app-drawer-layout fullbleed>
-    <app-drawer slot="drawer" swipe-open opened>
-      <div class="drawer-content-wrapper">
-        {% block drawer %}{% endblock %}
-      </div>
-    </app-drawer>
     <app-header-layout>
-      <app-header slot="header" reveals fixed effects="waterfall">
+      <app-header slot="header">
         <div class="main-toolbar">
           <div class="toolbar-content">
             {% include "header.html" %}
-            {% block subheader %}{% endblock %}
           </div>
         </div>
       </app-header>
 
       <div id="content">
         <div id="spinner"><img src="/static/img/ring.svg"></div>
-        {% block content %}{% endblock %}
+        <div id="column-container">
+           <div id="drawer-column">{% block drawer %}{% endblock %}</div>
+           <div id="content-column">
+             {% block subheader %}{% endblock %}
+             {% block content %}{% endblock %}
+           </div>
+         </div>
       </div>
 
     </app-header-layout>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -12,9 +12,5 @@
     <a href="https://docs.google.com/document/d/1jrSlM4Yhae7XCJ8BuasWx71CvDEMMbSKbXwx7hoh1Co/edit?pli=1"
        target="_blank"
        >About</a>
-    {% if user %}
-    <a href="/settings">Settings</a>
-    <b>{{user.email}}</b>
-    {% endif %}  <a href="{{login.1}}">{{login.0}}</a>
   </div>
 </footer>

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,21 +1,41 @@
 <header>
   <aside>
-    <iron-icon icon="chromestatus:menu" drawer-toggle></iron-icon>
     <hgroup>
       <a href="/features" target="_top"><h1>{{APP_TITLE}}</h1></a>
       <!--<span>feature support, releases, usage metrics</span>-->
     </hgroup>
   </aside>
   <nav>
+    <div style="flex:0.2"></div>
     <a href="/features">All features</a>
     <a href="/features/schedule">Releases</a>
     <a href="/samples" class="features">Samples</a>
     <div class="nav-dropdown-container">
-      <a class="nav-dropdown-trigger">Stats</a>
+      <a class="nav-dropdown-trigger">Stats
+        <iron-icon icon="chromestatus:arrow-drop-down"></iron-icon>
+      </a>
       <ul>
         <li><a href="/metrics/css/popularity">CSS</a></li>
         <li><a href="/metrics/feature/popularity">JS/HTML</a></li>
       </ul>
     </div>
+
+    <div style="flex:1"></div>
+
+    {% if user %}
+      <div class="nav-dropdown-container">
+        <a class="nav-dropdown-trigger">
+          {{user.email}}
+          <iron-icon icon="chromestatus:arrow-drop-down"></iron-icon>
+        </a>
+        <ul>
+          <li><a href="/settings">Settings</a></li>
+          <li><a href="{{login.1}}">{{login.0}}</a></li>
+        </ul>
+      </div>
+    {% else %}
+      <a href="{{login.1}}">{{login.0}}</a>
+    {% endif %}
+
   </nav>
 </header>


### PR DESCRIPTION
Implement a new UX layout to simplify our markup and CSS and address some reported problems.
Resolves issues #1001, #955, #897, #896.

In this CL:
+ Make the header and footer scroll with the page rather than have fixed positions
+ Move the Sign-in and Sign-out links from the footer to a more standard location in the upper-right (also the Settings link)
+ Change the left nav from using app-layout's app-drawer to a left-hand column in the content area
     - On pages that have a left nav, the change is not too significant
     - On pages that do not have anything in the left nav, we now make use of a big area of previously empty space
 + Eliminate default initial scrolling to IN_DEVELOPMENT section because that is non-standard behavior