### PR TITLE
Remove serviceworker unregister.

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -128,17 +128,6 @@ limitations under the License.
     (function() {
       'use strict';
 
-      // Unregister any existing service workers.
-      // Note, this leaves existing service workers on existing browser tabs.
-      // TODO(jrobbins): remove this in a future release.
-      if (window.navigator && navigator.serviceWorker) {
-        navigator.serviceWorker.getRegistrations().then(function(registrations) {
-          for (let registration of registrations) {
-            registration.unregister();
-          }
-        });
-      }
-
       {% inline_file "/static/js/shared.min.js" %}
     })();
   </script>


### PR DESCRIPTION
After we stopped using service worker, I added this code to unregister the worker if it was previously installed for any users.

It was added 10 months do, so I think we can delete this code now.
https://github.com/GoogleChrome/chromium-dashboard/commit/53a92edd2b65485259777341d855ca243ef62053#diff-2fdf9cac2396a7b0dfd648b1512b61bd87eaf37ed45678555eca3d0943e29a78