### PR TITLE
Upgrade admin.py to use flask.

### DIFF
--- a/guide.py
+++ b/guide.py
@@ -115,7 +115,7 @@ class FeatureNew(common.FlaskHandler):
   def get_template_data(self):
     user = users.get_current_user()
     if user is None:
-      return self.redirect(users.create_login_url(self.request_uri))
+      return self.redirect(users.create_login_url(self.request.path))
 
     if not self.user_can_edit(user):
       self.abort(403)

--- a/tests/admin_test.py
+++ b/tests/admin_test.py
@@ -20,8 +20,8 @@ import testing_config  # Must be imported before the module under test.
 import urllib
 
 import mock
-import webapp2
-from webob import exc
+import flask
+import werkzeug
 
 import admin
 import models
@@ -37,11 +37,9 @@ class IntentEmailPreviewHandlerTest(unittest.TestCase):
         intent_stage=models.INTENT_IMPLEMENT)
     self.feature_1.put()
 
-    request = webapp2.Request.blank(
-        '/admin/features/launch/%d/%d?intent' % (
-            models.INTENT_SHIP, self.feature_1.key().id()))
-    response = webapp2.Response()
-    self.handler = admin.IntentEmailPreviewHandler(request, response)
+    self.request_path = '/admin/features/launch/%d/%d?intent' % (
+        models.INTENT_SHIP, self.feature_1.key().id())
+    self.handler = admin.IntentEmailPreviewHandler()
 
   def tearDown(self):
     self.feature_1.delete()
@@ -50,41 +48,46 @@ class IntentEmailPreviewHandlerTest(unittest.TestCase):
     """Anon cannot view this preview features, gets redirected to login."""
     testing_config.sign_out()
     feature_id = self.feature_1.key().id()
-    self.handler.get(feature_id=feature_id)
-    self.assertEqual('302 Moved Temporarily', self.handler.response.status)
+    with admin.app.test_request_context(self.request_path):
+      actual_response = self.handler.get_template_data(feature_id=feature_id)
+    self.assertEqual('302 FOUND', actual_response.status)
 
   def test_get__no_existing(self):
     """Trying to view a feature that does not exist gives a 404."""
     testing_config.sign_in('user1@google.com', 123567890)
     bad_feature_id = self.feature_1.key().id() + 1
-    self.handler.get(feature_id=bad_feature_id)
-    self.assertEqual('404 Not Found', self.handler.response.status)
+    with admin.app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.NotFound):
+        self.handler.get_template_data(feature_id=bad_feature_id)
 
   def test_get__no_stage_specified(self):
     """Allowed user can preview intent email for a feature using an old URL."""
-    self.handler.request = webapp2.Request.blank(
+    request_path = (
         '/admin/features/launch/%d?intent' % self.feature_1.key().id())
     testing_config.sign_in('user1@google.com', 123567890)
     feature_id = self.feature_1.key().id()
-    self.handler.get(feature_id=feature_id)
-    self.assertEqual('200 OK', self.handler.response.status)
-    self.assertIn('feature one', self.handler.response.body)
+    with admin.app.test_request_context(self.request_path):
+      actual_data = self.handler.get_template_data(feature_id=feature_id)
+    self.assertIn('feature', actual_data)
+    self.assertEqual('feature one', actual_data['feature']['name'])
 
   def test_get__normal(self):
     """Allowed user can preview intent email for a feature."""
     testing_config.sign_in('user1@google.com', 123567890)
     feature_id = self.feature_1.key().id()
-    self.handler.get(feature_id=feature_id)
-    self.assertEqual('200 OK', self.handler.response.status)
-    self.assertIn('feature one', self.handler.response.body)
+    with admin.app.test_request_context(self.request_path):
+      actual_data = self.handler.get_template_data(feature_id=feature_id)
+    self.assertIn('feature', actual_data)
+    self.assertEqual('feature one', actual_data['feature']['name'])
 
   def test_get_page_data(self):
     """page_data has correct values."""
     feature_id = self.feature_1.key().id()
-    page_data = self.handler.get_page_data(
-        feature_id, self.feature_1, models.INTENT_IMPLEMENT)
+    with admin.app.test_request_context(self.request_path):
+      page_data = self.handler.get_page_data(
+          feature_id, self.feature_1, models.INTENT_IMPLEMENT)
     self.assertEqual(
-        'http://localhost:80/feature/%d' % feature_id,
+        'http://localhost/feature/%d' % feature_id,
         page_data['default_url'])
     self.assertEqual(
         ['motivation'],
@@ -164,7 +167,7 @@ class IntentEmailPreviewHandlerTest(unittest.TestCase):
             self.feature_1, models.INTENT_EXTEND_TRIAL))
 
 
-class FeatureHandlerTest(unittest.TestCase):
+class BaseFeatureHandlerTest(unittest.TestCase):
 
   def setUp(self):
     self.feature_1 = models.Feature(
@@ -172,10 +175,9 @@ class FeatureHandlerTest(unittest.TestCase):
         standardization=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_1.put()
 
-    request = webapp2.Request.blank(
+    self.request_path = (
         '/admin/features/edit/%d' % self.feature_1.key().id())
-    response = webapp2.Response()
-    self.handler = admin.FeatureHandler(request, response)
+    self.handler = admin.BaseFeatureHandler()
 
   def tearDown(self):
     self.feature_1.delete()
@@ -184,46 +186,40 @@ class FeatureHandlerTest(unittest.TestCase):
     """Anon cannot edit features, gets a 401."""
     testing_config.sign_out()
     feature_id = self.feature_1.key().id()
-    actual = self.handler.post(self.handler.request.path, feature_id=feature_id)
-    self.assertIsNone(actual)
-    self.assertEqual('401 Unauthorized', self.handler.response.status)
+    with admin.app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
+        self.handler.process_post_data(feature_id=feature_id)
 
-  @mock.patch('admin.FeatureHandler.redirect')
-  def test_post__no_existing(self, mock_redirect):
+  def test_post__no_existing(self):
     """Trying to edit a feature that does not exist redirects."""
     testing_config.sign_in('user1@google.com', 123567890)
-    mock_redirect.return_value = 'fake redirect return value'
     bad_feature_id = self.feature_1.key().id() + 1
     path = '/admin/features/edit/%d' % bad_feature_id
-    self.handler.request = webapp2.Request.blank(path)
-    actual = self.handler.post(path, feature_id=bad_feature_id)
-    self.assertEqual('fake redirect return value', actual)
-    mock_redirect.assert_called_once()
+    with admin.app.test_request_context(path):
+      actual_response = self.handler.process_post_data(feature_id=bad_feature_id)
+    self.assertEqual('302 FOUND', actual_response.status)
 
-  @mock.patch('admin.FeatureHandler.redirect')
-  def test_post__normal(self, mock_redirect):
+  def test_post__normal(self):
     """Allowed user can edit a feature."""
     testing_config.sign_in('user1@google.com', 123567890)
-    mock_redirect.return_value = 'fake redirect return value'
     feature_id = self.feature_1.key().id()
     params = {
-      "category": 1,
+      "category": "1",
       "name": "name",
       "summary": "sum",
-      "impl_status_chrome": 1,
-      "visibility": 1,
-      "ff_views": 1,
-      "ie_views": 1,
-      "safari_views": 1,
-      "web_dev_views": 1,
-      "standardization": 1,
+      "impl_status_chrome": "1",
+      "visibility": "1",
+      "ff_views": "1",
+      "ie_views": "1",
+      "safari_views": "1",
+      "web_dev_views": "1",
+      "standardization": "1",
       "experiment_goals": "Measure something",
       }
     path = '/admin/features/edit/%d' % feature_id
-    self.handler.request = webapp2.Request.blank(
-        path, POST=urllib.urlencode(params))
-    actual = self.handler.post(path, feature_id=feature_id)
-    self.assertEqual('fake redirect return value', actual)
-    mock_redirect.assert_called_once_with('/feature/%d' % feature_id)
+    with admin.app.test_request_context(path, method='POST', data=params):
+      actual_response = self.handler.process_post_data(feature_id=feature_id)
+    self.assertEqual('302 FOUND', actual_response.status)
+
     updated_feature = models.Feature.get_by_id(feature_id)
     self.assertEqual('Measure something', updated_feature.experiment_goals)


### PR DESCRIPTION
This is the next step in resolving issue #1070.

In this CL:
+ Convert admin.py to use the new flask base classes in common.py.
+ Refactor some of the code in common.py from having one huge handler with lots of if-statements that look at the path into separate handlers for each path for the old UI new feature, edit feature, and delete feature handlers.
+ Change a helper property in FlaskHandler from request_uri to instead return the whole request.
+ Refactor calls to invalidate the RAM cache on every GET and POST request sent to any FlaskHandler, this removes a requirement that individual handlers make this call before accessing cached data.
+ Update existing unit tests in admin_test.py