### PR TITLE
Re-enabled experiment timeline if it is not empty.

### DIFF
--- a/static/js-src/admin/feature_form.js
+++ b/static/js-src/admin/feature_form.js
@@ -1,22 +1,28 @@
 (function() {
-'use strict';
+  'use strict';
 
-const fields = document.querySelectorAll('input, textarea');
-for (let i = 0; i < fields.length; ++i) {
-  fields[i].addEventListener('blur', (e) => {
-    e.target.classList.add('interacted');
+  const fields = document.querySelectorAll('input, textarea');
+  for (let i = 0; i < fields.length; ++i) {
+    fields[i].addEventListener('blur', (e) => {
+      e.target.classList.add('interacted');
+    });
+  }
+
+  // Allow editing if there was already a value specified in this
+  // deprecated field.
+  const timelineField = document.querySelector('#id_experiment_timeline');
+  if (timelineField && timelineField.value) {
+    timelineField.disabled = '';
+  }
+
+
+  if (document.querySelector('#cancel-button')) {
+    document.querySelector('#cancel-button').addEventListener('click', (e) => {
+      window.location.href = `/guide/edit/${e.currentTarget.dataset.id}`;
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    document.body.classList.remove('loading');
   });
-}
-
-
-if (document.querySelector('#cancel-button')) {
-  document.querySelector('#cancel-button').addEventListener('click', (e) => {
-    window.location.href = `/guide/edit/${e.currentTarget.dataset.id}`;
-  });
-}
-
-
-document.addEventListener('DOMContentLoaded', function() {
-  document.body.classList.remove('loading');
-});
 })();


### PR DESCRIPTION
This is based on an email thread from earlier today.

The field remains disabled in the python code because we have a nice declarative way to do that, and that does not allow for conditions.  However, in JS we can just re-enable it for this case.