### PR TITLE
Refactor Secrets and add session_secret.

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -27,11 +27,11 @@ import flask.views
 from google.appengine.api import users
 from google.appengine.ext import db
 
+import settings
 from framework import permissions
 from framework import ramcache
-from framework import xsrf
 from framework import secrets
-import settings
+from framework import xsrf
 from internals import models
 
 from django.template.loader import render_to_string

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -30,6 +30,7 @@ from google.appengine.ext import db
 from framework import permissions
 from framework import ramcache
 from framework import xsrf
+from framework import secrets
 import settings
 from internals import models
 
@@ -380,6 +381,8 @@ def FlaskApplication(routes, pattern_base='', debug=False):
   """Make a Flask app and add routes and handlers that work like webapp2."""
 
   app = flask.Flask(__name__)
+  app.secret_key = secrets.get_session_secret()  # For flask.session
+
   for i, rule in enumerate(routes):
     pattern = rule[0]
     handler_class = rule[1]

--- a/framework/secrets.py
+++ b/framework/secrets.py
@@ -58,12 +58,12 @@ class Secrets(db.Model):
 
     if not singleton.xsrf_secret:
       singleton.xsrf_secret = make_random_key()
-      logging.info('Added XSRF secret: %r' % singleton.xsrf_secret)
+      logging.info('Added XSRF secret: %r' % singleton.xsrf_secret[:8])
       needs_save = True
 
     if not singleton.session_secret:
       singleton.session_secret = make_random_key()
-      logging.info('Added session secret: %r' % singleton.session_secret)
+      logging.info('Added session secret: %r' % singleton.session_secret[:8])
       needs_save = True
 
     if needs_save:

--- a/framework/secrets.py
+++ b/framework/secrets.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+from __future__ import print_function
+
+import base64
+import hmac
+import logging
+import random
+import string
+import time
+
+from google.appengine.ext import db
+
+
+# For random key generation
+RANDOM_KEY_LENGTH = 128
+RANDOM_KEY_CHARACTERS = string.ascii_letters + string.digits
+
+
+def make_random_key(length=RANDOM_KEY_LENGTH, chars=RANDOM_KEY_CHARACTERS):
+  """Return a string with lots of random characters."""
+  chars = [random.choice(chars) for _ in range(length)]
+  return ''.join(chars)
+
+
+class Secrets(db.Model):
+  """A server-side-only value that we use to generate security tokens."""
+
+  xsrf_secret = db.StringProperty()
+  session_secret = db.StringProperty()
+
+  @classmethod
+  def _get_or_make_singleton(cls):
+    needs_save = False
+    singleton = None
+    existing = Secrets.all().fetch(1)
+    if existing:
+      singleton = existing[0]
+
+    if not singleton:
+      logging.info('Creating new secrets')
+      singleton = Secrets()
+      needs_save = True
+
+    if not singleton.xsrf_secret:
+      singleton.xsrf_secret = make_random_key()
+      logging.info('Added XSRF secret: %r' % singleton.xsrf_secret)
+      needs_save = True
+
+    if not singleton.session_secret:
+      singleton.session_secret = make_random_key()
+      logging.info('Added session secret: %r' % singleton.session_secret)
+      needs_save = True
+
+    if needs_save:
+      logging.info('Saving new secrets')
+      singleton.put()
+
+    return singleton
+
+
+def get_xsrf_secret():
+  """Return the xsrf secret key."""
+  singleton = Secrets._get_or_make_singleton()
+  return singleton.xsrf_secret
+
+
+def get_session_secret():
+  """Return the session secret key."""
+  singleton = Secrets._get_or_make_singleton()
+  return singleton.session_secret

--- a/framework/secrets_test.py
+++ b/framework/secrets_test.py
@@ -1,0 +1,88 @@
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+import testing_config  # Must be imported before the module under test.
+
+import mock
+
+from framework import secrets
+
+
+class SecretsFunctionsTest(unittest.TestCase):
+  """Set of unit tests for accessing server-side secret values."""
+
+  def test_make_random_key__long(self):
+    """The random keys have the desired length."""
+    key = secrets.make_random_key()
+    self.assertEqual(secrets.RANDOM_KEY_LENGTH, len(key))
+
+  def test_make_random_key__distinct(self):
+    """The random keys are different."""
+    key_set = set()
+    for i in range(1000):
+      key_set.add(secrets.make_random_key())
+    self.assertEqual(1000, len(key_set))
+
+  def test_get_xsrf_secret(self):
+    """We can get this secret, and it is the same for repeated calls."""
+    s1 = secrets.get_xsrf_secret()
+    s2 = secrets.get_xsrf_secret()
+    self.assertIsNotNone(s1)
+    self.assertEqual(s1, s2)
+
+  def test_get_session_secret(self):
+    """We can get this secret, and it is the same for repeated calls."""
+    s1 = secrets.get_session_secret()
+    s2 = secrets.get_session_secret()
+    self.assertIsNotNone(s1)
+    self.assertEqual(s1, s2)
+
+
+class SecretsTest(unittest.TestCase):
+  """Set of unit tests for generating and storing server-side secret values."""
+
+  def delete_all(self):
+    for old_entity in secrets.Secrets.all():
+      old_entity.delete()
+
+  def setUp(self):
+    self.delete_all()
+
+  def tearDown(self):
+    self.delete_all()
+
+  def test_create_and_persist(self):
+    """When a new instance is deployed, it sets up secrets."""
+    singleton = secrets.Secrets._get_or_make_singleton()
+    self.assertIsInstance(singleton, secrets.Secrets)
+
+    singleton2 = secrets.Secrets._get_or_make_singleton()
+    self.assertEqual(singleton.xsrf_secret, singleton2.xsrf_secret)
+    self.assertEqual(singleton.session_secret, singleton2.session_secret)
+
+  @mock.patch('framework.secrets.make_random_key')
+  def test_upgrade(self, mock_make_random_key):
+    """When we add a new secret field, it is added to existing secrets."""
+    mock_make_random_key.return_value = 'fake new random'
+    singleton = secrets.Secrets(xsrf_secret='old secret field')
+    singleton.put()
+
+    singleton2 = secrets.Secrets._get_or_make_singleton()
+    mock_make_random_key.assert_called_once_with()
+    self.assertEqual(singleton2.xsrf_secret, 'old secret field')
+    self.assertEqual(singleton2.session_secret, 'fake new random')

--- a/framework/xsrf_test.py
+++ b/framework/xsrf_test.py
@@ -26,18 +26,6 @@ from framework import xsrf
 class XsrfTest(unittest.TestCase):
   """Set of unit tests for blocking XSRF attacks."""
 
-  def test_make_random_key__long(self):
-    """The random keys have the desired length."""
-    key = xsrf.make_random_key()
-    self.assertEqual(xsrf.RANDOM_KEY_LENGTH, len(key))
-
-  def test_make_random_key__distinct(self):
-    """The random keys are different."""
-    key_set = set()
-    for i in range(1000):
-      key_set.add(xsrf.make_random_key())
-    self.assertEqual(1000, len(key_set))
-
   def test_generate_token__anon(self):
     """Anon users get a real token."""
     self.assertNotEqual('', xsrf.generate_token(None))


### PR DESCRIPTION
This is step toward solving issue #1201.

As part of the py3 upgrade, we need to replace the GAE users library with Google Sign-In.  However, Google Sign-In does not set a cookie, it only provides an ID token in javascript.  So, we will use flask.session to save the user's ID token.  See
https://github.com/GoogleChrome/chromium-dashboard/pull/1275

Before that can work, we need a session secret.  This PR refactors and expands on the existing code for XSRF secrets.