### PR TITLE
Fix an off-by-one error in feature list left-nav.

### DIFF
--- a/static/elements/chromedash-metadata.js
+++ b/static/elements/chromedash-metadata.js
@@ -175,10 +175,10 @@ class ChromedashMetadata extends LitElement {
 
     // Consolidate channels if they're the same.
     if (this._channels.canary == this._channels.dev) {
-      this._versions.splice(5, 1);
+      this._versions.splice(4, 1);
       this._className = 'canaryisdev';
     } else if (this._channels.dev == this._channels.beta) {
-      this._versions.splice(6, 1);
+      this._versions.splice(5, 1);
       this._className = 'betaisdev';
     }
 


### PR DESCRIPTION
This fixes an error that was pointed out on chat today.

The error was introduced in
https://github.com/GoogleChrome/chromium-dashboard/pull/1097
where I removed one of the status nav elements but did not update the index constants on these lines.

Basically, four nav elements are added for dev, canary, beta, and stable.  If some of those channels as the same version number of as the neighboring channel, then the entries are merged rather than keeping both.   Since these indexes were off by one, the wrong ones were being merged.

The defect was probably not noticed sooner because the channels have distinct versions on most days.