### PR TITLE
Make metrics fetch more robust and debuggable.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -47,7 +47,7 @@ handlers:
 # Admin ------------------------------------------------------------------------
 - url: /cron/.*
   script: admin.app
-  login: admin # Prevents raw access to this handler. Cron runs as admin.
+  # Any cron job must be harmless if it is called too often or with bad args
 
 - url: /tasks/.*
   script: notifier.app

--- a/cron.yaml
+++ b/cron.yaml
@@ -4,7 +4,7 @@ cron:
   schedule: every day 04:00
 - description: retrieve from UMA Cloud Storage data gathered yesterday
   url: /cron/metrics
-  schedule: every day 22:00
+  schedule: every 6 hours synchronized
 - description: update list of Blink components
   url: /cron/update_blink_components
   schedule: every day 04:30

--- a/metrics.py
+++ b/metrics.py
@@ -182,10 +182,13 @@ class FeatureHandler(common.FlaskHandler):
 
     else:
       properties = ramcache.get(self.CACHE_KEY)
+      logging.info('looked at cache %r and found %R', self.CACHE_KEY, properties)
       if properties is None:
+        logging.info('Loading properties from datastore')
         properties = self.__query_metrics_for_properties()
         ramcache.set(self.CACHE_KEY, properties, time=CACHE_AGE)
 
+    logging.info('before filtering: %r', properties)
     return _filter_metric_data(properties)
 
 

--- a/scripts/deploy_site.sh
+++ b/scripts/deploy_site.sh
@@ -32,4 +32,5 @@ gcloud app deploy \
   --project $appName \
   --version $deployVersion \
   --no-promote \
-  $BASEDIR/../app.yaml $BASEDIR/../notifier.yaml $BASEDIR/../dispatch.yaml
+  $BASEDIR/../app.yaml $BASEDIR/../notifier.yaml \
+  $BASEDIR/../dispatch.yaml $BASEDIR/../cron.yaml

--- a/settings.py
+++ b/settings.py
@@ -32,6 +32,7 @@ BOUNCE_ESCALATION_ADDR = 'cr-status-bounces@google.com'
 ################################################################################
 
 PROD = False
+STAGING = False
 DEBUG = True
 SEND_EMAIL = False  # Just log email
 DEV_MODE = os.environ['SERVER_SOFTWARE'].startswith('Development')
@@ -57,6 +58,7 @@ elif APP_ID == 'cr-status':
   SEND_ALL_EMAIL_TO = None  # Deliver it to the intended users
   SITE_URL = 'http://chromestatus.com/'
 elif APP_ID == 'cr-status-staging':
+  STAGING = True
   SEND_EMAIL = True
   APP_TITLE = 'Chrome Platform Status Staging'
 else:

--- a/tests/admin_test.py
+++ b/tests/admin_test.py
@@ -15,6 +15,7 @@
 from __future__ import division
 from __future__ import print_function
 
+import datetime
 import unittest
 import testing_config  # Must be imported before the module under test.
 import urllib
@@ -26,6 +27,105 @@ import werkzeug
 import admin
 import models
 import processes
+
+class FetchMetricsTest(unittest.TestCase):
+
+  @mock.patch('settings.PROD', True)
+  @mock.patch('google.appengine.api.urlfetch.fetch')
+  def test__prod(self, mock_fetch):
+    """In prod, we actually request metrics from uma-export."""
+    mock_fetch.return_value = 'mock response'
+    actual = admin._FetchMetrics('a url')
+
+    self.assertEqual('mock response', actual)
+    mock_fetch.assert_called_once_with(
+        'a url', deadline=120, follow_redirects=False)
+
+
+  @mock.patch('settings.STAGING', True)
+  @mock.patch('google.appengine.api.urlfetch.fetch')
+  def test__staging(self, mock_fetch):
+    """In prod, we actually request metrics from uma-export."""
+    mock_fetch.return_value = 'mock response'
+    actual = admin._FetchMetrics('a url')
+
+    self.assertEqual('mock response', actual)
+    mock_fetch.assert_called_once_with(
+        'a url', deadline=120, follow_redirects=False)
+
+  @mock.patch('google.appengine.api.urlfetch.fetch')
+  def test__dev(self, mock_fetch):
+    """In Dev, we cannot access uma-export."""
+    actual = admin._FetchMetrics('a url')
+
+    self.assertIsNone(actual)
+    mock_fetch.assert_not_called()
+
+
+class UmaQueryTest(unittest.TestCase):
+
+  def setUp(self):
+    self.uma_query = admin.UmaQuery(
+        query_name='usecounter.features',
+        model_class=models.FeatureObserver,
+        property_map_class=models.FeatureObserverHistogram)
+
+  def testHasCapstone__not_found(self):
+    """If there is no capstone entry, we get False."""
+    query_date = datetime.date(2021, 1, 20)
+    actual = self.uma_query._HasCapstone(query_date)
+    self.assertFalse(actual)
+
+  def testHasCapstone__found(self):
+    """If we set a capstone entry, we can find it."""
+    query_date = datetime.date(2021, 1, 20)
+    capstone = self.uma_query._SetCapstone(query_date)
+
+    try:
+      actual = self.uma_query._HasCapstone(query_date)
+    finally:
+      capstone.delete()
+
+    self.assertTrue(actual)
+
+
+class YesterdayHandlerTest(unittest.TestCase):
+
+  def setUp(self):
+    self.request_path = '/cron/metrics'
+    self.handler = admin.YesterdayHandler()
+
+  @mock.patch('admin.UmaQuery.FetchAndSaveData')
+  def test_get__normal(self, mock_FetchAndSaveData):
+    """When requested with no date, we check the previous 5 days."""
+    mock_FetchAndSaveData.return_value = 200
+    today = datetime.date(2021, 1, 20)
+
+    with admin.app.test_request_context(self.request_path):
+      actual_response = self.handler.get_template_data(today=today)
+
+    self.assertEqual('Success', actual_response)
+    expected_calls = [
+        mock.call(datetime.date(2021, 1, day))
+        for day in [19, 18, 17, 16, 15]
+        for query in admin.UMA_QUERIES]
+    mock_FetchAndSaveData.assert_has_calls(expected_calls)
+
+  @mock.patch('admin.UmaQuery.FetchAndSaveData')
+  def test_get__debugging(self, mock_FetchAndSaveData):
+    """We can request that the app get metrics for one specific day."""
+    mock_FetchAndSaveData.return_value = 200
+    today = datetime.date(2021, 1, 20)
+
+    with admin.app.test_request_context(
+        self.request_path, query_string={'date': '20210120'}):
+      actual_response = self.handler.get_template_data(today=today)
+
+    self.assertEqual('Success', actual_response)
+    expected_calls = [
+        mock.call(datetime.date(2021, 1, 20))
+        for query in admin.UMA_QUERIES]
+    mock_FetchAndSaveData.assert_has_calls(expected_calls)
 
 
 class IntentEmailPreviewHandlerTest(unittest.TestCase):


### PR DESCRIPTION
Make fetching metrics more robust based on a new understanding of how uma-export works.
Specifically, uma-export may take as long as 48 hours to produce metrics, so we want to keep trying.

In this CL:
+ Add ability to specify a date in the query string so that that we can manually fill in data for any missed dates.
 - This helps avoid the problem where running the cron uses a value of "yesterday" that does not match what was used in a recent failure.
+ When run normally, it tries each of the past 5 days rather than just yesterday
+ To avoid requesting data that it already has, bucket_id 0 is used as a "capstone" entry to indicate that all datapoints for a given day were already saved
+ Add logging to aid in any future debugging
+ Eliminate the "cookie" mode for working with metrics in a development environment because uma-export does not support that.  (In a separate uma-export CL, I have added cr-status-staging to its allowlist).
+ Run the cron job more often.  It will be a no-op if we already have all the data that we need.
+ Deploy cron.yaml every time that we deploy the app so that it is not forgotten
+ Add unit tests
