### PR TITLE
Move the deprecated experiment timeline field lower.

### DIFF
--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -379,7 +379,7 @@ ALL_FIELDS = {
             'disabled': 'disabled'}),
         help_text=('When does the experiment start and expire? '
                    'Deprecated: '
-                   'Please use the following numeric fields instead.')),
+                   'Please use the numeric fields above instead.')),
 
     # TODO(jrobbins and jmedley): Refine help text.
     'ot_milestone_desktop_start': forms.IntegerField(
@@ -706,9 +706,10 @@ NewFeature_OriginTrial = define_form_class_using_shared_fields(
 
 ImplStatus_OriginTrial = define_form_class_using_shared_fields(
     'ImplStatus_OriginTrial',
-    ('experiment_timeline',  # deprecated
-     'ot_milestone_desktop_start', 'ot_milestone_desktop_end',
-     'ot_milestone_android_start', 'ot_milestone_android_end'))
+    ('ot_milestone_desktop_start', 'ot_milestone_desktop_end',
+     'ot_milestone_android_start', 'ot_milestone_android_end',
+     'experiment_timeline',  # deprecated
+     ))
 
 
 Most_PrepareToShip = define_form_class_using_shared_fields(
@@ -761,7 +762,10 @@ Deprecation_PrepareToShip = define_form_class_using_shared_fields(
 # Note: Even though this is similar to another form, it is likely to change.
 Deprecation_DeprecationTrial = define_form_class_using_shared_fields(
     'Deprecation_DeprecationTrial',
-    ('experiment_goals', 'experiment_timeline', 'experiment_risks',
+    ('experiment_goals', 'experiment_risks',
+     'ot_milestone_desktop_start', 'ot_milestone_desktop_end',
+     'ot_milestone_android_start', 'ot_milestone_android_end',
+     'experiment_timeline',  # deprecated
      'experiment_extension_reason', 'ongoing_constraints',
      'intent_to_experiment_url',
      'i2e_lgtms=r4dt_lgtms',  # form field name matches underlying DB field.
@@ -838,9 +842,10 @@ Flat_OriginTrial = define_form_class_using_shared_fields(
      'origin_trial_feedback_url',
 
      # Implementation
-     'experiment_timeline',
      'ot_milestone_desktop_start', 'ot_milestone_desktop_end',
-     'ot_milestone_android_start', 'ot_milestone_android_end'))
+     'ot_milestone_android_start', 'ot_milestone_android_end',
+     'experiment_timeline',  # deprecated
+    ))
 
 
 Flat_PrepareToShip = define_form_class_using_shared_fields(
@@ -937,9 +942,9 @@ DISPLAY_FIELDS_IN_STAGES = {
         'experiment_extension_reason', 'ongoing_constraints',
         'origin_trial_feedback_url', 'intent_to_experiment_url',
         'i2e_lgtms', 'r4dt_lgtms',
-        'experiment_timeline',  # Deprecated
         'ot_milestone_desktop_start', 'ot_milestone_desktop_end',
         'ot_milestone_android_start', 'ot_milestone_android_end',
+        'experiment_timeline',  # Deprecated
         ),
     models.INTENT_SHIP: make_display_specs(
         'shipped_milestone', 'shipped_android_milestone',


### PR DESCRIPTION
This addresses the change you requested in email today.

In this PR:
+ Moves experiment_timeline lower in the field order
+ Changes the help text from "following" to "above"
+ Adds specific milestone fields to deprecation trials, they were missing before
+ Makes the same order change for the flat form and the feature details page