### PR TITLE
Convert old UI-style user admin requests to JSON API.

### DIFF
--- a/api/accounts_api.py
+++ b/api/accounts_api.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+from __future__ import print_function
+
+import logging
+
+from google.appengine.ext import db
+
+from framework import basehandlers
+from framework import permissions
+from framework import ramcache
+from internals import models
+
+class AccountsAPI(basehandlers.APIHandler):
+  """User accounts store info on registered users."""
+
+  # TODO(jrobbins): do_get
+
+  @permissions.require_admin_site
+  def do_post(self):
+    """Process a request to create an account."""
+    email = self.get_param('email', required=True)
+    is_admin = self.get_bool_param('isAdmin')
+    user = self.create_account(email, is_admin)
+    response_json = user.format_for_template()
+    return response_json
+
+  def create_account(self, email, is_admin):
+    """Create and store a new account entity."""
+    # Don't add a duplicate email address.
+    user = models.AppUser.all(keys_only=True).filter('email = ', email).get()
+    if not user:
+      user = models.AppUser(email=db.Email(email))
+      user.is_admin = is_admin
+      user.put()
+      return user
+    else:
+      self.abort(400, 'User already exists')
+
+  # TODO(jrobbins): do_patch
+
+  @permissions.require_admin_site
+  def do_delete(self, account_id):
+    """Process a request to delete the specified account."""
+    if account_id:
+      self.delete_account(account_id)
+      return {'message': 'Done'}
+    else:
+      self.abort(400, msg='Account ID not specified')
+
+  def delete_account(self, account_id):
+    """Delete the specified account."""
+    if account_id:
+      found_user = models.AppUser.get_by_id(long(account_id))
+      if found_user:
+        found_user.delete()
+        ramcache.flush_all()
+      else:
+        self.abort(404, msg='Specified account ID not found')

--- a/api/accounts_api_test.py
+++ b/api/accounts_api_test.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+import testing_config  # Must be imported before the module under test.
+
+import flask
+import mock
+import werkzeug.exceptions  # Flask HTTP stuff.
+
+from api import accounts_api
+from api import register
+from internals import models
+
+
+class AccountsAPITest(unittest.TestCase):
+
+  def setUp(self):
+    self.appuser_1 = models.AppUser(email='user@example.com')
+    self.appuser_1.put()
+    self.appuser_id = self.appuser_1.key().id()
+
+    self.request_path = '/api/v0/accounts/%d' % self.appuser_id
+    self.handler = accounts_api.AccountsAPI()
+
+  def tearDown(self):
+    self.appuser_1.delete()
+
+  def test_create__normal_valid(self):
+    """Admin wants to register a normal account."""
+    testing_config.sign_in('admin@example.com', 123567890, is_admin=True)
+
+    json_data = {'email': 'new@example.com', 'isAdmin': False}
+    with register.app.test_request_context(self.request_path, json=json_data):
+      actual_json = self.handler.do_post()
+    self.assertEqual('new@example.com', actual_json['email'])
+    self.assertFalse(actual_json['is_admin'])
+
+    new_appuser = (models.AppUser.all().
+                   filter('email = ', 'new@example.com').get())
+    self.assertEqual('new@example.com', new_appuser.email)
+    self.assertFalse(new_appuser.is_admin)
+
+  def test_create__admin_valid(self):
+    """Admin wants to register a new admin account."""
+    testing_config.sign_in('admin@example.com', 123567890, is_admin=True)
+
+    json_data = {'email': 'new_admin@example.com', 'isAdmin': True}
+    with register.app.test_request_context(self.request_path, json=json_data):
+      actual_json = self.handler.do_post()
+    self.assertEqual('new_admin@example.com', actual_json['email'])
+    self.assertTrue(actual_json['is_admin'])
+
+    new_appuser = (models.AppUser.all().
+                   filter('email = ', 'new_admin@example.com').get())
+    self.assertEqual('new_admin@example.com', new_appuser.email)
+    self.assertTrue(new_appuser.is_admin)
+
+  def test_create__forbidden(self):
+    """Regular user cannot create an account."""
+    testing_config.sign_in('one@example.com', 123567890)
+
+    with register.app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
+        self.handler.do_post(self.appuser_id)
+
+    new_appuser = (models.AppUser.all().
+                   filter('email = ', 'new@example.com').get())
+    self.assertIsNone(new_appuser)
+
+  def test_create__invalid(self):
+    """We cannot create an account without an email address."""
+    testing_config.sign_in('admin@example.com', 123567890, is_admin=True)
+
+    json_data = {'isAdmin': False}  # No email
+    with register.app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest, json=json_data):
+        self.handler.do_post()
+
+    new_appuser = (models.AppUser.all().
+                   filter('email = ', 'new@example.com').get())
+    self.assertIsNone(new_appuser)
+
+  def test_create__duplicate(self):
+    """We cannot create an account with a duplicate email."""
+    testing_config.sign_in('admin@example.com', 123567890, is_admin=True)
+
+    json_data = {'email': 'user@example.com'}
+    with register.app.test_request_context(self.request_path, json=json_data):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post()
+
+    unrevised_appuser = models.AppUser.get_by_id(self.appuser_id)
+    self.assertEqual('user@example.com', unrevised_appuser.email)
+
+  def test_delete__valid(self):
+    """Admin wants to delete an account."""
+    testing_config.sign_in('admin@example.com', 123567890, is_admin=True)
+
+    with register.app.test_request_context(self.request_path):
+      actual_json = self.handler.do_delete(self.appuser_id)
+    self.assertEqual({'message': 'Done'}, actual_json)
+
+    revised_appuser = models.AppUser.get_by_id(self.appuser_id)
+    self.assertIsNone(revised_appuser)
+
+  def test_delete__forbidden(self):
+    """Regular user cannot delete an account."""
+    testing_config.sign_in('one@example.com', 123567890)
+
+    with register.app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
+        self.handler.do_delete(self.appuser_id)
+
+    unrevised_appuser = models.AppUser.get_by_id(self.appuser_id)
+    self.assertEqual('user@example.com', unrevised_appuser.email)
+
+  def test_delete__invalid(self):
+    """We cannot delete an account without an account_id."""
+    testing_config.sign_in('admin@example.com', 123567890, is_admin=True)
+
+    with register.app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_delete(None)
+
+    unrevised_appuser = models.AppUser.get_by_id(self.appuser_id)
+    self.assertEqual('user@example.com', unrevised_appuser.email)
+
+
+  def test_delete__not_found(self):
+    """We cannot delete an account with the wrong account_id."""
+    testing_config.sign_in('admin@example.com', 123567890, is_admin=True)
+
+    with register.app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.NotFound):
+        self.handler.do_delete(self.appuser_id + 1)
+
+    unrevised_appuser = models.AppUser.get_by_id(self.appuser_id)
+    self.assertEqual('user@example.com', unrevised_appuser.email)

--- a/api/register.py
+++ b/api/register.py
@@ -17,6 +17,7 @@ from __future__ import division
 from __future__ import print_function
 
 import settings
+from api import accounts_api
 from api import approvals_api
 from api import cues_api
 from api import features_api
@@ -37,6 +38,7 @@ app = basehandlers.FlaskApplication([
     ('/features/<int:feature_id>/approvals/<int:field_id>',
      approvals_api.ApprovalsAPI),
     # ('/features/<int:feature_id>/approvals/<int:field_id>/comments', TODO),
+
     ('/login', login_api.LoginAPI),
     ('/logout', logout_api.LogoutAPI),
     ('/currentuser/stars', stars_api.StarsAPI),
@@ -45,7 +47,9 @@ app = basehandlers.FlaskApplication([
     # ('/currentuser/autosaves', TODO),
     # ('/currentuser/settings', TODO),
 
-    # ('/users', TODO),  # Admin pages to list, add, delete users.
+    # Admin operations for user accounts
+    ('/accounts', accounts_api.AccountsAPI),
+    ('/accounts/<int:account_id>', accounts_api.AccountsAPI),
 
     # ('/channels', TODO),  # omaha data
     # ('/schedule', TODO),  # chromiumdash data

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -160,6 +160,7 @@ class APIHandler(BaseHandler):
 
   def post(self, *args, **kwargs):
     """Handle an incoming HTTP POST request."""
+    logging.info('POST data is %r', self.request.get_json())
     is_login_request = str(self.request.url_rule) == '/api/v0/login'
 
     if not is_login_request:

--- a/pages/users.py
+++ b/pages/users.py
@@ -53,43 +53,6 @@ class UserListHandler(basehandlers.FlaskHandler):
     return template_data
 
 
-class CreateUserAPIHandler(basehandlers.FlaskHandler):
-
-  @permissions.require_admin_site
-  def process_post_data(self):
-    email = self.form['email']
-
-    # Don't add a duplicate email address.
-    user = models.AppUser.all(keys_only=True).filter('email = ', email).get()
-    if not user:
-      user = models.AppUser(email=db.Email(email))
-      user.is_admin = 'is_admin' in self.form
-      user.put()
-
-      response_json = user.format_for_template()
-    else:
-      response_json = {
-          'error_message': 'User already exists',
-          'id': user.id()}
-
-    return response_json
-
-
-class DeleteUserAPIHandler(basehandlers.FlaskHandler):
-
-  @permissions.require_admin_site
-  def process_post_data(self, user_id=None):
-    if user_id:
-      self._delete(user_id)
-    return flask.redirect('/admin/users/new')
-
-  def _delete(self, user_id):
-    if user_id:
-      found_user = models.AppUser.get_by_id(long(user_id))
-      if found_user:
-        found_user.delete()
-
-
 class SettingsHandler(basehandlers.FlaskHandler):
 
   TEMPLATE_PATH = 'settings.html'
@@ -120,7 +83,5 @@ class SettingsHandler(basehandlers.FlaskHandler):
 
 app = basehandlers.FlaskApplication([
   ('/settings', SettingsHandler),
-  ('/admin/users/create', CreateUserAPIHandler),
-  ('/admin/users/delete/<int:user_id>', DeleteUserAPIHandler),
   ('/admin/users/new', UserListHandler),
 ], debug=settings.DEBUG)

--- a/static/elements/chromedash-userlist.js
+++ b/static/elements/chromedash-userlist.js
@@ -66,31 +66,14 @@ class ChromedashUserlist extends LitElement {
     if (formEl.checkValidity()) {
       const email = formEl.querySelector('input[name="email"]').value;
       const isAdmin = formEl.querySelector('input[name="is_admin"]').checked;
-      const formData = new FormData();
-      formData.append('email', email);
-      if (isAdmin) {
-        formData.append('is_admin', 'on');
-      }
-      await window.csClient.ensureTokenIsValid();
-      formData.append('token', window.csClient.token);
-
-      const resp = await fetch(this.actionPath, {
-        method: 'POST',
-        body: formData,
-        credentials: 'same-origin', // Needed for admin permissions to be sent.
-      });
-
-      if (resp.status !== 200) {
-        throw new Error('Server error adding new user');
-      } else {
-        const json = await resp.json();
+      window.csClient.createAccount(email, isAdmin).then((json) => {
         if (json.error_message) {
           alert(json.error_message);
         } else {
           this.addUser(json);
           formEl.reset();
         }
-      }
+      });
     }
   }
 
@@ -101,14 +84,7 @@ class ChromedashUserlist extends LitElement {
     }
 
     const idx = e.target.dataset.index;
-    const formData = new FormData();
-    formData.append('token', this.token);
-
-    fetch(e.currentTarget.href, {
-      method: 'POST',
-      body: formData,
-      credentials: 'same-origin',
-    }).then(() => {
+    window.csClient.deleteAccount(e.target.dataset.account).then(() => {
       this.removeUser(idx);
     });
   }
@@ -131,8 +107,10 @@ class ChromedashUserlist extends LitElement {
       <ul id="user-list">
         ${this.users.map((user, index) => html`
           <li>
-            <a href="/admin/users/delete/${user.id}"
-               data-index="${index}" @click="${this.ajaxDelete}">delete</a>
+            <a href="#"
+               data-index="${index}"
+               data-account="${user.id}"
+               @click="${this.ajaxDelete}">delete</a>
             <span>${user.email}</span>
             ${user.is_admin ? html`(admin)` : nothing}
           </li>

--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -154,6 +154,18 @@ class ChromeStatusClient {
       .then((res) => res);
     // TODO: catch((error) => { display message }
   }
+
+  // Accounts API
+
+  createAccount(email, isAdmin) {
+    return this.doPost('/accounts', {email, isAdmin});
+    // TODO: catch((error) => { display message }
+  }
+
+  deleteAccount(accountId) {
+    return this.doDelete('/accounts/' + accountId);
+    // TODO: catch((error) => { display message }
+  }
 };
 
 exports.ChromeStatusClient = ChromeStatusClient;


### PR DESCRIPTION
Simplify the part of our code that adds and deletes registered users.  The old implementation used javascript to construct and submit an HTML form that was then processed by one of our UI-style request handlers.   This version goes through our JSON API.  

The reason for doing this is to reduce the amount of random JS logic, especially duplication of logic to deal with XSRF tokens for form submission.  And, to set the example of how JS components should focus on interacting with the user while csClient manages the protocol of how to make requests to our python code.