### PR TITLE
Give 404 or 400 instead of 500 for unexpected HTTP methods.

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -46,16 +46,16 @@ class BaseHandler(flask.views.MethodView):
   def request(self):
     return flask.request
 
-  def abort(self, status, msg=None):
+  def abort(self, status, msg=None, **kwargs):
     """Support webapp2-style, e.g., self.abort(400)."""
     if msg:
       if status == 500:
         logging.error('ISE: %s' % msg)
       else:
         logging.info('Abort %r: %s' % (status, msg))
-      flask.abort(status, msg)
+      flask.abort(status, description=msg, **kwargs)
     else:
-      flask.abort(status)
+      flask.abort(status, **kwargs)
 
   def redirect(self, url):
     """Support webapp2-style, e.g., return self.redirect(url)."""
@@ -153,6 +153,17 @@ class APIHandler(BaseHandler):
     handler_data = self.do_delete(*args, **kwargs)
     return flask.jsonify(handler_data), headers
 
+  def _get_valid_methods(self):
+    """For 405 responses, list methods the concrete handler implements."""
+    valid_methods = ['GET']
+    if self.do_post.__code__ is not APIHandler.do_post.__code__:
+      valid_methods.append('POST')
+    if self.do_patch.__code__ is not APIHandler.do_patch.__code__:
+      valid_methods.append('PATCH')
+    if self.do_delete.__code__ is not APIHandler.do_delete.__code__:
+      valid_methods.append('DELETE')
+    return valid_methods
+
   def do_get(self, **kwargs):
     """Subclasses should implement this method to handle a GET request."""
     # Every API handler must handle GET.
@@ -160,15 +171,15 @@ class APIHandler(BaseHandler):
 
   def do_post(self, **kwargs):
     """Subclasses should implement this method to handle a POST request."""
-    self.abort(400, msg='Unexpected HTTP method')
+    self.abort(405, valid_methods=self._get_valid_methods())
 
   def do_patch(self, **kwargs):
     """Subclasses should implement this method to handle a PATCH request."""
-    self.abort(400, msg='Unexpected HTTP method')
+    self.abort(405, valid_methods=self._get_valid_methods())
 
   def do_delete(self, **kwargs):
     """Subclasses should implement this method to handle a DELETE request."""
-    self.abort(400, msg='Unexpected HTTP method')
+    self.abort(405, valid_methods=self._get_valid_methods())
 
 
 class FlaskHandler(BaseHandler):
@@ -213,7 +224,7 @@ class FlaskHandler(BaseHandler):
 
   def process_post_data(self):
     """Subclasses should implement this method to handle a POST request."""
-    self.abort(400, msg='Unexpected HTTP method')
+    self.abort(405, msg='Unexpected HTTP method', valid_methods=['GET'])
 
   def get_common_data(self, path=None):
     """Return template data used on all pages, e.g., sign-in info."""

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -155,7 +155,8 @@ class APIHandler(BaseHandler):
 
   def do_get(self, **kwargs):
     """Subclasses should implement this method to handle a GET request."""
-    self.abort(404)
+    # Every API handler must handle GET.
+    raise NotImplementedError()
 
   def do_post(self, **kwargs):
     """Subclasses should implement this method to handle a POST request."""
@@ -212,7 +213,7 @@ class FlaskHandler(BaseHandler):
 
   def process_post_data(self):
     """Subclasses should implement this method to handle a POST request."""
-    raise NotImplementedError()
+    self.abort(400, msg='Unexpected HTTP method')
 
   def get_common_data(self, path=None):
     """Return template data used on all pages, e.g., sign-in info."""

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -153,21 +153,21 @@ class APIHandler(BaseHandler):
     handler_data = self.do_delete(*args, **kwargs)
     return flask.jsonify(handler_data), headers
 
-  def do_get(self):
+  def do_get(self, **kwargs):
     """Subclasses should implement this method to handle a GET request."""
-    raise NotImplementedError()
+    self.abort(404)
 
-  def do_post(self):
+  def do_post(self, **kwargs):
     """Subclasses should implement this method to handle a POST request."""
-    raise NotImplementedError()
+    self.abort(400, msg='Unexpected HTTP method')
 
-  def do_patch(self):
+  def do_patch(self, **kwargs):
     """Subclasses should implement this method to handle a PATCH request."""
-    raise NotImplementedError()
+    self.abort(400, msg='Unexpected HTTP method')
 
-  def do_delete(self):
+  def do_delete(self, **kwargs):
     """Subclasses should implement this method to handle a DELETE request."""
-    raise NotImplementedError()
+    self.abort(400, msg='Unexpected HTTP method')
 
 
 class FlaskHandler(BaseHandler):

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -301,38 +301,37 @@ class APIHandlerTests(unittest.TestCase):
   def setUp(self):
     self.handler = basehandlers.APIHandler()
 
+  def test_do_get(self):
+    """If a subclass does not implement do_get(), raise NotImplementedError."""
+    with self.assertRaises(NotImplementedError):
+      self.handler.do_get()
+
+    with self.assertRaises(NotImplementedError):
+      self.handler.do_get(feature_id=1234)
+
   @mock.patch('flask.abort')
-  def check_bad_HTTP_method(self, handler_method, expected_status, mock_abort):
-    if expected_status == 404:
-      mock_abort.side_effect = werkzeug.exceptions.NotFound
-      expected_args = (expected_status,)
-    else:
-      mock_abort.side_effect = werkzeug.exceptions.BadRequest
-      expected_args = (expected_status, 'Unexpected HTTP method')
+  def check_bad_HTTP_method(self, handler_method, mock_abort):
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
 
     with self.assertRaises(mock_abort.side_effect):
       handler_method()
-    mock_abort.assert_called_once_with(*expected_args)
+    mock_abort.assert_called_once_with(400, 'Unexpected HTTP method')
 
     # Extra URL parameters do not crash the app.
     with self.assertRaises(mock_abort.side_effect):
       handler_method(feature_id=1234)
 
-  def test_do_get(self):
-    """If a subclass does not implement do_get(), return a 404."""
-    self.check_bad_HTTP_method(self.handler.do_get, 404)
-
   def test_do_post(self):
     """If a subclass does not implement do_post(), return a 400."""
-    self.check_bad_HTTP_method(self.handler.do_post, 400)
+    self.check_bad_HTTP_method(self.handler.do_post)
 
   def test_do_patch(self):
     """If a subclass does not implement do_patch(), return a 400."""
-    self.check_bad_HTTP_method(self.handler.do_patch, 400)
+    self.check_bad_HTTP_method(self.handler.do_patch)
 
   def test_do_delete(self):
     """If a subclass does not implement do_delete(), return a 400."""
-    self.check_bad_HTTP_method(self.handler.do_delete, 400)
+    self.check_bad_HTTP_method(self.handler.do_delete)
 
 
 class FlaskHandlerTests(unittest.TestCase):
@@ -401,9 +400,9 @@ class FlaskHandlerTests(unittest.TestCase):
     self.assertEqual('special.html', actual)
 
   def test_process_post_data__missing(self):
-    """Every subsclass should overide process_post_data()."""
+    """Subsclass that don't overide process_post_data() give a 400."""
     self.handler = basehandlers.FlaskHandler()
-    with self.assertRaises(NotImplementedError):
+    with self.assertRaises(werkzeug.exceptions.BadRequest):
       self.handler.process_post_data()
 
   def test_get_common_data__signed_out(self):

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -53,7 +53,7 @@ class BaseHandlerTests(unittest.TestCase):
   def test_abort__with_msg(self, mock_abort, mock_info):
     """We can abort request handling."""
     self.handler.abort(400, msg='You messed up')
-    mock_abort.assert_called_once_with(400, 'You messed up')
+    mock_abort.assert_called_once_with(400, description='You messed up')
     mock_info.assert_called_once()
 
   @mock.patch('logging.error')
@@ -61,7 +61,7 @@ class BaseHandlerTests(unittest.TestCase):
   def test_abort__with_500_msg(self, mock_abort, mock_error):
     """We can abort request handling."""
     self.handler.abort(500, msg='We messed up')
-    mock_abort.assert_called_once_with(500, 'We messed up')
+    mock_abort.assert_called_once_with(500, description='We messed up')
     mock_error.assert_called_once()
 
   @mock.patch('flask.redirect')
@@ -311,26 +311,26 @@ class APIHandlerTests(unittest.TestCase):
 
   @mock.patch('flask.abort')
   def check_bad_HTTP_method(self, handler_method, mock_abort):
-    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+    mock_abort.side_effect = werkzeug.exceptions.MethodNotAllowed
 
     with self.assertRaises(mock_abort.side_effect):
       handler_method()
-    mock_abort.assert_called_once_with(400, 'Unexpected HTTP method')
+    mock_abort.assert_called_once_with(405, valid_methods=['GET'])
 
     # Extra URL parameters do not crash the app.
     with self.assertRaises(mock_abort.side_effect):
       handler_method(feature_id=1234)
 
   def test_do_post(self):
-    """If a subclass does not implement do_post(), return a 400."""
+    """If a subclass does not implement do_post(), return a 405."""
     self.check_bad_HTTP_method(self.handler.do_post)
 
   def test_do_patch(self):
-    """If a subclass does not implement do_patch(), return a 400."""
+    """If a subclass does not implement do_patch(), return a 405."""
     self.check_bad_HTTP_method(self.handler.do_patch)
 
   def test_do_delete(self):
-    """If a subclass does not implement do_delete(), return a 400."""
+    """If a subclass does not implement do_delete(), return a 405."""
     self.check_bad_HTTP_method(self.handler.do_delete)
 
 
@@ -400,9 +400,9 @@ class FlaskHandlerTests(unittest.TestCase):
     self.assertEqual('special.html', actual)
 
   def test_process_post_data__missing(self):
-    """Subsclass that don't overide process_post_data() give a 400."""
+    """Subsclasses that don't override process_post_data() give a 405."""
     self.handler = basehandlers.FlaskHandler()
-    with self.assertRaises(werkzeug.exceptions.BadRequest):
+    with self.assertRaises(werkzeug.exceptions.MethodNotAllowed):
       self.handler.process_post_data()
 
   def test_get_common_data__signed_out(self):


### PR DESCRIPTION
This avoids some noise on the GAE Error Reporting page.  

Some spammers or fuzzers try to do a POST to our site home page.  With our existing code, that actually caused a python exception and gave the requester a 500 response.  We don't really care about those requests, but giving a non-500 response makes it easier to spot true defects in our logs and on the GAE Error Reporting page. 