### PR TITLE
Refactor CSS into theme.css and lit-css.  First steps.

### DIFF
--- a/static/elements/chromedash-callout.js
+++ b/static/elements/chromedash-callout.js
@@ -1,4 +1,5 @@
 import {LitElement, css, html} from 'lit-element';
+import SHARED_STYLES from '../css/shared.css';
 
 class ChromedashCallout extends LitElement {
   static get properties() {
@@ -39,20 +40,15 @@ class ChromedashCallout extends LitElement {
   }
 
   static get styles() {
-    return css`
-      :host {
-        /* TODO(jrobins): Put this into a global theme.css file. */
-        --blue-900: #174EA6;
-
-        --callout-bg-color: var(--blue-900);
-        --callout-text-color: white;
-      }
+    return [
+      SHARED_STYLES,
+      css`
       #bubble {
         position: absolute;
         display: inline-block;
         background: var(--callout-bg-color);
-        border-radius: 8px;
-        padding: 8px;
+        border-radius: var(--large-border-radius);
+        padding: var(--content-padding-half);
         max-width: 24em;
         color: var(--callout-text-color);
         font-weight: bold;
@@ -76,12 +72,13 @@ class ChromedashCallout extends LitElement {
      }
      #closebox {
        float: right;
-       margin-left: 8px;
+       margin-left: var(--content-padding-half);
+       color: var(--light-icon-fill-color);
      }
      #cue-content-container {
-       margin: 4px;
+       margin: var(--content-padding-quarter);
      }
-    `;
+    `];
   }
 
   // TODO(jrobbins): Consider using:

--- a/static/elements/chromedash-process-overview.js
+++ b/static/elements/chromedash-process-overview.js
@@ -1,14 +1,11 @@
-import {LitElement, html} from 'lit-element';
+import {LitElement, css, html} from 'lit-element';
 import {nothing} from 'lit-html';
 import '@polymer/iron-icon';
 import './chromedash-callout';
 import './chromedash-color-status';
-
-import style from '../css/elements/chromedash-process-overview.css';
+import SHARED_STYLES from '../css/shared.css';
 
 class ChromedashProcessOverview extends LitElement {
-  static styles = style;
-
   static get properties() {
     return {
       feature: {type: Object},
@@ -24,6 +21,68 @@ class ChromedashProcessOverview extends LitElement {
     this.process = [];
     this.progress = {};
     this.dismissedCues = {};
+  }
+  static get styles() {
+    return [
+      SHARED_STYLES,
+      css`
+      :host {
+        display: block;
+        position: relative;
+        box-sizing: border-box;
+        contain: content;
+        overflow: hidden;
+        background: inherit;
+      }
+
+      table {
+        border-spacing: 0;
+        width: 100%;
+      }
+
+      th {
+        text-align: left;
+        padding: var(--content-padding-half);
+        background: var(--table-header-background);
+      }
+
+      td {
+        padding: var(--content-padding-half) var(--content-padding) var(--content-padding) var(--content-padding-half);
+        vertical-align: top;
+        border-bottom: var(--table-divider);
+        background: var(--table-row-background);
+      }
+
+      tr.active td {
+        background: var(--light-accent-color);
+      }
+
+      td div.done:before {
+        content: "\\2713";
+        position: absolute;
+        left: 0;
+      }
+
+      td div.pending:before {
+        content: "\\25cb";
+        position: absolute;
+        left: 0;
+      }
+
+      td div.done, td div.pending {
+        position: relative;
+        padding-left: 1.2em;
+      }
+
+      ol {
+        list-style: none;
+        padding: 0;
+      }
+
+      ol li {
+        margin-top: .5em;
+      }
+    `];
   }
 
   inFinalStage(stage) {

--- a/static/sass/_base.scss
+++ b/static/sass/_base.scss
@@ -6,3 +6,4 @@
 }
 
 @import "shared";
+@import "theme";

--- a/static/sass/features/launch.scss
+++ b/static/sass/features/launch.scss
@@ -6,7 +6,7 @@
   height: auto;
   margin-bottom: 86px;
 
-  > section {
+  section {
     max-width: 600px;
     flex: 1 0 auto;
     margin-bottom: 15px;

--- a/static/sass/guide.scss
+++ b/static/sass/guide.scss
@@ -2,11 +2,11 @@
    style rules inside that component. */
 
 #metadata-buttons {
-  margin-left: 20px;
+  margin-left: var(--content-padding);
 }
 
 #metadata-buttons div {
-  margin-top: 20px;
+  margin-top: var(--content-padding);
 }
 
 .flex-cols {
@@ -17,17 +17,17 @@
 }
 
 table.property-sheet {
-  margin-right: 16px;
-  margin-bottom: 16px;
+  margin-right: var(--content-padding);
+  margin-bottom: var(--content-padding);
 }
 
 table.property-sheet tr:nth-of-type(odd) {
-  background: #f8f8f8;
+  background: var(--table-alternate-background);
 }
 
 
 table.property-sheet th, #metadata-readonly td {
-  padding: 6px 30px 6px 6px;
+  padding: var(--content-padding-half) 30px var(--content-padding-half) var(--content-padding-half);
 }
 
 table.property-sheet th {

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -5,11 +5,9 @@ html, body {
 }
 
 body {
-  color: $default-font-color;
-  font: 14px "Roboto", sans-serif;
-  font-weight: 400;
-  -webkit-font-smoothing: antialiased;
-  background: $page-background;
+  color: var(--default-color);
+  font: var(--default-font);
+  background: var(--page-background);
 
   &.loading {
     #spinner {
@@ -27,7 +25,7 @@ body {
   justify-content: center;
   position: fixed;
   height: 60%; // Centered, half that.
-  max-width: $max-content-width;
+  max-width: var(--max-content-width);
   width: 100%;
 }
 
@@ -49,9 +47,7 @@ body {
   box-shadow: inset 0px 5px 6px -3px rgba(0, 0, 0, 0.4);
 
   iron-icon {
-    margin-right: $content-padding / 4;
-    height: 20px;
-    width: 20px;
+    margin-right: var(--content-padding-half);
   }
 
   a {
@@ -111,9 +107,9 @@ header, footer {
 
 header {
   user-select: none;
-  background: $card-background;
-  border-bottom: $card-border;
-  box-shadow: $card-box-shadow;
+  background: var(--card-background);
+  border-bottom: var(--card-border);
+  box-shadow: var(--card-box-shadow);
 
   a {
     text-decoration: none !important;
@@ -123,20 +119,20 @@ header {
     display: flex;
     flex: 1;
     align-items: center;
-    margin: 0 $content-padding;
+    margin: 0 var(--content-padding);
     -webkit-font-smoothing: initial;
 
     a {
       cursor: pointer;
-      font-size: 16px;
+      font-size: var(--nav-link-font-size);
       text-align: center;
-      padding: 8px 16px;
-      color: $nav-link-color;
+      padding: var(--content-padding-half) var(--content-padding);
+      color: var(--nav-link-color);
       white-space: nowrap;
 
       &:hover {
         color: black;
-        background: $light-grey;
+        background: var(--nav-link-hover-background);
       }
 
       &.disabled {
@@ -155,9 +151,9 @@ header {
         left: 0;
         list-style: none;
         z-index: 1;
-        background: $card-background;
-        border-bottom: $card-border;
-        box-shadow: $card-box-shadow;
+        background: var(--card-background);
+        border-bottom: var(--card-border);
+        box-shadow: var(--card-box-shadow);
       }
 
       a {
@@ -182,7 +178,7 @@ header {
 
     hgroup {
       a {
-        color: currentcolor;
+        color: var(--logo-color);
       }
     }
 
@@ -198,21 +194,19 @@ header {
 }
 
 footer {
-  // No background: allow footer to blend into page background to de-emphaize it.
-  box-shadow: 0 -2px 5px $bar-shadow-color;
+  background: var(--footer-background);
+  box-shadow: 0 -2px 5px var(--shadow-color);
   display: flex;
   flex-direction: column;
   justify-content: center;
   text-align: center;
   margin-top: 2em;
-  padding: 8px;
+  padding: var(--content-padding-half);
 
   div {
-    margin-top: $content-padding / 4;
-
     > * + * {
-      margin-left: 1em;
-      padding-left: 1em;
+      margin-left: var(--content-padding);
+      padding-left: var(--content-padding);
     }
   }
 }
@@ -224,8 +218,8 @@ footer {
 #subheader, .subheader {
   display: flex;
   align-items: center;
-  margin: $content-padding 0;
-  max-width: $max-content-width;
+  margin: var(--content-padding) 0;
+  max-width: var(--max-content-width);
   width: 100%;
 
   .num-features {
@@ -248,8 +242,8 @@ footer {
       flex: 1 0 auto;
 
       .blue-button {
-        background: $material-primary-button;
-        color: #fff;
+        background: var(--primary-button-background);
+        color: var(--primary-button-color);
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -258,15 +252,14 @@ footer {
         -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
         -webkit-tap-highlight-color: transparent;
         text-decoration: none;
-        border-radius: 3px;
+        border: var(--button-border);
+        border-radius: var(--button-border-radius);
         user-select: none;
         cursor: pointer;
         padding: 0.7em 0.57em;
 
         iron-icon {
           margin-right: $content-padding / 4;
-          height: 18px;
-          width: 18px;
         }
       }
 
@@ -294,7 +287,7 @@ footer {
 }
 
 #content {
-  margin: $content-padding;
+  margin: var(--content-padding);
   position: relative;
 }
 
@@ -322,7 +315,8 @@ footer {
 .alertbox {
   margin: 2em;
   padding: 1em;
-  border: 2px solid orange;
+  background: var(--warning-background);
+  color: var(--warning-color);
 }
 
 @media only screen and (min-width: 701px) {
@@ -369,7 +363,7 @@ footer {
     display: none;
   }
   #content-column {
-    padding-left: 8px;
+    padding-left: var(--content-padding-half);
   }
 
   header {
@@ -379,7 +373,7 @@ footer {
     display: block;
     aside {
       display: flex;
-      padding: $content-padding / 2;
+      padding: var(--content-padding-half);
       border-radius: 0;
       background: inherit;  // no logo
 
@@ -389,7 +383,7 @@ footer {
       justify-content: center;
       flex-wrap: wrap;
       a {
-        padding: 8px 16px;
+        padding: var(--content-padding-half) var(--content-padding);
         margin: 0;
         border-radius: 0;
         flex: 1 0 auto;
@@ -406,7 +400,7 @@ footer {
 
   .subheader {
     .description {
-      margin: 0 $content-padding;
+      margin: 0 var(--content-padding);
     }
   }
 

--- a/static/sass/shared.scss
+++ b/static/sass/shared.scss
@@ -9,29 +9,31 @@
 h1, h2, h3, h4 {
   font-weight: 300;
 }
+
 h1 {
   font-size: 30px;
 }
+
 h2, h3, h4 {
-  color: #444;
+  background: var(--heading-background);
+  color: var(--heading-color);
 }
+
 h2 {
   font-size: 25px;
 }
+
 h3 {
   font-size: 20px;
 }
+
 a {
   text-decoration: none;
-  color: $chromium-color-center;
+  color: var(--link-color);
   &:hover {
     text-decoration: underline;
-    color: $chromium-color-dark;
+    color: var(--link-hover-color);
   }
-}
-
-b {
-  font-weight: 600;
 }
 
 input:not([type="submit"]), textarea {
@@ -45,21 +47,25 @@ input:not([type="submit"]), textarea {
 button, input[type="submit"], .button {
   display: inline-block;
   padding: 4px 16px;
-  background: inherit;
-  border: 0;
-  border-radius: 4px;
-  color: #444;
+  background: var(--button-background);;
+  border: var(--button-border);
+  border-radius: var(--button-border-radius);
+  color: var(--button-color);
   white-space: nowrap;
   user-select: none;
   cursor: pointer;
-  font-size: 10pt;
+  font-size: var(--button-font-size);
 }
 
 button.primary, input[type="submit"], .button.primary {
-  background: $material-primary-button;
-  color: white;
+  background: var(--primary-button-background);
+  color: var(--primary-button-color);
   font-weight: bold;
 }
+
+// button.primary iron-icon, .button.primary iron-icon {
+//   color: var(--light-icon-fill-color);
+// }
 
 button:not(:disabled):hover {
   border-color: $gray-4;
@@ -72,4 +78,10 @@ button:not(:disabled):hover {
 
 .no-web-share {
   display: none;
+}
+
+iron-icon {
+  height: var(--icon-size);
+  width: var(--icon-size);
+//  color: var(--icon-fill-color);
 }

--- a/static/sass/theme.scss
+++ b/static/sass/theme.scss
@@ -1,0 +1,88 @@
+// This file contains style rules that define fonts, colors, etc. that give
+// a theme to the site.
+
+@import "vars";
+
+// These colors should be the complete palette of the app, with no
+// other colors defined.  These are a subset of
+// https://material.io/design/color/the-color-system.html.
+:root {
+  --md-red-50: #ffebee;
+  --md-red-700: #d32f2f;
+  --md-light-blue-50: #e1f5fe;
+  --md-blue-700: #1976d2;
+  --md-blue-900: #01579b;
+  --md-orange-50: #fff3e0;
+  --md-orange-200: #ffcc80;
+  // TODO(jrobbins): Add all colors from pallet selected in Figma mocks.
+  --md-gray-50: #fafafa;
+  --md-gray-300: #e0e0e0;
+  /* To make grays used for font styles and icons maintain consistent
+   * contrast ratios across colored backgrounds, we repesent them as pure black
+   * with opacity set. */
+  --md-gray-50-alpha: hsla(0, 0%, 0%, 0.04);
+  --md-gray-100-alpha: hsla(0, 0%, 0%, 0.12);
+  --md-gray-700-alpha: hsla(0, 0%, 0%, 0.62);
+  --md-gray-900-alpha: hsla(0, 0%, 0%, 0.87);
+}
+
+
+// These are logical colors, borders, padding, etc. that are used consistently
+// throughout the app.
+:root {
+  --page-background: var(--md-gray-50);
+  --default-font: 14px "Roboto", sans-serif;
+  --default-color: var(--md-gray-900-alpha);
+
+  --content-padding: 16px;
+  --content-padding-half: 8px;
+  --content-padding-quarter: 4px;
+
+  --max-content-width: 760px;
+  --border-radius: 4px;
+  --large-border-radius: 8px;
+  --logo-color: var(--default-color);
+  --logo-size: 32px;
+  --icon-size: 20px;
+  --link-color: var(--md-blue-700);
+  --link-hover-color: var(--md-blue-900);
+
+  --light-accent-color: var(--md-light-blue-50);
+  --dark-spot-color: var(--md-blue-900);
+
+  --heading-background: transparent;
+  --heading-color: var(--md-gray-700-alpha);
+
+  --nav-link-color: var(--md-gray-700-alpha);
+  --nav-link-font-size: 16px;
+  --nav-link-hover-background: var(--md-gray-100-alpha);
+
+  --button-background: inherit;
+  --button-color: var(--md-gray-900-alpha);
+  --button-font-size: 10pt;
+  --button-border: 0;
+  --button-border-radius: var(--border-radius);
+  --primary-button-background: var(--md-blue-700);
+  --primary-button-color: white;
+
+  --default-border: 1px solid hsl(0, 0%, 85%);
+
+  --card-background: white;
+  --card-border: var(--default-border);
+  --shadow-color: var(--md-gray-100-alpha);
+  --card-box-shadow: var(--shadow-color) 1px 1px 4px;
+
+  --warning-background: var(--md-orange-200);
+  --warning-color: var(--md-gray-900-alpha);
+  --invalid-color: var(--md-red-700);
+
+  --table-header-background: var(--md-gray-300);
+  --table-row-background: white;
+  --table-divider: var(--default-border);
+  --table-alternate-background: var(--md-gray-50-alpha);
+
+  --callout-bg-color: var(--dark-spot-color);
+  --callout-text-color: white;
+
+  --footer-background: transparent;
+}


### PR DESCRIPTION
This implements part of the the work under the covers for the visual refresh.  The user-visible changes are pretty minor changes in the shades of various colors.  The purpose is to refactor the CSS code to make it easier to maintain.

This CL addresses issue #894, and partly addresses issue #899.

Design doc:
https://docs.google.com/document/d/1uF79Pk-UeD1DSpDvp5DPyMnVmDJi1ZwqkOcuqW5vVT4/edit

In this CL:
+ Create theme.css with font and colors in CSS variables.
+ Change several existing rules to use CSS variables instead of sass variables.
+ Refactor chromedash-process-overview CSS from sass to lit-css.
+ Also, fix a defect in the CSS for intent email generation.  The ">" operator made the rule too specific and it stopped working when I added more divs in _main.html.
