### PR TITLE
Add missing index for Feature.deleted.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -136,6 +136,12 @@ indexes:
     direction: desc
   - name: name
 
+- kind: Feature
+  properties:
+  - name: deleted
+  - name: updated
+    direction: desc
+
 - kind: FeatureObserver
   properties:
   - name: bucket_id


### PR DESCRIPTION
This was needed to prevent an error that was starting to happen in production.

It used to be that running the dev_server would update index.yaml to add any indexes that are needed, and then that would get committed and deployed.  However, I don't see that happening now for whatever reason.  I needed to manually add these lines, and then deploy with:
gcloud datastore indexes --project cr-status-staging create index.yaml
and
gcloud datastore indexes --project cr-status create index.yaml