### PR TITLE
Fix problems problems now that we use pre-wrap.

### DIFF
--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -296,15 +296,15 @@ class ChromedashFeature extends LitElement {
              html`<p><b>This feature is only shown in the feature list
                         to users with edit access.</b></p>
              `: nothing }
-          <p class="${this.open ? 'preformatted' : ''}">
-            <span>${autolink(this.feature.summary)}</span>
-          </p>
+          <p class="${this.open ? 'preformatted' : ''}"
+            ><span>${autolink(this.feature.summary)}</span
+          ></p>
         </summary>
         ${this.feature.motivation ?
           html`<p><h3>Motivation</h3></p>
-        <p class="${this.open ? 'preformatted' : ''}">
-          <span>${autolink(this.feature.motivation)}</span>
-        </p>`
+        <p class="${this.open ? 'preformatted' : ''}"
+          ><span>${autolink(this.feature.motivation)}</span
+        ></p>`
           : nothing }
       </section>
       ${this.open ? html`

--- a/static/sass/features/feature.scss
+++ b/static/sass/features/feature.scss
@@ -39,12 +39,6 @@ section {
   }
 }
 
-#summary, #comments, #motivation {
-  p {
-    white-space: pre-line;
-  }
-}
-
 /* TODO(iclelland): DRY - factor this style out of here and
  * chromedash-feature.scss into somewhere common.
  */


### PR DESCRIPTION
This is a follow-up to https://github.com/GoogleChrome/chromium-dashboard/pull/1050

In testing on staging I realized that the whitespace used to indent the HTML <span> element in the source code was now being rendered on the page.  This only shows up in Chrome, not in Safari.  So, I tweaked the code to have no space inside the tag.

Also, I previously missed a place where pre-line was still in effect.