### PR TITLE
Update the interop risk help link to a target that is more specific.

### DIFF
--- a/guideforms.py
+++ b/guideforms.py
@@ -211,8 +211,8 @@ ALL_FIELDS = {
         widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
         help_text=
         ('Describe the degree of <a target="_blank" '
-         'href="https://sites.google.com/a/chromium.org/dev/blink?'
-         'pli=1#TOC-Policy-for-shipping-and-removing-web-platform-API-features'
+         'href="https://www.chromium.org/blink/guidelines/'
+         'web-platform-changes-guidelines#TOC-Finding-balance'
          '">interoperability risk</a>. For a new feature, the main risk is '
          'that it fails to become an interoperable part of the web platform '
          'if other browsers do not implement it. For a removal, please review '

--- a/models.py
+++ b/models.py
@@ -1302,7 +1302,7 @@ class FeatureForm(forms.Form):
 
   interop_compat_risks = forms.CharField(label='Interoperability and Compatibility Risks', required=True,
       widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
-      help_text='Describe the degree of <a target="_blank" href="https://sites.google.com/a/chromium.org/dev/blink?pli=1#TOC-Policy-for-shipping-and-removing-web-platform-API-features">interoperability risk</a>. For a new feature, the main risk is that it fails to become an interoperable part of the web platform if other browsers do not implement it. For a removal, please review our <a target="_blank" href="https://docs.google.com/document/d/1RC-pBBvsazYfCNNUSkPqAVpSpNJ96U8trhNkfV0v9fk/edit">principles of web compatibility</a>.<br><br>Please include citation links below where possible. Examples include resolutions from relevant standards bodies (e.g. W3C working group), tracking bugs, or links to online conversations.')
+      help_text='Describe the degree of <a target="_blank" href="https://www.chromium.org/blink/guidelines/web-platform-changes-guidelines#TOC-Finding-balance">interoperability risk</a>. For a new feature, the main risk is that it fails to become an interoperable part of the web platform if other browsers do not implement it. For a removal, please review our <a target="_blank" href="https://docs.google.com/document/d/1RC-pBBvsazYfCNNUSkPqAVpSpNJ96U8trhNkfV0v9fk/edit">principles of web compatibility</a>.<br><br>Please include citation links below where possible. Examples include resolutions from relevant standards bodies (e.g. W3C working group), tracking bugs, or links to online conversations.')
 
   safari_views = forms.ChoiceField(
       required=False, label='Safari views',


### PR DESCRIPTION
Resolves #1082.

This is the link suggested by the issue reporter.  It was indirectly linked to in the old page, so hopefully this makes it more clear and saves the user a click.  However, there seem to be a lot of overlapping docs that we could link to, so let me know if you have any better suggestions.