### PR TITLE
Remove links to use old feature editing UI.

### DIFF
--- a/templates/guide/edit.html
+++ b/templates/guide/edit.html
@@ -8,8 +8,8 @@
 {% block subheader %}
 <div id="subheader" style="display:block">
   <a style="float:right"
-     href="/admin/features/edit/{{ feature_id }}">Use old UI</a>
-  <span style="float:right; margin-right: 2em">Beta:
+     href="/guide/editall/{{ feature_id }}">Edit all fields</a>
+  <span style="float:right; margin-right: 2em">
   <a href="https://github.com/GoogleChrome/chromium-dashboard/issues/new?labels=Feedback&template=process-and-guide-ux-feedback.md"
      target="_blank">Process and UI feedback</a></span>
   <h2 id="breadcrumbs">

--- a/templates/guide/new.html
+++ b/templates/guide/new.html
@@ -10,9 +10,7 @@
 
 {% block subheader %}
 <div id="subheader" style="display:block">
-  <a style="float:right"
-     href="/admin/features/new">Use old UI</a>
-  <span style="float:right; margin-right: 2em">Beta:
+  <span style="float:right; margin-right: 2em">
   <a href="https://github.com/GoogleChrome/chromium-dashboard/issues/new?labels=Feedback&template=process-and-guide-ux-feedback.md"
      target="_blank">Process and UI feedback</a></span>
   <h2>Add a feature</h2>


### PR DESCRIPTION
I reviewed access logs for the old editing pages and found that only 2 users had done a POST to them in the past few months.  I emailed each user and got back a response from one of them.  He said that he just wanted a flat list of all fields, so he would be willing to use the new flat list rather than the old UI.

Rather than completely remove the "Use old UI" link from the editing page, I changed it to "Edit all fields" so that users who are looking for the "Use old UI" link will see that in the same position.  Eventually we can actually remove it to simplify the page content.