### PR TITLE
Use white-space: pre-wrap for text fields that might have paragraphs.

### DIFF
--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -296,13 +296,13 @@ class ChromedashFeature extends LitElement {
              html`<p><b>This feature is only shown in the feature list
                         to users with edit access.</b></p>
              `: nothing }
-          <p class="${this.open ? 'pre-line' : ''}">
+          <p class="${this.open ? 'preformatted' : ''}">
             <span>${autolink(this.feature.summary)}</span>
           </p>
         </summary>
         ${this.feature.motivation ?
           html`<p><h3>Motivation</h3></p>
-        <p class="${this.open ? 'pre-line' : ''}">
+        <p class="${this.open ? 'preformatted' : ''}">
           <span>${autolink(this.feature.motivation)}</span>
         </p>`
           : nothing }

--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -296,11 +296,15 @@ class ChromedashFeature extends LitElement {
              html`<p><b>This feature is only shown in the feature list
                         to users with edit access.</b></p>
              `: nothing }
-          <p><span>${autolink(this.feature.summary)}</span></p>
+          <p class="${this.open ? 'pre-line' : ''}">
+            <span>${autolink(this.feature.summary)}</span>
+          </p>
         </summary>
         ${this.feature.motivation ?
           html`<p><h3>Motivation</h3></p>
-        <p><span>${autolink(this.feature.motivation)}</span></p>`
+        <p class="${this.open ? 'pre-line' : ''}">
+          <span>${autolink(this.feature.motivation)}</span>
+        </p>`
           : nothing }
       </section>
       ${this.open ? html`

--- a/static/sass/shared.scss
+++ b/static/sass/shared.scss
@@ -89,6 +89,6 @@ iron-icon {
   width: var(--icon-size);
 }
 
-.pre-line {
-  white-space: pre-line;
+.preformatted {
+  white-space: pre-wrap;
 }

--- a/static/sass/shared.scss
+++ b/static/sass/shared.scss
@@ -88,3 +88,7 @@ iron-icon {
   height: var(--icon-size);
   width: var(--icon-size);
 }
+
+.pre-line {
+  white-space: pre-line;
+}

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -40,7 +40,7 @@
   {% endif %}
 
   <br><br><h4>Summary</h4>
-  {{ feature.summary | urlize }}
+  <p class="pre-line">{{ feature.summary | urlize }}</p>
 
   <br><br><h4>Blink component</h4>
   {% for c in feature.blink_components %}
@@ -49,7 +49,7 @@
 
   {% if 'motivation' in sections_to_show %}
     <br><br><h4>Motivation</h4>
-    {{feature.motivation|urlize}}
+    <p class="pre-line">{{feature.motivation|urlize}}</p>
 
     <br><br><h4>Initial public proposal</h4>
     {{feature.initial_public_proposal_url|urlize}}
@@ -79,7 +79,7 @@
   <br><br><h4>Risks</h4>
   <div style="margin-left: 4em;">
     <br><br><h4>Interoperability and Compatibility</h4>
-    {{feature.interop_compat_risks|urlize}}
+    <p class="pre-line">{{feature.interop_compat_risks|urlize}}</p>
 
     <br><br><i>Gecko</i>: {{feature.ff_views.text}}
     {% if feature.ff_views_link %}
@@ -107,17 +107,17 @@
 
     {% if feature.ergonomics_risks %}
       <br><br><h4>Ergonomics</h4>
-      {{feature.ergonomics_risks|urlize}}
+      <p class="pre-line">{{feature.ergonomics_risks|urlize}}</p>
     {% endif %}
 
     {% if feature.activation_risks %}
       <br><br><h4>Activation</h4>
-      {{feature.activation_risks|urlize}}
+      <p class="pre-line">{{feature.activation_risks|urlize}}</p>
     {% endif %}
 
     {% if feature.security_risks %}
       <br><br><h4>Security</h4>
-      {{feature.security_risks|urlize}}
+      <p class="pre-line">{{feature.security_risks|urlize}}</p>
     {% endif %}
 
   </div> <!-- end risks -->
@@ -125,37 +125,37 @@
 {% if 'experiment' in sections_to_show %}
 
   <br><br><h4>Goals for experimentation</h4>
-  {{feature.experiment_goals|urlize}}
+  <p class="pre-line">{{feature.experiment_goals|urlize}}</p>
 
   {% if feature.experiment_timeline %}
     <br><br><h4>Experimental timeline</h4>
-    {{feature.experiment_timeline|urlize}}
+    <p class="pre-line">{{feature.experiment_timeline|urlize}}</p>
   {% endif %}
 
   {% if 'extension_reason' in sections_to_show %}
     <br><br><h4>Reason this experiment is being extended</h4>
-    {{feature.experiment_extension_reason|urlize}}
+    <p class="pre-line">{{feature.experiment_extension_reason|urlize}}</p>
   {% endif %}
 
   <br><br><h4>Ongoing technical constraints</h4>
-  {{feature.ongoing_constraints|urlize}}
+  <p class="pre-line">{{feature.ongoing_constraints|urlize}}</p>
 
 {% endif %}
 
 {% if feature.debuggability %}
   <br><br><h4>Debuggability</h4>
-  {{feature.debuggability|urlize}}
+  <p class="pre-line">{{feature.debuggability|urlize}}</p>
 {% endif %}
 
 <br><br><h4>Will this feature be supported on all six Blink platforms
     (Windows, Mac, Linux, Chrome OS, Android, and Android WebView)?</h4>
 {% if feature.all_platforms %}Yes{% else %}No{% endif %}
-{{feature.all_platforms_descr|urlize}}
+<p class="pre-line">{{feature.all_platforms_descr|urlize}}</p>
 
 <br><br><h4>Is this feature fully tested by <a href="https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_platform_tests.md">web-platform-tests</a>?</h4>
 {% if feature.wpt %}Yes{% else %}No{% endif %}
 {% if feature.wpt_desc %}
-  {{feature.wpt_descr|urlize}}
+  <p class="pre-line">{{feature.wpt_descr|urlize}}</p>
 {% endif %}
 
 {% if feature.bug_url %}
@@ -213,7 +213,3 @@
 </small></div>
 
 </div> <!-- end email body div -->
-
-<p style="padding-bottom: 6em">
- <!-- work around overlap by floating footer. -->
-</p>

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -40,7 +40,7 @@
   {% endif %}
 
   <br><br><h4>Summary</h4>
-  <p class="pre-line">{{ feature.summary | urlize }}</p>
+  <p class="preformatted">{{ feature.summary | urlize }}</p>
 
   <br><br><h4>Blink component</h4>
   {% for c in feature.blink_components %}
@@ -49,7 +49,7 @@
 
   {% if 'motivation' in sections_to_show %}
     <br><br><h4>Motivation</h4>
-    <p class="pre-line">{{feature.motivation|urlize}}</p>
+    <p class="preformatted">{{feature.motivation|urlize}}</p>
 
     <br><br><h4>Initial public proposal</h4>
     {{feature.initial_public_proposal_url|urlize}}
@@ -79,7 +79,7 @@
   <br><br><h4>Risks</h4>
   <div style="margin-left: 4em;">
     <br><br><h4>Interoperability and Compatibility</h4>
-    <p class="pre-line">{{feature.interop_compat_risks|urlize}}</p>
+    <p class="preformatted">{{feature.interop_compat_risks|urlize}}</p>
 
     <br><br><i>Gecko</i>: {{feature.ff_views.text}}
     {% if feature.ff_views_link %}
@@ -107,17 +107,17 @@
 
     {% if feature.ergonomics_risks %}
       <br><br><h4>Ergonomics</h4>
-      <p class="pre-line">{{feature.ergonomics_risks|urlize}}</p>
+      <p class="preformatted">{{feature.ergonomics_risks|urlize}}</p>
     {% endif %}
 
     {% if feature.activation_risks %}
       <br><br><h4>Activation</h4>
-      <p class="pre-line">{{feature.activation_risks|urlize}}</p>
+      <p class="preformatted">{{feature.activation_risks|urlize}}</p>
     {% endif %}
 
     {% if feature.security_risks %}
       <br><br><h4>Security</h4>
-      <p class="pre-line">{{feature.security_risks|urlize}}</p>
+      <p class="preformatted">{{feature.security_risks|urlize}}</p>
     {% endif %}
 
   </div> <!-- end risks -->
@@ -125,37 +125,37 @@
 {% if 'experiment' in sections_to_show %}
 
   <br><br><h4>Goals for experimentation</h4>
-  <p class="pre-line">{{feature.experiment_goals|urlize}}</p>
+  <p class="preformatted">{{feature.experiment_goals|urlize}}</p>
 
   {% if feature.experiment_timeline %}
     <br><br><h4>Experimental timeline</h4>
-    <p class="pre-line">{{feature.experiment_timeline|urlize}}</p>
+    <p class="preformatted">{{feature.experiment_timeline|urlize}}</p>
   {% endif %}
 
   {% if 'extension_reason' in sections_to_show %}
     <br><br><h4>Reason this experiment is being extended</h4>
-    <p class="pre-line">{{feature.experiment_extension_reason|urlize}}</p>
+    <p class="preformatted">{{feature.experiment_extension_reason|urlize}}</p>
   {% endif %}
 
   <br><br><h4>Ongoing technical constraints</h4>
-  <p class="pre-line">{{feature.ongoing_constraints|urlize}}</p>
+  <p class="preformatted">{{feature.ongoing_constraints|urlize}}</p>
 
 {% endif %}
 
 {% if feature.debuggability %}
   <br><br><h4>Debuggability</h4>
-  <p class="pre-line">{{feature.debuggability|urlize}}</p>
+  <p class="preformatted">{{feature.debuggability|urlize}}</p>
 {% endif %}
 
 <br><br><h4>Will this feature be supported on all six Blink platforms
     (Windows, Mac, Linux, Chrome OS, Android, and Android WebView)?</h4>
 {% if feature.all_platforms %}Yes{% else %}No{% endif %}
-<p class="pre-line">{{feature.all_platforms_descr|urlize}}</p>
+<p class="preformatted">{{feature.all_platforms_descr|urlize}}</p>
 
 <br><br><h4>Is this feature fully tested by <a href="https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_platform_tests.md">web-platform-tests</a>?</h4>
 {% if feature.wpt %}Yes{% else %}No{% endif %}
 {% if feature.wpt_desc %}
-  <p class="pre-line">{{feature.wpt_descr|urlize}}</p>
+  <p class="preformatted">{{feature.wpt_descr|urlize}}</p>
 {% endif %}
 
 {% if feature.bug_url %}

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -85,14 +85,14 @@
 
     {% if feature.summary %}
     <section id="summary">
-      <p class="pre-line">{{ feature.summary|urlize }}</p>
+      <p class="preformatted">{{ feature.summary|urlize }}</p>
     </section>
     {% endif %}
 
     {% if feature.motivation %}
     <section id="motivation">
       <h3>Motivation</h3>
-      <p class="pre-line">{{ feature.motivation|urlize }}</p>
+      <p class="preformatted">{{ feature.motivation|urlize }}</p>
     </section>
     {% endif %}
 
@@ -225,7 +225,7 @@
     {% if feature.comments %}
     <section id="comments">
       <h3>Comments</h3>
-      <p class="pre-line">{{ feature.comments|urlize }}</p>
+      <p class="preformatted">{{ feature.comments|urlize }}</p>
     </section>
     {% endif %}
 

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -85,14 +85,14 @@
 
     {% if feature.summary %}
     <section id="summary">
-      <p>{{ feature.summary|urlize }}</p>
+      <p class="pre-line">{{ feature.summary|urlize }}</p>
     </section>
     {% endif %}
 
     {% if feature.motivation %}
     <section id="motivation">
       <h3>Motivation</h3>
-      <p>{{ feature.motivation|urlize }}</p>
+      <p class="pre-line">{{ feature.motivation|urlize }}</p>
     </section>
     {% endif %}
 
@@ -225,7 +225,7 @@
     {% if feature.comments %}
     <section id="comments">
       <h3>Comments</h3>
-      <p>{{ feature.comments|urlize }}</p>
+      <p class="pre-line">{{ feature.comments|urlize }}</p>
     </section>
     {% endif %}
 


### PR DESCRIPTION
This should resolve issue #1030.

In this CL:
+ Define shared CSS class reformatted that sets white-space:pre-wrap.
+ Apply that class to some fields in the intent emails.
+ Apply that class to features in the feature list, only when the user has clicked to expand the feature.
+ Apply that class to the feature detail page.