### PR TITLE
Fix module name in notifier config file.

### DIFF
--- a/notifier.yaml
+++ b/notifier.yaml
@@ -5,7 +5,7 @@ service: notifier
 
 handlers:
 - url: /tasks/.*
-  script: notifier.app
+  script: internals.notifier.app
   # Header checks prevent raw access to this handler.  Tasks have headers.
 
 includes:


### PR DESCRIPTION
AppEngine gave an error for a very old task that had been stuck in our task queue since Dec 2020.  Surprisingly, recently created tasks seem to work with either the old or new version of this config file, and I verified that they are being routed through the correct GAE service.  Even if both work, this seems more correct.