### PR TITLE
Fixes chromedash-feature-collapse 

### DIFF
--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -140,10 +140,14 @@ class ChromedashFeature extends LitElement {
   }
 
   _togglePanelExpansion(e) {
-    // Don't toggle panel if tooltip or link is being clicked.
+    // Don't toggle panel if tooltip or link is being clicked
+    // or if text is being selected.
     const target = e.currentTarget;
+    const textSelection = window.getSelection();
+
     if (target.classList.contains('tooltip') || 'tooltip' in target.dataset ||
-        target.tagName == 'A' || target.tagName == 'CHROMEDASH-MULTI-LINKS') {
+        target.tagName == 'A' || target.tagName == 'CHROMEDASH-MULTI-LINKS' ||
+        e.path[0].nodeName === 'A' || textSelection.type === 'RANGE' || textSelection.toString()) {
       return;
     }
 


### PR DESCRIPTION
The old conditions to check whether the clicked element is a link weren't working because _e.currentTarget_ wasn't returning the required element. 

I used the _nodeName_ property to determine if it's a link and the _type_ property of _window.getSelection()_ object if text has been selected. Some browsers don't return the _type_ property, so I added another condition for that.

Fixes #636
@jrobbins 