### PR TITLE
Add flag_name to intent emails.

### DIFF
--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -168,6 +168,9 @@
   <p class="preformatted">{{feature.wpt_descr|urlize}}</p>
 {% endif %}
 
+<br><br><h4>Flag name</h4>
+{{feature.flag_name}}
+
 {% if feature.bug_url %}
   <br><br><h4>Tracking bug</h4>
   <a href="{{feature.bug_url}}">{{feature.bug_url}}</a>


### PR DESCRIPTION
I think this addresses issue #1209.

This just always shows the flag name in every intent email.  If it has not been filled in yet, it will just be a blank space in the intent email.

I let it appear in all intents because I am thinking that it might be useful in all intent emails, even for later stages.  Let me know if you think it is worth focusing these emails more.