### PR TITLE
Implement api_spec checkbox.

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -387,6 +387,7 @@ class FeatureHandler(common.ContentHandler):
       return
 
     spec_link = self.__FullQualifyLink('spec_link')
+    api_spec = self.request.get('api_spec') == 'on'
 
     explainer_links = self.request.get('explainer_links') or []
     if explainer_links:
@@ -520,6 +521,7 @@ class FeatureHandler(common.ContentHandler):
       feature.web_dev_views_notes = self.request.get('web_dev_views_notes')
       feature.prefixed = self.request.get('prefixed') == 'on'
       feature.spec_link = spec_link
+      feature.api_spec = api_spec
       feature.security_review_status = int(self.request.get(
           'security_review_status', models.REVIEW_PENDING))
       feature.privacy_review_status = int(self.request.get(
@@ -596,6 +598,7 @@ class FeatureHandler(common.ContentHandler):
           web_dev_views_notes=self.request.get('web_dev_views_notes'),
           prefixed=self.request.get('prefixed') == 'on',
           spec_link=spec_link,
+          api_spec=api_spec,
           security_review_status=int(self.request.get(
               'security_review_status', models.REVIEW_PENDING)),
           privacy_review_status=int(self.request.get(

--- a/guide.py
+++ b/guide.py
@@ -225,10 +225,19 @@ class FeatureEditStage(common.ContentHandler):
     # to have been touched.  Later we will add javascript to populate a
     # hidden form field named "touched" that lists the names of all fields
     # actually touched by the user.
-    # For now, checkboxes are always considered "touched", otherwise there
-    # would be no way to uncheck.
-    if param_name in ('unlisted', 'all_platforms', 'wpt', 'prefixed'):
-      return True
+
+    # For now, checkboxes are always considered "touched", if they are
+    # present on the form.
+    # TODO(jrobbins): Simplify this after next deployment.
+    checkboxes = ('unlisted', 'all_platforms', 'wpt', 'prefixed', 'api_spec')
+    if param_name in checkboxes:
+      form_fields_str = self.request.get('form_fields')
+      if form_fields_str:
+        form_fields = [field_name.strip()
+                       for field_name in form_fields_str.split(',')]
+        return param_name in form_fields
+      else:
+        return True
     return param_name in self.request.POST
 
   def get_blink_component_from_bug(self, blink_components, bug_url):
@@ -319,6 +328,9 @@ class FeatureEditStage(common.ContentHandler):
 
     if self.touched('spec_link'):
       feature.spec_link = self.parse_link('spec_link')
+
+    if self.touched('api_spec'):
+      feature.api_spec = self.request.get('api_spec') == 'on'
 
     if self.touched('security_review_status'):
       feature.security_review_status = self.parse_int('security_review_status')

--- a/guideforms.py
+++ b/guideforms.py
@@ -145,6 +145,11 @@ ALL_FIELDS = {
                    'chromestatus.com entry and the intent thread(s) with the '
                    'spec link when available.')),
 
+    'api_spec': forms.BooleanField(
+        required=False, initial=False, label='API spec',
+        help_text=('The spec document has details in a specification language '
+                   'such as Web IDL, or there is an exsting MDN page.')),
+
     'explainer_links': forms.CharField(
         label='Explainer link(s)', required=False,
         widget=forms.Textarea(
@@ -609,7 +614,7 @@ NewFeature_Incubate = define_form_class_using_shared_fields(
 
 NewFeature_Prototype = define_form_class_using_shared_fields(
     'NewFeature_Prototype',
-    ('spec_link',
+    ('spec_link', 'api_spec',
      'intent_to_implement_url', 'comments'))
   # TODO(jrobbins): advise user to request a tag review
 
@@ -695,7 +700,7 @@ Any_Ship = define_form_class_using_shared_fields(
 Any_Identify = define_form_class_using_shared_fields(
     'Any_Identify',
     ('owner', 'blink_components', 'motivation', 'explainer_links',
-     'bug_url', 'launch_bug_url', 'comments'))
+     'spec_link', 'api_spec', 'bug_url', 'launch_bug_url', 'comments'))
 
 
 Any_Implement = define_form_class_using_shared_fields(
@@ -766,7 +771,7 @@ Flat_Identify = define_form_class_using_shared_fields(
 Flat_Implement = define_form_class_using_shared_fields(
     'Flat_Implement',
     (# Standardization
-     'spec_link', 'intent_to_implement_url'))
+     'spec_link', 'api_spec', 'intent_to_implement_url'))
 
 
 Flat_DevTrial = define_form_class_using_shared_fields(

--- a/models.py
+++ b/models.py
@@ -1032,6 +1032,7 @@ class Feature(DictModel):
   # Standards details.
   standardization = db.IntegerProperty(required=True)
   spec_link = db.LinkProperty()
+  api_spec = db.BooleanProperty(default=False)
   security_review_status = db.IntegerProperty(default=REVIEW_PENDING)
   privacy_review_status = db.IntegerProperty(default=REVIEW_PENDING)
 
@@ -1259,6 +1260,11 @@ class FeatureForm(forms.Form):
       widget=forms.URLInput(attrs={'placeholder': 'https://'}),
       help_text="Link to spec, if and when available. Please update the chromestatus.com entry and the intent thread(s) with the spec link when available.")
 
+  api_spec = forms.BooleanField(
+      required=False, initial=False, label='API spec',
+      help_text=('The spec document has details in a specification language '
+                 'such as Web IDL, or there is an existing MDN page.'))
+
   security_review_status = forms.ChoiceField(
       required=False,
       choices=REVIEW_STATUS_CHOICES.items(),
@@ -1398,8 +1404,8 @@ class FeatureForm(forms.Form):
       help_text='Description of the desired DevTools debugging support for your feature. Consider emailing the <a href="https://groups.google.com/forum/?fromgroups#!forum/google-chrome-developer-tools">google-chrome-developer-tools</a> list for additional help. For new language features in V8 specifically, refer to the debugger support checklist. If your feature doesn\'t require changes to DevTools in order to provide a good debugging experience, feel free to leave this section empty.')
 
   all_platforms = forms.BooleanField(required=False, initial=False, label='Supported on all platforms?',
-      help_text='Will this feature be supported on all six Blink platforms (Windows, Mac, Linux, Chrome OS, Android, and Android WebView)?')
-
+      help_text='Will this feature be supported on all six Blink platforms (Windows, Mac, Linux, Chrome OS, Android, and Android WebView)?'
+)
   all_platforms_descr = forms.CharField(label='Platform Support Explanation', required=False,
       widget=forms.Textarea(attrs={'rows': 2, 'cols': 50, 'maxlength': 2000}),
       help_text='Explanation for why this feature is, or is not, supported on all platforms.')

--- a/processes.py
+++ b/processes.py
@@ -76,9 +76,10 @@ BLINK_PROCESS_STAGES = [
       'Start prototyping',
       'Share an explainer doc and API. '
       'Start prototyping code in a public repo.',
-      ['API design',
+      ['Spec link',
+       'Spec mentor',  # TODO(jrobbins): needs detector.
+       'Draft API spec',
        'Intent to Prototype email',
-       'Spec mentor',
       ],
       [('Draft Intent to Prototype email', INTENT_EMAIL_URL)],
       models.INTENT_INCUBATE, models.INTENT_IMPLEMENT),
@@ -93,7 +94,7 @@ BLINK_PROCESS_STAGES = [
        'Request signals',
        'Security review issues addressed',
        'Privacy review issues addressed',
-       'External reviews',
+       'External reviews',  # TODO(jrobbins): needs detector.
        'Ready for Trial email',
       ],
       [('Draft Ready for Trial email', INTENT_EMAIL_URL)],
@@ -105,7 +106,7 @@ BLINK_PROCESS_STAGES = [
       ['TAG review requested',
        'Vendor signals',
        'Doc links',
-       'Documentation signoff',
+       'Documentation signoff',  # TODO(jrobbins): needs detector.
        'Estimated target milestone',
       ],
       [],
@@ -115,9 +116,9 @@ BLINK_PROCESS_STAGES = [
       'Origin Trial',
       '(Optional) Set up and run an origin trial. '
       'Act on feedback from partners and web developers.',
-      ['OT request',
-       'OT available',
-       'OT results',
+      ['OT request',  # TODO(jrobbins): needs detector.
+       'OT available',  # TODO(jrobbins): needs detector.
+       'OT results',  # TODO(jrobbins): needs detector.
        'Intent to Experiment email',
        'One LGTM on Intent to Experiment',
       ],
@@ -142,8 +143,8 @@ BLINK_PROCESS_STAGES = [
       'Ship',
       'Update milestones and other information when the feature '
       'actually ships.',
-      ['Finalized vendor signals',
-       'Finalized target milestone',
+      ['Finalized vendor signals',  # TODO(jrobbins): needs detector.
+       'Finalized target milestone',  # TODO(jrobbins): needs detector.
       ],
       [],
       models.INTENT_SHIP, models.INTENT_SHIPPED),
@@ -162,7 +163,8 @@ BLINK_FAST_TRACK_STAGES = [
       'Identify feature',
       'Create an initial WebStatus feature entry to implement part '
       'of an existing specification or combinaton of specifications.',
-      ['Spec links',
+      ['Spec link',
+       'API spec',
       ],
       [],
       models.INTENT_NONE, models.INTENT_INCUBATE),
@@ -193,9 +195,9 @@ BLINK_FAST_TRACK_STAGES = [
       'Origin Trial',
       '(Optional) Set up and run an origin trial. '
       'Act on feedback from partners and web developers.',
-      ['OT request',
-       'OT available',
-       'OT results',
+      ['OT request',  # TODO(jrobbins): needs detector.
+       'OT available',  # TODO(jrobbins): needs detector.
+       'OT results',  # TODO(jrobbins): needs detector.
        'Intent to Experiment email',
        'One LGTM on Intent to Experiment',
       ],
@@ -206,8 +208,8 @@ BLINK_FAST_TRACK_STAGES = [
       'Prepare to ship',
       'Lock in shipping milestone. Finalize docs and announcements. '
       'Further standardization.',
-      ['Documentation signoff',
-       'Updated target milestone',
+      ['Documentation signoff',  # TODO(jrobbins): needs detector.
+       'Updated target milestone',  # TODO(jrobbins): needs detector.
        'Intent to Ship email',
        'Three LGTMs on Intent to Ship',
       ],
@@ -218,8 +220,8 @@ BLINK_FAST_TRACK_STAGES = [
       'Ship',
       'Update milestones and other information when the feature '
       'actually ships.',
-      ['Finalized vendor signals',
-       'Finalized target milestone',
+      ['Finalized vendor signals',  # TODO(jrobbins): needs detector.
+       'Finalized target milestone',  # TODO(jrobbins): needs detector.
       ],
       [],
       models.INTENT_SHIP, models.INTENT_SHIPPED),
@@ -276,8 +278,8 @@ PSA_ONLY_STAGES = [
       'Ship',
       'Update milestones and other information when the feature '
       'actually ships.',
-      ['Finalized vendor signals',
-       'Finalized target milestone',
+      ['Finalized vendor signals',  # TODO(jrobbins): needs detector.
+       'Finalized target milestone',  # TODO(jrobbins): needs detector.
       ],
       [],
       models.INTENT_SHIP, models.INTENT_SHIPPED),
@@ -296,7 +298,7 @@ DEPRECATION_STAGES = [
       'Create an initial WebStatus feature entry to deprecate '
       'an existing feature, including motivation and impact. '
       'Then, move existing Chromium code under a flag.',
-      ['Link to existing feature',
+      ['Link to existing feature',  # TODO(jrobbins): needs detector.
        'Motivation',
        'Code in Chromium',
       ],
@@ -317,9 +319,9 @@ DEPRECATION_STAGES = [
   ProcessStage(
       'Prepare for Deprecation Trial',
       '(Optional) Set up and run a deprecation trial. ',
-      ['DT request',
-       'DT available',
-       'Removal of DT',
+      ['DT request',  # TODO(jrobbins): needs detector.
+       'DT available',  # TODO(jrobbins): needs detector.
+       'Removal of DT',  # TODO(jrobbins): needs detector.
        'Request for Deprecation Trial email',
        'One LGTM on Request for Deprecation Trial',
       ],
@@ -331,7 +333,7 @@ DEPRECATION_STAGES = [
       'Prepare to ship',
       'Lock in shipping milestone. '
       'Finalize docs and announcements before disabling feature by default.',
-      ['Updated target milestone',
+      ['Updated target milestone',  # TODO(jrobbins): needs detector.
        'Intent to Ship email',
        'Three LGTMs on Intent to Ship',
       ],
@@ -433,6 +435,15 @@ PROGRESS_DETECTORS = {
 
     'Doc links':
     lambda f: f.doc_links and f.doc_links[0],
+
+    'Spec link':
+    lambda f: f.spec_link,
+
+    'Draft API spec':
+    lambda f: f.api_spec,
+
+    'API spec':
+    lambda f: f.api_spec,
 
     'TAG review requested':
     lambda f: f.tag_review,

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -32,6 +32,12 @@
   <br><br><h4>Specification</h4>
   {{feature.spec_link|urlize}}
 
+  {% if feature.api_spec %}
+    <br><br><h4>API spec</h4>
+    Yes
+  {% endif %}
+
+
   {% if feature.doc_links %}
     <br><br><h4>Design docs</h4>
     {% for link in feature.doc_links %}

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -99,6 +99,9 @@
 
   <div id="metadata-editing" style="display:none">
     <form name="overview_form" method="POST" action="/guide/stage/{{ feature_id }}/0">
+      <input type="hidden" name="form_fields"
+             value="{{ overview_form.fields.keys | join:',' }}" >
+
       <table>
         {{ overview_form }}
 

--- a/templates/guide/stage.html
+++ b/templates/guide/stage.html
@@ -20,6 +20,12 @@
 {% block content %}
 <form name="feature_form" method="POST" action="{{current_path}}">
 
+  <input type="hidden" name="form_fields"
+         value="{{ feature_form.fields.keys | join:',' }},
+                {% if impl_status_form %}
+                   {{ impl_status_form.fields.keys | join:',' }}
+                 {% endif %}" >
+  
   <section class="stage_form">
     <table>
       {{ feature_form }}


### PR DESCRIPTION
This helps resolve issue #934.

This is a do-over for 
https://github.com/GoogleChrome/chromium-dashboard/pull/1048

In this CL:
+ Add api_spec boolean field
+ Add the api_spec field to the old editing UX and guide UX
+ Add api_spec to the intent email template
+ Add a progress detector for api_spec and spec_link
+ Mark all progress items that lack progress detector functions with TODOs
+ Fix the logic in touched() to detect when a checkbox was present on a form, and add a form_fields hidden field to the templates to make that work.