### PR TITLE
Also cache AppUser entities for non-registered users.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -1245,12 +1245,9 @@ class AppUser(DictModel):
 
     query = cls.all()
     query.filter('email =', email)
-    found_app_user = query.get()
-    if found_app_user:
-      ramcache.set(cache_key, found_app_user)
-      return found_app_user
-
-    return None
+    found_app_user_or_none = query.get()
+    ramcache.set(cache_key, found_app_user_or_none)
+    return found_app_user_or_none
 
 
 def list_with_component(l, component):


### PR DESCRIPTION
We check the list of registered users (AppUser) to see if the signed-in user is registered, and if they are marked as being a site admin.  This check happens a lot because site admin status is checked on any permission check.  So, it is cached.    However, the existing code only cached an AppUser entry that was found, meaning that a random user who signed in would cause multiple cache misses and datastore retrievals on each page view.

In this PR:
+ Cache whatever we get back from retrieving the signed-in user's AppUser entity, even if that is None
  (If the user becomes a registered user, our distributed cache is invalidated via the existing logic in the put() method.)
