### PR TITLE
Replaced app identity lib with env vars

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -37,12 +37,15 @@ DEV_MODE = os.environ['SERVER_SOFTWARE'].startswith('Development')
 UNIT_TEST_MODE = os.environ['SERVER_SOFTWARE'].startswith('test')
 
 #setting GOOGLE_CLOUD_PROJECT manually in dev mode
-APP_ID = os.environ.get('GOOGLE_CLOUD_PROJECT', 'dev') if DEV_MODE else os.environ['GOOGLE_CLOUD_PROJECT']
+if DEV_MODE or UNIT_TEST_MODE:
+  APP_ID = os.environ.get('GOOGLE_CLOUD_PROJECT', 'dev')  
+else: 
+  APP_ID = os.environ['GOOGLE_CLOUD_PROJECT']
 
 SITE_URL = 'http://%s.appspot.com/' % APP_ID
 CLOUD_TASKS_REGION = 'us-central1'
 
-if UNIT_TEST_MODE == 'testbed-test':
+if UNIT_TEST_MODE:
   APP_TITLE = 'Local testing'
   SITE_URL = 'http://127.0.0.1:8888/'
 elif DEV_MODE:

--- a/settings.py
+++ b/settings.py
@@ -4,8 +4,6 @@ from __future__ import print_function
 import logging
 import os
 
-from google.appengine.api import app_identity
-
 
 #Hack to get custom tags working django 1.3 + python27.
 INSTALLED_APPS = (
@@ -39,7 +37,7 @@ DEV_MODE = os.environ['SERVER_SOFTWARE'].startswith('Development')
 UNIT_TEST_MODE = os.environ['SERVER_SOFTWARE'].startswith('test')
 
 
-APP_ID = app_identity.get_application_id()
+APP_ID = os.environ['APPLICATION_ID']
 SITE_URL = 'http://%s.appspot.com/' % APP_ID
 CLOUD_TASKS_REGION = 'us-central1'
 

--- a/settings.py
+++ b/settings.py
@@ -36,12 +36,13 @@ SEND_EMAIL = False  # Just log email
 DEV_MODE = os.environ['SERVER_SOFTWARE'].startswith('Development')
 UNIT_TEST_MODE = os.environ['SERVER_SOFTWARE'].startswith('test')
 
+#setting GOOGLE_CLOUD_PROJECT manually in dev mode
+APP_ID = os.environ.get('GOOGLE_CLOUD_PROJECT', 'dev') if DEV_MODE else os.environ['GOOGLE_CLOUD_PROJECT']
 
-APP_ID = os.environ['APPLICATION_ID']
 SITE_URL = 'http://%s.appspot.com/' % APP_ID
 CLOUD_TASKS_REGION = 'us-central1'
 
-if APP_ID == 'testbed-test':
+if UNIT_TEST_MODE == 'testbed-test':
   APP_TITLE = 'Local testing'
   SITE_URL = 'http://127.0.0.1:8888/'
 elif DEV_MODE:

--- a/static/elements/chromedash-metadata.js
+++ b/static/elements/chromedash-metadata.js
@@ -154,7 +154,6 @@ class ChromedashMetadata extends LitElement {
 
   _processResponse(response) {
     // TODO(ericbidelman): Share this data across instances.
-    console.log(response);
     const windowsVersions = response[0];
     for (let i = 0, el; el = windowsVersions.versions[i]; ++i) {
       // Include previous version if current is foobar'd.


### PR DESCRIPTION
This PR is corresponding to the issue #1073 (created by @jrobbins)

- Removed the import of app identity library, thereby, reducing dependence on GAE SDK for smooth transition to python3 later on.
- Used the value of key 'APPLICATION_ID' from os.environ as the new APP_ID