### PR TITLE
Refactor code for accessing JSON parameters.

### DIFF
--- a/api/approvals_api.py
+++ b/api/approvals_api.py
@@ -40,35 +40,17 @@ class ApprovalsAPI(basehandlers.APIHandler):
 
   def do_post(self):
     """Set an approval value for the specified feature."""
-    json_body = self.request.get_json(force=True)
-    feature_id = json_body.get('feature_id')
-    field_id = json_body.get('field_id')
-    new_state = json_body.get('state')
-
-    if not approval_defs.is_valid_field_id(field_id):
-      logging.info('Invalid field_id: %r', field_id)
-      self.abort(400)
-
-    if not models.Approval.is_valid_state(new_state):
-      logging.info('Invalid state: %r', new_state)
-      self.abort(400)
-
-    if type(feature_id) != int:
-      logging.info('Invalid feature_id: %r', feature_id)
-      self.abort(400)
-    feature = models.Feature.get_feature(feature_id)
-    if not feature:
-      logging.info('Feature not found: %r', feature_id)
-      self.abort(404)
-
-
-    user = self.get_current_user()
+    field_id = self.get_int_param('fieldId')
+    new_state = self.get_int_param(
+        'state', validator= models.Approval.is_valid_state)
+    feature = self.get_specified_feature()
+    user = self.get_current_user(required=True)
 
     approvers = approval_defs.get_approvers(field_id)
     if not permissions.can_approve_feature(user, feature, approvers):
-      logging.info('User is not an approver')
-      self.abort(403)
+      self.abort(403, msg='User is not an approver')
 
-    models.Approval.set_approval(feature_id, field_id, new_state, user.email())
+    models.Approval.set_approval(
+        feature.key().id(), field_id, new_state, user.email())
     # Callers don't use the JSON response for this API call.
     return {'message': 'Done'}

--- a/api/approvals_api_test.py
+++ b/api/approvals_api_test.py
@@ -119,42 +119,42 @@ class ApprovalsAPITest(unittest.TestCase):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_post()
 
-    params = {'feature_id': 'not an int'}
+    params = {'featureId': 'not an int'}
     with register.app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_post()
 
   def test_post__bad_field_id(self):
     """Handler rejects requests that don't specify a field ID correctly."""
-    params = {'feature_id': self.feature_id}
+    params = {'featureId': self.feature_id}
     with register.app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_post()
 
-    params = {'feature_id': self.feature_id, 'field_id': 'not an int'}
+    params = {'featureId': self.feature_id, 'fieldId': 'not an int'}
     with register.app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_post()
 
-    params = {'feature_id': self.feature_id, 'field_id': 999}
+    params = {'featureId': self.feature_id, 'fieldId': 999}
     with register.app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_post()
 
   def test_post__bad_state(self):
     """Handler rejects requests that don't specify a state correctly."""
-    params = {'feature_id': self.feature_id, 'field_id': 1}
+    params = {'featureId': self.feature_id, 'fieldId': 1}
     with register.app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_post()
 
-    params = {'feature_id': self.feature_id, 'field_id': 1,
+    params = {'featureId': self.feature_id, 'fieldId': 1,
               'state': 'not an int'}
     with register.app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_post()
 
-    params = {'feature_id': self.feature_id, 'field_id': 1,
+    params = {'featureId': self.feature_id, 'fieldId': 1,
               'state': 999}
     with register.app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
@@ -162,7 +162,7 @@ class ApprovalsAPITest(unittest.TestCase):
 
   def test_post__feature_not_found(self):
     """Handler rejects requests that don't match an existing feature."""
-    params = {'feature_id': 12345, 'field_id': 1,
+    params = {'featureId': 12345, 'fieldId': 1,
               'state': models.Approval.NEED_INFO }
     with register.app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.NotFound):
@@ -170,7 +170,7 @@ class ApprovalsAPITest(unittest.TestCase):
 
   def test_post__forbidden(self):
     """Handler rejects requests from anon users and non-approvers."""
-    params = {'feature_id': self.feature_id, 'field_id': 1,
+    params = {'featureId': self.feature_id, 'fieldId': 1,
               'state': models.Approval.NEED_INFO}
 
     testing_config.sign_out()
@@ -193,7 +193,7 @@ class ApprovalsAPITest(unittest.TestCase):
     """Handler adds approval when one did not exist before."""
     mock_get_approvers.return_value = ['owner1@example.com']
     testing_config.sign_in('owner1@example.com', 123567890)
-    params = {'feature_id': self.feature_id, 'field_id': 1,
+    params = {'featureId': self.feature_id, 'fieldId': 1,
               'state': models.Approval.NEED_INFO}
     with register.app.test_request_context(self.request_path, json=params):
       actual = self.handler.do_post()

--- a/api/cues_api.py
+++ b/api/cues_api.py
@@ -36,16 +36,8 @@ class CuesAPI(basehandlers.APIHandler):
 
   def do_post(self):
     """Dismisses a cue card for the signed in user."""
-    json_body = self.request.get_json()
-    cue = json_body.get('cue')
-    if cue not in ALLOWED_CUES:
-      logging.info('Unexpected cue: %r', cue)
-      self.abort(400)
-
-    user = self.get_current_user()
-    if not user:
-      logging.info('User must be signed in before dismissing cues')
-      self.abort(400)
+    cue = self.get_param('cue', allowed=ALLOWED_CUES)
+    user = self.get_current_user(required=True)
 
     models.UserPref.dismiss_cue(cue)
     # Callers don't use the JSON response for this API call.

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -36,15 +36,7 @@ class FeaturesAPI(basehandlers.APIHandler):
   def do_delete(self, feature_id):
     """Delete the specified feature."""
     # TODO(jrobbins): implement undelete UI.  For now, use cloud console.
-    if not feature_id:
-      logging.info('feature_id not specified')
-      self.abort(400)
-
-    feature = models.Feature.get_by_id(feature_id)
-    if not feature:
-      logging.info('feature %r not found' % feature_id)
-      self.abort(404)
-
+    feature = self.get_specified_feature(feature_id=feature_id)
     feature.deleted = True
     feature.put()
     ramcache.flush_all()

--- a/api/stars_api.py
+++ b/api/stars_api.py
@@ -43,24 +43,10 @@ class StarsAPI(basehandlers.APIHandler):
 
   def do_post(self):
     """Set or clear a star on the specified feature."""
-    json_body = self.request.get_json(force=True)
-    feature_id = json_body.get('featureId')
-    starred = json_body.get('starred', True)
+    feature = self.get_specified_feature()
+    starred = self.get_bool_param('starred', default=True)
+    user = self.get_current_user(required=True)
 
-    if type(feature_id) != int:
-      logging.info('Invalid feature_id: %r', feature_id)
-      self.abort(400)
-
-    feature = models.Feature.get_feature(feature_id)
-    if not feature:
-      logging.info('feature not found: %r', feature_id)
-      self.abort(404)
-
-    user = self.get_current_user()
-    if not user:
-      logging.info('User must be signed in before starring')
-      self.abort(400)
-
-    notifier.FeatureStar.set_star(user.email(), feature_id, starred)
+    notifier.FeatureStar.set_star(user.email(), feature.key().id(), starred)
     # Callers don't use the JSON response for this API call.
     return {'message': 'Done'}

--- a/api/stars_api_test.py
+++ b/api/stars_api_test.py
@@ -95,7 +95,7 @@ class StarsAPITest(unittest.TestCase):
     params = {"featureId": feature_id}
     testing_config.sign_out()
     with register.app.test_request_context(self.request_path, json=params):
-      with self.assertRaises(werkzeug.exceptions.BadRequest):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.do_post()
 
   def test_post__duplicate(self):

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -30,6 +30,193 @@ from internals import models
 import settings
 
 
+
+class BaseHandlertests(unittest.TestCase):
+
+  def setUp(self):
+    self.handler = basehandlers.BaseHandler()
+
+  @mock.patch('flask.request', 'fake request')
+  def test_request(self):
+    """We can get the flask request."""
+    actual = self.handler.request
+    self.assertEqual('fake request', actual)
+
+  @mock.patch('flask.abort')
+  def test_abort__no_msg(self, mock_abort):
+    """We can abort request handling."""
+    self.handler.abort(400)
+    mock_abort.assert_called_once_with(400)
+
+  @mock.patch('logging.info')
+  @mock.patch('flask.abort')
+  def test_abort__with_msg(self, mock_abort, mock_info):
+    """We can abort request handling."""
+    self.handler.abort(400, msg='You messed up')
+    mock_abort.assert_called_once_with(400, 'You messed up')
+    mock_info.assert_called_once()
+
+  @mock.patch('logging.error')
+  @mock.patch('flask.abort')
+  def test_abort__with_500_msg(self, mock_abort, mock_error):
+    """We can abort request handling."""
+    self.handler.abort(500, msg='We messed up')
+    mock_abort.assert_called_once_with(500, 'We messed up')
+    mock_error.assert_called_once()
+
+  @mock.patch('flask.redirect')
+  def test_redirect(self, mock_redirect):
+    """We can return a redirect."""
+    mock_redirect.return_value = 'fake response'
+    actual = self.handler.redirect('test url')
+    self.assertEqual('fake response', actual)
+    mock_redirect.assert_called_once_with('test url')
+
+  def test_get_current_user__anon(self):
+    """If the user is signed out, we get back None."""
+    testing_config.sign_out()
+    actual = self.handler.get_current_user()
+    self.assertIsNone(actual)
+
+  @mock.patch('framework.basehandlers.BaseHandler.abort')
+  def test_get_current_user__required_but_anon(self, mock_abort):
+    """If the user is signed out, we give a 403."""
+    mock_abort.side_effect = werkzeug.exceptions.Forbidden
+    testing_config.sign_out()
+    with self.assertRaises(werkzeug.exceptions.Forbidden):
+      self.handler.get_current_user(required=True)
+
+  def test_get_current_user__signed_in(self):
+    """We can get the signed in user."""
+    testing_config.sign_in('test@example.com', 111)
+    actual = self.handler.get_current_user()
+    self.assertEqual('test@example.com', actual.email())
+
+  @mock.patch('flask.request')
+  def test_get_param__simple(self, mock_request):
+    """We can simply get a JSON parameter, with defaults."""
+    mock_request.get_json.return_value = {'x': 1}
+
+    self.assertEqual(1, self.handler.get_param('x'))
+    self.assertEqual(None, self.handler.get_param('missing', required=False))
+    self.assertEqual('usual', self.handler.get_param(
+        'missing', default='usual'))
+
+  @mock.patch('framework.basehandlers.BaseHandler.abort')
+  @mock.patch('flask.request')
+  def test_get_param__missing_required(self, mock_request, mock_abort):
+    """If a required param is missing, we abort."""
+    mock_request.get_json.return_value = {'x': 1}
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+
+    with self.assertRaises(werkzeug.exceptions.BadRequest):
+      self.handler.get_param('missing')
+    mock_abort.assert_called_once_with(400, msg="Missing parameter 'missing'")
+
+  @mock.patch('framework.basehandlers.BaseHandler.abort')
+  @mock.patch('flask.request')
+  def test_get_param__validator(self, mock_request, mock_abort):
+    """If a param fails validation, we abort."""
+    mock_request.get_json.return_value = {'x': 1}
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+
+    actual = self.handler.get_param(
+        'x', validator=lambda num: num % 2 == 1)
+    self.assertEqual(1, actual)
+
+    actual = self.handler.get_param(
+        'missing', default=3, validator=lambda num: num % 2 == 1)
+    self.assertEqual(3, actual)
+
+    with self.assertRaises(werkzeug.exceptions.BadRequest):
+      self.handler.get_param(
+          'x', validator=lambda num: num % 2 == 0)
+    mock_abort.assert_called_once_with(
+        400, msg="Invalid value for parameter 'x'")
+
+  @mock.patch('framework.basehandlers.BaseHandler.abort')
+  @mock.patch('flask.request')
+  def test_get_param__allowed(self, mock_request, mock_abort):
+    """If a param has an unexpected value, we abort."""
+    mock_request.get_json.return_value = {'x': 1}
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+
+    actual = self.handler.get_param('x', allowed=[1, 2, 3])
+    self.assertEqual(1, actual)
+
+    actual = self.handler.get_param(
+        'missing', default=3, allowed=[1, 2, 3])
+    self.assertEqual(3, actual)
+
+    with self.assertRaises(werkzeug.exceptions.BadRequest):
+      self.handler.get_param('x', allowed=[10, 20, 30])
+    mock_abort.assert_called_once_with(
+        400, msg="Unexpected value for parameter 'x'")
+
+  @mock.patch('framework.basehandlers.BaseHandler.abort')
+  @mock.patch('flask.request')
+  def test_get_int_param(self, mock_request, mock_abort):
+    """We can get an int, or abort."""
+    mock_request.get_json.return_value = {'x': 1, 'foo': 'bar'}
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+
+    actual = self.handler.get_int_param('x')
+    self.assertEqual(1, actual)
+
+    actual = self.handler.get_int_param('missing', default=3)
+    self.assertEqual(3, actual)
+
+    with self.assertRaises(werkzeug.exceptions.BadRequest):
+      self.handler.get_int_param('foo')
+    mock_abort.assert_called_once_with(
+        400, msg="Parameter 'foo' was not an int")
+
+  @mock.patch('framework.basehandlers.BaseHandler.abort')
+  @mock.patch('flask.request')
+  def test_get_bool_param(self, mock_request, mock_abort):
+    """We can get a bool, or abort."""
+    mock_request.get_json.return_value = {'x': True, 'foo': 'bar'}
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+
+    actual = self.handler.get_bool_param('x')
+    self.assertEqual(True, actual)
+
+    actual = self.handler.get_bool_param('missing')
+    self.assertEqual(False, actual)
+
+    actual = self.handler.get_bool_param('missing', default=True)
+    self.assertEqual(True, actual)
+
+    with self.assertRaises(werkzeug.exceptions.BadRequest):
+      self.handler.get_bool_param('foo')
+    mock_abort.assert_called_once_with(
+        400, msg="Parameter 'foo' was not a bool")
+
+  @mock.patch('framework.basehandlers.BaseHandler.abort')
+  @mock.patch('flask.request')
+  def test_get_specified_feature__missing(self, mock_request, mock_abort):
+    """Reject requests that need a feature ID but don't provide one."""
+    mock_request.get_json.return_value = {}
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+
+    with self.assertRaises(werkzeug.exceptions.BadRequest):
+      self.handler.get_specified_feature()
+    mock_abort.assert_called_once_with(
+        400, msg="Missing parameter 'featureId'")
+
+  @mock.patch('framework.basehandlers.BaseHandler.abort')
+  @mock.patch('flask.request')
+  def test_get_specified_feature__bad(self, mock_request, mock_abort):
+    """Reject requests that need a feature ID but provide junk."""
+    mock_request.get_json.return_value = {'featureId': 'junk'}
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+
+    with self.assertRaises(werkzeug.exceptions.BadRequest):
+      self.handler.get_specified_feature()
+    mock_abort.assert_called_once_with(
+        400, msg="Parameter 'featureId' was not an int")
+
+
 class TestableFlaskHandler(basehandlers.FlaskHandler):
 
   TEMPLATE_PATH = 'test_template.html'

--- a/internals/fetchmetrics.py
+++ b/internals/fetchmetrics.py
@@ -190,8 +190,7 @@ class YesterdayHandler(basehandlers.FlaskHandler):
         specified_day = datetime.datetime.strptime(date_str, '%Y%m%d').date()
         days.append(specified_day)
       except ValueError:
-        logging.info('Falsed to parse date string %r', date_str)
-        self.abort(400)
+        self.abort(400, msg='Failed to parse date string.')
 
     else:
       today = today or datetime.date.today()

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -241,10 +241,9 @@ class FeatureChangeHandler(basehandlers.FlaskHandler):
   def process_post_data(self):
     self.require_task_header()
 
-    json_body = self.request.get_json(force=True)
-    feature = json_body.get('feature') or None
-    is_update = json_body.get('is_update') or False
-    changes = json_body.get('changes') or []
+    feature = self.get_param('feature')
+    is_update = self.get_bool_param('is_update')
+    changes = self.get_param('changes', required=False) or []
 
     logging.info('Starting to notify subscribers for feature %r', feature)
 
@@ -268,10 +267,9 @@ class OutboundEmailHandler(basehandlers.FlaskHandler):
   def process_post_data(self):
     self.require_task_header()
 
-    json_body = self.request.get_json(force=True)
-    to = json_body['to']
-    subject = json_body['subject']
-    email_html = json_body['html']
+    to = self.get_param('to', required=True)
+    subject = self.get_param('subject', required=True)
+    email_html = self.get_param('html', required=True)
 
     if settings.SEND_ALL_EMAIL_TO:
       to_user, to_domain = to.split('@')

--- a/pages/featuredetail.py
+++ b/pages/featuredetail.py
@@ -33,11 +33,11 @@ class FeatureDetailHandler(basehandlers.FlaskHandler):
   def get_template_data(self, feature_id):
     f = models.Feature.get_by_id(feature_id)
     if f is None:
-      self.abort(404)
+      self.abort(404, msg='Feature not found')
 
     if f.deleted:
       # TODO(jrobbins): Check permissions and offer option to undelete.
-      self.abort(404)
+      self.abort(404, msg='Feature has been deleted')
 
     feature_process = processes.ALL_PROCESSES.get(
         f.feature_type, processes.BLINK_LAUNCH_PROCESS)

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -169,7 +169,7 @@ class ProcessOverview(basehandlers.FlaskHandler):
   def get_template_data(self, feature_id):
     f = models.Feature.get_by_id(long(feature_id))
     if f is None:
-      self.abort(404)
+      self.abort(404, msg='Feature not found')
 
     feature_process = processes.ALL_PROCESSES.get(
         f.feature_type, processes.BLINK_LAUNCH_PROCESS)
@@ -223,7 +223,7 @@ class FeatureEditStage(basehandlers.FlaskHandler):
     """Look up the feature that the user wants to edit, and its process."""
     f = models.Feature.get_by_id(feature_id)
     if f is None:
-      self.abort(404)
+      self.abort(404, msg='Feature not found')
 
     feature_process = processes.ALL_PROCESSES.get(
         f.feature_type, processes.BLINK_LAUNCH_PROCESS)
@@ -278,7 +278,7 @@ class FeatureEditStage(basehandlers.FlaskHandler):
     if feature_id:
       feature = models.Feature.get_by_id(feature_id)
       if feature is None:
-        self.abort(404)
+        self.abort(404, msg='Feature not found')
 
     logging.info('POST is %r', self.form)
 

--- a/pages/intentpreview.py
+++ b/pages/intentpreview.py
@@ -36,12 +36,7 @@ class IntentEmailPreviewHandler(basehandlers.FlaskHandler):
 
   @permissions.require_edit_feature
   def get_template_data(self, feature_id=None, stage_id=None):
-    if not feature_id:
-      self.abort(404)
-    f = models.Feature.get_by_id(feature_id)
-    if f is None:
-      self.abort(404)
-
+    f = self.get_specified_feature(feature_id=feature_id)
     intent_stage = stage_id if stage_id is not None else f.intent_stage
 
     page_data = self.get_page_data(feature_id, f, intent_stage)

--- a/pages/users.py
+++ b/pages/users.py
@@ -107,7 +107,7 @@ class SettingsHandler(basehandlers.FlaskHandler):
   def process_post_data(self):
     user_pref = models.UserPref.get_signed_in_user_pref()
     if not user_pref:
-      flask.abort(403)
+      self.abort(403, msg='User must be signed in')
 
     new_notify = flask.request.form.get('notify_as_starrer')
     logging.info('setting notify_as_starrer for %r to %r',


### PR DESCRIPTION
Now that I am starting to write more API handlers, I want to reduce the amount of redundant code for simply accessing JSON parameters in the request and raising validation errors.

In this PR:
+ Add a required= option when getting the current user so that the error response can be generated in just one place.
+ Add methods to get JSON parameters of any type, int, or bool.
+ Add get_specified_feature() to go through the steps of getting the ID and retrieving the associated feature or returning an error.
+ Filled in some missing unit tests.