### PR TITLE
Change some process stages and forms to better match launching-features doc

### DIFF
--- a/internals/processes.py
+++ b/internals/processes.py
@@ -161,22 +161,15 @@ BLINK_LAUNCH_PROCESS = Process(
 
 BLINK_FAST_TRACK_STAGES = [
   ProcessStage(
-      'Identify feature',
-      'Create an initial WebStatus feature entry to implement part '
-      'of an existing specification or combinaton of specifications.',
+      'Start prototyping',
+      'Write up use cases and scenarios, start coding as a '
+      'runtime enabled feature.',
       ['Spec link',
        'API spec',
-      ],
-      [],
-      models.INTENT_NONE, models.INTENT_INCUBATE),
-
-  ProcessStage(
-      'Implement',
-      'Check code into Chromium under a flag.',
-      ['Code in Chromium',
-      ],
-      [],
-      models.INTENT_INCUBATE, models.INTENT_IMPLEMENT),
+       'Code in Chromium',
+       ],
+      [('Draft Intent to Prototype email', INTENT_EMAIL_URL)],
+      models.INTENT_NONE, models.INTENT_IMPLEMENT),
 
   ProcessStage(
       'Dev trials and iterate on implementation',
@@ -238,25 +231,17 @@ BLINK_FAST_TRACK_PROCESS = Process(
 
 PSA_ONLY_STAGES = [
   ProcessStage(
-      'Identify feature',
-      'Create an initial WebStatus feature entry for a web developer '
-      'facing change to existing code.',
-      ['Spec links',
-      ],
-      [],
-      models.INTENT_NONE, models.INTENT_INCUBATE),
-
-  ProcessStage(
       'Implement',
       'Check code into Chromium under a flag.',
-      ['Code in Chromium',
+      ['Spec links',
+       'Code in Chromium',
       ],
       [],
-      models.INTENT_INCUBATE, models.INTENT_IMPLEMENT),
+      models.INTENT_NONE, models.INTENT_IMPLEMENT),
 
   ProcessStage(
       'Dev trials and iterate on implementation',
-      'Publicize availablity for developers to try. '
+      '(Optional) Publicize availablity for developers to try. '
       'Act on feedback from partners and web developers.',
       ['Ready for Trial email',
        'Vendor signals',
@@ -304,7 +289,7 @@ DEPRECATION_STAGES = [
        'Code in Chromium',
       ],
       [('Draft Intent to Deprecate and Remove email', INTENT_EMAIL_URL)],
-      models.INTENT_NONE, models.INTENT_INCUBATE),
+      models.INTENT_NONE, models.INTENT_IMPLEMENT),
 
   # TODO(cwilso): Work out additional steps for flag defaulting to disabled.
   ProcessStage(
@@ -315,7 +300,7 @@ DEPRECATION_STAGES = [
        'Estimated target milestone',
       ],
       [('Draft Ready for Trial email', INTENT_EMAIL_URL)],
-      models.INTENT_INCUBATE, models.INTENT_EXPERIMENT),
+      models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
   ProcessStage(
       'Prepare for Deprecation Trial',

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -53,8 +53,7 @@ STAGE_FORMS = {
         },
 
     models.FEATURE_TYPE_EXISTING_ID: {
-        models.INTENT_INCUBATE: guideforms.Any_Identify,
-        models.INTENT_IMPLEMENT: guideforms.Any_Implement,
+        models.INTENT_IMPLEMENT: guideforms.Existing_Prototype,
         models.INTENT_EXPERIMENT: guideforms.Any_DevTrial,
         models.INTENT_EXTEND_TRIAL: guideforms.Existing_OriginTrial,
         models.INTENT_SHIP: guideforms.Most_PrepareToShip,
@@ -62,16 +61,14 @@ STAGE_FORMS = {
         },
 
     models.FEATURE_TYPE_CODE_CHANGE_ID: {
-        models.INTENT_INCUBATE: guideforms.Any_Identify,
-        models.INTENT_IMPLEMENT: guideforms.Any_Implement,
+        models.INTENT_IMPLEMENT: guideforms.PSA_Implement,
         models.INTENT_EXPERIMENT: guideforms.Any_DevTrial,
         models.INTENT_SHIP: guideforms.PSA_PrepareToShip,
         models.INTENT_SHIPPED: guideforms.Any_Ship,
         },
 
     models.FEATURE_TYPE_DEPRECATION_ID: {
-        models.INTENT_INCUBATE: guideforms.Any_Identify,
-        models.INTENT_IMPLEMENT: guideforms.Any_Implement,
+        models.INTENT_IMPLEMENT: guideforms.Deprecation_Implement,
         models.INTENT_EXPERIMENT: guideforms.Any_DevTrial,
         models.INTENT_EXTEND_TRIAL: guideforms.Deprecation_DeprecationTrial,
         models.INTENT_SHIP: guideforms.Deprecation_PrepareToShip,

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -715,15 +715,8 @@ ImplStatus_OriginTrial = define_form_class_using_shared_fields(
 Most_PrepareToShip = define_form_class_using_shared_fields(
     'Most_PrepareToShip',
     ('tag_review', 'tag_review_status',
-     'intent_to_implement_url', 'origin_trial_feedback_url',
+     'origin_trial_feedback_url',
      'launch_bug_url', 'intent_to_ship_url', 'i2s_lgtms', 'comments'))
-
-
-PSA_PrepareToShip = define_form_class_using_shared_fields(
-    'PSA_PrepareToShip',
-    ('tag_review',
-     'intent_to_implement_url', 'origin_trial_feedback_url',
-     'launch_bug_url', 'intent_to_ship_url', 'comments'))
 
 
 Any_Ship = define_form_class_using_shared_fields(
@@ -731,16 +724,11 @@ Any_Ship = define_form_class_using_shared_fields(
     ('launch_bug_url', 'comments'))
 
 
-Any_Identify = define_form_class_using_shared_fields(
-    'Any_Identify',
+Existing_Prototype = define_form_class_using_shared_fields(
+    'Most_Prototype',
     ('owner', 'blink_components', 'motivation', 'explainer_links',
-     'spec_link', 'api_spec', 'bug_url', 'launch_bug_url', 'comments'))
-
-
-Any_Implement = define_form_class_using_shared_fields(
-    'Any_Implement',
-    ('spec_link', 'comments'))
-  # TODO(jrobbins): advise user to request a tag review
+     'spec_link', 'api_spec', 'bug_url', 'launch_bug_url',
+     'intent_to_implement_url', 'comments'))
 
 
 Existing_OriginTrial = define_form_class_using_shared_fields(
@@ -750,6 +738,23 @@ Existing_OriginTrial = define_form_class_using_shared_fields(
      'intent_to_experiment_url', 'i2e_lgtms',
      'origin_trial_feedback_url', 'comments'))
 
+
+PSA_Implement = define_form_class_using_shared_fields(
+    'Any_Implement',
+    ('spec_link', 'comments'))
+  # TODO(jrobbins): advise user to request a tag review
+
+
+PSA_PrepareToShip = define_form_class_using_shared_fields(
+    'PSA_PrepareToShip',
+    ('tag_review',
+     'intent_to_implement_url', 'origin_trial_feedback_url',
+     'launch_bug_url', 'intent_to_ship_url', 'comments'))
+
+
+Deprecation_Implement = define_form_class_using_shared_fields(
+    'Deprecation_Implement',
+    ('motivation', 'spec_link', 'comments'))
 
 # Note: Even though this is similar to another form, it is likely to change.
 Deprecation_PrepareToShip = define_form_class_using_shared_fields(

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -725,7 +725,7 @@ Any_Ship = define_form_class_using_shared_fields(
 
 
 Existing_Prototype = define_form_class_using_shared_fields(
-    'Most_Prototype',
+    'Existing_Prototype',
     ('owner', 'blink_components', 'motivation', 'explainer_links',
      'spec_link', 'api_spec', 'bug_url', 'launch_bug_url',
      'intent_to_implement_url', 'comments'))


### PR DESCRIPTION
This PR partially addresses #1111 and the meeting that we had yesterday to go over my four emails with numbered points about launching-features.

In this PR:
+ For existing features: 
     - merge old "Identify" and "Implement" stages into a "Start prototyping" stage.
     - Add a link to generate an "Intent to prototype" email preview
     - Move the field for intent_to_implement_url from "Prepare to ship" to the "Start prototyping" stage
+ For code changes: 
     - merge old "Identify" and "Implement" stages into just an "Implement" stage.
+ For code changes: 
     - mark dev trials as "(Optional)"
+ For deprecations: 
     - stages are labeled the same so far, but first stage uses value INTENT_IMPLEMENT instead of INTENT_INCUBATE.
     - instead of the Any_Identify form that had a bunch of fields, use a new Deprecation_Implement form that has just motivation and spec link.
+ Reorder a couple guideforms.py items to match the order that corresponding parts are declared in processes.py.


 