### PR TITLE
Allow site admins to be specified via AppUser entities.

### DIFF
--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -24,10 +24,20 @@ from google.appengine.api import users
 from internals import models
 
 
-def can_admin_site(unused_user):
+def can_admin_site(user):
   """Return True if the current user is allowed to administer the site."""
-  # TODO(jrobbins): replace this with user.is_admin.
-  return users.is_current_user_admin()
+  # A user is an admin if they are an admin of the GAE project.
+  # TODO(jrobbins): delete this statement after legacy admins moved to AppUser.
+  if users.is_current_user_admin():
+    return True
+
+  # A user is an admin if they have an AppUser entity that has is_admin set.
+  if user:
+    app_user = models.AppUser.get_app_user(user.email())
+    if app_user is not None:
+      return app_user.is_admin
+
+  return False
 
 
 def can_view_feature(unused_user, unused_feature):

--- a/framework/ramcache.py
+++ b/framework/ramcache.py
@@ -133,7 +133,7 @@ def delete(key):
   """Emulate the memcache.delete() method using a RAM cache."""
   if key in global_cache:
     del global_cache[key]
-    flush_all()  # Note: this is wasteful but infrequent in our app.
+  flush_all()  # Note: this is wasteful but infrequent in our app.
 
 
 def flush_all():

--- a/framework/ramcache_test.py
+++ b/framework/ramcache_test.py
@@ -85,10 +85,10 @@ class RAMCacheFunctionTests(unittest.TestCase):
 
   @mock.patch('framework.ramcache.SharedInvalidate.invalidate')
   def testDelete_NotFound(self, mock_invalidate):
-    """Deleting an item that is not in the cache is a no-op."""
+    """Deleting an item that is not in the cache still invalidates."""
     ramcache.delete(KEY_5)
 
-    mock_invalidate.assert_not_called()
+    mock_invalidate.assert_called()
 
   @mock.patch('framework.ramcache.SharedInvalidate.invalidate')
   def testDelete_Found(self, mock_invalidate):

--- a/internals/models.py
+++ b/internals/models.py
@@ -1221,9 +1221,38 @@ class AppUser(DictModel):
 
   #user = db.UserProperty(required=True, verbose_name='Google Account')
   email = db.EmailProperty(required=True)
-  #is_admin = db.BooleanProperty(default=False)
+  is_admin = db.BooleanProperty(default=False)
   created = db.DateTimeProperty(auto_now_add=True)
   updated = db.DateTimeProperty(auto_now=True)
+
+  def put(self, **kwargs):
+    """when we update an AppUser, also invalidate ramcache."""
+    key = super(DictModel, self).put(**kwargs)
+    cache_key = 'user|%s' % self.email
+    ramcache.delete(cache_key)
+
+  def delete(self, **kwargs):
+    """when we delete an AppUser, also invalidate ramcache."""
+    key = super(DictModel, self).delete(**kwargs)
+    cache_key = 'user|%s' % self.email
+    ramcache.delete(cache_key)
+
+  @classmethod
+  def get_app_user(cls, email):
+    """Return the AppUser for the specified user, or None."""
+    cache_key = 'user|%s' % email
+    cached_app_user = ramcache.get(cache_key)
+    if cached_app_user:
+      return cached_app_user
+
+    query = cls.all()
+    query.filter('email =', email)
+    found_app_user = query.get()
+    if found_app_user:
+      ramcache.set(cache_key, found_app_user)
+      return found_app_user
+
+    return None
 
 
 def list_with_component(l, component):

--- a/pages/users.py
+++ b/pages/users.py
@@ -57,12 +57,13 @@ class CreateUserAPIHandler(basehandlers.FlaskHandler):
 
   @permissions.require_admin_site
   def process_post_data(self):
-    email = flask.request.form['email']
+    email = self.form['email']
 
     # Don't add a duplicate email address.
     user = models.AppUser.all(keys_only=True).filter('email = ', email).get()
     if not user:
       user = models.AppUser(email=db.Email(email))
+      user.is_admin = 'is_admin' in self.form
       user.put()
 
       response_json = user.format_for_template()

--- a/static/elements/chromedash-userlist.js
+++ b/static/elements/chromedash-userlist.js
@@ -1,5 +1,6 @@
 import {LitElement, css, html} from 'lit-element';
 import SHARED_STYLES from '../css/shared.css';
+import {nothing} from 'lit-html';
 
 
 class ChromedashUserlist extends LitElement {
@@ -20,6 +21,18 @@ class ChromedashUserlist extends LitElement {
     return [
       SHARED_STYLES,
       css`
+      form {
+        padding: var(--content-padding);
+        background: var(--card-background);
+        border: var(--card-border);
+        box-shadow: var(--card-box-shadow);
+        margin-bottom: var(--content-padding);
+        max-width: 20em;
+      }
+      form > * + * {
+        margin-top: var(--content-padding-half);
+      }
+
       ul {
         margin-top: 10px;
       }
@@ -52,8 +65,12 @@ class ChromedashUserlist extends LitElement {
 
     if (formEl.checkValidity()) {
       const email = formEl.querySelector('input[name="email"]').value;
+      const isAdmin = formEl.querySelector('input[name="is_admin"]').checked;
       const formData = new FormData();
       formData.append('email', email);
+      if (isAdmin) {
+        formData.append('is_admin', 'on');
+      }
       formData.append('token', this.token);
 
       const resp = await fetch(this.actionPath, {
@@ -98,14 +115,25 @@ class ChromedashUserlist extends LitElement {
   render() {
     return html`
       <form id="form" name="user_form" method="POST" action="${this.actionPath}" onsubmit="return false;">
-        <input type="email" placeholder="Email address" name="email" id="id_email" required>
-        <td><input type="submit" @click="${this.ajaxSubmit}">
+        <div>
+          <input type="email" placeholder="Email address" name="email"
+                 required>
+        </div>
+        <div>
+          <label><input type="checkbox" name="is_admin"> User is admin</label>
+        </div>
+        <div>
+          <input type="submit" @click="${this.ajaxSubmit}" value="Add user">
+        </div>
       </form>
+
       <ul id="user-list">
         ${this.users.map((user, index) => html`
           <li>
-            <a href="/admin/users/delete/${user.id}" data-index="${index}" @click="${this.ajaxDelete}">delete</a>
+            <a href="/admin/users/delete/${user.id}"
+               data-index="${index}" @click="${this.ajaxDelete}">delete</a>
             <span>${user.email}</span>
+            ${user.is_admin ? html`(admin)` : nothing}
           </li>
           `)}
       </ul>

--- a/templates/admin/users/new.html
+++ b/templates/admin/users/new.html
@@ -6,7 +6,7 @@
 
 {% block subheader %}
 <div id="subheader">
-  <h2>Allowlist a user</h2>
+  <h2>Application users</h2>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
In GAE's python 2 environment, we can call users.is_current_user_admin() to check if the user signed in with a GAE cookie is the same as one of the GAE project admins.   However, GAE cookies are not available in GAE's python 3 environment, in fact, the whole users library is not available.  So, instead we will now keep track of our list users who are administrators of data in our app.

In this CL:
+ Add an is_admin field to AppUser.  This line has been commented out since it was first added in 2013
https://github.com/GoogleChrome/chromium-dashboard/commit/6bff1fbf2a36ebb8407e95689df78fbb6783cfe4
+ Add AppUser methods to return a cached AppUser instance, because we will need one for each permission check.
+ Implement a new case in the logic in permissions.py can_admin_site() to check for is_admin.
+ Add UI form field and form handler logic to create AppUser records with is_admin set, and display which users are admins.