### PR TITLE
Fixed the footer to the bottom for easy accessibility

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -195,7 +195,11 @@ header {
 
 footer {
   background: var(--footer-background);
+  background-color: #fff;
   box-shadow: 0 -2px 5px var(--shadow-color);
+  width: 100%;
+  position: fixed;
+  bottom: 0;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
Merging this will close #1096 

Since the features list isn't paginated yet, one had to scroll to the bottom to reach the footer links. To solve this I have fixed the position of the footer to the bottom of the viewport. This can be reverted back once we are done paginating the features list.

- **Earlier**

> ![Screenshot from 2021-03-17 21-25-18](https://user-images.githubusercontent.com/59053662/111498846-578ae100-8768-11eb-98f4-4938aece6513.png)

- **Now** 


> ![Screenshot from 2021-03-17 21-24-35](https://user-images.githubusercontent.com/59053662/111498892-65d8fd00-8768-11eb-8ec2-5e41a84fa082.png)

