### PR TITLE
Make test output quiet.

### DIFF
--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -91,11 +91,13 @@ class ConstHandlerTests(unittest.TestCase):
     self.assertEqual(200, actual_status)
     self.assertIn('Access-Control-Allow-Origin', actual_headers)
 
-  def test_bad_template_path(self):
+  @mock.patch('logging.error')
+  def test_bad_template_path(self, mock_err):
     """We can run a template that requires no handler logic."""
     with test_app.test_request_context('/messed_up_template'):
       with self.assertRaises(werkzeug.exceptions.InternalServerError):
         test_app.dispatch_request()
+    self.assertEqual(1, len(mock_err.mock_calls))
 
   def test_json(self):
     """We can return constant JSON."""

--- a/framework/utils_test.py
+++ b/framework/utils_test.py
@@ -47,8 +47,11 @@ class CommonFunctionTests(unittest.TestCase):
         '/feature/123',
         utils.format_feature_url(123))
 
+  @mock.patch('logging.error')
+  @mock.patch('logging.warning')
   @mock.patch('time.sleep')  # Run test full speed.
-  def testRetryDecorator_ExceedFailures(self, mock_sleep):
+  def testRetryDecorator_ExceedFailures(
+      self, mock_sleep, mock_warn, mock_err):
     class Tracker(object):
       func_called = 0
     tracker = Tracker()
@@ -63,9 +66,12 @@ class CommonFunctionTests(unittest.TestCase):
       testFunc(tracker)
     self.assertEquals(3, tracker.func_called)
     self.assertEqual(2, len(mock_sleep.mock_calls))
+    self.assertEqual(2, len(mock_warn.mock_calls))
+    self.assertEqual(1, len(mock_err.mock_calls))
 
+  @mock.patch('logging.warning')
   @mock.patch('time.sleep')  # Run test full speed.
-  def testRetryDecorator_EventuallySucceed(self, mock_sleep):
+  def testRetryDecorator_EventuallySucceed(self, mock_sleep, mock_warn):
     class Tracker(object):
       func_called = 0
     tracker = Tracker()
@@ -80,6 +86,7 @@ class CommonFunctionTests(unittest.TestCase):
     testFunc(tracker)
     self.assertEquals(2, tracker.func_called)
     self.assertEqual(1, len(mock_sleep.mock_calls))
+    self.assertEqual(1, len(mock_warn.mock_calls))
 
   def test_strip_trailing_slash(self):
     handlerInstance = MockHandler('/request/path')

--- a/tests/admin_test.py
+++ b/tests/admin_test.py
@@ -50,7 +50,7 @@ class FetchMetricsTest(unittest.TestCase):
     actual = admin._FetchMetrics('a url')
 
     self.assertEqual('mock response', actual)
-    mock_fetch.assert_called_once_with('GET', 
+    mock_fetch.assert_called_once_with('GET',
         'a url', timeout=120, allow_redirects=False)
 
   @mock.patch('requests.request')
@@ -294,8 +294,9 @@ class BaseFeatureHandlerTest(unittest.TestCase):
     """Trying to edit a feature that does not exist redirects."""
     testing_config.sign_in('user1@google.com', 123567890)
     bad_feature_id = self.feature_1.key().id() + 1
+    params = { "intent_stage": "1" }
     path = '/admin/features/edit/%d' % bad_feature_id
-    with admin.app.test_request_context(path):
+    with admin.app.test_request_context(path, data=params):
       actual_response = self.handler.process_post_data(feature_id=bad_feature_id)
     self.assertEqual('302 FOUND', actual_response.status)
 
@@ -307,6 +308,7 @@ class BaseFeatureHandlerTest(unittest.TestCase):
       "category": "1",
       "name": "name",
       "summary": "sum",
+      "intent_stage": "1",
       "impl_status_chrome": "1",
       "visibility": "1",
       "ff_views": "1",


### PR DESCRIPTION
The logging of certain errors is good in case they happen in production, but I want to eliminate them from normal unit test runs because the noise makes it harder to see actual test failures.