### PR TITLE
Stop hitting prod when testing locally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ To start the main server and the notifier backend, run:
 ```bash
 npm start
 ```
+Then visit `http://localhost:8080/`.
 
 To start front end code watching (sass, js lint check, babel, minify files), run
 
@@ -62,8 +63,6 @@ There are some developing information in developer-documentation.md.
 **Notes**
 
 - If you get an error saying `No module named protobuf`, try installing it locally with `python -m pip install protobuf`.
-
-- Locally, the `/feature` list pulls from prod (https://www.chromestatus.com/features.json). Opening one of the features will 404 because the entry is not actually in the local db. If you want to test local entries, go to `http://127.0.0.1:8080/` instead of `localhost` to use local data.
 
 - When installing the GAE SDK, make sure to get the version for python 2.7.  It is no longer the default version.
 

--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -51,8 +51,7 @@ class ChromedashFeaturelist extends LitElement {
   }
 
   async _loadData() {
-    const featureUrl = location.hostname == 'localhost' ?
-      'https://www.chromestatus.com/features_v2.json' : '/features_v2.json';
+    const featureUrl = '/features_v2.json';
 
     try {
       const features = await (await fetch(featureUrl)).json();

--- a/static/elements/chromedash-sample-panel.js
+++ b/static/elements/chromedash-sample-panel.js
@@ -95,8 +95,7 @@ class ChromedashSamplePanel extends LitElement {
 
   async _loadData() {
     // Fire of samples.json XHR right away so data can populate faster.
-    const url = location.hostname == 'localhost' ?
-      'https://www.chromestatus.com/samples.json' : '/samples.json';
+    const url = '/samples.json';
     this.features = await (await fetch(url)).json();
     this.features.forEach((feature) => {
       feature.sample_links = feature.sample_links.map((link) => {

--- a/static/elements/chromedash-timeline.js
+++ b/static/elements/chromedash-timeline.js
@@ -11,7 +11,6 @@ class ChromedashTimeline extends LitElement {
       selectedBucketId: {attribute: false},
       showAllHistoricalData: {attribute: false},
       props: {attribute: false}, // Directly edited from metrics/css/timeline/popularity and metrics/feature/timeline/popularity
-      useRemoteData: {attribute: false}, // If true, fetches live data from chromestatus.com instead of localhost.
 
       // Listed in the old code, but seems not used in the component:
       timeline: {attribute: false},
@@ -26,7 +25,6 @@ class ChromedashTimeline extends LitElement {
     this.type = '';
     this.view = '';
     this.props = [];
-    this.useRemoteData = false;
   }
 
   static get styles() {
@@ -94,7 +92,6 @@ class ChromedashTimeline extends LitElement {
       'selectedBucketId',
       'type',
       'view',
-      'useRemoteData',
       'showAllHistoricalData',
     ];
     if (TRACKING_PROPERTIES.some((property) => changedProperties.has(property))) {
@@ -213,9 +210,7 @@ class ChromedashTimeline extends LitElement {
       return;
     }
 
-    const prefix = this.useRemoteData ? 'https://www.chromestatus.com' : '';
-
-    const url = prefix + '/data/timeline/' + this.type + this.view +
+    const url = '/data/timeline/' + this.type + this.view +
               '?bucket_id=' + this.selectedBucketId;
 
     this._renderHTTPArchiveData();

--- a/static/js-src/schedule-page.js
+++ b/static/js-src/schedule-page.js
@@ -1,6 +1,5 @@
 // Start fetching right away.
-const url = location.hostname == 'localhost' ?
-  'https://www.chromestatus.com/features.json' : '/features.json';
+const url = '/features.json';
 const featuresPromise = fetch(url).then((res) => res.json());
 
 document.querySelector('.show-blink-checkbox').addEventListener('change', e => {


### PR DESCRIPTION
This removes logic to sometimes hit our prod server (chromestaus.com) when testing locally on localhost (rather than 127.0.0.1). 

This functionality always seemed a little odd to me and I have not made use of it.   There are three reasons to remove this now:
+ Simplify the app so that there is less to explain to new potential contributors
+ Avoid the risk of API requests that might try to alter data to prod
 - This risk will increase because with Google Sign-In we will be using real when testing locally rather than test@example.com.
+ Our OAuth client ID is configured in the Google Cloud console, and it might need a redirect URL which is not allowed to be numeric so we need to be able to use localhost.  I am not sure about that aspect yet.