### PR TITLE
Implement XSRF tokens for HTML forms (not enforced yet).

### DIFF
--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -536,7 +536,7 @@ class FlaskHandlerTests(unittest.TestCase):
   @unittest.skip('TODO(jrobbins): enable after next release')
   @mock.patch('settings.UNIT_TEST_MODE', False)
   def test_require_xsrf_token__missing(self):
-    """We reject a POST with a valid token."""
+    """We reject a POST with a missing token."""
     testing_config.sign_in('user1@example.com', 111)
     form_data = {}
     with test_app.test_request_context('/test', data=form_data):

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -26,6 +26,7 @@ import werkzeug.exceptions  # Flask HTTP stuff.
 from google.appengine.api import users
 
 from framework import basehandlers
+from framework import xsrf
 from internals import models
 import settings
 
@@ -485,6 +486,7 @@ class FlaskHandlerTests(unittest.TestCase):
 
   def test_post__json(self):
     """if process_post_data() returns a dict, it is passed to flask."""
+    testing_config.sign_in('user@example.com', 111)
     with test_app.test_request_context('/test'):
       actual_dict, actual_headers = self.handler.post()
 
@@ -495,6 +497,7 @@ class FlaskHandlerTests(unittest.TestCase):
 
   def test_post__redirect(self):
     """if process_post_data() returns a redirect response, it is used."""
+    testing_config.sign_in('user@example.com', 111)
     with test_app.test_request_context('/test'):
       actual_response, actual_headers = self.handler.post(
           redirect_to='some/other/path')
@@ -521,3 +524,31 @@ class FlaskHandlerTests(unittest.TestCase):
     with test_app.test_request_context('/test'):
       with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.require_task_header()
+
+  @mock.patch('settings.UNIT_TEST_MODE', False)
+  def test_require_xsrf_token__normal(self):
+    """We accept a POST with a valid token."""
+    testing_config.sign_in('user1@example.com', 111)
+    form_data = {'token': xsrf.generate_token('user1@example.com')}
+    with test_app.test_request_context('/test', data=form_data):
+      self.handler.require_xsrf_token()
+
+  @unittest.skip('TODO(jrobbins): enable after next release')
+  @mock.patch('settings.UNIT_TEST_MODE', False)
+  def test_require_xsrf_token__missing(self):
+    """We reject a POST with a valid token."""
+    testing_config.sign_in('user1@example.com', 111)
+    form_data = {}
+    with test_app.test_request_context('/test', data=form_data):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.require_xsrf_token()
+
+  @unittest.skip('TODO(jrobbins): enable after next release')
+  @mock.patch('settings.UNIT_TEST_MODE', False)
+  def test_require_xsrf_token__wrong(self):
+    """We reject a POST with a incorrect token."""
+    testing_config.sign_in('user1@example.com', 111)
+    form_data = {'token': xsrf.generate_token('user2@example.com')}
+    with test_app.test_request_context('/test', data=form_data):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.require_xsrf_token()

--- a/framework/constants.py
+++ b/framework/constants.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+from __future__ import print_function
+
+
+# Number of seconds in various periods.
+SECS_PER_MINUTE = 60
+SECS_PER_HOUR = SECS_PER_MINUTE * 60
+SECS_PER_DAY = SECS_PER_HOUR * 24

--- a/framework/xsrf.py
+++ b/framework/xsrf.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+from __future__ import print_function
+
+import base64
+import hmac
+import logging
+import random
+import string
+import time
+
+from google.appengine.ext import db
+
+from framework import constants
+
+
+# This is how long tokens are valid.
+TOKEN_TIMEOUT_SEC = 2 * constants.SECS_PER_HOUR
+
+# The token refresh servlet accepts old tokens to generate new ones, but
+# we still impose a limit on how old they can be.
+REFRESH_TOKEN_TIMEOUT_SEC = 10 * constants.SECS_PER_DAY
+
+# When the JS on a page decides whether or not it needs to refresh the
+# XSRF token before submitting a form, there could be some clock skew,
+# so we subtract a little time to avoid having the JS use an existing
+# token that the server might consider expired already.
+TOKEN_TIMEOUT_MARGIN_SEC = 5 * constants.SECS_PER_MINUTE
+
+# When checking that the token is not from the future, allow a little
+# margin for the possibliity that the clock of the GAE instance that
+# generated the token could be a little ahead of the one checking.
+CLOCK_SKEW_SEC = 5
+
+DELIMITER = ':'
+
+
+# For random key generation
+RANDOM_KEY_LENGTH = 128
+RANDOM_KEY_CHARACTERS = string.ascii_letters + string.digits
+
+
+def make_random_key(length=RANDOM_KEY_LENGTH, chars=RANDOM_KEY_CHARACTERS):
+  """Return a string with lots of random characters."""
+  chars = [random.choice(chars) for _ in range(length)]
+  return ''.join(chars)
+
+
+class Secrets(db.Model):
+  """A server-side-only value that we use to generate security tokens."""
+
+  xsrf_secret = db.StringProperty(required=True)
+
+  @classmethod
+  def _get_or_make_singleton(cls):
+    existing = Secrets.all().fetch(1)
+    if existing:
+      return existing[0]
+
+    logging.info('Creating new secrets')
+    xsrf_secret = make_random_key()
+    new_entity = Secrets(xsrf_secret=xsrf_secret)
+    new_entity.put()
+    return new_entity
+
+  @classmethod
+  def get_xsrf_secret(cls):
+    """Return the xsrf secret key."""
+    singleton = cls._get_or_make_singleton()
+    return singleton.xsrf_secret
+
+
+
+def generate_token(user_email, token_time=None):
+  """Return a security token specifically for the given user.
+  Args:
+    user_email: email addr of the user viewing an HTML form.  This can
+        be None for anon vistors.
+    token_time: Time at which the token is generated in seconds since the epoch.
+  Returns:
+    A url-safe security token.  The token is a string with the digest
+    the email and time, followed by plain-text copy of the time that is
+    used in validation.
+  Raises:
+    ValueError: if the XSRF secret was not configured.
+  """
+  token_time = token_time or int(time.time())
+  digester = hmac.new(Secrets.get_xsrf_secret())
+  digester.update(user_email or '')
+  digester.update(DELIMITER)
+  digester.update(str(token_time))
+  digest = digester.digest()
+  token = base64.urlsafe_b64encode('%s%s%d' % (digest, DELIMITER, token_time))
+  return token
+
+
+def validate_token(
+    token, user_email, timeout=TOKEN_TIMEOUT_SEC):
+  """Return True if the given token is valid for the given scope.
+  Args:
+    token: String token that was presented by the user.
+    user_email: user email addr.
+    timeout: int max token age in seconds.
+  Raises:
+    TokenIncorrect: if the token is missing or invalid.
+  """
+  if not token:
+    raise TokenIncorrect('missing token')
+  try:
+    decoded = base64.urlsafe_b64decode(str(token))
+    token_time = int(decoded.split(DELIMITER)[-1])
+  except (TypeError, ValueError):
+    raise TokenIncorrect('could not decode token')
+  now = int(time.time())
+
+  # The given token should match the generated one with the same time.
+  expected_token = generate_token(user_email, token_time=token_time)
+  if len(token) != len(expected_token):
+    raise TokenIncorrect('presented token is wrong size')
+
+  # Perform constant time comparison to avoid timing attacks
+  different = 0
+  for x, y in zip(token, expected_token):
+    different |= ord(x) ^ ord(y)
+  if different:
+    raise TokenIncorrect(
+        'presented token does not match expected token: %r != %r' % (
+            token, expected_token))
+
+  # We reject tokens from the future.
+  if token_time > now + CLOCK_SKEW_SEC:
+    raise TokenIncorrect('token is from future')
+
+  # We check expiration last so that we only raise the expriration error
+  # if the token would have otherwise been valid.
+  if now - token_time > timeout:
+    raise TokenIncorrect('token has expired')
+
+
+def token_expires_sec():
+  """Return timestamp when current tokens will expire, minus a safety margin."""
+  now = int(time.time())
+  return now + TOKEN_TIMEOUT_SEC - TOKEN_TIMEOUT_MARGIN_SEC
+
+
+class Error(Exception):
+  """Base class for errors from this module."""
+  pass
+
+
+# Caught separately in servlet.py
+class TokenIncorrect(Error):
+  """The POST body has an incorrect URL Command Attack token."""
+  pass

--- a/framework/xsrf.py
+++ b/framework/xsrf.py
@@ -28,6 +28,10 @@ from google.appengine.ext import db
 from framework import constants
 
 
+# TODO(jrobbins): 2 hours is too short for usability, but a longer value
+# is not secure enough.  So, we will go with 2 hours and also implement
+# token refresh as done in Monorail.
+
 # This is how long tokens are valid.
 TOKEN_TIMEOUT_SEC = 2 * constants.SECS_PER_HOUR
 

--- a/framework/xsrf_test.py
+++ b/framework/xsrf_test.py
@@ -1,0 +1,116 @@
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+import testing_config  # Must be imported before the module under test.
+
+import mock
+
+from framework import xsrf
+
+
+class XsrfTest(unittest.TestCase):
+  """Set of unit tests for blocking XSRF attacks."""
+
+  def test_make_random_key__long(self):
+    """The random keys have the desired length."""
+    key = xsrf.make_random_key()
+    self.assertEqual(xsrf.RANDOM_KEY_LENGTH, len(key))
+
+  def test_make_random_key__distinct(self):
+    """The random keys are different."""
+    key_set = set()
+    for i in range(1000):
+      key_set.add(xsrf.make_random_key())
+    self.assertEqual(1000, len(key_set))
+
+  def test_generate_token__anon(self):
+    """Anon users get a real token."""
+    self.assertNotEqual('', xsrf.generate_token(None))
+
+  def test_generate_token__distinct(self):
+    """Each user gets their own distinct token."""
+    self.assertNotEqual(
+        xsrf.generate_token('user1@example.com'),
+        xsrf.generate_token('user2@example.com'))
+
+    self.assertNotEqual(
+        xsrf.generate_token('user1@example.com'),
+        xsrf.generate_token(None))
+
+  def test_validate_token__normal(self):
+    """We accept valid tokens."""
+    token = xsrf.generate_token('user1@example.com')
+    xsrf.validate_token(token, 'user1@example.com')  # no exception raised
+
+  def test_validate_token__malformed_token(self):
+    """We reject missing or non-matching tokens."""
+    with self.assertRaises(xsrf.TokenIncorrect):
+      xsrf.validate_token('bad', 'user1@example.com')
+
+    with self.assertRaises(xsrf.TokenIncorrect):
+      xsrf.validate_token('', 'user1@example.com')
+
+    with self.assertRaises(xsrf.TokenIncorrect):
+      xsrf.validate_token(
+          '098a08fe08b08c08a05e:9721973123',
+          'user1@example.com')
+
+  def test_validate_token__wrong_user(self):
+    """We reject a user attempting to use a different user's token."""
+    token = xsrf.generate_token('user1@example.com')
+    with self.assertRaises(xsrf.TokenIncorrect):
+      xsrf.validate_token(token, 'user2@example.com')
+    with self.assertRaises(xsrf.TokenIncorrect):
+      xsrf.validate_token(token, None)
+
+  @mock.patch('time.time')
+  def test_validate_token__expiration(self, mock_time):
+    """We accept non-expired tokens and reject expired ones."""
+    test_time = 1526671379
+    mock_time.return_value = test_time
+    token = xsrf.generate_token('user1@example.com')
+
+    xsrf.validate_token(token, 'user1@example.com')
+
+    mock_time.return_value = test_time + 1
+    xsrf.validate_token(token, 'user1@example.com')
+
+    mock_time.return_value = test_time + xsrf.TOKEN_TIMEOUT_SEC
+    xsrf.validate_token(token, 'user1@example.com')
+
+    mock_time.return_value = test_time + xsrf.TOKEN_TIMEOUT_SEC + 1
+    with self.assertRaises(xsrf.TokenIncorrect):
+      xsrf.validate_token(token, 'user1@example.com')
+
+  @mock.patch('time.time')
+  def test_validate_token__future(self, mock_time):
+    """We reject tokens from the future."""
+    test_time = 1526671379
+    mock_time.return_value = test_time
+    token = xsrf.generate_token('user1@example.com')
+
+    xsrf.validate_token(token, 'user1@example.com')
+
+    # The clock of the GAE instance doing the checking might be slightly slow.
+    mock_time.return_value = test_time - 1
+    xsrf.validate_token(token, 'user1@example.com')
+
+    # But, if the difference is too much, someone is trying to fake a token.
+    mock_time.return_value = test_time - xsrf.CLOCK_SKEW_SEC - 1
+    with self.assertRaises(xsrf.TokenIncorrect):
+      xsrf.validate_token(token, 'user1@example.com')

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -238,6 +238,8 @@ class FeatureStar(models.DictModel):
 class FeatureChangeHandler(basehandlers.FlaskHandler):
   """This task handles a feature creation or update by making email tasks."""
 
+  IS_INTERNAL_HANDLER = True
+
   def process_post_data(self):
     self.require_task_header()
 
@@ -263,6 +265,8 @@ class FeatureChangeHandler(basehandlers.FlaskHandler):
 
 class OutboundEmailHandler(basehandlers.FlaskHandler):
   """Task to send a notification email to one recipient."""
+
+  IS_INTERNAL_HANDLER = True
 
   def process_post_data(self):
     self.require_task_header()
@@ -296,6 +300,7 @@ class OutboundEmailHandler(basehandlers.FlaskHandler):
 class BouncedEmailHandler(basehandlers.FlaskHandler):
   BAD_WRAP_RE = re.compile('=\r\n')
   BAD_EQ_RE = re.compile('=3D')
+  IS_INTERNAL_HANDLER = True
 
   """Handler to notice when email to given user is bouncing."""
   # For docs on AppEngine's bounce email handling, see:

--- a/static/elements/chromedash-userlist.js
+++ b/static/elements/chromedash-userlist.js
@@ -6,6 +6,7 @@ class ChromedashUserlist extends LitElement {
   static get properties() {
     return {
       actionPath: {type: String},
+      token: {type: String},
       users: {attribute: false},
     };
   }
@@ -53,6 +54,7 @@ class ChromedashUserlist extends LitElement {
       const email = formEl.querySelector('input[name="email"]').value;
       const formData = new FormData();
       formData.append('email', email);
+      formData.append('token', this.token);
 
       const resp = await fetch(this.actionPath, {
         method: 'POST',
@@ -81,9 +83,12 @@ class ChromedashUserlist extends LitElement {
     }
 
     const idx = e.target.dataset.index;
+    const formData = new FormData();
+    formData.append('token', this.token);
 
     fetch(e.currentTarget.href, {
       method: 'POST',
+      body: formData,
       credentials: 'same-origin',
     }).then(() => {
       this.removeUser(idx);

--- a/templates/admin/users/new.html
+++ b/templates/admin/users/new.html
@@ -13,7 +13,10 @@
 {% block content %}
 <section>
 
-<chromedash-userlist actionPath="/admin/users/create"></chromedeash-userlist>
+  <chromedash-userlist
+    actionPath="/admin/users/create"
+    token="{{xsrf_token}}"
+    ></chromedeash-userlist>
 
 </section>
 {% endblock %}

--- a/templates/guide/editall.html
+++ b/templates/guide/editall.html
@@ -18,6 +18,7 @@
 
 {% block content %}
 <form name="feature_form" method="POST" action="{{current_path}}">
+  <input type="hidden" name="token" value="{{xsrf_token}}">
   {% for section_name, flat_form in flat_forms %}
     <h3>{{ section_name }}</h3>
     <section class="flat_form">

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -108,6 +108,7 @@
   {% if offer_editing == "yes" %}
     <div id="metadata-editing" style="display:none">
       <form name="overview_form" method="POST" action="/guide/stage/{{ feature_id }}/0">
+        <input type="hidden" name="token" value="{{xsrf_token}}">
         <input type="hidden" name="form_fields"
                value="{{ overview_form.fields.keys | join:',' }}" >
 

--- a/templates/guide/new.html
+++ b/templates/guide/new.html
@@ -21,6 +21,7 @@
 
 <section id="stage_form">
   <form name="overview_form" method="POST" action="{{ current_path }}">
+    <input type="hidden" name="token" value="{{xsrf_token}}">
     <table style="max-width: 60em">
       <tr>
         <th></th>

--- a/templates/guide/stage.html
+++ b/templates/guide/stage.html
@@ -19,7 +19,7 @@
 
 {% block content %}
 <form name="feature_form" method="POST" action="{{current_path}}">
-
+  <input type="hidden" name="token" value="{{xsrf_token}}">
   <input type="hidden" name="form_fields"
          value="{{ feature_form.fields.keys | join:',' }},
                 {% if impl_status_form %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -18,6 +18,7 @@
 <section>
 
   <form name="user_pref_form" method="POST" action="{{current_path}}">
+    <input type="hidden" name="token" value="{{xsrf_token}}">
     <table cellspacing=6>
       {{ user_pref_form }}
     </table>


### PR DESCRIPTION
As a prerequisite to doing more with approvals, we need to improve security.

In this PR:
+ Generate XSRF tokens for HTML forms the same way it is done in Monorail
+ Check those tokens when the forms are submitted, but rejections are just logged for now

Have not started giving error responses yet because doing so would reject form submission from users who already have browser tabs open before this is deployed.   So, we just log invalid tokens for now.  I'll wait a while until we no longer see rejections logged, and then enable checking.