### PR TITLE
Add separate prod client_id and registered release candidate URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Open the [Google Developer
 Console for the staging site](https://console.cloud.google.com/appengine/versions?project=cr-status-staging)
 and flip to the new version by selecting from the list and clicking *MIGRATE TRAFFIC*. Make sure to do this for both the 'default' service as well as for the 'notifier' service.
 
+Each deployment also uploads the same code to a version named `rc` for "Release candidate".  This is the only version that you can test using Google Sign-In at `https://rc-dot-cr-status-staging.appspot.com`.
+
 If manual testing on the staging server looks good, then repeat the same steps to deploy to prod:
 
     npm run deploy

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "lint": "gulp lint-fix && lit-analyzer \"static/elements/chromedash-!(featurelist)*.js\"",
     "build": "gulp",
     "watch": "gulp watch",
-    "deploy": "npm run build && ./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'`",
-    "staging": "npm run build && ./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'` cr-status-staging",
+    "deploy": "npm run build && ./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'` && ./scripts/deploy_site.sh rc",
+    "staging": "npm run build && ./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'` cr-status-staging && ./scripts/deploy_site.sh rc cr-status-staging",
     "start": "npm run build && ./scripts/start_server.sh"
   },
   "repository": {

--- a/settings.py
+++ b/settings.py
@@ -74,6 +74,9 @@ elif APP_ID == 'cr-status':
   SEND_EMAIL = True
   SEND_ALL_EMAIL_TO = None  # Deliver it to the intended users
   SITE_URL = 'http://chromestatus.com/'
+  GOOGLE_SIGN_IN_CLIENT_ID = (
+      '999517574127-7ueh2a17bv1ave9thlgtap19pt5qjp4g.'
+      'apps.googleusercontent.com')
 elif APP_ID == 'cr-status-staging':
   STAGING = True
   SEND_EMAIL = True


### PR DESCRIPTION
This is a step toward resolving issue #1059 by allowing us to deploy and use Google Sign-In on our staging and prod servers.

In this CL:
+ Use a separate client_id just for the prod servers, so that there is no temptation to add more JS origins to that oauth client.
+ When we deploy a new version, also push to the `rc` version.  We need a constant version name so that we have a constant URL for testing because oauth clients can only have a list of specific JS origins with no wildcards.
+ Update README to indicate that testing should be done on rc-dot-cr-status-staging.appspot.com.
