### PR TITLE
Only show all-platforms boolean in the r4t email.

### DIFF
--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -153,10 +153,14 @@
   <p class="preformatted">{{feature.debuggability|urlize}}</p>
 {% endif %}
 
-<br><br><h4>Will this feature be supported on all six Blink platforms
-    (Windows, Mac, Linux, Chrome OS, Android, and Android WebView)?</h4>
-{% if feature.all_platforms %}Yes{% else %}No{% endif %}
-<p class="preformatted">{{feature.all_platforms_descr|urlize}}</p>
+{% if 'experiment' in sections_to_show %}
+  <br><br><h4>Will this feature be supported on all six Blink platforms
+      (Windows, Mac, Linux, Chrome OS, Android, and Android WebView)?</h4>
+  {% if feature.all_platforms %}Yes{% else %}No{% endif %}
+  {% if feature.all_platforms_descr %}
+    <p class="preformatted">{{feature.all_platforms_descr|urlize}}</p>
+  {% endif %}
+{% endif %}
 
 <br><br><h4>Is this feature fully tested by <a href="https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_platform_tests.md">web-platform-tests</a>?</h4>
 {% if feature.wpt %}Yes{% else %}No{% endif %}


### PR DESCRIPTION
This should resolve issue #1081.

For most of the fields in the intent emails, I basically show the field if it has a non-empty value.  This means that as the process progresses, fields get filled in, and the later intent emails have more information because everything is shown.  However, booleans have no non-empty values so for this one, I had shown it only when showing fields relevant to dev trials.