### PR TITLE
Add Blink>Storage>FontAccess to fallback components list

### DIFF
--- a/hack_components.py
+++ b/hack_components.py
@@ -147,6 +147,7 @@ HACK_BLINK_COMPONENTS = [
   "Blink>Storage>DataTransfer",
   "Blink>Storage>FileAPI",
   "Blink>Storage>FileSystem",
+  "Blink>Storage>FontAccess",
   "Blink>Storage>IndexedDB",
   "Blink>Storage>Quota",
   "Blink>Storage>WebSQL",


### PR DESCRIPTION
This change adds `Blink>Storage>FontAccess` to the fallback components list, which isn't in sync with crbug.