### PR TITLE
Continue requesting metrics if one is missing.

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -195,7 +195,7 @@ class YesterdayHandler(common.FlaskHandler):
     for query_day in days:
       for query in UMA_QUERIES:
         response_code = query.FetchAndSaveData(query_day)
-        if response_code != 200:
+        if response_code not in (200, 404):
           error_message = (
               'Got error %d while fetching usage data' % response_code)
           return error_message, 500


### PR DESCRIPTION
After testing in staging I realized that there was a logical error in the code.  When the first day is not yet ready, our app should continue to request previous days to fill in any data that was not previously available but might now be available.