### PR TITLE
Add links to signals docs and web dev checkmark.

### DIFF
--- a/guideforms.py
+++ b/guideforms.py
@@ -233,7 +233,10 @@ ALL_FIELDS = {
     'safari_views': forms.ChoiceField(
         required=False, label='Safari views',
         choices=models.VENDOR_VIEWS_WEBKIT.items(),
-        initial=models.NO_PUBLIC_SIGNALS),
+        initial=models.NO_PUBLIC_SIGNALS,
+        help_text=(
+            'See <a target="_blank" href="https://bit.ly/blink-signals">'
+            'https://bit.ly/blink-signals</a>')),
 
     'safari_views_link': forms.URLField(
         required=False, label='',
@@ -260,7 +263,10 @@ ALL_FIELDS = {
         required=False, label='',
         widget=forms.Textarea(
             attrs={'rows': 2, 'cols': 50, 'placeholder': 'Notes',
-                   'maxlength': 1480})),
+                   'maxlength': 1480}),
+        help_text=(
+            'See <a target="_blank" href="https://bit.ly/blink-signals">'
+            'https://bit.ly/blink-signals</a>')),
 
     'ie_views': forms.ChoiceField(
         required=False, label='Edge views',
@@ -282,7 +288,10 @@ ALL_FIELDS = {
         required=False, label='Web / Framework developer views',
         choices=models.WEB_DEV_VIEWS.items(),
         initial=models.DEV_NO_SIGNALS,
-        help_text='If unsure, default to "No signals".'),
+        help_text=(
+            'If unsure, default to "No signals". '
+            'See <a target="_blank" href="https://goo.gle/developer-signals">'
+            'https://goo.gle/developer-signals</a>')),
 
     'web_dev_views_link': forms.URLField(
         required=False, label='',

--- a/models.py
+++ b/models.py
@@ -1298,7 +1298,10 @@ class FeatureForm(forms.Form):
   safari_views = forms.ChoiceField(
       required=False, label='Safari views',
       choices=VENDOR_VIEWS_WEBKIT.items(),
-      initial=NO_PUBLIC_SIGNALS)
+      initial=NO_PUBLIC_SIGNALS,
+      help_text=(
+          'See <a target="_blank" href="https://bit.ly/blink-signals">'
+          'https://bit.ly/blink-signals</a>'))
   safari_views_link = forms.URLField(
       required=False, label='',
       widget=forms.URLInput(attrs={'placeholder': 'https://'}),
@@ -1309,7 +1312,10 @@ class FeatureForm(forms.Form):
   ff_views = forms.ChoiceField(
       required=False, label='Firefox views',
       choices=VENDOR_VIEWS_GECKO.items(),
-      initial=NO_PUBLIC_SIGNALS)
+      initial=NO_PUBLIC_SIGNALS,
+      help_text=(
+          'See <a target="_blank" href="https://bit.ly/blink-signals">'
+          'https://bit.ly/blink-signals</a>'))
   ff_views_link = forms.URLField(
       required=False, label='',
       widget=forms.URLInput(attrs={'placeholder': 'https://'}),
@@ -1332,7 +1338,10 @@ class FeatureForm(forms.Form):
       required=False, label='Web / Framework developer views',
       choices=WEB_DEV_VIEWS.items(),
       initial=DEV_NO_SIGNALS,
-      help_text='If unsure, default to "No signals".')
+      help_text=(
+          'If unsure, default to "No signals". '
+          'See <a target="_blank" href="https://goo.gle/developer-signals">'
+          'https://goo.gle/developer-signals</a>'))
 
   web_dev_views_link = forms.URLField(
       required=False, label='',

--- a/processes.py
+++ b/processes.py
@@ -105,6 +105,7 @@ BLINK_PROCESS_STAGES = [
       'Work through a TAG review and gather vendor signals.',
       ['TAG review requested',
        'Vendor signals',
+       'Web developer signals',
        'Doc links',
        'Documentation signoff',  # TODO(jrobbins): needs detector.
        'Estimated target milestone',
@@ -450,6 +451,10 @@ PROGRESS_DETECTORS = {
 
     'TAG review issues addressed':
     lambda f: review_is_done(f.tag_review_status),
+
+    'Web developer signals':
+    lambda f: bool(f.web_dev_views and
+                   f.web_dev_views != models.DEV_NO_SIGNALS),
 
     'Vendor signals':
     lambda f: bool(

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -143,7 +143,7 @@ class RedirectorTests(unittest.TestCase):
   def test_redirector(self):
     """If the user hits a redirector, they get a redirect response."""
     with test_app.test_request_context('/old_path'):
-      actual_redirect = test_app.dispatch_request()
+      actual_redirect, actual_headers = test_app.dispatch_request()
 
     self.assertEqual(302, actual_redirect.status_code)
     self.assertEqual('/new_path', actual_redirect.headers['location'])

--- a/tests/guide_test.py
+++ b/tests/guide_test.py
@@ -99,7 +99,8 @@ class ProcessOverviewTest(unittest.TestCase):
   def setUp(self):
     self.feature_1 = models.Feature(
         name='feature one', summary='sum', category=1, visibility=1,
-        standardization=1, web_dev_views=1, impl_status_chrome=1)
+        standardization=1, web_dev_views=models.DEV_NO_SIGNALS,
+        impl_status_chrome=1)
     self.feature_1.put()
 
     self.request_path = '/guide/edit/%d' % self.feature_1.key().id()

--- a/tests/processes_test.py
+++ b/tests/processes_test.py
@@ -83,7 +83,8 @@ class ProgressDetectorsTest(unittest.TestCase):
   def setUp(self):
     self.feature_1 = models.Feature(
         name='feature one', summary='sum', category=1, visibility=1,
-        standardization=1, web_dev_views=1, impl_status_chrome=1,
+        standardization=1, web_dev_views=models.DEV_NO_SIGNALS,
+        impl_status_chrome=1,
         intent_stage=models.INTENT_IMPLEMENT)
     self.feature_1.put()
 
@@ -182,6 +183,12 @@ class ProgressDetectorsTest(unittest.TestCase):
     detector = processes.PROGRESS_DETECTORS['TAG review issues addressed']
     self.assertFalse(detector(self.feature_1))
     self.feature_1.tag_review_status = models.REVIEW_ISSUES_ADDRESSED
+    self.assertTrue(detector(self.feature_1))
+
+  def test_web_dav_signals(self):
+    detector = processes.PROGRESS_DETECTORS['Web developer signals']
+    self.assertFalse(detector(self.feature_1))
+    self.feature_1.web_dev_views = models.PUBLIC_SUPPORT
     self.assertTrue(detector(self.feature_1))
 
   def test_vendor_signals(self):


### PR DESCRIPTION
This should resolve issue #1051.

In this CL:
+ Add links to field-level help for three fields (in both guide UI and old UI).
+ Add progress item for developer signals, and progress detector for it
+ Add unit test for new progress detector and avoid breaking existing tests