### PR TITLE
Make auto-user fields non-auto.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -939,6 +939,8 @@ class Feature(DictModel):
     # Diff values to see what properties have changed.
     changed_props = []
     for prop_name, prop in self.properties().iteritems():
+      if prop_name in ('created_by', 'updated_by'):
+        continue
       new_val = getattr(self, prop_name, None)
       old_val = getattr(self, '_old_' + prop_name, None)
       if new_val != old_val:
@@ -972,8 +974,8 @@ class Feature(DictModel):
   # Metadata.
   created = db.DateTimeProperty(auto_now_add=True)
   updated = db.DateTimeProperty(auto_now=True)
-  updated_by = db.UserProperty(auto_current_user=True)
-  created_by = db.UserProperty(auto_current_user_add=True)
+  updated_by = db.UserProperty()
+  created_by = db.UserProperty()
 
   # General info.
   category = db.IntegerProperty(required=True)

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -26,7 +26,8 @@ import werkzeug.exceptions  # Flask HTTP stuff.
 
 from google.appengine.ext import db
 from google.appengine.api import mail
-# from google.appengine.api import users
+# TODO(jrobbins): phase out gae_users.
+from google.appengine.api import users as gae_users
 from framework import users
 
 from internals import models
@@ -40,8 +41,8 @@ class EmailFormattingTest(unittest.TestCase):
     self.feature_1 = models.Feature(
         name='feature one', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1,
-        created_by=users.User(email='creator@example.com'),
-        updated_by=users.User(email='editor@example.com'),
+        created_by=gae_users.User(email='creator@example.com'),
+        updated_by=gae_users.User(email='editor@example.com'),
         blink_components=['Blink'])
     self.feature_1.put()
     self.component_1 = models.BlinkComponent(name='Blink')
@@ -59,8 +60,8 @@ class EmailFormattingTest(unittest.TestCase):
     self.feature_2 = models.Feature(
         name='feature two', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1,
-        created_by=users.User(email='creator@example.com'),
-        updated_by=users.User(email='editor@example.com'),
+        created_by=gae_users.User(email='creator@example.com'),
+        updated_by=gae_users.User(email='editor@example.com'),
         blink_components=['Blink'])
     self.feature_2.put()
 


### PR DESCRIPTION
The datastore db library allows fields to be set automatically using the GAE session current user.  However, we will no longer have a GAE session.  So, instead, we set feature.created_by and feature.updated_by explicitly.