### PR TITLE
Upgrade blink_handlers.py and schedule.py to flask

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -115,7 +115,7 @@ handlers:
   script: notifier.app
   secure: always
 
-- url: /features/schedule.*
+- url: /features/schedule
   script: schedule.app
   secure: always
 

--- a/app.yaml
+++ b/app.yaml
@@ -66,7 +66,7 @@ handlers:
   login: required # non-admin
   secure: always
 
-- url: /admin/subscribers.*
+- url: /admin/subscribers
   script: blink_handler.app
   login: required # non-admin
   secure: always

--- a/blink_handler.py
+++ b/blink_handler.py
@@ -22,7 +22,6 @@ import collections
 import json
 import logging
 import os
-import webapp2
 import yaml
 
 import common
@@ -33,39 +32,9 @@ import util
 from schedule import construct_chrome_channels_details
 
 
-class PopulateSubscribersHandler(common.ContentHandler):
+class BlinkHandler(common.FlaskHandler):
 
-  def __populate_subscribers(self):
-    """Seeds the database with the team in devrel_team.yaml and adds the team
-      member to the specified blink components in that file. Should only be ran
-      if the FeatureOwner database entries have been cleared"""
-    f = file('%s/data/devrel_team.yaml' % settings.ROOT_DIR, 'r')
-    for profile in yaml.load_all(f):
-      blink_components = profile.get('blink_components', [])
-      blink_components = [models.BlinkComponent.get_by_name(name).key() for name in blink_components]
-      blink_components = filter(None, blink_components) # Filter out None values
-
-      user = models.FeatureOwner(
-        name=unicode(profile['name']),
-        email=unicode(profile['email']),
-        twitter=profile.get('twitter', None),
-        blink_components=blink_components,
-        primary_blink_components=blink_components,
-        watching_all_features=False,
-      )
-      user.put()
-    f.close()
-
-  @common.require_edit_permission
-  def get(self):
-    if settings.PROD:
-      return self.response.out.write('Handler not allowed in production.')
-    models.BlinkComponent.update_db()
-    self.__populate_subscribers()
-    return self.redirect('/admin/blink')
-
-
-class BlinkHandler(common.ContentHandler):
+  TEMPLATE_PATH = 'admin/blink.html'
 
   def __update_subscribers_list(self, add=True, user_id=None, blink_component=None, primary=False):
     if not user_id or not blink_component:
@@ -89,8 +58,7 @@ class BlinkHandler(common.ContentHandler):
     return True
 
   @common.require_edit_permission
-  @common.strip_trailing_slash
-  def get(self, path):
+  def get_template_data(self):
     components = models.BlinkComponent.all().order('name').fetch(None)
     subscribers = models.FeatureOwner.all().order('name').fetch(None)
 
@@ -104,47 +72,47 @@ class BlinkHandler(common.ContentHandler):
     # for c in components:
     #   c.wf_urls = wf_component_content.get(c.name) or []
 
-    data = {
+    template_data = {
       'subscribers': subscribers,
       'components': components[1:] # ditch generic "Blink" component
     }
-    self.render(data, template_path=os.path.join('admin/blink.html'))
+    return templatedata
 
   # Remove user from component subscribers.
-  def put(self, path):
-    params = json.loads(self.request.body)
+  @common.require_edit_permission
+  def put(self):
+    params = self.request.json
     self.__update_subscribers_list(False, user_id=params.get('userId'),
                                    blink_component=params.get('componentName'),
                                    primary=params.get('primary'))
-    self.response.set_status(200, message='User removed from subscribers')
-    return self.response.write(json.dumps({'done': True}))
+    return {'done': True}
 
   # Add user to component subscribers.
-  def post(self, path):
-    params = json.loads(self.request.body)
+  @common.require_edit_permission
+  def process_post_data(self):
+    params = self.request.json
 
     self.__update_subscribers_list(True, user_id=params.get('userId'),
                                    blink_component=params.get('componentName'),
                                    primary=params.get('primary'))
-    self.response.set_status(200, message='User added to subscribers')
-    return self.response.write(json.dumps(params))
+    return params
 
 
-class SubscribersHandler(common.ContentHandler):
+class SubscribersHandler(common.FlaskHandler):
+
+  TEMPLATE_PATH = 'admin/subscribers.html'
 
   @common.require_edit_permission
-  # @common.strip_trailing_slash
-  def get(self, path):
-    ramcache.check_for_distributed_invalidation()
+  def get_template_data(self):
     users = models.FeatureOwner.all().order('name').fetch(None)
     feature_list = models.Feature.get_chronological()
 
-    milestone = self.request.get('milestone') or None
+    milestone = self.request.args.get('milestone') or None
     if milestone:
       milestone = int(milestone)
       feature_list = filter(lambda f: (f['shipped_milestone'] or f['shipped_android_milestone']) == milestone, feature_list)
 
-    list_features_per_owner = 'showFeatures' in self.request.GET
+    list_features_per_owner = 'showFeatures' in self.request.args
     for user in users:
       # user.subscribed_components = [models.BlinkComponent.get(key) for key in user.blink_components]
       user.owned_components = [models.BlinkComponent.get(key) for key in user.primary_blink_components]
@@ -155,7 +123,7 @@ class SubscribersHandler(common.ContentHandler):
 
     details = construct_chrome_channels_details()
 
-    data = {
+    template_data = {
       'subscribers': users,
       'channels': collections.OrderedDict([
         ('stable', details['stable']),
@@ -165,12 +133,10 @@ class SubscribersHandler(common.ContentHandler):
       ]),
       'selected_milestone': int(milestone) if milestone else None
     }
+    return template_data
 
-    self.render(data, template_path=os.path.join('admin/subscribers.html'))
 
-
-app = webapp2.WSGIApplication([
-  ('/admin/blink/populate_subscribers', PopulateSubscribersHandler),
-  ('/admin/subscribers(.*)', SubscribersHandler),
-  ('(.*)', BlinkHandler),
+app = common.FlaskApplication([
+  ('/admin/subscribers', SubscribersHandler),
+  ('/admin/blink', BlinkHandler),
 ], debug=settings.DEBUG)

--- a/models.py
+++ b/models.py
@@ -409,12 +409,15 @@ class BlinkComponent(DictModel):
     if components is None or update_cache:
       components = {}
       url = self.WF_CONTENT_ENDPOINT + '?cache-buster=%s' % time.time()
-      result = urlfetch.fetch(url, deadline=60)
-      if result.status_code == 200:
-        components = json.loads(result.content)
-        ramcache.set(key, components)
-      else:
-        logging.error('Fetching /web blink components content returned: %s' % result.status_code)
+      try:
+        result = urlfetch.fetch(url, deadline=50)
+        if result.status_code == 200:
+          components = json.loads(result.content)
+          ramcache.set(key, components)
+        else:
+          logging.error('Fetching /web blink components content returned: %s' % result.status_code)
+      except urlfetch.DeadlineExceededError:
+        logging.info('deadline exceeded when fetching %r', url)
 
     if not components:
       components = hack_wf_components.HACK_WF_COMPONENTS

--- a/schedule.py
+++ b/schedule.py
@@ -21,7 +21,6 @@ __author__ = 'ericbidelman@chromium.org (Eric Bidelman)'
 import json
 import logging
 import os
-import webapp2
 
 import ramcache
 from google.appengine.api import urlfetch
@@ -90,22 +89,22 @@ def construct_chrome_channels_details():
   return channels
 
 
-class ScheduleHandler(common.ContentHandler):
+class ScheduleHandler(common.FlaskHandler):
 
-  @common.strip_trailing_slash
-  def get(self, path):
+  TEMPLATE_PATH = 'schedule.html'
+
+  def get_template_data(self):
     user = users.get_current_user()
     features = models.Feature.get_chronological(
         show_unlisted=self.user_can_edit(user))
-    data = {
+    template_data = {
       'features': json.dumps(features),
       'channels': json.dumps(construct_chrome_channels_details(),
                              indent=4)
     }
+    return template_data
 
-    self.render(data, template_path=os.path.join('schedule.html'))
 
-
-app = webapp2.WSGIApplication([
-  ('(.*)', ScheduleHandler),
+app = common.FlaskApplication([
+  ('/features/schedule', ScheduleHandler),
 ], debug=settings.DEBUG)

--- a/settings.py
+++ b/settings.py
@@ -34,6 +34,7 @@ BOUNCE_ESCALATION_ADDR = 'cr-status-bounces@google.com'
 PROD = False
 DEBUG = True
 SEND_EMAIL = False  # Just log email
+DEV_MODE = os.environ['SERVER_SOFTWARE'].startswith('Development')
 
 APP_ID = app_identity.get_application_id()
 SITE_URL = 'http://%s.appspot.com/' % APP_ID
@@ -41,6 +42,10 @@ SITE_URL = 'http://%s.appspot.com/' % APP_ID
 
 if APP_ID == 'testbed-test':
   APP_TITLE = 'Local testing'
+  SITE_URL = 'http://127.0.0.1:8888/'
+elif DEV_MODE:
+  PROD = False
+  APP_TITLE = 'Chrome Status Dev'
   SITE_URL = 'http://127.0.0.1:8888/'
 elif APP_ID == 'cr-status':
   PROD = True


### PR DESCRIPTION
This is more progress on issue #1070.

In this CL:
+ Upgrade blink_handler.py (which offers an admin UI for component subscribers) and schedule.py (which shows the chrome release page) to use flask
+ Simplified the app.yaml entry for the schedule page because the wildcard is not needed.
+ Tweaks to settings.py and models.py to get subscriber population working.  This is only used when testing locally.
+ No new tests for blink_handler.py because it seems like the wrong approach to subscriptions and I plan to replace it eventually


