### PR TITLE
Add rel="noopener" to all target="_blank" links.

### DIFF
--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -50,7 +50,7 @@
 
   <br><br><h4>Blink component</h4>
   {% for c in feature.blink_components %}
-    <a href="https://bugs.chromium.org/p/chromium/issues/list?q=component:{{c}}" target="_blank">{{c}}</a>
+    <a href="https://bugs.chromium.org/p/chromium/issues/list?q=component:{{c}}" target="_blank" rel="noopener">{{c}}</a>
   {% endfor %}
 
   {% if 'motivation' in sections_to_show %}

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -39,7 +39,7 @@
     </span>
   {% endif %}
   <span class="tooltip" title="File a bug against this feature">
-    <a href="{{ new_crbug_url }}" class="newbug" data-tooltip target="_blank">
+    <a href="{{ new_crbug_url }}" class="newbug" data-tooltip target="_blank" rel="noopener">
       <iron-icon icon="chromestatus:bug-report"></iron-icon>
     </a>
   </span>
@@ -118,7 +118,8 @@
     {% if feature.spec_link %}
     <section id="specification">
       <h3>Specification</h3>
-      <p><a href="{{feature.spec_link}}" target="_blank">{{feature.standardization.text}}</a></p>
+      <p><a href="{{feature.spec_link}}" target="_blank" rel="noopener"
+            >{{feature.standardization.text}}</a></p>
     </section>
     {% endif %}
 
@@ -128,7 +129,8 @@
         <p>
           <label>Blink components:</label>
           {% for c in feature.blink_components %}
-            <a href="https://bugs.chromium.org/p/chromium/issues/list?q=component:{{c}}" target="_blank">{{c}}</a>
+          <a href="https://bugs.chromium.org/p/chromium/issues/list?q=component:{{c}}"
+             target="_blank" rel="noopener">{{c}}</a>
           {% endfor %}
         </p>
       {% endif %}
@@ -136,7 +138,8 @@
       <p>
         <b>{{ feature.impl_status_chrome }}</b>
         {% if feature.bug_url %}
-          (<a href="{{feature.bug_url}}" target="_blank">tracking bug</a>)
+          (<a href="{{feature.bug_url}}" target="_blank" rel="noopener"
+              >tracking bug</a>)
         {% endif %}
         {% if feature.shipped_milestone or feature.shipped_android_milestone or feature.shipped_ios_milestone or feature.shipped_webview_milestone %}
           in:

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,13 +1,13 @@
 <footer>
   <div>
      <a href="https://groups.google.com/a/chromium.org/forum/#!newtopic/blink-dev"
-        target="_blank"
+        target="_blank" rel="noopener"
         >Discuss</a>
      <a href="https://github.com/GoogleChrome/chromium-dashboard/issues"
-        target="_blank"
+        target="_blank" rel="noopener"
        >File an issue</a>
      <a href="https://www.google.com/policies/privacy/"
-        target="_blank"
+        target="_blank" rel="noopener"
         >Privacy</a>
   </div>
 </footer>

--- a/templates/guide/edit.html
+++ b/templates/guide/edit.html
@@ -11,7 +11,7 @@
      href="/guide/editall/{{ feature_id }}">Edit all fields</a>
   <span style="float:right; margin-right: 2em">
   <a href="https://github.com/GoogleChrome/chromium-dashboard/issues/new?labels=Feedback&template=process-and-guide-ux-feedback.md"
-     target="_blank">Process and UI feedback</a></span>
+     target="_blank" rel="noopener">Process and UI feedback</a></span>
   <h2 id="breadcrumbs">
     <a href="/feature/{{ feature_id }}">
       <iron-icon icon="chromestatus:arrow-back"></iron-icon>
@@ -38,7 +38,7 @@
 <section style="margin: 1em 0 8em 0">
   Please see the
  <a href="https://www.chromium.org/blink/launching-features"
-    target="_blank">Launching features</a>
+    target="_blank" rel="noopener">Launching features</a>
  page for process instructions.
 </section>
 

--- a/templates/guide/new.html
+++ b/templates/guide/new.html
@@ -12,7 +12,7 @@
 <div id="subheader" style="display:block">
   <span style="float:right; margin-right: 2em">
   <a href="https://github.com/GoogleChrome/chromium-dashboard/issues/new?labels=Feedback&template=process-and-guide-ux-feedback.md"
-     target="_blank">Process and UI feedback</a></span>
+     target="_blank" rel="noopener">Process and UI feedback</a></span>
   <h2>Add a feature</h2>
 </div>
 {% endblock %}
@@ -28,7 +28,7 @@
         <td>
           Please see the
           <a href="https://www.chromium.org/blink/launching-features"
-             target="_blank">Launching features</a>
+             target="_blank" rel="noopener">Launching features</a>
           page for process instructions.
         </td>
       </tr>

--- a/templates/metrics/css/animated.html
+++ b/templates/metrics/css/animated.html
@@ -15,9 +15,9 @@
     <nav class="data-panel">
       <td>View All Properties As:</td>
       <td>
-        <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a> | 
+        <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a> |
         <a href="/metrics/css/popularity"  class="sub-nav-links">Stack Rank</a>
-      </td>  
+      </td>
     </nav>
   </tr>
 
@@ -25,7 +25,7 @@
     <nav class="data-panel">
       <td>View Animated Properties As:</td>
       <td>
-        <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a> | 
+        <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a> |
         <a href="/metrics/css/animated"  class="sub-nav-links">Stack Rank</a>
       </td>
     </nav>
@@ -43,7 +43,7 @@
 <div class="data-panel">
   <h3>About this data</h3>
   <p class="description">
-    We've been using Chrome's <a href="https://cs.chromium.org/chromium/src/tools/metrics/histograms/enums.xml" target="_blank">anonymous usage statistics</a> to count the CSS properties which are animated. <b>Percentages on this page indicate the fraction of Chrome page loads that animates the corresponding CSS property (in a transition or animation) at least once</b>. Data is ~24 hrs old and reflects usage across all channels and platforms.</p>
+    We've been using Chrome's <a href="https://cs.chromium.org/chromium/src/tools/metrics/histograms/enums.xml" target="_blank" rel="noopener">anonymous usage statistics</a> to count the CSS properties which are animated. <b>Percentages on this page indicate the fraction of Chrome page loads that animates the corresponding CSS property (in a transition or animation) at least once</b>. Data is ~24 hrs old and reflects usage across all channels and platforms.</p>
   <chromedash-metrics type="css" view="animated"></chromedash-metrics>
 </div>
 {% endblock %}

--- a/templates/metrics/css/popularity.html
+++ b/templates/metrics/css/popularity.html
@@ -15,9 +15,9 @@
     <nav class="data-panel">
       <td>View All Properties As:</td>
       <td>
-        <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a> | 
+        <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a> |
         <a href="/metrics/css/popularity"  class="sub-nav-links">Stack Rank</a>
-      </td>  
+      </td>
     </nav>
   </tr>
 
@@ -25,7 +25,7 @@
     <nav class="data-panel">
       <td>View Animated Properties As:</td>
       <td>
-        <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a> | 
+        <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a> |
         <a href="/metrics/css/animated"  class="sub-nav-links">Stack Rank</a>
       </td>
     </nav>
@@ -45,7 +45,7 @@
   <p class="description">
     We've been using Chrome's <a
     href="https://cs.chromium.org/chromium/src/tools/metrics/histograms/enums.xml"
-    target="_blank">anonymous usage statistics</a> to count the
+    target="_blank" rel="noopener">anonymous usage statistics</a> to count the
     occurrences of certain CSS features in the wild. The numbers on
     this page indicate the <b>percentages of Chrome page loads (across
     all channels and platforms) that use the corresponding CSS

--- a/templates/metrics/css/timeline/animated.html
+++ b/templates/metrics/css/timeline/animated.html
@@ -19,9 +19,9 @@
     <nav class="data-panel">
       <td>View All Properties As:</td>
       <td>
-        <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a> | 
+        <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a> |
         <a href="/metrics/css/popularity"  class="sub-nav-links">Stack Rank</a>
-      </td>  
+      </td>
     </nav>
   </tr>
 
@@ -29,7 +29,7 @@
     <nav class="data-panel">
       <td>View Animated Properties As:</td>
       <td>
-        <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a> | 
+        <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a> |
         <a href="/metrics/css/animated"  class="sub-nav-links">Stack Rank</a>
       </td>
     </nav>
@@ -51,7 +51,7 @@
       ></chromedash-timeline>
   <p class="callout">
     <b>Note</b>: on 2017-10-26 the underlying metrics were switched over to a newer collection system
-    which is <a href="https://groups.google.com/a/chromium.org/forum/#!msg/blink-api-owners-discuss/IpIkbz0qtrM/HUCfSMv2AQAJ" target="_blank">more accurate</a>.
+    which is <a href="https://groups.google.com/a/chromium.org/forum/#!msg/blink-api-owners-discuss/IpIkbz0qtrM/HUCfSMv2AQAJ" target="_blank" rel="noopener">more accurate</a>.
     This is also the reason for the abrupt spike around 2017-10-26.
   </p>
 </div>

--- a/templates/metrics/css/timeline/popularity.html
+++ b/templates/metrics/css/timeline/popularity.html
@@ -19,9 +19,9 @@
     <nav class="data-panel">
       <td>View All Properties As:</td>
       <td>
-        <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a> | 
+        <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a> |
         <a href="/metrics/css/popularity"  class="sub-nav-links">Stack Rank</a>
-      </td>  
+      </td>
     </nav>
   </tr>
 
@@ -29,7 +29,7 @@
     <nav class="data-panel">
       <td>View Animated Properties As:</td>
       <td>
-        <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a> | 
+        <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a> |
         <a href="/metrics/css/animated"  class="sub-nav-links">Stack Rank</a>
       </td>
     </nav>
@@ -52,7 +52,7 @@
       ></chromedash-timeline>
   <p class="callout">
     <b>Note</b>: on 2017-10-26 the underlying metrics were switched over to a newer collection system
-    which is <a href="https://groups.google.com/a/chromium.org/forum/#!msg/blink-api-owners-discuss/IpIkbz0qtrM/HUCfSMv2AQAJ" target="_blank">more accurate</a>.
+    which is <a href="https://groups.google.com/a/chromium.org/forum/#!msg/blink-api-owners-discuss/IpIkbz0qtrM/HUCfSMv2AQAJ" target="_blank" rel="noopener">more accurate</a>.
     This is also the reason for the abrupt spike around 2017-10-26.
   </p>
 </div>

--- a/templates/metrics/feature/popularity.html
+++ b/templates/metrics/feature/popularity.html
@@ -11,7 +11,7 @@
 
 {% block horizontalsubnav %}
 <nav class="data-panel">
-  View As:<a href="/metrics/feature/timeline/popularity" class="sub-nav-links">Timeline</a> | 
+  View As:<a href="/metrics/feature/timeline/popularity" class="sub-nav-links">Timeline</a> |
   <a href="/metrics/feature/popularity"  class="sub-nav-links">Stack Rank</a>
 </nav>
 {% endblock %}
@@ -28,7 +28,7 @@
   <p class="description">
     We've been using Chrome's <a
     href="https://cs.chromium.org/chromium/src/tools/metrics/histograms/enums.xml"
-    target="_blank">anonymous usage statistics</a> to count the
+    target="_blank" rel="noopener">anonymous usage statistics</a> to count the
     occurrences of certain HTML and JavaScript features in the
     wild. The numbers on this page indicate the <b>percentages of
     Chrome page loads (across all channels and platforms) that use the

--- a/templates/samples.html
+++ b/templates/samples.html
@@ -32,7 +32,8 @@
       <input type="search" placeholder="Search">
     </div>
     <div class="actionlinks">
-      <a href="https://github.com/GoogleChrome/samples" target="_blank" class="blue-button">
+      <a href="https://github.com/GoogleChrome/samples"
+         target="_blank" rel="noopener" class="blue-button">
         <iron-icon src="/static/img/github-white.png"></iron-icon>Fork on Github
       </a>
     </div>


### PR DESCRIPTION
This is recommended on https://web.dev/external-anchors-use-rel-noopener/.
It is not actually needed for chrome 88 and later, but it could help with earlier chrome versions or other older browsers.