### PR TITLE
Add simple spec mentor support

### DIFF
--- a/guide.py
+++ b/guide.py
@@ -314,6 +314,9 @@ class FeatureEditStage(common.FlaskHandler):
     if self.touched('api_spec'):
       feature.api_spec = self.form.get('api_spec') == 'on'
 
+    if self.touched('spec_mentors'):
+      feature.spec_mentors = self.split_emails('spec_mentors')
+
     if self.touched('security_review_status'):
       feature.security_review_status = self.parse_int('security_review_status')
 

--- a/guideforms.py
+++ b/guideforms.py
@@ -147,6 +147,16 @@ ALL_FIELDS = {
         help_text=('The spec document has details in a specification language '
                    'such as Web IDL, or there is an exsting MDN page.')),
 
+    'spec_mentors': forms.EmailField(
+        required=False, label='Spec mentor',
+        widget=forms.EmailInput(
+            attrs={'multiple': True, 'placeholder': 'email'}),
+        help_text=
+        ('Experienced <a target="_blank" '
+         'href="https://www.chromium.org/blink/spec-mentors">'
+         'spec mentors</a> are available to help you improve your '
+         'feature spec.')),
+
     'explainer_links': forms.CharField(
         label='Explainer link(s)', required=False,
         widget=forms.Textarea(
@@ -621,7 +631,7 @@ NewFeature_Incubate = define_form_class_using_shared_fields(
 
 NewFeature_Prototype = define_form_class_using_shared_fields(
     'NewFeature_Prototype',
-    ('spec_link', 'api_spec',
+    ('spec_link', 'api_spec', 'spec_mentors',
      'intent_to_implement_url', 'comments'))
   # TODO(jrobbins): advise user to request a tag review
 
@@ -778,7 +788,7 @@ Flat_Identify = define_form_class_using_shared_fields(
 Flat_Implement = define_form_class_using_shared_fields(
     'Flat_Implement',
     (# Standardization
-     'spec_link', 'api_spec', 'intent_to_implement_url'))
+     'spec_link', 'api_spec', 'spec_mentors', 'intent_to_implement_url'))
 
 
 Flat_DevTrial = define_form_class_using_shared_fields(
@@ -888,7 +898,7 @@ DISPLAY_FIELDS_IN_STAGES = {
     models.INTENT_INCUBATE: make_display_specs(
         'initial_public_proposal_url', 'explainer_links'),
     models.INTENT_IMPLEMENT: make_display_specs(
-        'spec_link', 'api_spec', 'intent_to_implement_url'),
+        'spec_link', 'api_spec', 'spec_mentors', 'intent_to_implement_url'),
     models.INTENT_EXPERIMENT: make_display_specs(
         'doc_links',
         'interop_compat_risks',

--- a/models.py
+++ b/models.py
@@ -708,6 +708,7 @@ class Feature(DictModel):
     #d['id'] = self.key().id
     d['owner'] = ', '.join(self.owner)
     d['explainer_links'] = '\r\n'.join(self.explainer_links)
+    d['spec_mentors'] = ', '.join(self.spec_mentors)
     d['doc_links'] = '\r\n'.join(self.doc_links)
     d['sample_links'] = '\r\n'.join(self.sample_links)
     d['search_tags'] = ', '.join(self.search_tags)
@@ -1030,6 +1031,7 @@ class Feature(DictModel):
   standardization = db.IntegerProperty(required=True)
   spec_link = db.LinkProperty()
   api_spec = db.BooleanProperty(default=False)
+  spec_mentors = db.ListProperty(db.Email)
   security_review_status = db.IntegerProperty(default=REVIEW_PENDING)
   privacy_review_status = db.IntegerProperty(default=REVIEW_PENDING)
 

--- a/processes.py
+++ b/processes.py
@@ -77,7 +77,7 @@ BLINK_PROCESS_STAGES = [
       'Share an explainer doc and API. '
       'Start prototyping code in a public repo.',
       ['Spec link',
-       'Spec mentor',  # TODO(jrobbins): needs detector.
+       'Spec mentor',
        'Draft API spec',
        'Intent to Prototype email',
       ],
@@ -441,10 +441,13 @@ PROGRESS_DETECTORS = {
     lambda f: f.spec_link,
 
     'Draft API spec':
-    lambda f: f.api_spec,
+    lambda f: f.spec_link,
 
     'API spec':
     lambda f: f.api_spec,
+
+    'Spec mentor':
+    lambda f: f.spec_mentors,
 
     'TAG review requested':
     lambda f: f.tag_review,

--- a/templates/admin/features/launch.html
+++ b/templates/admin/features/launch.html
@@ -35,6 +35,16 @@
 
 {% if intent %}
 <section>
+<h3>Reach out to a spec mentor</h3>
+<p style="margin-left: 1em">
+  Consider showing your draft intent email to your spec mentor or
+  sending it to spec-mentors@chromium.org.  They can help make sure
+  that your intent email is ready for review.</p>
+</section>
+{% endif %}
+
+{% if intent %}
+<section>
 <h3>Copy and send this text for your "Intent to ..." email</h3>
 {% include "blink/intent_to_implement.html" %}
 </section>


### PR DESCRIPTION
This change is in response to a recent email thread on blink-api-owners-discuss@.

In this CL:
+ Add a Feature entry field spec_mentors.  The field can hold a list of email addresses, in case we ever need multiple mentors in the future.
+ Add Guide UX fields for "Spec mentor" with help text that links to the spec mentor page.
+ Implement the 'Spec mentor' progress detector so that users can earn that checkmark
+ Add help text to the intent preview page suggesting that the user consider pre-review with spec-mentors@.