### PR TITLE
remove fix_sys_path

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -2,11 +2,11 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import sys
 # name of the django settings module
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 
 from google.appengine.ext import vendor
 vendor.add('lib') # add third party libs to "lib" folder.
 
-import dev_appserver
-dev_appserver.fix_sys_path()
+print(sys.path)

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -8,5 +8,3 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 
 from google.appengine.ext import vendor
 vendor.add('lib') # add third party libs to "lib" folder.
-
-print(sys.path)


### PR DESCRIPTION
It turns out that calling fix_sys_path() was working around a problem with some import statements inside the jinja2 library.  There is no way to call fix_sys_path() in prod, so I needed to solve the underlying problem.  This work-around is no longer needed.