### PR TITLE
Add search tags to feature list entries and feature detail page.

### DIFF
--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -484,6 +484,18 @@ class ChromedashFeature extends LitElement {
           </section>
           ` : nothing}
         ` : nothing}
+        ${this.open && this.feature.tags ? html`
+          <section>
+            <h3>Search tags</h3>
+            <div class="resources">
+              ${this.feature.tags.map((tag, index) => html`
+                <a href="#tags:${tag}" target="_blank"
+                  class="${index < this.feature.tags.length - 1 ? 'comma' : ''}"
+                  >${tag}</a>
+              `)}
+            </div>
+          </section>
+          ` : nothing}
     `;
   }
 }

--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -487,11 +487,10 @@ class ChromedashFeature extends LitElement {
         ${this.open && this.feature.tags ? html`
           <section>
             <h3>Search tags</h3>
-            <div class="resources">
-              ${this.feature.tags.map((tag, index) => html`
+            <div class="resources comma-sep-links">
+              ${this.feature.tags.map((tag) => html`
                 <a href="#tags:${tag}" target="_blank"
-                  class="${index < this.feature.tags.length - 1 ? 'comma' : ''}"
-                  >${tag}</a>
+                  >${tag}</a><span class="conditional-comma">,&nbsp; </span>
               `)}
             </div>
           </section>

--- a/static/sass/elements/_element.scss
+++ b/static/sass/elements/_element.scss
@@ -21,3 +21,7 @@ $feature-min-height: 75px;
   text-align: center;
   color: $default-font-color;
 }
+
+.conditional-comma:last-child {
+  display: none;
+}

--- a/static/sass/features/feature.scss
+++ b/static/sass/features/feature.scss
@@ -86,6 +86,16 @@ iron-icon {
   font-style: italic;
 }
 
+#updated {
+  padding-top: var(--content-padding);
+}
+
+#updated span {
+  color: var(--unimportant-text-color);
+  border-top: var(--default-border);
+  padding: var(--content-padding-quarter) var(--content-padding) 0 0;
+}
+
 @media only screen and (max-width: 700px) {
   #feature {
     border-radius: 0 !important;

--- a/static/sass/shared.scss
+++ b/static/sass/shared.scss
@@ -76,15 +76,8 @@ button:not(:disabled):hover {
   margin-right: .2em;
 }
 
-.comma-sep-links a {
-  margin-right: 0;
-}
-.conditional-comma::after {
-  content: ', ';
-  color: var(--default-color);
-}
-.conditional-comma:last-child::after {
-  content: '';
+.conditional-comma:last-child {
+  display: none;
 }
 
 .no-web-share {

--- a/static/sass/shared.scss
+++ b/static/sass/shared.scss
@@ -76,6 +76,17 @@ button:not(:disabled):hover {
   margin-right: .2em;
 }
 
+.comma-sep-links a {
+  margin-right: 0;
+}
+.conditional-comma::after {
+  content: ', ';
+  color: var(--default-color);
+}
+.conditional-comma:last-child::after {
+  content: '';
+}
+
 .no-web-share {
   display: none;
 }

--- a/static/sass/theme.scss
+++ b/static/sass/theme.scss
@@ -37,6 +37,7 @@
   --default-font: 14px "Roboto", sans-serif;
   --form-element-font: system-ui;
   --default-color: var(--md-gray-900-alpha);
+  --unimportant-text-color: var(--md-gray-700-alpha);
 
   --content-padding: 16px;
   --content-padding-half: 8px;

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -96,13 +96,6 @@
     </section>
     {% endif %}
 
-    {% if feature.comments %}
-    <section id="comments">
-      <h3>Comments</h3>
-      <p>{{ feature.comments|urlize }}</p>
-    </section>
-    {% endif %}
-
     {% if feature.sample_links %}
     <section id="demo">
       <h3>{% if feature.sample_links|length == 1 %}Demo{% else %}Demos{% endif %}</h3>
@@ -229,8 +222,25 @@
     </section>
     {% endif %}
 
+    {% if feature.comments %}
+    <section id="comments">
+      <h3>Comments</h3>
+      <p>{{ feature.comments|urlize }}</p>
+    </section>
+    {% endif %}
+
+    {% if feature.search_tags %}
+    <section class="comma-sep-links">
+      <h3>Search tags</h3>
+        {% for tag in feature.search_tags %}
+          <a href="/features#tags:{{ tag }}">{{ tag }}</a><span
+            class="conditional-comma"></span>
+        {% endfor %}
+    </section>
+    {% endif %}
+
     <section id="updated">
-      <p>Last updated on {{ feature.updated_display }}</p>
+      <p><span>Last updated on {{ feature.updated_display }}</span></p>
     </section>
   </div>
 {% endblock %}

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -230,11 +230,11 @@
     {% endif %}
 
     {% if feature.search_tags %}
-    <section class="comma-sep-links">
+    <section>
       <h3>Search tags</h3>
         {% for tag in feature.search_tags %}
           <a href="/features#tags:{{ tag }}">{{ tag }}</a><span
-            class="conditional-comma"></span>
+            class="conditional-comma">, </span>
         {% endfor %}
     </section>
     {% endif %}

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -52,7 +52,7 @@
         <td>
           {% for tag in feature.search_tags %}
             <a href="/features#tags:{{tag}}"
-               >{{tag}}</a>{% if not forloop.last %}, {% endif %}
+               >{{tag}}</a><span class="conditional-comma">, </span>
           {% endfor %}
         </td>
       </tr>

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -49,7 +49,12 @@
       </tr>
       <tr>
         <th>Search tags</th>
-        <td>{{ feature.search_tags | join:', ' }}</td>
+        <td>
+          {% for tag in feature.search_tags %}
+            <a href="/features#tags:{{tag}}"
+               >{{tag}}</a>{% if not forloop.last %}, {% endif %}
+          {% endfor %}
+        </td>
       </tr>
     </table>
 


### PR DESCRIPTION
Up until now, search tags were missing from parts of the UI where they could be useful.

Adding this was inspired by the discussion of how features might be released.  Regardless of how we implement explicitly related features, the existing search tags field should be actually useful.

In this CL:
+ Add links for search tags to the feature element for the feature list.
+ Add links for search tags to the feature detail page.
+ Linkify the search terms shown in read-only mode on the guide editing UX.
+ Implement comma separators using CSS rather than additional JS or template logic.