### PR TITLE
Hide components by default on the schedule page.

### DIFF
--- a/static/elements/chromedash-schedule.js
+++ b/static/elements/chromedash-schedule.js
@@ -44,8 +44,9 @@ class ChromedashSchedule extends LitElement {
 
   static get properties() {
     return {
-      channels: {attribute: false}, // Assigned in schedule.js, value from Django
-      showBlink: {attribute: false}, // Edited in schedule.js
+      // Assigned in schedule-apge.js, value from Django
+      channels: {attribute: false},
+      showBlink: {attribute: false}, // Set by code in schedule-page.js
       signedin: {type: Boolean},
       loginUrl: {type: String},
       starredFeatures: {attribute: false},

--- a/static/elements/chromedash-schedule.js
+++ b/static/elements/chromedash-schedule.js
@@ -45,7 +45,7 @@ class ChromedashSchedule extends LitElement {
   static get properties() {
     return {
       channels: {attribute: false}, // Assigned in schedule.js, value from Django
-      hideBlink: {attribute: false}, // Edited in schedule.js
+      showBlink: {attribute: false}, // Edited in schedule.js
       signedin: {type: Boolean},
       loginUrl: {type: String},
       starredFeatures: {attribute: false},
@@ -114,7 +114,7 @@ class ChromedashSchedule extends LitElement {
     }
     return html`
       ${['stable', 'beta', 'dev'].map((type) => html`
-        <section class="release ${this.hideBlink ? 'no-components' : nothing}">
+        <section class="release ${this.showBlink ? nothing : 'no-components'}">
           <div class="layout vertical center">
             <h1 class="channel_label">${TEMPLATE_CONTENT[type].channelLabel}</h1>
             <h1 class="chrome_version layout horizontal center ${TEMPLATE_CONTENT[type].h1Class}">

--- a/static/js-src/schedule-page.js
+++ b/static/js-src/schedule-page.js
@@ -3,9 +3,9 @@ const url = location.hostname == 'localhost' ?
   'https://www.chromestatus.com/features.json' : '/features.json';
 const featuresPromise = fetch(url).then((res) => res.json());
 
-document.querySelector('.hide-blink-checkbox').addEventListener('change', e => {
+document.querySelector('.show-blink-checkbox').addEventListener('change', e => {
   e.stopPropagation();
-  document.querySelector('chromedash-schedule').hideBlink = e.target.checked;
+  document.querySelector('chromedash-schedule').showBlink = e.target.checked;
 });
 
 const header = document.querySelector('app-header-layout app-header');

--- a/static/sass/elements/chromedash-schedule.scss
+++ b/static/sass/elements/chromedash-schedule.scss
@@ -121,19 +121,11 @@ iron-icon {
     display: flex;
     justify-content: space-between;
 
-    &::before {
-      counter-increment: featurecount;
-      content: counter(featurecount) ".";
-      position: absolute;
-      color: $gray-2;
-    }
-
     .icon_row {
       flex-shrink: 0;
     }
 
     > :first-child {
-      margin-left: $content-padding + 4px;
       overflow: hidden;
       text-overflow: ellipsis;
     }

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -14,7 +14,7 @@
     </div>
     <!-- <paper-toggle-button> doesn't working here. Related links:
       https://github.com/PolymerElements/paper-toggle-button/pull/132 -->
-    <label><input type="checkbox" class="hide-blink-checkbox">Hide Blink components</label>
+    <label><input type="checkbox" class="show-blink-checkbox">Show Blink components</label>
   </div>
 {% endblock %}
 


### PR DESCRIPTION
This is a baby step toward the UI changes I presented to the team recently.

In this CL:
+ Change the "Hide blink components" checkbox to "Show blink components" and reverse the logic.
+ Streamline the styling by removing the list item numbering.
