### PR TITLE
Add a sentence clarifying meaning of recently-added UseCounters

### DIFF
--- a/static/elements/chromedash-timeline.js
+++ b/static/elements/chromedash-timeline.js
@@ -249,16 +249,16 @@ class ChromedashTimeline extends LitElement {
       hadEl.src = dsEmbedUrl;
 
       const bigqueryEl = this.shadowRoot.getElementById('bigquery');
-      bigqueryEl.textContent = `#standardSQL  
-SELECT yyyymmdd, client, pct_urls, sample_urls  
-FROM \`httparchive.blink_features.usage\`  
-WHERE feature = '${featureName}'  
+      bigqueryEl.textContent = `#standardSQL
+SELECT yyyymmdd, client, pct_urls, sample_urls
+FROM \`httparchive.blink_features.usage\`
+WHERE feature = '${featureName}'
 ORDER BY yyyymmdd DESC, client`;
     }
   }
 
   render() {
-    return html`  
+    return html`
       <select .value="${this.selectedBucketId}" @change="${this.updateSelectedBucketId}">
         <option disabled value="1">Select a property</option>
         ${this.props.map((prop) => html`
@@ -269,6 +269,8 @@ ORDER BY yyyymmdd DESC, client`;
       <h3 id="usage" class="header_title">Percentage of page loads that use this feature</h3>
       <p class="description">The chart below shows the percentage of page loads (in Chrome) that use
         this feature at least once. Data is across all channels and platforms.
+        Newly added use counters that are not on Chrome stable yet
+        only have data from the Chrome channels they're on.
       </p>
       <div id="chart"></div>
       <p class="callout">

--- a/templates/metrics/css/popularity.html
+++ b/templates/metrics/css/popularity.html
@@ -19,7 +19,18 @@
 <div class="data-panel">
   <h3>About this data</h3>
   <p class="description">
-    We've been using Chrome's <a href="https://cs.chromium.org/chromium/src/tools/metrics/histograms/enums.xml" target="_blank">anonymous usage statistics</a> to count the occurrences of certain CSS features in the wild. The numbers on this page indicate the <b>percentages of Chrome page loads (across all channels and platforms) that use the corresponding CSS property at least once</b>. Data is ~24 hrs old.</p>
+    We've been using Chrome's <a
+    href="https://cs.chromium.org/chromium/src/tools/metrics/histograms/enums.xml"
+    target="_blank">anonymous usage statistics</a> to count the
+    occurrences of certain CSS features in the wild. The numbers on
+    this page indicate the <b>percentages of Chrome page loads (across
+    all channels and platforms) that use the corresponding CSS
+    property at least once</b>.
+
+    Newly added use counters that are not on Chrome stable yet
+    only have data from the Chrome channels they're on.
+
+    Data is ~24 hrs old.</p>
   <chromedash-metrics type="css" view="popularity" {% if prod %}prod{% endif %}></chromedash-metrics>
 </div>
 {% endblock %}

--- a/templates/metrics/feature/popularity.html
+++ b/templates/metrics/feature/popularity.html
@@ -19,7 +19,18 @@
 <div class="data-panel">
   <h3>About this data</h3>
   <p class="description">
-    We've been using Chrome's <a href="https://cs.chromium.org/chromium/src/tools/metrics/histograms/enums.xml" target="_blank">anonymous usage statistics</a> to count the occurrences of certain HTML and JavaScript features in the wild. The numbers on this page indicate the <b>percentages of Chrome page loads (across all channels and platforms) that use the corresponding feature at least once</b>. Data is ~24 hrs old.</p>
+    We've been using Chrome's <a
+    href="https://cs.chromium.org/chromium/src/tools/metrics/histograms/enums.xml"
+    target="_blank">anonymous usage statistics</a> to count the
+    occurrences of certain HTML and JavaScript features in the
+    wild. The numbers on this page indicate the <b>percentages of
+    Chrome page loads (across all channels and platforms) that use the
+    corresponding feature at least once</b>.
+
+    Newly added use counters that are not on Chrome stable yet
+    only have data from the Chrome channels they're on.
+
+    Data is ~24 hrs old.</p>
   <chromedash-metrics type="feature" view="popularity" {% if prod %}prod{% endif %}></chromedash-metrics>
 </div>
 {% endblock %}


### PR DESCRIPTION
Resolves #1094 

In a recent email thread it was discovered that UseCounter metrics are calculated with a denominator for the channels that include that feature, which can be significantly different for features that have reached the stable channel vs not reached stable yet. 