### PR TITLE
Fix new crbug link on feature detail page.

### DIFF
--- a/server.py
+++ b/server.py
@@ -59,6 +59,7 @@ class FeatureDetailHandler(common.FlaskHandler):
         'feature_id': f.key().id(),
         'feature_json': json.dumps(f.format_for_template()),
         'updated_display': f.updated.strftime("%Y-%m-%d"),
+        'new_crbug_url': f.new_crbug_url(),
     }
     return template_data
 

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -39,7 +39,7 @@
     </span>
   {% endif %}
   <span class="tooltip" title="File a bug against this feature">
-    <a href="{{ feature.new_crbug_url }}" class="newbug" data-tooltip target="_blank">
+    <a href="{{ new_crbug_url }}" class="newbug" data-tooltip target="_blank">
       <iron-icon icon="chromestatus:bug-report"></iron-icon>
     </a>
   </span>


### PR DESCRIPTION
Fixes #1192.

I think this defect arose because of an unclear mix of info in the python dict returned from Feature.get_feature().  It would be better to consistently do like I am doing here in server.py where the python dict for the feature has *only* info directly from the Feature DB entity, whereas other info needed for the UI is passed to the template engine separately by the handler.