### PR TITLE
Upgrade metrics.py to use flask.

### DIFF
--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1,0 +1,139 @@
+from __future__ import division
+from __future__ import print_function
+
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import testing_config  # Must be imported before the module under test.
+
+import datetime
+import mock
+import flask
+
+from google.appengine.api import users
+
+import metrics
+import models
+
+
+class MetricsFunctionTests(unittest.TestCase):
+
+  def setUp(self):
+    self.datapoint = models.StableInstance(
+        day_percentage=0.0123456789, date=datetime.date.today(),
+        bucket_id=1, property_name='prop')
+
+  def test_truncate_day_percentage(self):
+    updated_datapoint = metrics._truncate_day_percentage(self.datapoint)
+    self.assertEqual(0.01234568, updated_datapoint.day_percentage)
+
+  def test_is_googler__anon(self):
+    testing_config.sign_out()
+    user = users.get_current_user()
+    self.assertFalse(metrics._is_googler(user))
+
+  def test_is_googler__nongoogler(self):
+    testing_config.sign_in('test@example.com', 111)
+    user = users.get_current_user()
+    self.assertFalse(metrics._is_googler(user))
+
+  def test_is_googler__googler(self):
+    testing_config.sign_in('test@google.com', 111)
+    user = users.get_current_user()
+    self.assertTrue(metrics._is_googler(user))
+
+  def test_clean_data__no_op(self):
+    testing_config.sign_in('test@google.com', 111)
+    datapoints = [self.datapoint]
+    updated_datapoints = metrics._clean_data(datapoints)
+    self.assertEqual(0.0123456789, updated_datapoints[0].day_percentage)
+
+  def test_clean_data__clean_datapoints(self):
+    testing_config.sign_out()
+    datapoints = [self.datapoint]
+    updated_datapoints = metrics._clean_data(datapoints)
+    self.assertEqual(0.01234568, updated_datapoints[0].day_percentage)
+
+
+class PopularityTimelineHandlerTests(unittest.TestCase):
+
+  def setUp(self):
+    self.handler = metrics.PopularityTimelineHandler()
+    self.datapoint = models.StableInstance(
+        day_percentage=0.0123456789, date=datetime.date.today(),
+        bucket_id=1, property_name='prop')
+    self.datapoint.put()
+
+  def tearDown(self):
+    self.datapoint.delete()
+
+  def test_make_query(self):
+    actual_query = self.handler.make_query(1)
+    self.assertEqual(actual_query._model_class, models.StableInstance)
+
+  def test_get_template_data__bad_bucket(self):
+    url = '/data/timeline/csspopularity?bucket_id=not-a-number'
+    with metrics.app.test_request_context(url):
+      actual = self.handler.get_template_data()
+    self.assertEqual([], actual)
+
+  def test_get_template_data__normal(self):
+    testing_config.sign_out()
+    url = '/data/timeline/csspopularity?bucket_id=1'
+    with metrics.app.test_request_context(url):
+      actual_datapoints = self.handler.get_template_data()
+    self.assertEqual(1, len(actual_datapoints))
+    self.assertEqual(0.01234568, actual_datapoints[0]['day_percentage'])
+
+
+# TODO(jrobbins): Test for metrics.FeatureHandler.
+
+
+class FeatureBucketsHandlerTest(unittest.TestCase):
+
+  def setUp(self):
+    self.handler = metrics.FeatureBucketsHandler()
+    self.prop_1 = models.CssPropertyHistogram(
+        bucket_id=1, property_name='b prop')
+    self.prop_1.put()
+    self.prop_2 = models.CssPropertyHistogram(
+        bucket_id=2, property_name='a prop')
+    self.prop_2.put()
+    self.prop_3 = models.FeatureObserverHistogram(
+        bucket_id=3, property_name='b feat')
+    self.prop_3.put()
+    self.prop_4 = models.FeatureObserverHistogram(
+        bucket_id=4, property_name='a feat')
+    self.prop_4.put()
+
+  def tearDown(self):
+    self.prop_1.delete()
+    self.prop_2.delete()
+    self.prop_3.delete()
+    self.prop_4.delete()
+
+  def test_get_template_data__css(self):
+    with metrics.app.test_request_context('/data/blink/cssprops'):
+      actual_buckets = self.handler.get_template_data('cssprops')
+    self.assertEqual(
+        [(2, 'a prop'), (1, 'b prop')],
+        actual_buckets)
+
+  def test_get_template_data__js(self):
+    with metrics.app.test_request_context('/data/blink/features'):
+      actual_buckets = self.handler.get_template_data('features')
+    self.assertEqual(
+        [(4, 'a feat'), (3, 'b feat')],
+        actual_buckets)


### PR DESCRIPTION
This is the next step in resolving issue #1070.

In this CL:
+ Upgrade request handlers in metrics.py
+ Refactor some functions from common.JSONHandler to metrics.py because they were only used there.
+ Improve common.FlaskHandler to add per-class options for HTTP cache control and allow JSON handlers to return a list (Flask automatically JSONifies python dicts, but not lists).
+ Added some unit tests for metrics.py
 