### PR TITLE
Remove unneeded MEMCACHE_KEY_PREFIX and simplify other names.

### DIFF
--- a/common.py
+++ b/common.py
@@ -272,7 +272,7 @@ class FlaskHandler(flask.views.MethodView):
     elif user.email().endswith(('@chromium.org', '@google.com')):
       can_edit = True
     else:
-      # TODO(ericbidelman): memcache user lookup.
+      # TODO(ericbidelman): cache user lookup.
       query = models.AppUser.all(keys_only=True).filter('email =', user.email())
       found_user = query.get()
 

--- a/metrics.py
+++ b/metrics.py
@@ -88,7 +88,7 @@ class TimelineHandler(common.FlaskHandler):
       # TODO(jrobbins): Why return [] instead of 400?
       return []
 
-    cache_key = '%s|%s' % (self.MEMCACHE_KEY, bucket_id)
+    cache_key = '%s|%s' % (self.CACHE_KEY, bucket_id)
 
     datapoints = ramcache.get(cache_key)
 
@@ -107,7 +107,7 @@ class TimelineHandler(common.FlaskHandler):
 
 class PopularityTimelineHandler(TimelineHandler):
 
-  MEMCACHE_KEY = 'css_pop_timeline'
+  CACHE_KEY = 'css_pop_timeline'
   MODEL_CLASS = models.StableInstance
 
   def get_template_data(self):
@@ -116,7 +116,7 @@ class PopularityTimelineHandler(TimelineHandler):
 
 class AnimatedTimelineHandler(TimelineHandler):
 
-  MEMCACHE_KEY = 'css_animated_timeline'
+  CACHE_KEY = 'css_animated_timeline'
   MODEL_CLASS = models.AnimatedProperty
 
   def get_template_data(self):
@@ -125,7 +125,7 @@ class AnimatedTimelineHandler(TimelineHandler):
 
 class FeatureObserverTimelineHandler(TimelineHandler):
 
-  MEMCACHE_KEY = 'featureob_timeline'
+  CACHE_KEY = 'featureob_timeline'
   MODEL_CLASS = models.FeatureObserver
 
   def get_template_data(self):
@@ -173,29 +173,25 @@ class FeatureHandler(common.FlaskHandler):
     return datapoints
 
   def get_template_data(self):
-    # TODO(jrobbins): chunking is unneeded with ramcache, so we can
-    # simplify this code.
-    # Memcache doesn't support saving values > 1MB. Break up features into chunks
-    # and save those to memcache.
     if self.MODEL_CLASS == models.FeatureObserver:
-      properties = ramcache.get(self.MEMCACHE_KEY)
+      properties = ramcache.get(self.CACHE_KEY)
 
       if not properties or self.request.args.get('refresh'):
         properties = self.__query_metrics_for_properties()
-        ramcache.set(self.MEMCACHE_KEY, properties, time=CACHE_AGE)
+        ramcache.set(self.CACHE_KEY, properties, time=CACHE_AGE)
 
     else:
-      properties = ramcache.get(self.MEMCACHE_KEY)
+      properties = ramcache.get(self.CACHE_KEY)
       if properties is None:
         properties = self.__query_metrics_for_properties()
-        ramcache.set(self.MEMCACHE_KEY, properties, time=CACHE_AGE)
+        ramcache.set(self.CACHE_KEY, properties, time=CACHE_AGE)
 
     return _filter_metric_data(properties)
 
 
 class CSSPopularityHandler(FeatureHandler):
 
-  MEMCACHE_KEY = 'css_popularity'
+  CACHE_KEY = 'css_popularity'
   MODEL_CLASS = models.StableInstance
   PROPERTY_CLASS = models.CssPropertyHistogram
 
@@ -205,7 +201,7 @@ class CSSPopularityHandler(FeatureHandler):
 
 class CSSAnimatedHandler(FeatureHandler):
 
-  MEMCACHE_KEY = 'css_animated'
+  CACHE_KEY = 'css_animated'
   MODEL_CLASS = models.AnimatedProperty
   PROPERTY_CLASS = models.CssPropertyHistogram
 
@@ -215,7 +211,7 @@ class CSSAnimatedHandler(FeatureHandler):
 
 class FeatureObserverPopularityHandler(FeatureHandler):
 
-  MEMCACHE_KEY = 'featureob_popularity'
+  CACHE_KEY = 'featureob_popularity'
   MODEL_CLASS = models.FeatureObserver
   PROPERTY_CLASS = models.FeatureObserverHistogram
 

--- a/models.py
+++ b/models.py
@@ -375,7 +375,7 @@ class BlinkComponent(DictModel):
   @classmethod
   def fetch_all_components(self, update_cache=False):
     """Returns the list of blink components from live endpoint if unavailable in the cache."""
-    key = '%s|blinkcomponents' % (settings.MEMCACHE_KEY_PREFIX)
+    key = 'blinkcomponents'
 
     components = ramcache.get(key)
     if components is None or update_cache:
@@ -397,7 +397,7 @@ class BlinkComponent(DictModel):
   @classmethod
   def fetch_wf_content_for_components(self, update_cache=False):
     """Returns the /web content that use each blink component."""
-    key = '%s|wfcomponents' % (settings.MEMCACHE_KEY_PREFIX)
+    key = 'wfcomponents'
 
     components = ramcache.get(key)
     if components is None or update_cache:
@@ -422,7 +422,7 @@ class BlinkComponent(DictModel):
   @classmethod
   def update_db(self):
     """Updates the db with new Blink components from the json endpoint"""
-    self.fetch_wf_content_for_components(update_cache=True) # store /web content in memcache
+    self.fetch_wf_content_for_components(update_cache=True) # store /web content in cache
     new_components = self.fetch_all_components(update_cache=True)
     existing_comps = self.all().fetch(None)
     for name in new_components:
@@ -470,7 +470,7 @@ class FeatureObserver(StableInstance):
 class Feature(DictModel):
   """Container for a feature."""
 
-  DEFAULT_MEMCACHE_KEY = '%s|features' % (settings.MEMCACHE_KEY_PREFIX)
+  DEFAULT_CACHE_KEY = 'features'
 
   @classmethod
   def _first_of_milestone(self, feature_list, milestone, start=0):
@@ -719,7 +719,7 @@ class Feature(DictModel):
   @classmethod
   def get_all(self, limit=None, order='-updated', filterby=None,
               update_cache=False):
-    KEY = '%s|%s|%s' % (Feature.DEFAULT_MEMCACHE_KEY, order, limit)
+    KEY = '%s|%s|%s' % (Feature.DEFAULT_CACHE_KEY, order, limit)
 
     # TODO(ericbidelman): Support more than one filter.
     if filterby is not None:
@@ -749,7 +749,7 @@ class Feature(DictModel):
     if not statuses:
       return []
 
-    KEY = '%s|%s' % (Feature.DEFAULT_MEMCACHE_KEY, sorted(statuses))
+    KEY = '%s|%s' % (Feature.DEFAULT_CACHE_KEY, sorted(statuses))
 
     feature_list = ramcache.get(KEY)
 
@@ -766,7 +766,7 @@ class Feature(DictModel):
 
   @classmethod
   def get_feature(self, feature_id, update_cache=False):
-    KEY = '%s|%s' % (Feature.DEFAULT_MEMCACHE_KEY, feature_id)
+    KEY = '%s|%s' % (Feature.DEFAULT_CACHE_KEY, feature_id)
     feature = ramcache.get(KEY)
 
     if feature is None or update_cache:
@@ -784,7 +784,7 @@ class Feature(DictModel):
   @classmethod
   def get_chronological(
       self, limit=None, update_cache=False, version=None, show_unlisted=False):
-    cache_key = '%s|%s|%s|%s' % (Feature.DEFAULT_MEMCACHE_KEY,
+    cache_key = '%s|%s|%s|%s' % (Feature.DEFAULT_CACHE_KEY,
                                  'cronorder', limit, version)
 
     feature_list = ramcache.get(cache_key)
@@ -857,8 +857,6 @@ class Feature(DictModel):
 
       self._annotate_first_of_milestones(feature_list, version=version)
 
-      # Memcache doesn't support saving values > 1MB. Break up features list into
-      # chunks so we don't hit the limit.
       ramcache.set(cache_key, feature_list)
 
     allowed_feature_list = [
@@ -869,7 +867,7 @@ class Feature(DictModel):
 
   @classmethod
   def get_shipping_samples(self, limit=None, update_cache=False):
-    cache_key = '%s|%s|%s' % (Feature.DEFAULT_MEMCACHE_KEY, 'samples', limit)
+    cache_key = '%s|%s|%s' % (Feature.DEFAULT_CACHE_KEY, 'samples', limit)
 
     feature_list = ramcache.get(cache_key)
 
@@ -966,7 +964,7 @@ class Feature(DictModel):
       self.__notify_feature_subscribers_of_changes(is_update)
 
     # Invalidate ramcache for the individual feature view.
-    cache_key = '%s|%s' % (Feature.DEFAULT_MEMCACHE_KEY, self.key().id())
+    cache_key = '%s|%s' % (Feature.DEFAULT_CACHE_KEY, self.key().id())
     ramcache.delete(cache_key)
 
     return key

--- a/schedule.py
+++ b/schedule.py
@@ -33,7 +33,7 @@ import util
 
 
 def fetch_chrome_release_info(version):
-  key = '%s|chromerelease|%s' % (settings.MEMCACHE_KEY_PREFIX, version)
+  key = 'chromerelease|%s' % version
 
   data = ramcache.get(key)
   if data is None:

--- a/server.py
+++ b/server.py
@@ -84,7 +84,7 @@ class FeatureListXMLHandler(common.FlaskHandler):
             filterby = ('category =', k)
             break
 
-      feature_list = models.Feature.get_all( # Memcached
+      feature_list = models.Feature.get_all( # cached
           limit=max_items,
           filterby=filterby,
           order='-updated')
@@ -185,7 +185,7 @@ class SamplesHandler(common.FlaskHandler):
   TEMPLATE_PATH = 'samples.html'
 
   def get_template_data(self):
-    feature_list = models.Feature.get_shipping_samples() # Memcached
+    feature_list = models.Feature.get_shipping_samples() # cached
 
     template_data = {}
     template_data['FEATURES'] = json.dumps(feature_list, separators=(',',':'))
@@ -204,14 +204,14 @@ class SamplesJSONHandler(common.FlaskHandler):
   JSONIFY = True
 
   def get_template_data(self):
-    feature_list = models.Feature.get_shipping_samples() # Memcached
+    feature_list = models.Feature.get_shipping_samples() # cached
     return feature_list
 
 
 class SamplesXMLHandler(common.FlaskHandler):
 
   def get_template_data(self):
-    feature_list = models.Feature.get_shipping_samples() # Memcached
+    feature_list = models.Feature.get_shipping_samples() # cached
 
     # Support setting larger-than-default Atom feed sizes so that web
     # crawlers can use this as a full site feed.

--- a/settings.py
+++ b/settings.py
@@ -64,10 +64,6 @@ SECRET_KEY = os.environ['DJANGO_SECRET']
 
 APP_VERSION = os.environ['CURRENT_VERSION_ID'].split('.')[0]
 
-# TODO(jrobbins): This is not needed with ramcache because each deployment
-# creates fresh appengine instances with empty ramcaches.
-MEMCACHE_KEY_PREFIX = APP_VERSION # For memcache busting on new version
-
 RSS_FEED_LIMIT = 15
 
 VULCANIZE = True #PROD

--- a/tests/ramcache_test.py
+++ b/tests/ramcache_test.py
@@ -25,13 +25,13 @@ from google.appengine.ext import db
 import ramcache
 
 
-KEY_1 = 'memcache_key|1'
-KEY_2 = 'memcache_key|2'
-KEY_3 = 'memcache_key|3'
-KEY_4 = 'memcache_key|4'
-KEY_5 = 'memcache_key|5'
-KEY_6 = 'memcache_key|6'
-KEY_7 = 'memcache_key|7'
+KEY_1 = 'cache_key|1'
+KEY_2 = 'cache_key|2'
+KEY_3 = 'cache_key|3'
+KEY_4 = 'cache_key|4'
+KEY_5 = 'cache_key|5'
+KEY_6 = 'cache_key|6'
+KEY_7 = 'cache_key|7'
 
 
 class RAMCacheFunctionTests(unittest.TestCase):


### PR DESCRIPTION
This is a follow-up CL to last week's removal of some unneeded logic that was used with memcache.  In this CL:

+ Remove settings.MEMCACHE_KEY_PREFIX.  The purpose of that constant was to separate memcache entries used by different versions of the app.  That is not needed with ramcache because each app version runs in separate GAE instances that have their own RAM.

+ Simplify some names and comments from "memcache" to "cache" to avoid misleading comments.

+ Delete some TODOs that were done in last week's CL.