### PR TITLE
Upgrade from GAE taskqueue to Google Cloud Tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 python:
   - "2.7"
 dist: trusty
-sudo: false
+sudo: true
 git:
   depth: 1
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,7 @@ before_install:
 install:
   - npm install -g gulp
   - npm install
-  - echo "About to run travis-deps"
   - npm run travis-deps
-  - echo "Done with travis-deps"
 script:
   - npm run lint
   - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,9 @@ before_install:
 install:
   - npm install -g gulp
   - npm install
+  - echo "About to run travis-deps"
   - npm run travis-deps
+  - echo "Done with travis-deps"
 script:
   - npm run lint
   - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
   - npm install -g gulp
   - npm install
   - npm run deps
+  - python -m pip install --no-deps -r requirements.dev.txt
 script:
   - npm run lint
   - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 python:
   - "2.7"
 dist: trusty
-sudo: true
+sudo: false
 git:
   depth: 1
 env:
@@ -27,8 +27,7 @@ before_install:
 install:
   - npm install -g gulp
   - npm install
-  - python -m pip install --no-deps -r requirements.dev.txt
-  - npm run deps
+  - npm run travis-deps
 script:
   - npm run lint
   - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ before_install:
 install:
   - npm install -g gulp
   - npm install
-  - npm run deps
   - python -m pip install --no-deps -r requirements.dev.txt
+  - npm run deps
 script:
   - npm run lint
   - npm run test

--- a/app.yaml
+++ b/app.yaml
@@ -51,7 +51,7 @@ handlers:
 
 - url: /tasks/.*
   script: notifier.app
-  login: admin # Prevents raw access to this handler. Tasks runs as admin.
+  # Header checks prevent raw access to this handler.  Tasks have headers.
 
 - url: /_ah/bounce
   script: notifier.app
@@ -127,3 +127,7 @@ includes:
 inbound_services:
 - mail
 - mail_bounce
+
+libraries:
+- name: grpcio
+  version: 1.0.0

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -1,10 +1,20 @@
 from __future__ import division
 from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import sys
 # name of the django settings module
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 
+lib_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'lib')
+
 from google.appengine.ext import vendor
-vendor.add('lib') # add third party libs to "lib" folder.
+vendor.add(lib_path) # add third party libs to "lib" folder.
+
+# Add libraries to pkg_resources working set to find the distribution.
+import pkg_resources
+pkg_resources.working_set.add_entry(lib_path)
+
+import six
+reload(six)

--- a/cloud_tasks_helpers.py
+++ b/cloud_tasks_helpers.py
@@ -1,0 +1,106 @@
+from __future__ import division
+from __future__ import print_function
+
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import json
+
+from google.appengine.api import urlfetch
+from google.api_core import retry
+
+import settings
+
+if not settings.UNIT_TEST_MODE:
+  import grpc  # See requirements.dev.txt.
+  from google.cloud import tasks
+
+
+
+_client = None
+
+# Default exponential backoff retry config for enqueueing, not to be confused
+# with retry config for dispatching, which exists per queue.
+_DEFAULT_RETRY = retry.Retry(initial=.1, maximum=1.6, multiplier=2, deadline=10)
+
+
+class LocalCloudTasksClient(object):
+  """We have no GCT server running locally, so hit the target synchronously."""
+
+  def queue_path(self, project, location, queue):
+    """Return a fully-qualified queue string."""
+    # This is value is not actually used, but it might be good for debugging.
+    return "projects/{project}/locations/{location}/queues/{queue}".format(
+        project=project, location=location, queue=queue)
+
+  def create_task(self, unused_parent, task, **kwargs):
+    """Immediately hit the target URL."""
+    uri = task.get('app_engine_http_request').get('relative_uri')
+    target_url = 'http://localhost:8080' + uri
+    body = task.get('app_engine_http_request').get('body')
+    logging.info('Making request to %r', target_url)
+    handler_response = urlfetch.fetch(
+        target_url, payload=body, method=urlfetch.POST,
+        follow_redirects=False,
+        # This header can only be set on internal requests, not by users.
+        headers={'X-AppEngine-QueueName': 'default'})
+    logging.info('Task handler status: %d', handler_response.status_code)
+    logging.info('Task handler text: %r', handler_response.content)
+
+
+def _get_client():
+  """Returns a cloud tasks client."""
+  global _client
+  if not _client:
+    if settings.DEV_MODE:
+      _client = LocalCloudTasksClient()
+    else:
+      _client = tasks.CloudTasksClient()
+  return _client
+
+
+def _make_task(handler_path, task_params):
+  body_json = json.dumps(task_params)
+  return {
+      'app_engine_http_request': {
+          'relative_uri': handler_path,
+          'body': body_json,
+      }
+  }
+
+
+def enqueue_task(handler_path, task_params, queue='default', **kwargs):
+  """Enqueue a JSON task item for Google Cloud Tasks.
+
+  Args:
+    handler_path: Rooted path of the task handler.
+    task_params: Task parameters dict.
+    queue: A string indicating name of the queue to add task to.
+    kwargs: Additional arguments to pass to cloud task client's create_task
+
+  Returns:
+    Successfully created Task object.
+  """
+  task = _make_task(handler_path, task_params)
+  client = _get_client()
+  parent = client.queue_path(
+      settings.APP_ID, settings.CLOUD_TASKS_REGION, queue)
+
+  target = task.get('app_engine_http_request').get('relative_uri')
+  logging.info('Enqueueing %s task to %s', target, parent)
+
+  kwargs.setdefault('retry', _DEFAULT_RETRY)
+  return client.create_task(parent, task, **kwargs)

--- a/cloud_tasks_helpers.py
+++ b/cloud_tasks_helpers.py
@@ -23,12 +23,12 @@ import logging
 import json
 
 from google.appengine.api import urlfetch
-from google.api_core import retry
 
 import settings
 
 if not settings.UNIT_TEST_MODE:
   import grpc  # See requirements.dev.txt.
+  from google.api_core import retry
   from google.cloud import tasks
 
 
@@ -37,7 +37,10 @@ _client = None
 
 # Default exponential backoff retry config for enqueueing, not to be confused
 # with retry config for dispatching, which exists per queue.
-_DEFAULT_RETRY = retry.Retry(initial=.1, maximum=1.6, multiplier=2, deadline=10)
+_DEFAULT_RETRY = None
+if not settings.UNIT_TEST_MODE:
+  _DEFAULT_RETRY = retry.Retry(
+      initial=.1, maximum=1.6, multiplier=2, deadline=10)
 
 
 class LocalCloudTasksClient(object):

--- a/cloud_tasks_helpers.py
+++ b/cloud_tasks_helpers.py
@@ -16,6 +16,9 @@ from __future__ import print_function
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This code is based on a file from Monorail:
+# https://chromium.googlesource.com/infra/infra/+/master/appengine/monorail/framework/cloud_tasks_helpers.py
+
 import logging
 import json
 

--- a/common.py
+++ b/common.py
@@ -290,6 +290,14 @@ class FlaskHandler(flask.views.MethodView):
     """Property for POST values dict."""
     return flask.request.form
 
+  def require_task_header(self):
+    """Abort if this is not a Google Cloud Tasks request."""
+    if settings.UNIT_TEST_MODE:
+      return
+    if 'X-AppEngine-QueueName' not in self.request.headers:
+      logging.info('Lacking X-AppEngine-QueueName header')
+      self.abort(403)
+
   def split_input(self, field_name, delim='\\r?\\n'):
     """Split the input lines, strip whitespace, and skip blank lines."""
     input_text = flask.request.form.get(field_name) or ''

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,0 +1,3 @@
+dispatch:
+- url: "*/tasks/*"
+  service: notifier

--- a/guide.py
+++ b/guide.py
@@ -29,7 +29,6 @@ from django import forms
 import ramcache
 from google.appengine.api import users
 from google.appengine.ext import db
-from google.appengine.api import taskqueue
 
 # File imports.
 import common

--- a/models.py
+++ b/models.py
@@ -28,9 +28,10 @@ from google.appengine.ext import db
 from google.appengine.api import mail
 import ramcache
 from google.appengine.api import urlfetch
-from google.appengine.api import taskqueue
 from google.appengine.api import users
 
+import cloud_tasks_helpers
+import common
 import settings
 import util
 
@@ -944,17 +945,14 @@ class Feature(DictModel):
         changed_props.append({
             'prop_name': prop_name, 'old_val': old_val, 'new_val': new_val})
 
-    payload = json.dumps({
+    params = {
       'changes': changed_props,
       'is_update': is_update,
       'feature': self.format_for_template(version=2)
-    })
+    }
 
     # Create task to email subscribers.
-    queue = taskqueue.Queue()#name='emailer')
-    task = taskqueue.Task(method="POST", url='/tasks/email-subscribers',
-        target='notifier', payload=payload)
-    queue.add(task)
+    cloud_tasks_helpers.enqueue_task('/tasks/email-subscribers', params)
 
 
   def put(self, notify=True, **kwargs):

--- a/notifier.yaml
+++ b/notifier.yaml
@@ -4,10 +4,14 @@ threadsafe: true
 service: notifier
 
 handlers:
-- url: /.*
+- url: /tasks/.*
   script: notifier.app
-  login: admin
+  # Header checks prevent raw access to this handler.  Tasks have headers.
 
 includes:
 - skip_files.yaml
 - env_vars.yaml
+
+libraries:
+- name: grpcio
+  version: 1.0.0

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "deps": "pip install -t lib -r requirements.txt --upgrade",
-    "travis-deps": "pip install -t lib -r requirements.travis.txt --upgrade",
+    "travis-deps": "echo this is travis-deps && pip install -t lib -r requirements.travis.txt --upgrade",
     "dev-deps": "pip install -r requirements.dev.txt --upgrade",
     "test": "python -m unittest discover -p *_test.py -s tests -b",
     "coverage": "python -m coverage erase && python -m coverage run -m unittest discover -p *_test.py -s tests -b && python -m coverage html",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "deps": "pip install -t lib -r requirements.txt --upgrade",
-    "travis-deps": "echo this is travis-deps && pip install -t lib -r requirements.travis.txt --upgrade",
+    "travis-deps": "pip install -t lib -r requirements.travis.txt --upgrade",
     "dev-deps": "pip install -r requirements.dev.txt --upgrade",
     "test": "python -m unittest discover -p *_test.py -s tests -b",
     "coverage": "python -m coverage erase && python -m coverage run -m unittest discover -p *_test.py -s tests -b && python -m coverage html",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   },
   "scripts": {
     "deps": "pip install -t lib -r requirements.txt --upgrade",
+    "travis-deps": "pip install -t lib -r requirements.travis.txt --upgrade",
+    "dev-deps": "pip install -r requirements.dev.txt --upgrade",
     "test": "python -m unittest discover -p *_test.py -s tests -b",
     "coverage": "python -m coverage erase && python -m coverage run -m unittest discover -p *_test.py -s tests -b && python -m coverage html",
     "lint": "gulp lint-fix && lit-analyzer \"static/elements/chromedash-!(featurelist)*.js\"",

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,5 @@
+# This must be installed on your local venv or system, not in lib.
+# Via the command:
+# python -m pip install --no-deps -r requirements.dev.txt
+
+grpcio==1.31.0

--- a/requirements.travis.txt
+++ b/requirements.travis.txt
@@ -1,0 +1,8 @@
+Django==1.11.29
+mock==3.0.5
+funcsigs
+coverage
+Flask==1.1.2
+
+# Google cloud tasks is not used on travis because one of its dependencies
+# will not compiled.  The unit tests use a fake object as the GCT client.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,27 @@
 Django==1.11.29
 mock==3.0.5
+funcsigs
 coverage
 Flask==1.1.2
+
+google-cloud-tasks==1.5.0
+
+# Required by google-cloud-tasks
+googleapis-common-protos==1.52.0
+enum34==1.1.10
+grpc-google-iam-v1==0.12.3
+google-api-core==1.22.0
+pytz==2020.1
+google-auth==1.20.1
+setuptools==44.1.1
+requests==2.24.0
+six==1.15.0
+urllib3==1.25.10
+certifi==2020.6.20
+chardet==3.0.4
+idna==2.10
+pyasn1-modules==0.2.8
+cachetools==3.1.1
+rsa==4.5
+
+# See also: requirements.dev.txt

--- a/scripts/deploy_site.sh
+++ b/scripts/deploy_site.sh
@@ -32,4 +32,4 @@ gcloud app deploy \
   --project $appName \
   --version $deployVersion \
   --no-promote \
-  $BASEDIR/../app.yaml $BASEDIR/../notifier.yaml
+  $BASEDIR/../app.yaml $BASEDIR/../notifier.yaml $BASEDIR/../dispatch.yaml

--- a/settings.py
+++ b/settings.py
@@ -35,10 +35,12 @@ PROD = False
 DEBUG = True
 SEND_EMAIL = False  # Just log email
 DEV_MODE = os.environ['SERVER_SOFTWARE'].startswith('Development')
+UNIT_TEST_MODE = os.environ['SERVER_SOFTWARE'].startswith('test')
+
 
 APP_ID = app_identity.get_application_id()
 SITE_URL = 'http://%s.appspot.com/' % APP_ID
-
+CLOUD_TASKS_REGION = 'us-central1'
 
 if APP_ID == 'testbed-test':
   APP_TITLE = 'Local testing'

--- a/tests/cloud_tasks_helpers_test.py
+++ b/tests/cloud_tasks_helpers_test.py
@@ -1,0 +1,104 @@
+from __future__ import division
+from __future__ import print_function
+
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import unittest
+import testing_config  # Must be imported before the module under test.
+
+from google.appengine.api import urlfetch
+
+import cloud_tasks_helpers
+# Note that testing_config sets cloud_tasks_helpers._client to a fake.
+
+
+class LocalCloudTasksClientTest(unittest.TestCase):
+
+  def setUp(self):
+    self.client = cloud_tasks_helpers.LocalCloudTasksClient()
+
+  def test_queue_path(self):
+    """We get back a string like the kind that GCT uses."""
+    actual = self.client.queue_path('P', 'L', 'Q')
+    self.assertEqual(
+        'projects/P/locations/L/queues/Q',
+        actual)
+
+  @mock.patch('google.appengine.api.urlfetch.fetch')
+  def test_create_task(self, mock_fetch):
+    """The local stub makes a synchronous HTTP request to the task handler."""
+    parent = 'parent'
+    task = cloud_tasks_helpers._make_task('/handler', {'a': 1})
+    mock_fetch.return_value = testing_config.Blank(
+        status_code=200, content='content')
+
+    actual = self.client.create_task(parent, task)
+
+    self.assertIsNone(actual)
+    mock_fetch.assert_called_once_with(
+        'http://localhost:8080/handler',
+        payload='{"a": 1}', method=urlfetch.POST,
+        follow_redirects=False,
+        headers={'X-AppEngine-QueueName': 'default'})
+
+
+class CloudTasksHelpersTest(unittest.TestCase):
+
+  def test_get_client__unit_tests(self):
+    """During unit testing, we are using a fake object."""
+    actual = cloud_tasks_helpers._get_client()
+    self.assertEqual(
+        testing_config.FakeCloudTasksClient,
+        type(actual))
+
+  @mock.patch('settings.DEV_MODE', True)
+  def test_get_client__dev_mode(self):
+    """When running locally, we make a LocalCloudTasksClient."""
+    orig_client = cloud_tasks_helpers._client
+    try:
+      cloud_tasks_helpers._client = None
+      actual = cloud_tasks_helpers._get_client()
+      self.assertEqual(
+          cloud_tasks_helpers.LocalCloudTasksClient,
+          type(actual))
+    finally:
+      cloud_tasks_helpers._client = orig_client
+
+  def test_make_task(self):
+    """We can make a task info dict in the expected format."""
+    handler_path = '/handler'
+    task_params = {'a': 1}
+
+    actual = cloud_tasks_helpers._make_task(handler_path, task_params)
+
+    self.assertEqual(
+        { 'app_engine_http_request': {
+            'relative_uri': '/handler',
+            'body': '{"a": 1}',
+            }
+         },
+        actual)
+
+  def test_enqueue_task(self):
+    """We can call the GCT client to enqueue a task."""
+    handler_path = '/handler'
+    task_params = {'a': 1}
+
+    actual = cloud_tasks_helpers.enqueue_task(handler_path, task_params)
+
+    self.assertEqual('fake task', actual)
+    self.assertEqual('/handler', cloud_tasks_helpers._client.uri)
+    self.assertEqual('{"a": 1}', cloud_tasks_helpers._client.body)


### PR DESCRIPTION
Resolves issue #1072.

In this CL:
+ Add entries to requirements.txt for Google Cloud Tasks and specific version of indirect dependencies with versions that work with python 2.7.
+ Add requirements.dev.txt and a libraries section in app.yaml and notifier.yaml to allow GCT to work
+ Various changes to appengine_config to get the new libraries to work
+ cloud_tasks_helpers.py with new functions to enqueue a task.  This is based on the corresponding file in Monorail.
  - Include a local version of the GCT client that simply hits the task handler synchronously since we have no GCT server locally.
+ Change the auth for task handlers from GAE admin check to checking GCT headers in common.py.  This allows them to be run locally and also aligns with how this auth would need to happen in python 3.
+ Add dispatch.yaml and change the deploy_site.sh script to include that file.  taskqueue could target the notifier service of our app, but GCT just makes a general incoming request that needs to be routed to the app service that we want.
+  Update models.py and notifier.py code that created tasks to call our new code.
+ Add unit tests