### PR TITLE
Refresh XSRF token in form submission.

### DIFF
--- a/static/elements/chromedash-userlist.js
+++ b/static/elements/chromedash-userlist.js
@@ -7,7 +7,6 @@ class ChromedashUserlist extends LitElement {
   static get properties() {
     return {
       actionPath: {type: String},
-      token: {type: String},
       users: {attribute: false},
     };
   }
@@ -59,6 +58,7 @@ class ChromedashUserlist extends LitElement {
     this.users = this.users.slice(0); // Refresh the list
   }
 
+  // TODO(jrobbins): Change this to be a JSON API call via csClient.
   async ajaxSubmit(e) {
     e.preventDefault();
     const formEl = this.shadowRoot.querySelector('form');
@@ -71,7 +71,8 @@ class ChromedashUserlist extends LitElement {
       if (isAdmin) {
         formData.append('is_admin', 'on');
       }
-      formData.append('token', this.token);
+      await window.csClient.ensureTokenIsValid();
+      formData.append('token', window.csClient.token);
 
       const resp = await fetch(this.actionPath, {
         method: 'POST',

--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -25,9 +25,7 @@ class ChromeStatusClient {
     this.baseUrl = '/api/v0'; // Same scheme, host, and port.
   }
 
-  /**
-   * Refresh the XSRF token if necessary.
-   */
+  /* Refresh the XSRF token if necessary. */
   async ensureTokenIsValid() {
     if (ChromeStatusClient.isTokenExpired(this.tokenExpiresSec)) {
       const refreshResponse = await this.doFetch(
@@ -37,11 +35,41 @@ class ChromeStatusClient {
     }
   }
 
+  /* Return true if the XSRF token has expired. */
   static isTokenExpired(tokenExpiresSec) {
     const tokenExpiresDate = new Date(tokenExpiresSec * 1000);
     return tokenExpiresDate < new Date();
   }
 
+  /* Return all hidden form fields for XSRF tokens. */
+  allTokenFields() {
+    return document.querySelectorAll('input[name=token]');
+  }
+
+  /* Add updateFormToken() as a listener on all forms use XSRF. */
+  addFormSubmitListner() {
+    this.allTokenFields().forEach((field) => {
+      field.form.addEventListener('submit', (event) => {
+        this.updateFormToken(event);
+      });
+    });
+  }
+
+  /* If too much time has passed since the page loaded, get a new XSRF
+   * token from the server and stuff it into the XSRF token form field
+   * before submitting. */
+  updateFormToken(event) {
+    event.preventDefault();
+    this.ensureTokenIsValid().then(() => {
+      this.allTokenFields().forEach((field) => {
+        field.value = this.token;
+      });
+      event.target.submit();
+    });
+  }
+
+  /* Make a JSON API call to the server, including an XSRF header.
+   * Then strip off the defensive prefix from the response. */
   async doFetch(resource, httpMethod, body, includeToken=true) {
     const url = this.baseUrl + resource;
     let headers = {

--- a/static/js-src/shared.js
+++ b/static/js-src/shared.js
@@ -25,3 +25,6 @@ gtag('js', new Date());
 
 gtag('config', 'UA-179341418-1');
 // End Google Analytics
+
+
+window.csClient.addFormSubmitListner();

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -63,12 +63,8 @@ limitations under the License.
     {% inline_file "/static/js/metric.min.js" %}
     {% inline_file "/static/js/cs-client.min.js" %}
 
-    window.CS_env = {
-        token: '{{xsrf_token}}',
-        tokenExpiresSec: {{xsrf_token_expires}},
-    };
     window.csClient = new ChromeStatusClient(
-        window.CS_env.token, window.CS_env.tokenExpiresSec);
+        '{{xsrf_token}}', {{xsrf_token_expires}});
   </script>
 
   <script src="https://unpkg.com/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>

--- a/templates/admin/users/new.html
+++ b/templates/admin/users/new.html
@@ -15,7 +15,6 @@
 
   <chromedash-userlist
     actionPath="/admin/users/create"
-    token="{{xsrf_token}}"
     ></chromedeash-userlist>
 
 </section>


### PR DESCRIPTION
This is the last piece of new code needed to implement XSRF tokens.  It checks if the XSRF token supplied on page load has expired, and if so it updates the `<input type="hidden" name="token">` form fields on pages that submit forms. 

In this PR:
+ Add new methods to our client to add submit listeners and handle form submission events.
+ Call that on every page.
+ Make chromedash-userlist.js get the XSRF token via csClient rather than passing it in as a property. 
+ Also, eliminate the global variable CS_env because the only state that we need is in csClient.