### PR TITLE
Remove unused field intent_template_use_count.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -974,8 +974,6 @@ class Feature(DictModel):
   updated_by = db.UserProperty(auto_current_user=True)
   created_by = db.UserProperty(auto_current_user_add=True)
 
-  intent_template_use_count = db.IntegerProperty(default = 0)
-
   # General info.
   category = db.IntegerProperty(required=True)
   name = db.StringProperty(required=True)

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -496,9 +496,6 @@ class FeatureEditStage(basehandlers.FlaskHandler):
     if self.touched('ongoing_constraints'):
       feature.ongoing_constraints = self.form.get('ongoing_constraints')
 
-    if self.form.get('intent_to_implement') == 'on':
-      feature.intent_template_use_count += 1
-
     key = feature.put()
 
     # TODO(jrobbins): enumerate and remove only the relevant keys.


### PR DESCRIPTION
I don't believe that Feature field intent_template_use_count was ever used.  It was added in your 2019 PR
https://github.com/GoogleChrome/chromium-dashboard/commit/18b81b4fbcf463959783ef126af9d47d5b3b7578
but I don't see where its value was ever output anywhere.

