### PR TITLE
Return something from Yesterday handler to satisfy Flask.

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -159,6 +159,8 @@ class YesterdayHandler(common.FlaskHandler):
             'Got error %s while fetching usage data' % response_code)
         return error_message, 500
 
+    return 'Success'
+
 
 class HistogramsHandler(common.FlaskHandler):
 


### PR DESCRIPTION
This should resolve an error that we see in the GAE cron jobs page.

The "YesterdayHandler" grabs metrics data for the previous day.  I intend to change the logic there, but not in this CL.

The error is happening simply because the request handler completes and falls off the end without returning anything.  Flask handlers are always supposed to return a string, dict, or response object.  So, we are getting an error even after the handler has successfully done all its work.  This resolves that by just returning a constant string like some of our other handlers do.