### PR TITLE
Fix signed-out star icons on the schedule page.

### DIFF
--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -20,7 +20,6 @@ class ChromedashFeature extends LitElement {
       feature: {type: Object},
       canEdit: {type: Boolean},
       signedin: {type: Boolean},
-      loginUrl: {type: String},
       open: {type: Boolean, reflect: true}, // Attribute used in the parent for styling
       starred: {type: Boolean},
       // Values used in the template

--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -12,7 +12,6 @@ class ChromedashFeaturelist extends LitElement {
     return {
       canEdit: {type: Boolean},
       signedin: {type: Boolean},
-      loginUrl: {type: String},
       features: {attribute: false}, // Directly edited and accessed in template/features.html
       metadataEl: {attribute: false}, // The metadata component element. Directly edited in template/features.html
       searchEl: {attribute: false}, // The search input element. Directly edited in template/features.html
@@ -405,7 +404,6 @@ class ChromedashFeaturelist extends LitElement {
                  @feature-toggled="${this._onFeatureToggledBound}"
                  @star-toggled="${this._onStarToggledBound}"
                  .feature="${item.feature}"
-                 loginurl="${this.loginUrl}"
                  ?canedit="${this.canEdit}"
                  ?signedin="${this.signedin}"
           ></chromedash-feature>

--- a/static/elements/chromedash-schedule.js
+++ b/static/elements/chromedash-schedule.js
@@ -182,7 +182,7 @@ class ChromedashSchedule extends LitElement {
                       ` : html`
                         <span class="tooltip"
                               title="Sign in to get email notifications for updates">
-                          <a href="${this.loginUrl}" data-tooltip>
+                          <a href="#"  @click="${window.promptSignIn}" data-tooltip>
                             <iron-icon icon="chromestatus:star-border"
                                        class="pushicon"></iron-icon>
                           </a>

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -32,7 +32,6 @@
     </span>
   {% else %}
     <span class="tooltip" title="Sign in to get email notifications for updates">
-      {# TODO(jrobbins): redo to use Google Sign-in #}
       <a href="#" id="star-when-signed-out" data-tooltip>
         <iron-icon icon="chromestatus:star-border"
                     class="pushicon"></iron-icon>

--- a/templates/features.html
+++ b/templates/features.html
@@ -29,7 +29,6 @@
       <button class="legend-button"><iron-icon icon="chromestatus:help"></iron-icon></button>
     </div>
     <div class="actionlinks">
-      <!-- TODO(jrobbins): Re-implement Subscribe button to use emails. -->
       {% if user.can_edit %}
         <a href="/guide/new" class="blue-button" title="Adds a new feature to the site"><iron-icon icon="chromestatus:add-circle-outline"></iron-icon><span>Add new feature</span></a>
       {% endif %}
@@ -52,8 +51,6 @@
 {% block content %}
   <chromedash-featurelist
     {% if user %}signedin{% endif %}
-    {# TODO(jrobbins): Fix to work with Google Sign-In #}
-    loginurl="#"
     {% if user.can_edit %}canedit{% endif %}
     ></chromedash-featurelist>
 {% endblock %}


### PR DESCRIPTION
This initiates the sign-in flow if the user clicks a star icon when then are signed out.

I had made this work with Google Sign-In on the feature list and feature detail page and apparently I failed to do the same for the star icons on the schedule page.

Also in this PR:  Remove a few obsolete TODOs.