### PR TITLE
[py3] Add import __future__ lines to all files and update print statements

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -18,7 +18,6 @@ from __future__ import print_function
 
 __author__ = 'ericbidelman@chromium.org (Eric Bidelman)'
 
-
 import datetime
 import json
 import logging

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 import os
 # name of the django settings module
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'

--- a/blink_handler.py
+++ b/blink_handler.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # -*- coding: utf-8 -*-
 # Copyright 2017 Google Inc.
 #

--- a/bulkloader_helpers.py
+++ b/bulkloader_helpers.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 import datetime
 
 from google.appengine.ext import db

--- a/common.py
+++ b/common.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # -*- coding: utf-8 -*-
 # Copyright 2013 Google Inc.
 #
@@ -14,7 +17,6 @@
 # limitations under the License.
 
 __author__ = 'ericbidelman@chromium.org (Eric Bidelman)'
-
 
 import datetime
 import json

--- a/cues.py
+++ b/cues.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # -*- coding: utf-8 -*-
 # Copyright 2020 Google Inc.
 #

--- a/customtags/templatetags/inline_file.py
+++ b/customtags/templatetags/inline_file.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 import logging
 
 from django import template

--- a/customtags/templatetags/verbatim.py
+++ b/customtags/templatetags/verbatim.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 """
 jQuery templates use constructs like:
 

--- a/guide.py
+++ b/guide.py
@@ -16,7 +16,6 @@ from __future__ import print_function
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import datetime
 import json
 import logging

--- a/metrics.py
+++ b/metrics.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # -*- coding: utf-8 -*-
 # Copyright 2013 Google Inc.
 #

--- a/models.py
+++ b/models.py
@@ -16,7 +16,6 @@ from __future__ import print_function
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import collections
 import datetime
 import json

--- a/notifier.py
+++ b/notifier.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # -*- coding: utf-8 -*-
 # Copyright 2017 Google Inc.
 #

--- a/schedule.py
+++ b/schedule.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # -*- coding: utf-8 -*-
 # Copyright 2017 Google Inc.
 #

--- a/scripts/fetch_oauth_credentials.py
+++ b/scripts/fetch_oauth_credentials.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
@@ -26,11 +29,11 @@ def downloadUsage(err, downloadUrl=None):
     downloadString = 'Run'
   else:
     downloadString = 'Download available at %s or run' % downloadUrl
-  print '%s\n%s%s' % (
+  print('%s\n%s%s' % (
       err,
       downloadString,
       ' setup.py on the google-api-python-client:\n' +
-      'https://code.google.com/p/google-api-python-client/downloads')
+      'https://code.google.com/p/google-api-python-client/downloads'))
   sys.exit(1)
 
 def importUsage(lib, downloadUrl=None):
@@ -44,7 +47,7 @@ def importUsage(lib, downloadUrl=None):
 
 try:
   from gflags import gflags
-  print gflags.FLAGS
+  print(gflags.FLAGS)
 except:
   importUsage('gflags', 'https://code.google.com/p/python-gflags/downloads/')
 
@@ -78,7 +81,7 @@ if oauth2client_version is None:
 elif (parse_version(oauth2client_version) <
       parse_version(OAUTH2CLIENT_REQUIRED_VERSION)):
   downloadUsage(('oauth2client module version %s is too old.\n' +
-      'Miminum required version is %s.') % (oauth2client_version, 
+      'Miminum required version is %s.') % (oauth2client_version,
       OAUTH2CLIENT_REQUIRED_VERSION))
 
 #
@@ -108,14 +111,14 @@ def main(argv):
   try:
     argv = FLAGS(argv)
   except gflags.FlagsError, e:
-    print '%s\nUsage: %s ARGS\n%s' % (e, sys.argv[0], FLAGS)
+    print('%s\nUsage: %s ARGS\n%s' % (e, sys.argv[0], FLAGS))
     sys.exit(1)
 
   storage = Storage(FLAGS.credentials_file)
   credentials = storage.get()
   if credentials is None or credentials.invalid:
-    print 'Acquiring initial credentials...'
-    
+    print('Acquiring initial credentials...')
+
     # Need to acquire token using @google.com account.
     flow = flow_from_clientsecrets(
         FLAGS.client_secrets_file,
@@ -125,14 +128,14 @@ def main(argv):
 
     credentials = run(flow, storage)
   elif credentials.access_token_expired:
-    print 'Refreshing access token...'
+    print('Refreshing access token...')
     credentials.refresh(httplib2.Http())
 
-  print 'Refresh token:', credentials.refresh_token
-  print 'Access token:', credentials.access_token
+  print('Refresh token:', credentials.refresh_token)
+  print('Access token:', credentials.access_token)
   delta = credentials.token_expiry - datetime.datetime.utcnow()
-  print 'Access token expires: %sZ (%dm %ds)' % (credentials.token_expiry,
-      delta.seconds / 60, delta.seconds % 60)
+  print('Access token expires: %sZ (%dm %ds)' % (credentials.token_expiry,
+      delta.seconds / 60, delta.seconds % 60))
 
 
 if __name__ == '__main__':

--- a/scripts/fetch_oauth_credentials.py
+++ b/scripts/fetch_oauth_credentials.py
@@ -135,7 +135,7 @@ def main(argv):
   print('Access token:', credentials.access_token)
   delta = credentials.token_expiry - datetime.datetime.utcnow()
   print('Access token expires: %sZ (%dm %ds)' % (credentials.token_expiry,
-      delta.seconds / 60, delta.seconds % 60))
+      delta.seconds // 60, delta.seconds % 60))
 
 
 if __name__ == '__main__':

--- a/scripts/fix_data.py
+++ b/scripts/fix_data.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
@@ -61,16 +64,16 @@ def fix_up(props, corrector_func):
   for p in props:
     if p.bucket_id in need_correcting:
       new_name = need_correcting[p.bucket_id]
-      print p.bucket_id, p.property_name, '->', new_name
+      print(p.bucket_id, p.property_name, '->', new_name)
       p.property_name = new_name
       #p.put() # uncomment commit to the db changes.
 
 props = FetchAllFeaturesWithError()
-print 'Found', str(len(props)), 'properties tagged "ERROR"'
+print('Found', str(len(props)), 'properties tagged "ERROR"')
 fix_up(props, corrector_func=CorrectFeaturePropertyName)
 
 css_props = FetchAllCSSPropertiesWithError()
-print 'Found', str(len(css_props)), 'css properties tagged "ERROR"'
+print('Found', str(len(css_props)), 'css properties tagged "ERROR"')
 fix_up(css_props, corrector_func=CorrectCSSPropertyName)
 
-print 'Done'
+print('Done')

--- a/server.py
+++ b/server.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # -*- coding: utf-8 -*-
 # Copyright 2013 Google Inc.
 #

--- a/settings.py
+++ b/settings.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 import logging
 import os
 

--- a/tests/admin_test.py
+++ b/tests/admin_test.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import division
+from __future__ import print_function
+
 import unittest
 import testing_config  # Must be imported before the module under test.
 import urllib

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import division
+from __future__ import print_function
+
 import unittest
 import testing_config  # Must be imported before the module under test.
 

--- a/tests/cues_test.py
+++ b/tests/cues_test.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import division
+from __future__ import print_function
+
 import unittest
 import testing_config  # Must be imported before the module under test.
 

--- a/tests/guide_test.py
+++ b/tests/guide_test.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")

--- a/tests/guideforms_test.py
+++ b/tests/guideforms_test.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")

--- a/tests/notifier_test.py
+++ b/tests/notifier_test.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")

--- a/tests/processes_test.py
+++ b/tests/processes_test.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")

--- a/tests/schedule_test.py
+++ b/tests/schedule_test.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")

--- a/tests/testing_config.py
+++ b/tests/testing_config.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -12,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import sys
 import unittest

--- a/tests/users_test.py
+++ b/tests/users_test.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")

--- a/users.py
+++ b/users.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # -*- coding: utf-8 -*-
 # Copyright 2013 Google Inc.
 #

--- a/util.py
+++ b/util.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # -*- coding: utf-8 -*-
 # Copyright 2017 Google Inc.
 #


### PR DESCRIPTION
This addresses part of issue #1069.

The future import lines need to be at the very top of each file, even above the copyright header.
We have only a few uses of the print statement.  This changes them to print function calls.
We only had one integer division in the app.  This change updates that to the new syntax. 