### PR TITLE
Only show explainer in intents for non-PSA or when it has a value.

### DIFF
--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -23,11 +23,13 @@
     <a href="mailto:{{owner}}">{% if forloop.last %}{{owner}}</a>{% else %}{{owner}}</a>,{% endif %}
   {% endfor %}
 
-  <br><br><h4>Explainer</h4>
-  {% if not feature.explainer_links %}None{% endif %}
-  {% for link in feature.explainer_links %}
-    <br><a href="{{link}}">{{link}}</a>
-  {% endfor %}
+  {% if feature.explainer_links or feature.feature_type_int != 2 %}
+    <br><br><h4>Explainer</h4>
+    {% if not feature.explainer_links %}None{% endif %}
+    {% for link in feature.explainer_links %}
+      {% if forloop.counter0 %}<br>{% endif %}<a href="{{link}}">{{link}}</a>
+    {% endfor %}
+  {% endif %}
 
   <br><br><h4>Specification</h4>
   {{feature.spec_link|urlize}}


### PR DESCRIPTION
This should resolve issue #1273.

In this PR:
+ Rather than always show the explainer links, show them only for non-PSA feature entries, or if someone has put in an explainer value (e.g., before changing the type of the feature to PSA).
+ Refine the way that we add `<br>` elements in that loop so that there is not an extra one at the start.