### PR TITLE
Add feature details property sheet to collapsed section of feature detail page

### DIFF
--- a/guideforms.py
+++ b/guideforms.py
@@ -572,7 +572,7 @@ METADATA_FIELDS = [
      'category',
      'feature_type', 'intent_stage',
      'search_tags',
-     # Implementtion
+     # Implemention
      'impl_status_chrome',
      'blink_components',
      'bug_url', 'launch_bug_url',

--- a/guideforms.py
+++ b/guideforms.py
@@ -860,9 +860,24 @@ def make_display_specs(*shared_field_names):
 
 DEPRECATED_FIELDS = ['standardization']
 
+DISPLAY_IN_FEATURE_HIGHLIGHTS = [
+    'name', 'summary',
+    'motivation',
+    'unlisted', 'owner',
+    'search_tags',
+    # Implementtion
+    'impl_status_chrome',
+    'blink_components',
+    'bug_url',
+    'comments',
+]
+
 DISPLAY_FIELDS_IN_STAGES = {
+    'Metadata': make_display_specs(
+        'category', 'feature_type', 'intent_stage',
+        ),
     models.INTENT_INCUBATE: make_display_specs(
-        'motivation', 'initial_public_proposal_url', 'explainer_links'),
+        'initial_public_proposal_url', 'explainer_links'),
     models.INTENT_IMPLEMENT: make_display_specs(
         'spec_link', 'api_spec', 'intent_to_implement_url'),
     models.INTENT_EXPERIMENT: make_display_specs(
@@ -879,6 +894,7 @@ DISPLAY_FIELDS_IN_STAGES = {
         'sample_links', 'devrel', 'ready_for_trial_url',
         'flag_name'),
     models.INTENT_IMPLEMENT_SHIP: make_display_specs(
+        'launch_bug_url',
         'tag_review', 'tag_review_status',
         'measurement', 'prefixed'),
     models.INTENT_EXTEND_TRIAL: make_display_specs(
@@ -897,5 +913,5 @@ DISPLAY_FIELDS_IN_STAGES = {
     models.INTENT_SHIPPED: make_display_specs(
         ),
     'Misc': make_display_specs(
-        'comments'),
+        ),
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1007,6 +1007,15 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
+    "@polymer/iron-collapse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-collapse/-/iron-collapse-3.0.1.tgz",
+      "integrity": "sha512-yg6q5ZyckQR9VL9VmLrSTkSFXWy9AcJC8KtnD5cg0EHRPbakE8I9S/gVAgeP4nMWV2a/BjLLC4IBygcCMDhAGw==",
+      "requires": {
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
     "@polymer/iron-flex-layout": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "dependencies": {
     "@polymer/app-layout": "^3.1.0",
+    "@polymer/iron-collapse": "^3.0.1",
     "@polymer/iron-icon": "^3.0.1",
     "@polymer/iron-iconset-svg": "^3.0.1",
     "@polymer/paper-item": "^3.0.1",

--- a/static/components.js
+++ b/static/components.js
@@ -3,6 +3,7 @@
 // polymer components
 import '@polymer/app-layout';
 import '@polymer/app-layout/app-scroll-effects/effects/waterfall';
+import '@polymer/iron-collapse';
 import '@polymer/iron-icon';
 import '@polymer/iron-iconset-svg';
 import '@polymer/paper-item';
@@ -12,6 +13,7 @@ import '@polymer/paper-styles/color.js';
 
 // chromedash components
 import './elements/icons';
+import './elements/chromedash-accordion';
 import './elements/chromedash-callout';
 import './elements/chromedash-color-status';
 import './elements/chromedash-feature';

--- a/static/elements/chromedash-accordion.js
+++ b/static/elements/chromedash-accordion.js
@@ -1,0 +1,59 @@
+import {LitElement, css, html} from 'lit-element';
+import '@polymer/iron-icon';
+import '@polymer/iron-collapse';
+
+import SHARED_STYLES from '../css/shared.css';
+
+// This implements one section of an accordion widget.  In other words, it is
+// just a header that controls one secton on content.
+
+class ChromedashAccordion extends LitElement {
+  static get properties() {
+    return {
+      title: {type: String},
+      opened: {type: Boolean, reflect: true},
+    };
+  }
+
+  static get styles() {
+    return [
+      SHARED_STYLES,
+      css`
+      h3 {
+       margin: var(--content-padding-half) 0 0 0;
+       background: var(--accordion-background);
+       color: var(--accordion-color);
+       border-radius: var(--accordion-border-radius);
+       padding: var(--content-padding-quarter);
+       width: var(--max-content-width);
+      }
+    `];
+  }
+
+  constructor() {
+    super();
+    this.opened = false;
+  }
+
+  toggle() {
+    this.opened = !this.opened;
+  }
+
+  render() {
+    return html`
+     <h3 @click=${this.toggle}>
+       <iron-icon
+          icon="chromestatus:${this.opened ? 'expand-less' : 'expand-more'}">
+       </iron-icon>
+       ${this.title}
+     </h3>
+
+     <iron-collapse ?opened=${this.opened}>
+       <slot></slot>
+     </iron-collapse>
+    `;
+  }
+}
+
+customElements.define(
+  'chromedash-accordion', ChromedashAccordion);

--- a/static/elements/chromedash-accordion.js
+++ b/static/elements/chromedash-accordion.js
@@ -26,6 +26,7 @@ class ChromedashAccordion extends LitElement {
        border-radius: var(--accordion-border-radius);
        padding: var(--content-padding-quarter);
        width: var(--max-content-width);
+       cursor: pointer;
       }
     `];
   }
@@ -37,11 +38,15 @@ class ChromedashAccordion extends LitElement {
 
   toggle() {
     this.opened = !this.opened;
+    if (this.id) {
+      const anchor = this.opened ? this.id : '';
+      history.replaceState(null, null, '#' + anchor);
+    }
   }
 
   render() {
     return html`
-     <h3 @click=${this.toggle}>
+     <h3 @click=${this.toggle} title="Click to expand">
        <iron-icon
           icon="chromestatus:${this.opened ? 'expand-less' : 'expand-more'}">
        </iron-icon>

--- a/static/elements/chromedash-feature-detail.js
+++ b/static/elements/chromedash-feature-detail.js
@@ -33,7 +33,6 @@ class ChromedashFeatureDetail extends LitElement {
         contain: content;
         overflow: hidden;
         background: inherit;
-        margin: 1em 0;
       }
 
       .card {

--- a/static/elements/chromedash-feature-detail.js
+++ b/static/elements/chromedash-feature-detail.js
@@ -38,7 +38,7 @@ class ChromedashFeatureDetail extends LitElement {
       .card {
         background: var(--card-background);
         border: var(--card-border);
-        box-shadow:  var(--card-box-shadow);
+        box-shadow: var(--card-box-shadow);
         max-width: var(--max-content-width);
         margin-top: 1em;
         padding: 16px;
@@ -81,6 +81,17 @@ class ChromedashFeatureDetail extends LitElement {
         display: block;
         white-space: pre-wrap;
         padding: var(--content-padding-half);
+      }
+
+      .active {
+        border: var(--spot-card-border);
+        box-shadow: var(--spot-card-box-shadow);
+      }
+
+      .active h3::after {
+        content: "Active stage";
+        float: right;
+        color: var(--dark-spot-color);
       }
 
     `];
@@ -157,12 +168,16 @@ class ChromedashFeatureDetail extends LitElement {
   renderStage(stage) {
     let fields = [];
     let stageName = undefined;
+    let activeClass = '';
     if (typeof stage == 'string') {
       fields = this.fieldDefs[stage];
       stageName = stage;
     } else {
       fields = this.fieldDefs[stage.outgoing_stage];
       stageName = stage.name;
+      if (this.feature.intent_stage_int == stage.outgoing_stage) {
+        activeClass = 'active';
+      }
     }
     if (fields === undefined || fields.length == 0) {
       return nothing;
@@ -172,7 +187,7 @@ class ChromedashFeatureDetail extends LitElement {
       valuesPart = fields.map(fieldDef => this.renderField(fieldDef));
     }
     return html`
-      <section class="card">
+      <section class="card ${activeClass}">
        <h3>${stageName}</h3>
        ${valuesPart}
       </section>
@@ -181,6 +196,7 @@ class ChromedashFeatureDetail extends LitElement {
 
   render() {
     return html`
+       ${this.renderStage('Metadata')}
        ${this.process.stages.map(stage => html`
             ${this.renderStage(stage)}
        `)}

--- a/static/js-src/feature-page.js
+++ b/static/js-src/feature-page.js
@@ -61,6 +61,16 @@ if (SHOW_TOAST) {
   }, 500);
 }
 
+// Open an accordion that was bookmarked open
+if (location.hash) {
+  const targetId = decodeURIComponent(location.hash.substr(1));
+  const targetEl = document.getElementById(targetId);
+  if (targetEl && targetEl.tagName == 'CHROMEDASH-ACCORDION') {
+    targetEl.opened = true;
+  }
+}
+
+
 exports.subscribeToFeature = subscribeToFeature;
 exports.shareFeature = shareFeature;
 })(window);

--- a/static/sass/features/feature.scss
+++ b/static/sass/features/feature.scss
@@ -8,7 +8,7 @@
 
   box-sizing: border-box;
   word-wrap: break-word;
-  margin-bottom: $content-padding + 100; // padding + height of footer.
+  margin-bottom: $content-padding;
   max-width: $max-content-width;
 }
 

--- a/static/sass/theme.scss
+++ b/static/sass/theme.scss
@@ -82,6 +82,10 @@
   --shadow-color: var(--md-gray-100-alpha);
   --card-box-shadow: var(--shadow-color) 1px 1px 4px;
 
+  --accordion-background: var(--md-gray-100-alpha);
+  --accordion-color: var(--default-color);
+  --accordion-border-radius: var(--border-radius);
+
   --warning-background: var(--md-orange-200);
   --warning-color: var(--md-gray-900-alpha);
   --invalid-color: var(--md-red-700);

--- a/static/sass/theme.scss
+++ b/static/sass/theme.scss
@@ -81,6 +81,8 @@
   --card-border: var(--default-border);
   --shadow-color: var(--md-gray-100-alpha);
   --card-box-shadow: var(--shadow-color) 1px 1px 4px;
+  --spot-card-border: 1px solid var(--dark-spot-color);
+  --spot-card-box-shadow: none;
 
   --accordion-background: var(--md-gray-100-alpha);
   --accordion-color: var(--default-color);

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -241,12 +241,14 @@
     </section>
   </div>
 
-  <chromedash-accordion title="Feature details by stage">
+  <chromedash-accordion
+    id="details"
+    title="Additional fields by process phase">
     <chromedash-feature-detail
       feature='{{ feature_json }}'
       process='{{ process_json }}'
       fielddefs='{{ field_defs_json }}'
-      dismissedcues='{{ user.dismissed_cues }}'>
+      dismissedcues='{{ user.dismissed_cues|default:"[]" }}'>
     </chromedash-feature-detail>
   </chromedash-accordion>
 

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -10,72 +10,69 @@
 {% endblock %}
 
 {% block css %}
-  <style>{% inline_file "/static/css/features/feature.css" %}</style>
+    <style>{% inline_file "/static/css/features/feature.css" %}</style>
+    <link rel="stylesheet" href="/static/css/forms.css">
+    <link rel="stylesheet" href="/static/css/guide.css">
 {% endblock %}
 
 {% block rss %}
   <link rel="alternate" type="application/rss+xml" href="https://www.chromestatus.com/features.xml" title="All features" />
 {% endblock %}
 
-{% block content %}
-  <div id="feature">
-    <section id="name">
-      <h2>
-        {{ feature.name }}
+{% block subheader %}
+<div id="subheader" style="display:block">
+  <div style="float:right">
+  {% if user %}
+    <span class="tooltip" title="Receive an email notification when there are updates">
+      <a href="#" data-tooltip>
+        <iron-icon icon="chromestatus:star-border"
+                    onclick="subscribeToFeature({{ feature.id }})"
+                    class="pushicon"></iron-icon>
+      </a>
+    </span>
+  {% else %}
+    <span class="tooltip" title="Sign in to get email notifications for updates">
+      <a href="{{login.1}}" data-tooltip>
+        <iron-icon icon="chromestatus:star-border"
+                    class="pushicon"></iron-icon>
+      </a>
+    </span>
+  {% endif %}
+  <span class="tooltip" title="File a bug against this feature">
+    <a href="{{ feature.new_crbug_url }}" class="newbug" data-tooltip target="_blank">
+      <iron-icon icon="chromestatus:bug-report"></iron-icon>
+    </a>
+  </span>
+  <span class="tooltip no-web-share" title="Share this feature">
+    <a href="#" data-tooltip>
+      <iron-icon icon="chromestatus:share" onclick="shareFeature()"></iron-icon>
+    </a>
+  </span>
+  {% if user.can_edit %}
+    <span class="tooltip" title="Edit this feature">
+      <a href="/guide/edit/{{ feature.id }}" class="editfeature" data-tooltip>
+        <iron-icon icon="chromestatus:create"></iron-icon>
+      </a>
+    </span>
+  {% endif %}
+  </div>
+
+  <h2 id="breadcrumbs">
+    <a href="/features/{{ feature_id }}">
+      <iron-icon icon="chromestatus:arrow-back"></iron-icon>
+      Feature: {{ feature.name }}
+    </a>
         {% if feature.impl_status_chrome == "No longer pursuing" %} (No longer pursuing){% endif %}
         {% if feature.impl_status_chrome == "Deprecated" %} (deprecated){% endif %}
         {% if feature.impl_status_chrome == "Removed" %} (removed){% endif %}
-      </h2>
-      <div class="iconrow">
-      <a href="/features#category: {{ feature.category }}" class="category">{{ feature.category }}</a>
-      <div class="topcorner">
-      {% if feature.meta.origintrial %}
-      <span class="tooltip" title="Origin trial">
-        <iron-icon icon="chromestatus:extension" class="experimental"></iron-icon>
-      </span>
-      {% endif %}
-      {% if feature.meta.needsflag %}
-      <span class="tooltip" title="Experimental feature behind a flag">
-        <iron-icon icon="chromestatus:flag" class="experimental"></iron-icon>
-      </span>
-      {% endif %}
-      {% if user %}
-      <span class="tooltip" title="Receive an email notification when there are updates">
-        <a href="#" data-tooltip>
-          <iron-icon icon="chromestatus:star-border"
-                      onclick="subscribeToFeature({{ feature.id }})"
-                      class="pushicon"></iron-icon>
-        </a>
-      </span>
-      {% else %}
-      <span class="tooltip" title="Sign in to get email notifications for updates">
-        <a href="{{login.1}}" data-tooltip>
-          <iron-icon icon="chromestatus:star-border"
-                      class="pushicon"></iron-icon>
-        </a>
-      </span>
-      {% endif %}
-      <span class="tooltip" title="File a bug against this feature">
-        <a href="{{ feature.new_crbug_url }}" class="newbug" data-tooltip target="_blank">
-          <iron-icon icon="chromestatus:bug-report"></iron-icon>
-        </a>
-      </span>
-      <span class="tooltip no-web-share" title="Share this feature">
-        <a href="#" data-tooltip>
-          <iron-icon icon="chromestatus:share" onclick="shareFeature()"></iron-icon>
-        </a>
-      </span>
-      {% if user.can_edit %}
-      <span class="tooltip" title="Edit this feature">
-        <a href="/guide/edit/{{ feature.id }}" class="editfeature" data-tooltip>
-          <iron-icon icon="chromestatus:create"></iron-icon>
-        </a>
-      </span>
-      {% endif %}
-      </div>
-      </div>
-    </section>
+  </h2>
 
+</div>
+{% endblock %}
+
+
+{% block content %}
+  <div id="feature">
     {% if feature.unlisted %}
     <section id="access">
       <p><b>This feature is only shown in the feature list to users with
@@ -243,6 +240,16 @@
       <p><span>Last updated on {{ updated_display }}</span></p>
     </section>
   </div>
+
+  <chromedash-accordion title="Feature details">
+    <chromedash-feature-detail
+      feature='{{ feature_json }}'
+      process='{{ process_json }}'
+      fielddefs='{{ field_defs_json }}'
+      dismissedcues='{{ user.dismissed_cues }}'>
+    </chromedash-feature-detail>
+  </chromedash-accordion>
+
 {% endblock %}
 
 {% block js %}

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -241,7 +241,7 @@
     </section>
   </div>
 
-  <chromedash-accordion title="Feature details">
+  <chromedash-accordion title="Feature details by stage">
     <chromedash-feature-detail
       feature='{{ feature_json }}'
       process='{{ process_json }}'

--- a/tests/guideforms_test.py
+++ b/tests/guideforms_test.py
@@ -50,7 +50,7 @@ class DisplayFieldsTest(unittest.TestCase):
 
   def test_DISPLAY_FIELDS_IN_STAGES__no_duplicates(self):
     """Each field appears at most once."""
-    fields_seen = set(guideforms.METADATA_FIELDS +
+    fields_seen = set(guideforms.DISPLAY_IN_FEATURE_HIGHLIGHTS +
                       guideforms.DEPRECATED_FIELDS)
     for stage_id, field_spec_list in guideforms.DISPLAY_FIELDS_IN_STAGES.items():
       for field_spec in field_spec_list:
@@ -62,7 +62,7 @@ class DisplayFieldsTest(unittest.TestCase):
 
   def test_DISPLAY_FIELDS_IN_STAGES__complete_coverage(self):
     """Each field appears at least once."""
-    fields_seen = set(guideforms.METADATA_FIELDS +
+    fields_seen = set(guideforms.DISPLAY_IN_FEATURE_HIGHLIGHTS +
                       guideforms.DEPRECATED_FIELDS)
     for stage_id, field_spec_list in guideforms.DISPLAY_FIELDS_IN_STAGES.items():
       for field_spec in field_spec_list:


### PR DESCRIPTION
This resolves issue #925.

In this CL:
+ Add the <chromedash-feature-detail> element to the feature page inside a collapsed section (accordion)
+ Implement a new element <chromedash-accordion> that can be used as a collapsable section or one part of an accordion widget.
+ Improve chromedash-feature-detail to show the active stage, and allow both "Metadata" and "Misc" cards.
+ Change DISPLAY_FIELDS_IN_STAGES to not duplicate data contained in the legacy feature detail page

I realize that one expandable section looks a little lonely at the bottom of the page all by itself.  Eventually, it might be joined by other sections for metrics, reviews / approvals.