### PR TITLE
Start flask upgrading from webapp2 to flask

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -25,7 +25,6 @@ import os
 import re
 import sys
 import webapp2
-from bs4 import BeautifulSoup
 from HTMLParser import HTMLParser
 from xml.dom import minidom
 
@@ -322,13 +321,9 @@ class FeatureHandler(common.ContentHandler):
 
   def __get_blink_component_from_bug(self, blink_components, bug_url):
     if blink_components[0] == models.BlinkComponent.DEFAULT_COMPONENT and bug_url:
-      result = urlfetch.fetch(bug_url)
-      if result.status_code == 200:
-        soup = BeautifulSoup(result.content, 'html.parser')
-        components = soup.find_all(string=re.compile('^Blink'))
-
-        h = HTMLParser()
-        return [h.unescape(unicode(c)) for c in components]
+        # Scraping the bug URL no longer works because monorail uses
+        # web components and APIs rather than details in an HTML page.
+        return []
     return blink_components
 
   def get(self, path, feature_id=None):

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -7,3 +7,6 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 
 from google.appengine.ext import vendor
 vendor.add('lib') # add third party libs to "lib" folder.
+
+import dev_appserver
+dev_appserver.fix_sys_path()

--- a/common.py
+++ b/common.py
@@ -28,6 +28,7 @@ import traceback
 import webapp2
 
 import flask
+import flask.views
 
 # App Engine imports.
 from google.appengine.api import users
@@ -139,89 +140,6 @@ class BaseHandler(webapp2.RequestHandler):
       can_edit = True
     else:
       # TODO(ericbidelman): ramcache user lookup.
-      query = models.AppUser.all(keys_only=True).filter('email =', user.email())
-      found_user = query.get()
-
-      if found_user is not None:
-        can_edit = True
-
-    return can_edit
-
-
-class FlaskBaseHandler(flask.views.MethodView):
-
-  def get_headers(self):
-    """Add CORS and Chrome Frame to all responses."""
-    return {
-        'Access-Control-Allow-Origin': '*',
-        'X-UA-Compatible': 'IE=Edge,chrome=1',
-        }
-
-
-
-class FlaskContentHandler(FlaskBaseHandler):
-
-  TEMPLATE_PATH = None  # Subclasses can define this.
-
-  def get_template_data(self):
-    """Subclasses should implement this method to handle a GET request."""
-    raise NotImplementedError()
-
-  def get_template_path(self, *args, **kwargs):
-    """Subclasses can override this or define a class constant."""
-    if self.TEMPLATE_PATH:
-      return self.TEMPLATE_PATH
-
-    # Our existing code often has a 'path' argument based on the URL.
-    if args and type(args[0]) == str:
-      return args[0] + '.html'
-
-    raise ValueError('No TEMPLATE_PATH was defined or passed.')
-
-  def process_post_data(self):
-    """Subclasses should implement this method to handle a POST request."""
-    raise NotImplementedError()
-
-  def get_common_data(self):
-    """Return template data used on all pages, e.g., sign-in info."""
-    return {'TODO': 'jrobbins'}
-
-  def render(self, template_data, template_path):
-    return render_to_string(template_path, data))
-
-  def get(self, *args, **kwargs):
-    """GET handlers always render templates or do redirects."""
-    template_data = self.get_template_data(*args, **kwargs)
-
-    if type(template_data) == dict:
-      status = template_data.get('status', 200)
-      template_data.update(self.get_common_data())
-      template_path = self.get_template_path(*args, **kwargs)
-      template_text = self.render(template_data, os.path.join(template_path))
-      headers = self.get_headers()
-      return template_text, status, headers
-
-    return template_data  # the hander can return a redirect or string
-
-  def post(self, *args, **kwargs):
-    """POST handlers always process the request then redirect."""
-    redirect_response = self.process_post_data(*args, **kwargs)
-    headers = self.get_headers()
-    redirect_response.headers.update(headers)
-    return redirect_response
-
-  def user_can_edit(self, user):
-    if not user:
-      return False
-
-    can_edit = False
-
-    if users.is_current_user_admin():
-      can_edit = True
-    elif user.email().endswith(('@chromium.org', '@google.com')):
-      can_edit = True
-    else:
-      # TODO(ericbidelman): memcache user lookup.
       query = models.AppUser.all(keys_only=True).filter('email =', user.email())
       found_user = query.get()
 
@@ -411,11 +329,116 @@ def handle_500(request, response, exception):
   response.set_status(500)
 
 
+class FlaskHandler(flask.views.MethodView):
+
+  TEMPLATE_PATH = None  # Subclasses should define this.
+
+  def get_headers(self):
+    """Add CORS and Chrome Frame to all responses."""
+    return {
+        'Access-Control-Allow-Origin': '*',
+        'X-UA-Compatible': 'IE=Edge,chrome=1',
+        }
+
+  def get_template_data(self):
+    """Subclasses should implement this method to handle a GET request."""
+    raise NotImplementedError()
+
+  def get_template_path(self, template_data):
+    """Subclasses can override their class constant via template_data."""
+    if 'template_path' in template_data:
+      return template_data['template_path']
+    if self.TEMPLATE_PATH:
+      return self.TEMPLATE_PATH
+    raise ValueError(
+        'No TEMPLATE_PATH was defined in %r or returned in template_data.' %
+        self.__class__.__name__)
+
+  def process_post_data(self):
+    """Subclasses should implement this method to handle a POST request."""
+    raise NotImplementedError()
+
+  def get_common_data(self):
+    """Return template data used on all pages, e.g., sign-in info."""
+    current_path = flask.request.path
+    common_data = {
+      'prod': settings.PROD,
+      'APP_TITLE': settings.APP_TITLE,
+      'current_path': current_path,
+      'VULCANIZE': settings.VULCANIZE,
+      'TEMPLATE_CACHE_TIME': settings.TEMPLATE_CACHE_TIME
+      }
+
+    user = users.get_current_user()
+    if user:
+      user_pref = models.UserPref.get_signed_in_user_pref()
+      common_data['login'] = (
+          'Sign out', users.create_logout_url(dest_url=current_path))
+      common_data['user'] = {
+        'can_edit': self.user_can_edit(user),
+        'is_admin': users.is_current_user_admin(),
+        'email': user.email(),
+        'dismissed_cues': json.dumps(user_pref.dismissed_cues),
+      }
+    else:
+      common_data['user'] = None
+      common_data['login'] = (
+          'Sign in', users.create_login_url(dest_url=current_path))
+    return common_data
+
+  def render(self, template_data, template_path):
+    return render_to_string(template_path, template_data)
+
+  def get(self, *args, **kwargs):
+    """GET handlers always render templates or do redirects."""
+    template_data = self.get_template_data(*args, **kwargs)
+
+    if type(template_data) == dict:
+      status = template_data.get('status', 200)
+      template_data.update(self.get_common_data())
+      template_path = self.get_template_path(template_data)
+      template_text = self.render(template_data, os.path.join(template_path))
+      headers = self.get_headers()
+      return template_text, status, headers
+
+    return template_data  # the hander can return a redirect or string
+
+  def post(self, *args, **kwargs):
+    """POST handlers always process the request then redirect."""
+    response_or_dict = self.process_post_data(*args, **kwargs)
+    # If it is a dict, Flask will jsonify it.
+    return response_or_dict, self.get_headers()
+
+  def user_can_edit(self, user):
+    if not user:
+      return False
+
+    can_edit = False
+
+    if users.is_current_user_admin():
+      can_edit = True
+    elif user.email().endswith(('@chromium.org', '@google.com')):
+      can_edit = True
+    else:
+      # TODO(ericbidelman): memcache user lookup.
+      query = models.AppUser.all(keys_only=True).filter('email =', user.email())
+      found_user = query.get()
+
+      if found_user is not None:
+        can_edit = True
+
+    return can_edit
+
+
+
 def FlaskApplication(routes, debug=False):
   """Make a Flask app and add routes and handlers that work like webapp2."""
 
   app = flask.Flask(__name__)
   for pattern, handler_class in routes:
-    app.add_url_rule(pattern, view_func=handler_class.as_view())
+    app.add_url_rule(
+        pattern,
+        view_func=handler_class.as_view(handler_class.__name__))
 
-  logging.info('TODO: debug setting %r is unused', debug)
+  app.config["TRAP_BAD_REQUEST_ERRORS"] = True  # Needed to log execptions
+  return app

--- a/cues.py
+++ b/cues.py
@@ -18,12 +18,10 @@ from __future__ import print_function
 
 import logging
 import json
-import webapp2
+import flask
 
 from google.appengine.ext import db
 from google.appengine.api import users
-
-from django.template.loader import render_to_string
 
 import common
 import models
@@ -34,12 +32,12 @@ import settings
 ALLOWED_CUES = ['progress-checkmarks']
 
 
-class DismissCueHandler(webapp2.RequestHandler):
+class DismissCueHandler(common.FlaskHandler):
   """Handle JSON API requests to dismiss an on-page help cue card."""
 
-  def post(self):
+  def process_post_data(self):
     """Dismisses a cue card for the signed in user."""
-    json_body = json.loads(self.request.body)
+    json_body = flask.request.get_json()
     cue = json_body.get('cue')
     if cue not in ALLOWED_CUES:
       logging.info('Unexpected cue: %r', cue)
@@ -51,11 +49,9 @@ class DismissCueHandler(webapp2.RequestHandler):
       self.abort(400)
 
     models.UserPref.dismiss_cue(cue)
-    data = {}
-    self.response.headers['Content-Type'] = 'application/json;charset=utf-8'
-    result = self.response.write(json.dumps(data, separators=(',',':')))
+    return {}  # Empty JSON response.
 
 
-app = webapp2.WSGIApplication([
+app = common.FlaskApplication([
   ('/cues/dismiss', DismissCueHandler),
 ], debug=settings.DEBUG)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=6.0.0"
   },
   "scripts": {
-    "deps": "pip install -t lib -r requirements.txt",
+    "deps": "pip install -t lib -r requirements.txt --upgrade",
     "test": "python -m unittest discover -p *_test.py -s tests -b",
     "coverage": "python -m coverage erase && python -m coverage run -m unittest discover -p *_test.py -s tests -b && python -m coverage html",
     "lint": "gulp lint-fix && lit-analyzer \"static/elements/chromedash-!(featurelist)*.js\"",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Django==1.11.29
-beautifulsoup4
-mock
+mock==3.0.5
 coverage
 Flask==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django==1.11.29
 beautifulsoup4
 mock
 coverage
+Flask==1.1.2

--- a/static/elements/chromedash-userlist.js
+++ b/static/elements/chromedash-userlist.js
@@ -60,15 +60,16 @@ class ChromedashUserlist extends LitElement {
         credentials: 'same-origin', // Needed for admin permissions to be sent.
       });
 
-      if (resp.status === 200) {
-        alert('Thanks. But that user already exists');
-        throw new Error('User already added');
-      } else if (resp.status !== 201) {
-        throw new Error('Sever error adding new user');
+      if (resp.status !== 200) {
+        throw new Error('Server error adding new user');
       } else {
         const json = await resp.json();
-        this.addUser(json);
-        formEl.reset();
+        if (json.error_message) {
+          alert(json.error_message);
+        } else {
+          this.addUser(json);
+          formEl.reset();
+        }
       }
     }
   }
@@ -90,7 +91,7 @@ class ChromedashUserlist extends LitElement {
   }
 
   render() {
-    return html`  
+    return html`
       <form id="form" name="user_form" method="POST" action="${this.actionPath}" onsubmit="return false;">
         <input type="email" placeholder="Email address" name="email" id="id_email" required>
         <td><input type="submit" @click="${this.ajaxSubmit}">
@@ -98,7 +99,7 @@ class ChromedashUserlist extends LitElement {
       <ul id="user-list">
         ${this.users.map((user, index) => html`
           <li>
-            <a href="${this.actionPath}/${user.id}" data-index="${index}" @click="${this.ajaxDelete}">delete</a>
+            <a href="/admin/users/delete/${user.id}" data-index="${index}" @click="${this.ajaxDelete}">delete</a>
             <span>${user.email}</span>
           </li>
           `)}

--- a/templates/admin/users/new.html
+++ b/templates/admin/users/new.html
@@ -13,7 +13,7 @@
 {% block content %}
 <section>
 
-<chromedash-userlist action="{{current_path}}"></chromedeash-userlist>
+<chromedash-userlist actionPath="/admin/users/create"></chromedeash-userlist>
 
 </section>
 {% endblock %}

--- a/templates/test_template.html
+++ b/templates/test_template.html
@@ -1,0 +1,3 @@
+This is used by unit tests.
+
+Hi {{ name }}, how are you?


### PR DESCRIPTION
This addresses issue #1070, but several more CLs will be needed to fully resolve it.

Webapp2 is a framework that was recommended for use with GAE python 2.x, but it is not maintained and is not available for python 3.  The framework recommended for GAE Py3 is Flask.  We don't make much use of the framework because we also use Django, but we do rely on the framework for basic things.

In this CL:

+ Add flask to requirements.txt and make our 'nom run deps' command upgrade already-installed libraries.

+ Define a new base class in common.py to make our current code run on Flask without too many changes.

+ In that base class, start a pattern of having subclasses implement get_template_data() and process_post_data() rather than overriding the framework-level get() and post() methods.  That makes these methods more application-focused and easier to test. Specifically, they return JSON dicts rather than having the side-effect of rendering the output to the response stream.

+ Eliminate our dependency on BeautifulSoup.  It has not worked in over a year, and upgrading to a new version seems to have broken it in py2 somehow.

+ Convert users.py and cues.py to use the new framework.

+ Fix a non-important bug in adding new registered users.  The old code actually POSTed to /admin/users/undefined and that worked all this time because the routing had a wildcard in the URL pattern.  Flask does not have wildcards, so this bug was unmasked and fixed.

Upcoming CLs will upgrade the other pages on the site.