### PR TITLE
Make milestone query not match unrelased features.

### DIFF
--- a/models.py
+++ b/models.py
@@ -144,6 +144,10 @@ INTERVENTION = 9
 ON_HOLD = 10
 NO_LONGER_PURSUING = 1000 # insure bottom of list
 
+RELEASE_IMPL_STATES = {
+  ENABLED_BY_DEFAULT, DEPRECATED, REMOVED, ORIGIN_TRIAL, INTERVENTION,
+}
+
 # Ordered dictionary, make sure the order of this dictionary matches that of
 # the sorted list above!
 IMPLEMENTATION_STATUS = OrderedDict()
@@ -571,6 +575,8 @@ class Feature(DictModel):
   def format_for_template(self, version=None):
     self.migrate_views()
     d = self.to_dict()
+    is_released = self.impl_status_chrome in RELEASE_IMPL_STATES
+    d['is_released'] = is_released
 
     if version == 2:
       if self.is_saved():
@@ -658,9 +664,9 @@ class Feature(DictModel):
         }
       }
 
-      if self.shipped_milestone:
+      if is_released and self.shipped_milestone:
         d['browsers']['chrome']['status']['milestone_str'] = self.shipped_milestone
-      elif self.shipped_milestone is None and self.shipped_android_milestone:
+      elif is_released and self.shipped_android_milestone:
         d['browsers']['chrome']['status']['milestone_str'] = self.shipped_android_milestone
       else:
         d['browsers']['chrome']['status']['milestone_str'] = d['browsers']['chrome']['status']['text']
@@ -688,9 +694,9 @@ class Feature(DictModel):
         'intervention': self.impl_status_chrome == INTERVENTION,
         'needsflag': self.impl_status_chrome == BEHIND_A_FLAG,
         }
-      if self.shipped_milestone:
+      if is_released and self.shipped_milestone:
         d['meta']['milestone_str'] = self.shipped_milestone
-      elif self.shipped_milestone is None and self.shipped_android_milestone:
+      elif is_released and self.shipped_android_milestone:
         d['meta']['milestone_str'] = self.shipped_android_milestone
       else:
         d['meta']['milestone_str'] = d['impl_status_chrome']

--- a/models.py
+++ b/models.py
@@ -145,7 +145,8 @@ ON_HOLD = 10
 NO_LONGER_PURSUING = 1000 # insure bottom of list
 
 RELEASE_IMPL_STATES = {
-  ENABLED_BY_DEFAULT, DEPRECATED, REMOVED, ORIGIN_TRIAL, INTERVENTION,
+    BEHIND_A_FLAG, ENABLED_BY_DEFAULT,
+    DEPRECATED, REMOVED, ORIGIN_TRIAL, INTERVENTION,
 }
 
 # Ordered dictionary, make sure the order of this dictionary matches that of

--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -60,11 +60,13 @@ class ChromedashFeaturelist extends LitElement {
 
       features.map((feature) => {
         feature.receivePush = false;
-        feature.milestone = feature.browsers.chrome.desktop ||
-            feature.browsers.chrome.android ||
-            feature.browsers.chrome.webview ||
-            feature.browsers.chrome.ios ||
-            Infinity;
+        if (feature.is_released) {
+          feature.milestone = feature.browsers.chrome.desktop ||
+              feature.browsers.chrome.android ||
+              feature.browsers.chrome.webview ||
+              feature.browsers.chrome.ios ||
+              Infinity;
+        }
       });
       this.features = features;
 


### PR DESCRIPTION
This is a follow up to your question on this recent CL
https://github.com/GoogleChrome/chromium-dashboard/pull/1012

Clicking on a milestone link in the left does a query like "milestone=84" which looks for features that have a milestone field with value 84.  There is no milestone field in the JSON feed, it is set by JS code.  This CL adds a JS if-statement that only sets milestone when the feature has is_released set, and that is set based on the impl_status_chrome value.