### PR TITLE
Upgrade Guide pages to use flask web application framework

### DIFF
--- a/guide.py
+++ b/guide.py
@@ -110,7 +110,7 @@ FLAT_FORMS = [
 
 class FeatureNew(common.FlaskHandler):
 
-  TEMPLATE_PATH = 'admin/guide/new.html'
+  TEMPLATE_PATH = 'guide/new.html'
 
   def get_template_data(self):
     user = users.get_current_user()


### PR DESCRIPTION
This is progress toward resolving issue #1070.

In this CL:
+ Convert guide.py to use the flask-related base class and app object defined in common.py
+ Add a few methods to FlaskHandler in common.py to help streamline this and future conversions
+ The existing code returned 401 when the signed in user did not have permission to do something.  I think 403 is more correct.
+ Unit tests