### PR TITLE
pushState when clicking on sidenav links

### DIFF
--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -209,19 +209,25 @@ class ChromedashFeaturelist extends LitElement {
   }
 
   // Directly called from template/features.html
-  filter(val) {
+  filter(val, shouldPushState) {
+    this.searchEl.value = val;
+    const pushOrReplaceState = (
+      history &&
+          shouldPushState ? history.pushState.bind(history) :
+        history.replaceState.bind(history));
     // Clear filter if there's no search or if called directly.
     if (!val) {
-      if (history && history.replaceState) {
-        history.replaceState('', document.title, location.pathname + location.search);
+      if (pushOrReplaceState) {
+        pushOrReplaceState({query: ''}, document.title,
+          location.pathname + location.search);
       } else {
         location.hash = '';
       }
       this.filtered = this.features;
     } else {
       val = val.trim();
-      if (history && history.replaceState) {
-        history.replaceState({id: null}, document.title,
+      if (pushOrReplaceState) {
+        pushOrReplaceState({query: val}, document.title,
           '/features#' + encodeURIComponent(val));
       }
 

--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -213,8 +213,8 @@ class ChromedashFeaturelist extends LitElement {
     this.searchEl.value = val;
     const pushOrReplaceState = (
       history &&
-          shouldPushState ? history.pushState.bind(history) :
-        history.replaceState.bind(history));
+      (shouldPushState ? history.pushState.bind(history) :
+        history.replaceState.bind(history)));
     // Clear filter if there's no search or if called directly.
     if (!val) {
       if (pushOrReplaceState) {

--- a/static/js-src/features-page.js
+++ b/static/js-src/features-page.js
@@ -34,13 +34,13 @@ chromeMetadataEl.addEventListener('query-changed', (e) => {
   const isMilestone = value.match(/^[0-9]+$/);
   searchEl.value = isMilestone ? 'milestone=' + value :
     'browsers.chrome.status:"' + value + '"';
-  featureListEl.filter(searchEl.value);
+  featureListEl.filter(searchEl.value, true);
 });
 
 // Clear input when user clicks the 'x' button.
 searchEl.addEventListener('search', (e) => {
   if (!e.target.value) {
-    featureListEl.filter();
+    featureListEl.filter('', true);
     chromeMetadataEl.selected = null;
   }
 });
@@ -62,24 +62,26 @@ featureListEl.addEventListener('has-scroll-list', () => {
 featureListEl.addEventListener('filter-category', (e) => {
   e.stopPropagation();
   searchEl.value = 'category: ' + e.detail.val;
-  featureListEl.filter(searchEl.value);
+  featureListEl.filter(searchEl.value, true);
 });
 
 featureListEl.addEventListener('filter-owner', (e) => {
   e.stopPropagation();
   searchEl.value = 'browsers.chrome.owners: ' + e.detail.val;
-  featureListEl.filter(searchEl.value);
+  featureListEl.filter(searchEl.value, true);
 });
 
 featureListEl.addEventListener('filter-component', (e) => {
   e.stopPropagation();
   searchEl.value = 'component: ' + e.detail.val;
-  featureListEl.filter(searchEl.value);
+  featureListEl.filter(searchEl.value, true);
 });
 
 window.addEventListener('popstate', (e) => {
-  if (e.state) {
+  if (e.state && e.state.id) {
     featureListEl.scrollToId(e.state.id);
+  } else if (e.state && e.state.query) {
+    featureListEl.filter(e.state.query);
   }
 });
 


### PR DESCRIPTION
When changing the search query by clicking on sidebar links, add that to the browser history so that the user can navigate back to previous states without immediately leaving the page.