### PR TITLE
Add a field for devtrial instructions link.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -982,12 +982,16 @@ class Feature(DictModel):
   feature_type = db.IntegerProperty(default=FEATURE_TYPE_INCUBATE_ID)
   intent_stage = db.IntegerProperty(default=0)
   summary = db.StringProperty(required=True, multiline=True)
-  origin_trial_feedback_url = db.LinkProperty()
   unlisted = db.BooleanProperty(default=False)
   # TODO(jrobbins): Add an entry_state enum to track app-specific lifecycle
   # info for a feature entry as distinct from process-specific stage.
   deleted = db.BooleanProperty(default=False)
   motivation = db.StringProperty(multiline=True)
+  star_count = db.IntegerProperty(default=0)
+  search_tags = db.StringListProperty()
+  comments = db.StringProperty(multiline=True)
+  owner = db.ListProperty(db.Email)
+  footprint = db.IntegerProperty()  # Deprecated
 
   # Tracability to intent discussion threads
   intent_to_implement_url = db.LinkProperty()
@@ -1009,10 +1013,10 @@ class Feature(DictModel):
   shipped_android_milestone = db.IntegerProperty()
   shipped_ios_milestone = db.IntegerProperty()
   shipped_webview_milestone = db.IntegerProperty()
-  flag_name = db.StringProperty()
 
-  owner = db.ListProperty(db.Email)
-  footprint = db.IntegerProperty()  # Deprecated
+  # DevTrial details.
+  devtrial_instructions = db.LinkProperty()
+  flag_name = db.StringProperty()
   interop_compat_risks = db.StringProperty(multiline=True)
   ergonomics_risks = db.StringProperty(multiline=True)
   activation_risks = db.StringProperty(multiline=True)
@@ -1062,10 +1066,6 @@ class Feature(DictModel):
   sample_links = db.StringListProperty()
   #tests = db.StringProperty()
 
-  search_tags = db.StringListProperty()
-
-  comments = db.StringProperty(multiline=True)
-
   experiment_goals = db.StringProperty(multiline=True)
   experiment_timeline = db.StringProperty(multiline=True)
   ot_milestone_desktop_start = db.IntegerProperty()
@@ -1075,10 +1075,9 @@ class Feature(DictModel):
   experiment_risks = db.StringProperty(multiline=True)
   experiment_extension_reason = db.StringProperty(multiline=True)
   ongoing_constraints = db.StringProperty(multiline=True)
+  origin_trial_feedback_url = db.LinkProperty()
 
   finch_url = db.LinkProperty()
-
-  star_count = db.IntegerProperty(default=0)
 
 
 class Approval(DictModel):

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -375,6 +375,9 @@ class FeatureEditStage(basehandlers.FlaskHandler):
       feature.ot_milestone_android_end = self.parse_int(
           'ot_milestone_android_end')
 
+    if self.touched('devtrial_instructions'):
+      feature.devtrial_instructions = self.parse_link('devtrial_instructions')
+
     if self.touched('flag_name'):
       feature.flag_name = self.form.get('flag_name')
 

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -607,6 +607,17 @@ ALL_FIELDS = {
         widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
         help_text=SHIPPED_WEBVIEW_HELP_TXT),
 
+    'devtrial_instructions': forms.URLField(
+        required=False, label='DevTrial instructions',
+        widget=forms.URLInput(attrs={'placeholder': 'https://'}),
+        help_text=(
+            'Link to a HOWTO or FAQ describing how developers can get started '
+            'using this feature in a DevTrial.  <a target="_blank" href="'
+            'https://github.com/samuelgoto/WebID/blob/master/HOWTO.md'
+            '">Example 1</a>.  <a target="_blank" href="'
+            'https://github.com/WICG/idle-detection/blob/main/HOWTO.md'
+            '">Example 2</a>.')),
+
     'flag_name': forms.CharField(
         label='Flag name', required=False,
         help_text='Name of the flag that enables this feature.'),
@@ -679,7 +690,7 @@ NewFeature_Prototype = define_form_class_using_shared_fields(
 
 Any_DevTrial = define_form_class_using_shared_fields(
     'Any_DevTrial',
-    ('bug_url', 'doc_links',
+    ('bug_url', 'devtrial_instructions', 'doc_links',
      'interop_compat_risks',
      'safari_views', 'safari_views_link', 'safari_views_notes',
      'ff_views', 'ff_views_link', 'ff_views_notes',
@@ -844,7 +855,7 @@ Flat_Implement = define_form_class_using_shared_fields(
 Flat_DevTrial = define_form_class_using_shared_fields(
     'Flat_DevTrial',
     (# Standardizaton
-     'doc_links',
+     'devtrial_instructions', 'doc_links',
      'interop_compat_risks',
      'safari_views', 'safari_views_link', 'safari_views_notes',
      'ff_views', 'ff_views_link', 'ff_views_notes',
@@ -952,7 +963,7 @@ DISPLAY_FIELDS_IN_STAGES = {
     models.INTENT_IMPLEMENT: make_display_specs(
         'spec_link', 'api_spec', 'spec_mentors', 'intent_to_implement_url'),
     models.INTENT_EXPERIMENT: make_display_specs(
-        'doc_links',
+        'devtrial_instructions', 'doc_links',
         'interop_compat_risks',
         'safari_views', 'safari_views_link', 'safari_views_notes',
         'ff_views', 'ff_views_link', 'ff_views_notes',

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -168,6 +168,12 @@
   <p class="preformatted">{{feature.wpt_descr|urlize}}</p>
 {% endif %}
 
+{% if feature.devtrial_instructions %}
+  <br><br><h4>DevTrial instructions</h4>
+  <a href="{{feature.devtrial_instructions}}"
+     >{{feature.devtrial_instructions}}</a>
+{% endif %}
+
 <br><br><h4>Flag name</h4>
 {{feature.flag_name}}
 


### PR DESCRIPTION
This addresses the request made in a recent email thread.

In this PR:
+ Add new feature field devtrial_instructions.  Also, regroup some existing field declarations to make them more clear.
+ Add a corresponding form field and locate it in the dev trials stage of the process.  The help text links to two examples provided by goto@.
+ Add the new field to the details page.
+ Add the new field to the intent email template, whenever it has a value.
