### PR TITLE
Bugfix #1242 - Proposed, In development, and Deprecated features are not showing on mobile view

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -365,7 +365,7 @@ footer {
 
 
   #drawer-column {
-    display: none;
+    display: block;
   }
   #content-column {
     padding-left: var(--content-padding-half);


### PR DESCRIPTION
## What?
This addresses issue #1242 and made changes in CSS (main.css).

## Why?
```
@media only screen and (max-width: 700px)

#drawer-column {
    display: none;
}
```

the display with (max-width:700) is set to none that's why it disappear in mobile mode. We can create a dropdown taking the 
```
id="drawer-column" max-width:700px with display: block; 
```

## How?
Edited the main.css file and made drawer-column to display: block which was previously set to none.
