### PR TITLE
Remove banner for Google Sign-In.

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -29,14 +29,13 @@ BOUNCE_ESCALATION_ADDR = 'cr-status-bounces@google.com'
 
 
 # Display a site maintenance banner on every page.  Or, an empty string.
-BANNER_MESSAGE = ('This site will have a new method of signing in. '
-                  'Users will need to sign in again after ')
+BANNER_MESSAGE = ''
 
 # Timestamp used to notify users when the read only mode or other status
 # described in the banner message takes effect.  Or, None.  It is
 # expressed as a tuple of ints: (year, month, day[, hour[, minute[, second]]])
 # e.g. (2009, 3, 20, 21, 45) represents March 20 2009 9:45PM UTC.
-BANNER_TIME = (2021, 5, 11, 20, 00)  # May 11, noon pacific
+BANNER_TIME = None
 
 ################################################################################
 


### PR DESCRIPTION
When we deploy on Tuesday, the new sign-in method will be live, so the banner will not longer be needed.