### PR TITLE
Replace memcache with a RAM-based cache.

### DIFF
--- a/common.py
+++ b/common.py
@@ -135,7 +135,7 @@ class BaseHandler(webapp2.RequestHandler):
     elif user.email().endswith(('@chromium.org', '@google.com')):
       can_edit = True
     else:
-      # TODO(ericbidelman): memcache user lookup.
+      # TODO(ericbidelman): ramcache user lookup.
       query = models.AppUser.all(keys_only=True).filter('email =', user.email())
       found_user = query.get()
 

--- a/guide.py
+++ b/guide.py
@@ -26,7 +26,7 @@ import webapp2
 from django import forms
 
 # Appengine imports.
-from google.appengine.api import memcache
+import ramcache
 from google.appengine.api import users
 from google.appengine.ext import db
 from google.appengine.api import taskqueue
@@ -160,7 +160,7 @@ class FeatureNew(common.ContentHandler):
     key = feature.put()
 
     # TODO(jrobbins): enumerate and remove only the relevant keys.
-    memcache.flush_all()
+    ramcache.flush_all()
 
     redirect_url = '/guide/edit/' + str(key.id())
     return self.redirect(redirect_url)
@@ -531,7 +531,7 @@ class FeatureEditStage(common.ContentHandler):
     key = feature.put()
 
     # TODO(jrobbins): enumerate and remove only the relevant keys.
-    memcache.flush_all()
+    ramcache.flush_all()
 
     redirect_url = '/guide/edit/' + str(key.id())
     return self.redirect(redirect_url)

--- a/notifier.py
+++ b/notifier.py
@@ -26,6 +26,7 @@ import os
 import re
 import webapp2
 
+import ramcache
 from google.appengine.ext import db
 from google.appengine.api import mail
 from google.appengine.api import urlfetch
@@ -442,6 +443,7 @@ class NotificationSubscriptionInfoHandler(webapp2.RequestHandler):
 
 class NotificationsListHandler(common.ContentHandler):
   def get(self):
+    ramcache.check_for_distributed_invalidation()
     subscriptions = PushSubscription.all().fetch(None)
 
     template_data = {

--- a/ramcache.py
+++ b/ramcache.py
@@ -1,0 +1,168 @@
+from __future__ import division
+from __future__ import print_function
+
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module manages a distributed RAM cache as a global python dictionary in
+each AppEngine instance.  AppEngine can spin up new instances or kill old ones
+at any time.  Each instance's RAM cache is independent and might not have the
+same entries as found in the RAM caches of other instances.
+
+Each instance will do the work needed to compute a given RAM cache entry
+itself.  The values computed in a given instance will speed up future requests
+made to that instance only.
+
+When the user edits something in the app, the updated entity is stored in
+datastore.  Also, the singleton SharedInvalidate entity is updated with the
+timestamp of the change.  Every request handler must start processing a request
+by first calling SharedInvalidate.check_for_distributed_invalidation() which
+checks for any needed invalidations and clears RAM cache entries in
+that instance if needed.
+
+For now, there is only a single RAM cache per instance and when anything is
+invalidated, that entire RAM cache is completely cleared.  In the future,
+invalidations could be compartmentalized by RAM cache type, or even specific
+entity IDs.  Monorail uses that approach, but existing ChromeStatus code does
+not need it.
+
+Calling code must not mutate any value that is passed into set() or returned
+from get().  If calling code needs to mutate such objects, it should call
+copy.copy() or copy.deepcopy() to avoid unintentional cumulative mutations.
+
+Unlike memcache, this RAM cache has no concept of expiration time.  So,
+whenever a cached value would become invalid, it must be invalidated.
+"""
+
+import logging
+import time as time_module
+from google.appengine.ext import db
+
+
+global_cache = {}
+expires = {}
+
+# Whenever the cache would have more than this many items, some
+# random item is dropped, or the entire cache is cleared.
+# If our instances are killed by appengine for exceeding memory limits,
+# we can configure larger instances and/or reduce this value.
+MAX_CACHE_SIZE = 10000
+
+
+def set(key, value, time=None):
+  """Emulate the memcache.get() method using a RAM cache."""
+  if len(global_cache) + 1 > MAX_CACHE_SIZE:
+    popped_item = global_cache.popitem()
+    if popped_item[0] in expires:
+      del expires[popped_item[0]]
+  global_cache[key] = value
+  if time:
+    expires[key] = int(time_module.time()) + time
+
+
+def _check_expired(keys):
+  now = int(time_module.time())
+  for key in keys:
+    if key in expires and expires[key] < now:
+      del expires[key]
+      del global_cache[key]
+
+
+def get(key):
+  """Emulate the memcache.set() method using a RAM cache."""
+  _check_expired([key])
+  verb = 'hit' if key in global_cache else 'miss'
+  logging.info('cache %s for %r', verb, key)
+  return global_cache.get(key)
+
+
+def get_multi(keys):
+  """Emulate the memcache.get_multi() method using a RAM cache."""
+  _check_expired(keys)
+  return {
+      key: global_cache[key]
+      for key in keys
+      if key in global_cache}
+
+
+def set_multi(entries):
+  """Emulate the memcache.set_multi() method using a RAM cache."""
+  if len(global_cache) + len(entries) > MAX_CACHE_SIZE:
+    global_cache.clear()
+    expires.clear()
+  global_cache.update(entries)
+
+
+def delete(key):
+  """Emulate the memcache.delete() method using a RAM cache."""
+  if key in global_cache:
+    del global_cache[key]
+    flush_all()  # Note: this is wasteful but infrequent in our app.
+
+
+def flush_all():
+  """Emulate the memcache.flush_all() method using a RAM cache.
+
+     This does not clear the RAM cache in this instance.  That happens
+     at the start of the next request when the request handler calls
+     SharedInvalidate.check_for_distributed_invalidation().
+  """
+  SharedInvalidate.invalidate()
+
+
+class SharedInvalidateParent(db.Model):
+  pass
+
+
+class SharedInvalidate(db.Model):
+
+  PARENT_ENTITY_ID = 123
+  PARENT_KEY = db.Key.from_path('SharedInvalidateParent', PARENT_ENTITY_ID)
+  SINGLETON_ENTITY_ID = 456
+  SINGLETON_KEY = db.Key.from_path(
+      'SharedInvalidateParent', PARENT_ENTITY_ID,
+      'SharedInvalidate', SINGLETON_ENTITY_ID)
+  last_processed_timestamp = None
+
+  updated = db.DateTimeProperty(auto_now=True)
+
+  @classmethod
+  def invalidate(cls):
+    """Tell this and other appengine instances to invalidate their caches."""
+    singleton = cls.get(cls.SINGLETON_KEY)
+    if not singleton:
+      singleton = SharedInvalidate(key=cls.SINGLETON_KEY)
+    singleton.put()  # automatically sets singleton.updated to now.
+    # The cache in each instance (including this one) will be
+    # cleared on the next call to check_for_distributed_invalidation()
+    # which should happen at the start of request processing.
+
+  @classmethod
+  def check_for_distributed_invalidation(cls):
+    """Check if any appengine instance has invlidated the cache."""
+    singleton = cls.get(cls.SINGLETON_KEY, read_policy=db.STRONG_CONSISTENCY)
+    if not singleton:
+      return  # No news is good news
+    if (cls.last_processed_timestamp is None or
+        singleton.updated > cls.last_processed_timestamp):
+      global_cache.clear()
+      expires.clear()
+      cls.last_processed_timestamp = singleton.updated
+
+
+def check_for_distributed_invalidation():
+  """Just a shorthand way to call the class method."""
+  SharedInvalidate.check_for_distributed_invalidation()

--- a/ramcache.py
+++ b/ramcache.py
@@ -63,7 +63,7 @@ MAX_CACHE_SIZE = 10000
 
 
 def set(key, value, time=None):
-  """Emulate the memcache.get() method using a RAM cache."""
+  """Emulate the memcache.set() method using a RAM cache."""
   if len(global_cache) + 1 > MAX_CACHE_SIZE:
     popped_item = global_cache.popitem()
     if popped_item[0] in expires:
@@ -82,7 +82,7 @@ def _check_expired(keys):
 
 
 def get(key):
-  """Emulate the memcache.set() method using a RAM cache."""
+  """Emulate the memcache.get() method using a RAM cache."""
   _check_expired([key])
   verb = 'hit' if key in global_cache else 'miss'
   logging.info('cache %s for %r', verb, key)
@@ -95,7 +95,8 @@ def get_multi(keys):
   return {
       key: global_cache[key]
       for key in keys
-      if key in global_cache}
+      if key in global_cache
+  }
 
 
 def set_multi(entries):

--- a/schedule.py
+++ b/schedule.py
@@ -23,7 +23,7 @@ import logging
 import os
 import webapp2
 
-from google.appengine.api import memcache
+import ramcache
 from google.appengine.api import urlfetch
 from google.appengine.api import users
 
@@ -36,7 +36,7 @@ import util
 def fetch_chrome_release_info(version):
   key = '%s|chromerelease|%s' % (settings.MEMCACHE_KEY_PREFIX, version)
 
-  data = memcache.get(key)
+  data = ramcache.get(key)
   if data is None:
     url = ('https://chromiumdash.appspot.com/fetch_milestone_schedule?'
            'mstone=%s' % version)
@@ -50,7 +50,7 @@ def fetch_chrome_release_info(version):
           del data['owners']
           del data['feature_freeze']
           del data['ldaps']
-          memcache.set(key, data)
+          ramcache.set(key, data)
       except ValueError:
         pass  # Handled by next statement
 
@@ -62,7 +62,7 @@ def fetch_chrome_release_info(version):
           'mstone': version,
           'version': version,
       }
-      # Note: we don't put placeholder data into memcache.
+      # Note: we don't put placeholder data into ramcache.
 
   return data
 

--- a/server.py
+++ b/server.py
@@ -28,6 +28,7 @@ import common
 import guideforms
 import models
 import processes
+import ramcache
 import util
 
 from google.appengine.api import users
@@ -42,6 +43,7 @@ def normalized_name(val):
 class FeatureDetailHandler(common.ContentHandler):
 
   def get(self, feature_id):
+    ramcache.check_for_distributed_invalidation()
     f = models.Feature.get_by_id(long(feature_id))
     if f is None:
       self.abort(404)
@@ -65,6 +67,7 @@ class FeatureDetailHandler(common.ContentHandler):
 class MainHandler(http2push.PushHandler, common.ContentHandler, common.JSONHandler):
 
   def get(self, path, feature_id=None):
+    ramcache.check_for_distributed_invalidation()
     # Default to features page.
     # TODO: remove later when we want an index.html
     if not path:
@@ -178,6 +181,7 @@ class MainHandler(http2push.PushHandler, common.ContentHandler, common.JSONHandl
 class FeaturesAPIHandler(common.JSONHandler):
 
   def get(self, version=None):
+    ramcache.check_for_distributed_invalidation()
     if version is None:
       version = 2
     else:
@@ -193,6 +197,7 @@ class FeaturesAPIHandler(common.JSONHandler):
 class SamplesHandler(common.ContentHandler, common.JSONHandler):
 
   def get(self, path=None):
+    ramcache.check_for_distributed_invalidation()
     feature_list = models.Feature.get_shipping_samples() # Memcached
 
     if path == '/':

--- a/settings.py
+++ b/settings.py
@@ -58,6 +58,9 @@ else:
 SECRET_KEY = os.environ['DJANGO_SECRET']
 
 APP_VERSION = os.environ['CURRENT_VERSION_ID'].split('.')[0]
+
+# TODO(jrobbins): This is not needed with ramcache because each deployment
+# creates fresh appengine instances with empty ramcaches.
 MEMCACHE_KEY_PREFIX = APP_VERSION # For memcache busting on new version
 
 RSS_FEED_LIMIT = 15

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -11,9 +14,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import division
-from __future__ import print_function
 
 import unittest
 import testing_config  # Must be imported before the module under test.

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -19,7 +19,7 @@ import unittest
 import testing_config  # Must be imported before the module under test.
 
 import mock
-from google.appengine.api import memcache
+import ramcache
 from google.appengine.api import users
 
 import models
@@ -162,6 +162,7 @@ class ModelsFunctionsTest(unittest.TestCase):
 class FeatureTest(unittest.TestCase):
 
   def setUp(self):
+    ramcache.SharedInvalidate.check_for_distributed_invalidation()
     self.feature_1 = models.Feature(
         name='feature one', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1)
@@ -175,7 +176,7 @@ class FeatureTest(unittest.TestCase):
   def tearDown(self):
     self.feature_1.delete()
     self.feature_2.delete()
-    memcache.flush_all()
+    ramcache.flush_all()
 
   def test_get_chronological__normal(self):
     """We can retrieve a list of features."""

--- a/tests/ramcache_test.py
+++ b/tests/ramcache_test.py
@@ -1,0 +1,152 @@
+from __future__ import division
+from __future__ import print_function
+
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import mock
+import testing_config  # Must be imported before the module under test.
+import unittest
+
+from google.appengine.ext import db
+
+import ramcache
+
+
+KEY_1 = 'memcache_key|1'
+KEY_2 = 'memcache_key|2'
+KEY_3 = 'memcache_key|3'
+KEY_4 = 'memcache_key|4'
+KEY_5 = 'memcache_key|5'
+KEY_6 = 'memcache_key|6'
+KEY_7 = 'memcache_key|7'
+
+
+class RAMCacheFunctionTests(unittest.TestCase):
+
+  def testSetAndGet(self):
+    """We can cache a value and retrieve it from the cache."""
+    self.assertEquals(None, ramcache.get(KEY_1))
+
+    ramcache.set(KEY_1, 101)
+    self.assertEquals(101, ramcache.get(KEY_1))
+
+  def testSetAndGetMulti(self):
+    """We can cache values and retrieve them from the cache."""
+    self.assertEquals({}, ramcache.get_multi([]))
+
+    self.assertEquals({}, ramcache.get_multi([KEY_2, KEY_3]))
+
+    ramcache.set_multi({KEY_2: 202, KEY_3: 303})
+    self.assertEquals(
+        {KEY_2: 202, KEY_3: 303},
+        ramcache.get_multi([KEY_2, KEY_3]))
+
+    ramcache.set_multi({KEY_2: 202, KEY_3: 303})
+    self.assertEquals(
+        {KEY_2: 202, KEY_3: 303},
+        ramcache.get_multi([KEY_2, KEY_3, KEY_4]))
+
+  @mock.patch('time.time')
+  def testExpiration(self, mock_time):
+    """If a value is set with an expiration time, it is dropped later."""
+    NOW = 1607128969
+    mock_time.return_value = NOW
+    ramcache.set(KEY_1, 101, time=60)
+    self.assertEquals(101, ramcache.get(KEY_1))
+
+    mock_time.return_value = NOW + 59
+    self.assertEquals(101, ramcache.get(KEY_1))
+
+    mock_time.return_value = NOW + 61
+    self.assertEquals(None, ramcache.get(KEY_1))
+
+  @mock.patch('ramcache.SharedInvalidate.invalidate')
+  def testDelete_NotFound(self, mock_invalidate):
+    """Deleting an item that is not in the cache is a no-op."""
+    ramcache.delete(KEY_5)
+
+    mock_invalidate.assert_not_called()
+
+  @mock.patch('ramcache.SharedInvalidate.invalidate')
+  def testDelete_Found(self, mock_invalidate):
+    """We can delete an item from the cache, causing an invalidation."""
+    ramcache.set(KEY_6, 606)
+    self.assertEquals(606, ramcache.get(KEY_6))
+    ramcache.delete(KEY_6)
+    self.assertEquals(None, ramcache.get(KEY_6))
+
+    mock_invalidate.assert_called_once()
+
+  @mock.patch('ramcache.SharedInvalidate.invalidate')
+  def testFlushAll(self, mock_invalidate):
+    """flush_all simply causes an invalidation."""
+    ramcache.flush_all()
+    mock_invalidate.assert_called_once()
+
+
+class SharedInvalidateTests(unittest.TestCase):
+
+  def assertTimestampWasUpdated(self, start_time):
+    singleton = ramcache.SharedInvalidate.get(
+        ramcache.SharedInvalidate.SINGLETON_KEY,
+        read_policy=db.STRONG_CONSISTENCY)
+    self.assertTrue(singleton.updated > start_time)
+
+  def testInvalidate(self):
+    """Calling invalidate sets a new updated time."""
+    start_time = datetime.datetime.now()
+    ramcache.SharedInvalidate.invalidate()
+    self.assertTimestampWasUpdated(start_time)
+
+  def testCheckForDistributedInvalidation_Unneeded_NoEntity(self):
+    """When the system first launches, no need to clear cache."""
+    db.delete(ramcache.SharedInvalidate.SINGLETON_KEY)
+    ramcache.SharedInvalidate.last_processed_timestamp = None
+    ramcache.global_cache = {KEY_7: 777}
+    ramcache.SharedInvalidate.check_for_distributed_invalidation()
+    self.assertEquals({KEY_7: 777}, ramcache.global_cache)
+    self.assertIsNone(ramcache.SharedInvalidate.last_processed_timestamp)
+
+  def testCheckForDistributedInvalidation_Unneeded_Fresh(self):
+    """When no other instance has invalidated, this cache is fresh."""
+    ramcache.SharedInvalidate.invalidate()
+    ramcache.SharedInvalidate.check_for_distributed_invalidation()
+    # From this point on there are no invalidations, so our cache is fresh.
+
+    ramcache.global_cache = {KEY_7: 777}
+    ramcache.SharedInvalidate.check_for_distributed_invalidation()
+    # Since cache is fresh, it is not cleared.
+    self.assertEquals({KEY_7: 777}, ramcache.global_cache)
+
+  def testCheckForDistributedInvalidation_Needed_None(self):
+    """When needed, we clear our local RAM cache."""
+    start_time = datetime.datetime.now()
+    ramcache.SharedInvalidate.last_processed_timestamp = None
+    ramcache.global_cache = {KEY_7: 777}
+    ramcache.flush_all()
+    ramcache.SharedInvalidate.check_for_distributed_invalidation()
+    self.assertEquals({}, ramcache.global_cache)
+    self.assertTimestampWasUpdated(start_time)
+
+  def testCheckForDistributedInvalidation_Needed_Stale(self):
+    """When needed, we clear our local RAM cache."""
+    start_time = datetime.datetime.now()
+    ramcache.SharedInvalidate.last_processed_timestamp = start_time
+    ramcache.global_cache = {KEY_7: 777}
+    ramcache.flush_all()
+    ramcache.SharedInvalidate.check_for_distributed_invalidation()
+    self.assertEquals({}, ramcache.global_cache)
+    self.assertTimestampWasUpdated(start_time)

--- a/users.py
+++ b/users.py
@@ -38,7 +38,7 @@ class UserHandler(common.ContentHandler):
 
   @common.strip_trailing_slash
   def get(self, path):
-    users = models.AppUser.all().fetch(None) # TODO(ericbidelman): memcache this.
+    users = models.AppUser.all().fetch(None) # TODO(ericbidelman): ramcache this.
 
     user_list = [user.format_for_template() for user in users]
 

--- a/util.py
+++ b/util.py
@@ -20,14 +20,14 @@ __author__ = 'ericbidelman@chromium.org (Eric Bidelman)'
 
 import json
 
-from google.appengine.api import memcache
+import ramcache
 from google.appengine.api import urlfetch
 
 def get_omaha_data():
-  omaha_data = memcache.get('omaha_data')
+  omaha_data = ramcache.get('omaha_data')
   if omaha_data is None:
     result = urlfetch.fetch('https://omahaproxy.appspot.com/all.json')
     if result.status_code == 200:
       omaha_data = json.loads(result.content)
-      memcache.set('omaha_data', omaha_data, time=86400) # cache for 24hrs.
+      ramcache.set('omaha_data', omaha_data, time=86400) # cache for 24hrs.
   return omaha_data


### PR DESCRIPTION
This resolves issue #1071 and simplifies the overall app while doing that.

I looked into what it would take to upgrade from appengine's memcache to Cloud MemoryStore, and I decided to try avoid that because of the increased complexity of adding another backend dependency.  It would add a step for developers running locally and it would complicate our unit tests.

This new RAM cache is based on a similar approach that has been used in monorail since 2016 (in addition to memcache).  Basically, each AppEngine instance maintains its own python dictionary to cache objects locally.  We lose out on the potential speedup of one instance computing a value that another instance could then use, but if such a case made the app to slow, then we should solve that problem rather than relying on caching.  Local caches need a distributed invalidation scheme so that no instance holds onto data after some other instance has edited that data.  In this code, I use a simple datastore entry with a timestamp.  Monorail uses a more complex SQL table with rows that can specify individual cache entries to invalidate, but since we have such a low frequency of writes, I don't think that complexity is worth it.  We could always add it.

In this CL:
+ Add new ramcache module and its unit tests
+ Search and replace memcache -> ramcache. 
+ Add some TODO comments about chunking code that could be removed.
+ Add calls to check for cache invalidation at the start of each request handler.

In a future CL I will replace webapp2 with flask, and at that time I will make the call to check cache invalidation more systemic in a base class rather than in each handler.