### PR TITLE
Use proportional font "system-ui" in textarea elements.

### DIFF
--- a/static/sass/forms.scss
+++ b/static/sass/forms.scss
@@ -37,6 +37,7 @@ table {
   }
   input[type="text"], input[type="url"], input[type="email"], textarea {
     width: 100%;
+    font: var(--form-element-font);
   }
 
   select {

--- a/static/sass/theme.scss
+++ b/static/sass/theme.scss
@@ -32,6 +32,7 @@
 :root {
   --page-background: var(--md-gray-50);
   --default-font: 14px "Roboto", sans-serif;
+  --form-element-font: system-ui;
   --default-color: var(--md-gray-900-alpha);
 
   --content-padding: 16px;


### PR DESCRIPTION
This should resolve issue #969.

Rather than specify roboto, I am using "system-ui" which is the browser default for most inputs and <select> elements.  It is a proportional font on mac and chromeos.