### PR TITLE
Avoid underlining whitespace when hovering over icon links

### DIFF
--- a/static/sass/elements/chromedash-feature.scss
+++ b/static/sass/elements/chromedash-feature.scss
@@ -92,6 +92,10 @@ iron-icon {
   margin-left: 4px;
 }
 
+.topcorner a {
+  text-decoration: none;
+}
+
 hgroup {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
This resolves a tiny annoyance that I noticed while using the app.  When hovering over icons, the browser was underlining the whitespace between the closing tag for the icon and the closing tag for the link.