### PR TITLE
Replace non-standard event.path with e.composedPath().

### DIFF
--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -147,7 +147,8 @@ class ChromedashFeature extends LitElement {
 
     if (target.classList.contains('tooltip') || 'tooltip' in target.dataset ||
         target.tagName == 'A' || target.tagName == 'CHROMEDASH-MULTI-LINKS' ||
-        e.path[0].nodeName === 'A' || textSelection.type === 'RANGE' || textSelection.toString()) {
+        e.composedPath()[0].nodeName === 'A' ||
+        textSelection.type === 'RANGE' || textSelection.toString()) {
       return;
     }
 


### PR DESCRIPTION
This just fixes an error that I found when testing on safari.