### PR TITLE
Implement measurement field.

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -527,6 +527,7 @@ class FeatureHandler(common.ContentHandler):
           'tag_review_status', models.REVIEW_PENDING))
       feature.standardization = int(self.request.get('standardization'))
       feature.doc_links = doc_links
+      feature.measurement = self.request.get('measurement')
       feature.sample_links = sample_links
       feature.search_tags = search_tags
       feature.comments = self.request.get('comments')
@@ -602,6 +603,7 @@ class FeatureHandler(common.ContentHandler):
               'tag_review_status', models.REVIEW_PENDING)),
           standardization=int(self.request.get('standardization')),
           doc_links=doc_links,
+          measurement=self.request.get('measurement'),
           sample_links=sample_links,
           search_tags=search_tags,
           comments=self.request.get('comments'),

--- a/guide.py
+++ b/guide.py
@@ -83,17 +83,17 @@ STAGE_FORMS = {
 
 IMPL_STATUS_FORMS = {
     models.INTENT_EXPERIMENT:
-        (models.BEHIND_A_FLAG, guideforms.ImplStatus_DevTrial,),
+        (models.BEHIND_A_FLAG, guideforms.ImplStatus_DevTrial),
     models.INTENT_EXTEND_TRIAL:
-        (models.ORIGIN_TRIAL, guideforms.ImplStatus_OriginTrial,),
+        (models.ORIGIN_TRIAL, guideforms.ImplStatus_OriginTrial),
     models.INTENT_IMPLEMENT_SHIP:
-        (None, guideforms.ImplStatus_AllMilestones,),
+        (None, guideforms.ImplStatus_EvalReadinessToShip),
     models.INTENT_SHIP:
-        (models.ENABLED_BY_DEFAULT, guideforms.ImplStatus_AllMilestones,),
+        (models.ENABLED_BY_DEFAULT, guideforms.ImplStatus_AllMilestones),
     models.INTENT_SHIPPED:
-        (models.ENABLED_BY_DEFAULT, guideforms.ImplStatus_AllMilestones,),
+        (models.ENABLED_BY_DEFAULT, guideforms.ImplStatus_AllMilestones),
     models.INTENT_REMOVED:
-        (models.REMOVED, guideforms.ImplStatus_AllMilestones,),
+        (models.REMOVED, guideforms.ImplStatus_AllMilestones),
     }
 
 # Forms to be used on the "Edit all" page that shows a flat list of fields.
@@ -409,6 +409,9 @@ class FeatureEditStage(common.ContentHandler):
 
     if self.touched('doc_links'):
       feature.doc_links = self.split_input('doc_links')
+
+    if self.touched('measurement'):
+      feature.measurement = self.request.get('measurement')
 
     if self.touched('sample_links'):
       feature.sample_links = self.split_input('sample_links')

--- a/guideforms.py
+++ b/guideforms.py
@@ -115,6 +115,16 @@ ALL_FIELDS = {
                    'include links and data, where possible, to support any '
                    'claims.]')),
 
+    'measurement': forms.CharField(
+        label='Measurement', required=False,
+        widget=forms.Textarea(
+            attrs={'rows': 4, 'cols': 50, 'maxlength': 500}),
+        help_text=
+        ('It\'s important to measure the adoption and success of web-exposed '
+         'features.  Note here what measurements you have added to track the '
+         'success of this feature, such as a link to the UseCounter(s) you '
+         'have set up.')),
+
     'standardization': forms.ChoiceField(
         required=False, label='Standardization',
         choices=models.STANDARDIZATION.items(),
@@ -639,6 +649,13 @@ ImplStatus_AllMilestones = define_form_class_using_shared_fields(
     'ImplStatus_AllMilestones',
     ('shipped_milestone', 'shipped_android_milestone',
      'shipped_ios_milestone', 'shipped_webview_milestone'))
+
+
+ImplStatus_EvalReadinessToShip = define_form_class_using_shared_fields(
+    'ImplStatus_AllMilestones',
+    ('shipped_milestone', 'shipped_android_milestone',
+     'shipped_ios_milestone', 'shipped_webview_milestone',
+     'measurement'))
 
 
 NewFeature_OriginTrial = define_form_class_using_shared_fields(

--- a/guideforms.py
+++ b/guideforms.py
@@ -809,7 +809,9 @@ Flat_PrepareToShip = define_form_class_using_shared_fields(
     'Flat_PrepareToShip',
     (# Standardization
      'tag_review', 'tag_review_status',
-     'intent_to_ship_url', 'i2s_lgtms'))
+     'intent_to_ship_url', 'i2s_lgtms',
+     # Implementation
+     'measurement'))
 
 
 Flat_Ship = define_form_class_using_shared_fields(

--- a/models.py
+++ b/models.py
@@ -1078,6 +1078,7 @@ class Feature(DictModel):
   web_dev_views_notes = db.StringProperty(multiline=True)
 
   doc_links = db.StringListProperty()
+  measurement = db.StringProperty(multiline=True)
   sample_links = db.StringListProperty()
   #tests = db.StringProperty()
 
@@ -1256,6 +1257,15 @@ class FeatureForm(forms.Form):
           attrs={'rows': 4, 'cols': 50, 'maxlength': 500,
                  'placeholder': 'https://\nhttps://'}),
       help_text='Links to design doc(s) (one URL per line), if and when available. [This is not required to send out an Intent to Prototype. Please update the intent thread with the design doc when ready]. An explainer and/or design doc is sufficient to start this process. [Note: Please include links and data, where possible, to support any claims.]')
+
+  measurement = forms.CharField(label='Measurement', required=False,
+      widget=forms.Textarea(
+          attrs={'rows': 4, 'cols': 50, 'maxlength': 500}),
+      help_text=(
+          'It\'s important to measure the adoption and success of web-exposed '
+          'features.  Note here what measurements you have added to track the '
+          'success of this feature, such as a link to the UseCounter(s) you '
+          'have set up.'))
 
   standardization = forms.ChoiceField(
       required=False,

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -168,6 +168,11 @@
   <a href="{{feature.launch_bug_url}}">{{feature.launch_bug_url}}</a>
 {% endif %}
 
+{% if feature.measurement %}
+  <br><br><h4>Measurement</h4>
+  {{feature.measurement|urlize}}
+{% endif %}
+
 {% if 'sample_links' in sections_to_show %}
    {% if feature.sample_links %}
      <br><br><h4>Sample links</h4>


### PR DESCRIPTION
This should resolve issue #1017.

In this CL:
+ Define a measurement string field.
+ Define form fields for old and new UI, and POST handler logic for each.
  - In the Guide UI, the measurement field is included in the implementation section of the Evaluate Readiness to Ship stage for new feature incubations.
+ Add the measurement field to the intent email generation page.