### PR TITLE
Add Edge signals back to intent emails.

### DIFF
--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -95,6 +95,14 @@
      {{feature.ff_views_notes|urlize}}
     {% endif %}
 
+    <br><br><i>Edge</i>: {{feature.ie_views.text}}
+    {% if feature.ie_views_link %}
+      (<a href="{{feature.ie_views_link}}">{{feature.ie_views_link}}</a>)
+    {% endif %}
+    {% if feature.ie_views_notes %}
+     {{feature.ie_views_notes|urlize}}
+    {% endif %}
+
     <br><br><i>WebKit</i>: {{feature.safari_views.text}}
     {% if feature.safari_views_link %}
       (<a href="{{feature.safari_views_link}}">{{feature.safari_views_link}}</a>)


### PR DESCRIPTION
This resolves issue #1114 

Edge is not listed in the doc that I was looking at for the expected contents of intents emails, however as user asked for it, so I have added it back.