### PR TITLE
20201228 upgrade server to flask

### DIFF
--- a/common.py
+++ b/common.py
@@ -249,34 +249,37 @@ class ContentHandler(BaseHandler):
       logging.exception(e)
       handle_404(self.request, self.response, e)
 
-  def render_atom_feed(self, title, data):
-    features_url = '%s://%s%s' % (self.request.scheme,
-                                  self.request.host,
-                                  self.request.path.replace('.xml', ''))
-    feature_url_prefix = '%s://%s%s' % (self.request.scheme,
-                                        self.request.host,
-                                        '/feature')
 
-    feed = feedgenerator.Atom1Feed(
-        title=unicode('%s - %s' % (settings.APP_TITLE, title)),
-        link=features_url,
-        description=u'New features exposed to web developers',
-        language=u'en'
+
+def render_atom_feed(request, title, data):
+  features_url = '%s://%s%s' % (request.scheme,
+                                request.host,
+                                request.path.replace('.xml', ''))
+  feature_url_prefix = '%s://%s%s' % (request.scheme,
+                                      request.host,
+                                      '/feature')
+
+  feed = feedgenerator.Atom1Feed(
+      title=unicode('%s - %s' % (settings.APP_TITLE, title)),
+      link=features_url,
+      description=u'New features exposed to web developers',
+      language=u'en'
+  )
+  for f in data:
+    pubdate = datetime.datetime.strptime(str(f['updated'][:19]),
+                                         '%Y-%m-%d  %H:%M:%S')
+    feed.add_item(
+        title=unicode(f['name']),
+        link='%s/%s' % (feature_url_prefix, f.get('id')),
+        description=f.get('summary', ''),
+        pubdate=pubdate,
+        author_name=unicode(settings.APP_TITLE),
+        categories=[f['category']]
     )
-    for f in data:
-      pubdate = datetime.datetime.strptime(str(f['updated'][:19]),
-                                           '%Y-%m-%d  %H:%M:%S')
-      feed.add_item(
-          title=unicode(f['name']),
-          link='%s/%s' % (feature_url_prefix, f.get('id')),
-          description=f.get('summary', ''),
-          pubdate=pubdate,
-          author_name=unicode(settings.APP_TITLE),
-          categories=[f['category']]
-      )
-    self.response.headers.add_header('Content-Type',
-      'application/atom+xml;charset=utf-8')
-    self.response.out.write(feed.writeString('utf-8'))
+  headers = {
+      'Content-Type': 'application/atom+xml;charset=utf-8'}
+  text = feed.writeString('utf-8')
+  return text, headers
 
 
 def handle_401(request, response, exception):
@@ -488,16 +491,42 @@ class FlaskHandler(flask.views.MethodView):
     return param
 
 
+class Redirector(FlaskHandler):
+  """Reusable handler that always redirects.
+     Specify the location in the third part of a routing rule using:
+     {'location': '/path/to/page'}."""
+
+  def get_template_data(self, location='/'):
+    return flask.redirect(location)
+
+
+class EmptyHandler(FlaskHandler):
+  """Reusable handler for templates that require no page-specific data.
+     Specify the location in the third part of a routing rule using:
+     {'template_path': 'path/to/template.html'}."""
+
+  def get_template_data(self, template_path=None):
+    if '.html' not in template_path:
+      self.abort(500)
+    return {
+        'template_path': template_path,
+    }
+
+
 def FlaskApplication(routes, debug=False):
   """Make a Flask app and add routes and handlers that work like webapp2."""
 
   app = flask.Flask(__name__)
-  for i, (pattern, handler_class) in enumerate(routes):
+  for i, rule in enumerate(routes):
+    pattern = rule[0]
+    handler_class = rule[1]
+    defaults = rule[2] if len(rule) > 2 else None
     classname = handler_class.__name__
     app.add_url_rule(
         pattern,
         endpoint=classname + str(i),  # We don't use it, but it must be unique.
-        view_func=handler_class.as_view(classname))
+        view_func=handler_class.as_view(classname),
+        defaults=defaults)
 
   # Note: debug parameter is not used because the following accomplishes
   # what we need it to do.

--- a/common.py
+++ b/common.py
@@ -500,17 +500,21 @@ class Redirector(FlaskHandler):
     return flask.redirect(location)
 
 
-class EmptyHandler(FlaskHandler):
-  """Reusable handler for templates that require no page-specific data.
+class ConstHandler(FlaskHandler):
+  """Reusable handler for templates that require no page-specific logic.
      Specify the location in the third part of a routing rule using:
      {'template_path': 'path/to/template.html'}."""
 
-  def get_template_data(self, template_path=None):
-    if '.html' not in template_path:
-      self.abort(500)
-    return {
-        'template_path': template_path,
-    }
+  def get_template_data(self, **defaults):
+    """Render a template, or return a JSON constant."""
+    if 'template_path' in defaults:
+      template_path = defaults['template_path']
+      if '.html' not in template_path:
+        logging.error('template_path %r does not end with .html', template_path)
+        self.abort(500)
+      return defaults
+
+    return flask.jsonify(defaults)
 
 
 def FlaskApplication(routes, debug=False):

--- a/server.py
+++ b/server.py
@@ -20,8 +20,6 @@ __author__ = 'ericbidelman@chromium.org (Eric Bidelman)'
 
 import json
 import logging
-import os
-import webapp2
 
 import settings
 import common
@@ -33,18 +31,17 @@ import util
 
 from google.appengine.api import users
 
-import http2push.http2push as http2push
-
 
 def normalized_name(val):
   return val.lower().replace(' ', '').replace('/', '')
 
 
-class FeatureDetailHandler(common.ContentHandler):
+class FeatureDetailHandler(common.FlaskHandler):
 
-  def get(self, feature_id):
-    ramcache.check_for_distributed_invalidation()
-    f = models.Feature.get_by_id(long(feature_id))
+  TEMPLATE_PATH = 'feature.html'
+
+  def get_template_data(self, feature_id):
+    f = models.Feature.get_by_id(feature_id)
     if f is None:
       self.abort(404)
 
@@ -59,165 +56,125 @@ class FeatureDetailHandler(common.ContentHandler):
         'feature_json': json.dumps(f.format_for_template()),
         'updated_display': f.updated.strftime("%Y-%m-%d"),
     }
-
-    self._add_common_template_values(template_data)
-    self.render(data=template_data, template_path='feature.html')
+    return template_data
 
 
-class MainHandler(http2push.PushHandler, common.ContentHandler, common.JSONHandler):
+class FeatureListXMLHandler(common.FlaskHandler):
 
-  def get(self, path, feature_id=None):
-    ramcache.check_for_distributed_invalidation()
-    # Default to features page.
-    # TODO: remove later when we want an index.html
-    if not path:
-      return self.redirect('/features')
-
-    # Default /metrics to CSS ranking.
-    # TODO: remove later when we want /metrics/index.html
-    if path == 'metrics' or path == 'metrics/css':
-      return self.redirect('/metrics/css/popularity')
-
-    # Remove trailing slash from URL and redirect. e.g. /metrics/ -> /metrics
-    if feature_id == '':
-      return self.redirect(self.request.path.rstrip('/'))
-
-    template_data = {}
-    push_urls = [] # URLs to push in this response.
-
-    template_data['embed'] = self.request.get('embed', None) is not None
-
-    if path.startswith('features'):
-      if path.endswith('.xml'): # Atom feed request.
-        status = self.request.get('status', None)
-        if status:
-          feature_list = models.Feature.get_all_with_statuses(status.split(','))
-        else:
-          filterby = None
-          category = self.request.get('category', None)
-
-          # Support setting larger-than-default Atom feed sizes so that web
-          # crawlers can use this as a full site feed.
-          try:
-            max_items = int(self.request.get('max-items',
-                                             settings.RSS_FEED_LIMIT))
-          except TypeError:
-            max_items = settings.RSS_FEED_LIMIT
-
-          if category is not None:
-            for k,v in models.FEATURE_CATEGORIES.iteritems():
-              normalized = normalized_name(v)
-              if category == normalized:
-                filterby = ('category =', k)
-                break
-
-          feature_list = models.Feature.get_all( # Memcached
-              limit=max_items,
-              filterby=filterby,
-              order='-updated')
-
-        return self.render_atom_feed('Features', feature_list)
-      else:
-        template_data['categories'] = [
-          (v, normalized_name(v)) for k,v in
-          models.FEATURE_CATEGORIES.iteritems()]
-        template_data['IMPLEMENTATION_STATUSES'] = json.dumps([
-          {'key': k, 'val': v} for k,v in
-          models.IMPLEMENTATION_STATUS.iteritems()])
-        template_data['VENDOR_VIEWS'] = json.dumps([
-          {'key': k, 'val': v} for k,v in
-          models.VENDOR_VIEWS.iteritems()])
-        template_data['WEB_DEV_VIEWS'] = json.dumps([
-          {'key': k, 'val': v} for k,v in
-          models.WEB_DEV_VIEWS.iteritems()])
-        template_data['STANDARDS_VALS'] = json.dumps([
-          {'key': k, 'val': v} for k,v in
-          models.STANDARDIZATION.iteritems()])
-
-        push_urls = http2push.use_push_manifest('push_manifest_features.json')
-
-    elif path.startswith('feature'):
-      feature = None
-      try:
-        feature = models.Feature.get_feature(int(feature_id))
-      except TypeError:
-        pass
-      if feature is None:
-        self.abort(404)
-
-      was_updated = False
-      if self.request.referer:
-        was_updated = (self.request.referer.endswith('/admin/features/new') or
-                       '/admin/features/edit' in self.request.referer)
-
-      template_data['feature'] = feature
-      template_data['was_updated'] = was_updated
-
-    elif path.startswith('metrics/css/timeline'):
-      properties = sorted(
-          models.CssPropertyHistogram.get_all().iteritems(), key=lambda x:x[1])
-      template_data['CSS_PROPERTY_BUCKETS'] = json.dumps(
-          properties, separators=(',',':'))
-    elif path.startswith('metrics/feature/timeline'):
-      properties = sorted(
-          models.FeatureObserverHistogram.get_all().iteritems(), key=lambda x:x[1])
-      template_data['FEATUREOBSERVER_BUCKETS'] = json.dumps(
-          properties, separators=(',',':'))
-    elif path.startswith('omaha_data'):
-      omaha_data = util.get_omaha_data()
-      return common.JSONHandler.get(self, omaha_data, formatted=True)
-
-    if path.startswith('metrics/'):
-      push_urls = http2push.use_push_manifest('push_manifest_metrics.json')
-
-    # Add Link rel=preload header for h2 push on .html file requests.
-    if push_urls:
-      self.response.headers.add_header(
-          'Link', self._generate_link_preload_headers(push_urls))
-
-    self.render(data=template_data, template_path=os.path.join(path + '.html'))
-
-
-class FeaturesAPIHandler(common.JSONHandler):
-
-  def get(self, version=None):
-    ramcache.check_for_distributed_invalidation()
-    if version is None:
-      version = 2
+  def get_template_data(self):
+    status = self.request.args.get('status', None)
+    if status:
+      feature_list = models.Feature.get_all_with_statuses(status.split(','))
     else:
-      version = int(version)
+      filterby = None
+      category = self.request.args.get('category', None)
 
-    user = users.get_current_user()
-    feature_list = models.Feature.get_chronological(
-        version=version, show_unlisted=self.user_can_edit(user))
-    return common.JSONHandler.get(
-        self, feature_list, formatted=True, public=False)
-
-
-class SamplesHandler(common.ContentHandler, common.JSONHandler):
-
-  def get(self, path=None):
-    ramcache.check_for_distributed_invalidation()
-    feature_list = models.Feature.get_shipping_samples() # Memcached
-
-    if path == '/':
-      return self.redirect(self.request.path.rstrip('/'))
-
-    template_data = {}
-
-    if path and path.endswith('.json'): # JSON request.
-      return common.JSONHandler.get(self, feature_list, formatted=True)
-    elif path and path.endswith('.xml'): # Atom feed request.
       # Support setting larger-than-default Atom feed sizes so that web
       # crawlers can use this as a full site feed.
       try:
-        max_items = int(self.request.get('max-items',
-                                          settings.RSS_FEED_LIMIT))
+        max_items = int(self.request.args.get(
+            'max-items', settings.RSS_FEED_LIMIT))
       except TypeError:
         max_items = settings.RSS_FEED_LIMIT
 
-      return self.render_atom_feed('Samples', feature_list)
+      if category is not None:
+        for k,v in models.FEATURE_CATEGORIES.iteritems():
+          normalized = normalized_name(v)
+          if category == normalized:
+            filterby = ('category =', k)
+            break
 
+      feature_list = models.Feature.get_all( # Memcached
+          limit=max_items,
+          filterby=filterby,
+          order='-updated')
+
+    return common.render_atom_feed(self.request, 'Features', feature_list)
+
+
+class FeatureListHandler(common.FlaskHandler):
+
+  TEMPLATE_PATH = 'features.html'
+
+  def get_template_data(self, feature_id=None):
+    template_data = {}
+    template_data['categories'] = [
+      (v, normalized_name(v)) for k,v in
+      models.FEATURE_CATEGORIES.iteritems()]
+    template_data['IMPLEMENTATION_STATUSES'] = json.dumps([
+      {'key': k, 'val': v} for k,v in
+      models.IMPLEMENTATION_STATUS.iteritems()])
+    template_data['VENDOR_VIEWS'] = json.dumps([
+      {'key': k, 'val': v} for k,v in
+      models.VENDOR_VIEWS.iteritems()])
+    template_data['WEB_DEV_VIEWS'] = json.dumps([
+      {'key': k, 'val': v} for k,v in
+      models.WEB_DEV_VIEWS.iteritems()])
+    template_data['STANDARDS_VALS'] = json.dumps([
+      {'key': k, 'val': v} for k,v in
+      models.STANDARDIZATION.iteritems()])
+
+    return template_data
+
+
+
+class CssTimelineHandler(common.FlaskHandler):
+
+  TEMPLATE_PATH = 'metrics/css/timeline.html'
+
+  def get_template_data(self):
+    properties = sorted(
+        models.CssPropertyHistogram.get_all().iteritems(), key=lambda x:x[1])
+    template_data = {
+        'CSS_PROPERTY_BUCKETS': json.dumps(
+            properties, separators=(',',':')),
+        }
+    return template_data
+
+
+class FeatureTimelineHandler(common.FlaskHandler):
+
+  TEMPLATE_PATH = 'metrics/feature/timeline.html'
+
+  def get_template_data(self):
+    properties = sorted(
+        models.FeatureObserverHistogram.get_all().iteritems(), key=lambda x:x[1])
+    template_data = {
+        'FEATUREOBSERVER_BUCKETS': json.dumps(
+            properties, separators=(',',':')),
+    }
+    return template_data
+
+
+class OmahaDataHandler(common.FlaskHandler):
+
+  JSONIFY = True
+
+  def get_template_data(self):
+    omaha_data = util.get_omaha_data()
+    return omaha_data
+
+
+class FeaturesAPIHandler(common.FlaskHandler):
+
+  HTTP_CACHE_TYPE = 'private'
+  JSONIFY = True
+
+  def get_template_data(self, version=2):
+    user = users.get_current_user()
+    feature_list = models.Feature.get_chronological(
+        version=version, show_unlisted=self.user_can_edit(user))
+    return feature_list
+
+
+class SamplesHandler(common.FlaskHandler):
+
+  TEMPLATE_PATH = 'samples.html'
+
+  def get_template_data(self):
+    feature_list = models.Feature.get_shipping_samples() # Memcached
+
+    template_data = {}
     template_data['FEATURES'] = json.dumps(feature_list, separators=(',',':'))
     template_data['CATEGORIES'] = [
       (v, normalized_name(v)) for k,v in
@@ -226,21 +183,70 @@ class SamplesHandler(common.ContentHandler, common.JSONHandler):
       (v, normalized_name(v)) for k,v in
       models.FEATURE_CATEGORIES.iteritems()])
 
-    return self.render(data=template_data, template_path=os.path.join('samples.html'))
+    return template_data
+
+
+class SamplesJSONHandler(common.FlaskHandler):
+
+  JSONIFY = True
+
+  def get_template_data(self):
+    feature_list = models.Feature.get_shipping_samples() # Memcached
+    return feature_list
+
+
+class SamplesXMLHandler(common.FlaskHandler):
+
+  def get_template_data(self):
+    feature_list = models.Feature.get_shipping_samples() # Memcached
+
+    # Support setting larger-than-default Atom feed sizes so that web
+    # crawlers can use this as a full site feed.
+    try:
+      max_items = int(self.request.args.get(
+          'max-items', settings.RSS_FEED_LIMIT))
+    except TypeError:
+      max_items = settings.RSS_FEED_LIMIT
+
+    return common.render_atom_feed(self.request, 'Samples', feature_list)
 
 
 # Main URL routes.
 routes = [
-  (r'/features(?:_v(\d+))?.json', FeaturesAPIHandler),
-  ('/samples(.*)', SamplesHandler),
-  ('/feature/([0-9]*)', FeatureDetailHandler),
-  ('/(.*)/([0-9]*)', MainHandler),
-  ('/(.*)', MainHandler),
+  # Note: The only requests being made now hit /features.json and
+  # /features_v2.json, but both of those cause version == 2.
+  # There was logic to accept another version value, but it it was not used.
+  (r'/features.json', FeaturesAPIHandler),
+  (r'/features_v2.json', FeaturesAPIHandler),
+
+  ('/samples', SamplesHandler),
+  ('/samples.json', SamplesJSONHandler),
+  ('/samples.xml', SamplesXMLHandler),
+
+  ('/feature/<int:feature_id>', FeatureDetailHandler),
+
+  ('/', common.Redirector,
+   {'location': '/features'}),
+  ('/metrics', common.Redirector,
+   {'location': '/metrics/css/popularity'}),
+  ('/metrics/css', common.Redirector,
+   {'location': '/metrics/css/popularity'}),
+
+  ('/features', FeatureListHandler),
+  ('/features/<int:feature_id>', FeatureListHandler),
+  ('/features.xml', FeatureListXMLHandler),
+
+  # TODO(jrobbins): These seem like they belong in metrics.py.
+  ('/metrics/css/popularity', common.EmptyHandler,
+   {'template_path': 'metrics/css/popularity.html'}),
+  ('/metrics/css/timeline', CssTimelineHandler),
+  ('/metrics/feature/popularity', common.EmptyHandler,
+   {'template_path': 'metrics/feature/popularity.html'}),
+  ('/metrics/feature/timeline', FeatureTimelineHandler),
+
+  # TODO(jrobbins): util.py has only one thing in it, so maybe move
+  # it and this handler to a new omaha.py file.
+  ('/omaha_data', OmahaDataHandler),
 ]
 
-app = webapp2.WSGIApplication(routes, debug=settings.DEBUG)
-
-app.error_handlers[404] = common.handle_404
-
-if settings.PROD and not settings.DEBUG:
-  app.error_handlers[500] = common.handle_500
+app = common.FlaskApplication(routes, debug=settings.DEBUG)

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -18,6 +18,11 @@ from __future__ import print_function
 import unittest
 import testing_config  # Must be imported before the module under test.
 
+import flask
+import werkzeug
+
+import models
+import ramcache
 import server
 
 
@@ -31,3 +36,164 @@ class ServerFunctionsTest(unittest.TestCase):
     self.assertEqual('abc', server.normalized_name('A BC'))
     self.assertEqual('abc', server.normalized_name('A B/C'))
     self.assertEqual('abc', server.normalized_name(' /A B/C /'))
+
+
+class TestWithFeature(unittest.TestCase):
+
+  REQUEST_PATH_FORMAT = 'subclasses fill this in'
+  HANDLER_CLASS = 'subclasses fill this in'
+
+  def setUp(self):
+    self.feature_1 = models.Feature(
+        name='feature one', summary='detailed sum', category=1, visibility=1,
+        standardization=1, web_dev_views=1, impl_status_chrome=1,
+        intent_stage=models.INTENT_IMPLEMENT)
+    self.feature_1.put()
+    self.feature_id = self.feature_1.key().id()
+
+    self.request_path = self.REQUEST_PATH_FORMAT % {
+        'feature_id': self.feature_id,
+    }
+    self.handler = self.HANDLER_CLASS()
+
+  def tearDown(self):
+    self.feature_1.delete()
+    ramcache.flush_all()
+    ramcache.check_for_distributed_invalidation()
+
+
+class FeatureDetailHandlerTest(TestWithFeature):
+
+  REQUEST_PATH_FORMAT = '/feature/{feature_id}'
+  HANDLER_CLASS = server.FeatureDetailHandler
+
+  def test_get_template_data__missing(self):
+    """If a feature is not found, give a 404."""
+    feature_id = 123456
+    with server.app.test_request_context('/feature/123456'):
+      with self.assertRaises(werkzeug.exceptions.NotFound):
+        self.handler.get_template_data(feature_id=feature_id)
+
+  def test_get_template_data__normal(self):
+    """We can prep to render the feature detail page."""
+    with server.app.test_request_context(self.request_path):
+      template_data = self.handler.get_template_data(
+          feature_id=self.feature_id)
+
+    self.assertEqual(self.feature_id, template_data['feature_id'])
+    self.assertEqual('detailed sum', template_data['feature']['summary'])
+
+
+class FeatureListXMLHandlerTest(TestWithFeature):
+
+  REQUEST_PATH_FORMAT = '/features.xml'
+  HANDLER_CLASS = server.FeatureListXMLHandler
+
+  def test_get_template_data__no_filters(self):
+    """User can get an XML feed of all features."""
+    with server.app.test_request_context(self.request_path):
+      actual_text, actual_headers = self.handler.get_template_data()
+
+    self.assertTrue(actual_text.startswith('<?xml'))
+    self.assertIn('feature one', actual_text)
+    self.assertIn('detailed sum', actual_text)
+    self.assertIn(str(self.feature_id), actual_text)
+
+    self.assertIn('atom+xml', actual_headers['Content-Type'])
+
+  def test_get_template_data__category(self):
+    """User can get an XML feed of features by category."""
+    request_path = self.request_path + '?category=web components'
+    with server.app.test_request_context(request_path):
+      actual_text, actual_headers = self.handler.get_template_data()
+
+    # It is an XML feed
+    self.assertTrue(actual_text.startswith('<?xml'))
+    self.assertIn('atom+xml', actual_headers['Content-Type'])
+    self.assertIn('Features', actual_text)
+
+    # feature_1 is in the list
+    self.assertIn('feature one', actual_text)
+    self.assertIn('detailed sum', actual_text)
+    self.assertIn(str(self.feature_id), actual_text)
+
+
+    request_path = self.request_path + '?category=css'
+    with server.app.test_request_context(request_path):
+      actual_text, actual_headers = self.handler.get_template_data()
+
+    self.assertTrue(actual_text.startswith('<?xml'))
+    self.assertNotIn('feature one', actual_text)
+
+
+class FeatureListHandlerTest(TestWithFeature):
+
+  REQUEST_PATH_FORMAT = '/features'
+  HANDLER_CLASS = server.FeatureListHandler
+
+  def test_get_template_data(self):
+    """User can get a feature list page."""
+    with server.app.test_request_context(self.request_path):
+      template_data = self.handler.get_template_data()
+
+    self.assertIn('IMPLEMENTATION_STATUSES', template_data)
+
+
+class FeaturesAPIHandlerTest(TestWithFeature):
+
+  REQUEST_PATH_FORMAT = '/features.json'
+  HANDLER_CLASS = server.FeaturesAPIHandler
+
+  def test_get_template_data(self):
+    """User can get a JSON feed of all features."""
+    with server.app.test_request_context(self.request_path):
+      json_data = self.handler.get_template_data()
+
+    self.assertEqual(1, len(json_data))
+    self.assertEqual('feature one', json_data[0]['name'])
+
+
+class SamplesHandlerTest(TestWithFeature):
+
+  REQUEST_PATH_FORMAT = '/samples'
+  HANDLER_CLASS = server.SamplesHandler
+
+  def test_get_template_data(self):
+    """User can get a page with all samples."""
+    with server.app.test_request_context(self.request_path):
+      template_data = self.handler.get_template_data()
+
+    self.assertIn('FEATURES', template_data)
+
+
+class SamplesJSONHandlerTest(TestWithFeature):
+
+  REQUEST_PATH_FORMAT = '/samples'
+  HANDLER_CLASS = server.SamplesJSONHandler
+
+  def test_get_template_data(self):
+    """User can get a JSON feed of all samples."""
+    with server.app.test_request_context(self.request_path):
+      json_data = self.handler.get_template_data()
+
+    self.assertEqual([], json_data)
+
+
+class SamplesXMLHandlerTest(TestWithFeature):
+
+  REQUEST_PATH_FORMAT = '/samples.xml'
+  HANDLER_CLASS = server.SamplesXMLHandler
+
+  def test_get_template_data(self):
+    """User can get an XML feed of all samples."""
+    with server.app.test_request_context(self.request_path):
+      actual_text, actual_headers = self.handler.get_template_data()
+
+    # It is an XML feed
+    self.assertTrue(actual_text.startswith('<?xml'))
+    self.assertIn('atom+xml', actual_headers['Content-Type'])
+    self.assertIn('Samples', actual_text)
+
+    # feature_1 is not in the list because it does not have a sample.
+    self.assertNotIn('detailed sum', actual_text)
+    self.assertNotIn(str(self.feature_id), actual_text)


### PR DESCRIPTION
This should resolve issue #1070.

In this CL:
+ Break if-else logic of server.py into distinct handlers for each URL.
+ Upgrade each handler to use FlaskHandler
+ List all the routings explicitly, including redirects and templates that had no python logic.
+ Add utility classes to common.py for simple handlers for redirects and templates that need no python logic.
+ Add some long-missing unit tests now that this code is more testable
