### PR TITLE
Implement Comment API and storage.

### DIFF
--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+from __future__ import print_function
+
+import logging
+
+from framework import basehandlers
+from framework import permissions
+from internals import approval_defs
+from internals import models
+
+
+class CommentsAPI(basehandlers.APIHandler):
+  """Users may see the list of comments on one of the approvals of a feature,
+   and add their own, if allowed."""
+
+  def do_get(self, feature_id, field_id):
+    """Return a list of all review comments on the given feature."""
+    # Note: We assume that anyone may view approval comments.
+    comments = models.Comment.get_comments(feature_id, field_id)
+    dicts = [ac.format_for_template(add_id=False) for ac in comments]
+    data = {
+        'comments': dicts,
+        }
+    return data
+
+  def do_post(self, feature_id, field_id):
+    """Add a review comment and possibly set a approval value."""
+    new_state = self.get_int_param(
+        'state', required=False,
+        validator=models.Approval.is_valid_state)
+    feature = self.get_specified_feature(feature_id=feature_id)
+    user = self.get_current_user(required=True)
+
+    old_state = None
+    old_approvals = models.Approval.get_approvals(
+        feature_id=feature_id, field_id=field_id,
+        set_by=user.email())
+    if old_approvals:
+      old_state = old_approvals[0].state
+
+    approvers = approval_defs.get_approvers(field_id)
+    if new_state is not None:
+      if not permissions.can_approve_feature(user, feature, approvers):
+        self.abort(403, msg='User is not an approver')
+      models.Approval.set_approval(
+          feature.key().id(), field_id, new_state, user.email())
+
+    comment_content = self.get_param('comment', required=False)
+
+    if comment_content or new_state is not None:
+      comment = models.Comment(
+          feature_id=feature_id, field_id=field_id,
+          author=user.email(), content=comment_content,
+          old_approval_state=old_state,
+          new_approval_state=new_state)
+      comment.put()
+
+    # TODO(jrobbins): Trigger notificaton emails (or not).
+
+    # Callers don't use the JSON response for this API call.
+    return {'message': 'Done'}
+
+  # TODO(jrobbins): do_patch to soft-delete comments

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+from __future__ import print_function
+
+import datetime
+import unittest
+import testing_config  # Must be imported before the module under test.
+
+import flask
+import mock
+import werkzeug.exceptions  # Flask HTTP stuff.
+
+from api import register
+from api import comments_api
+from internals import models
+
+
+NOW = datetime.datetime.now()
+
+
+class CommentsAPITest(unittest.TestCase):
+
+  def setUp(self):
+    self.feature_1 = models.Feature(
+        name='feature one', summary='sum', category=1, visibility=1,
+        standardization=1, web_dev_views=1, impl_status_chrome=1)
+    self.feature_1.put()
+    self.feature_id = self.feature_1.key().id()
+    self.field_id = 1
+    self.handler = comments_api.CommentsAPI()
+    self.request_path = ('/api/v0/features/%d/approvals/%d/comments' %
+                         (self.feature_id, self.field_id))
+
+    self.appr_1_1 = models.Approval(
+        feature_id=self.feature_id, field_id=1,
+        set_by='owner1@example.com', set_on=NOW,
+        state=models.Approval.APPROVED)
+    self.appr_1_1.put()
+
+    # This is not in the datastore unless a specific test calls put().
+    self.cmnt_1_1 = models.Comment(
+        feature_id=self.feature_id, field_id=1,
+        author='owner1@example.com', created=NOW,
+        content='Good job',
+        new_approval_state=models.Approval.APPROVED)
+
+    self.expected_1 = {
+        'feature_id': self.feature_id,
+        'field_id': self.field_id,
+        'author': u'owner1@example.com',
+        'deleted_by': None,
+        'content': u'Good job',
+        'old_approval_state': None,
+        'new_approval_state': models.Approval.APPROVED,
+        }
+
+  def tearDown(self):
+    self.feature_1.delete()
+    for appr in models.Approval.all():
+      appr.delete()
+    for cmnt in models.Comment.all():
+      cmnt.delete()
+
+  def test_get__empty(self):
+    """We can get comments for a given approval, even if there none."""
+    testing_config.sign_out()
+    with register.app.test_request_context(self.request_path):
+      actual_response = self.handler.do_get(self.feature_id, self.field_id)
+    self.assertEqual({'comments': []}, actual_response)
+
+  def test_get__all_some(self):
+    """We can get all comments for a given approval."""
+    testing_config.sign_out()
+    self.cmnt_1_1.put()
+
+    with register.app.test_request_context(self.request_path):
+      actual_response = self.handler.do_get(self.feature_id, self.field_id)
+
+    actual_comment = actual_response['comments'][0]
+    del actual_comment['created']
+    self.assertEqual(
+        self.expected_1,
+        actual_comment)
+
+  def test_post__bad_state(self):
+    """Handler rejects requests that don't specify a state correctly."""
+    params = {'state': 'not an int'}
+    with register.app.test_request_context(self.request_path, json=params):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post(self.feature_id, self.field_id)
+
+    params = {'state': 999}
+    with register.app.test_request_context(self.request_path, json=params):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post(self.feature_id, self.field_id)
+
+  def test_post__feature_not_found(self):
+    """Handler rejects requests that don't match an existing feature."""
+    bad_path = '/api/v0/features/12345/approvals/1/comments'
+    params = {'state': models.Approval.NEED_INFO }
+    with register.app.test_request_context(bad_path, json=params):
+      with self.assertRaises(werkzeug.exceptions.NotFound):
+        self.handler.do_post(12345, self.field_id)
+
+  def test_post__forbidden(self):
+    """Handler rejects requests from anon users and non-approvers."""
+    params = {'state': models.Approval.NEED_INFO}
+
+    testing_config.sign_out()
+    with register.app.test_request_context(self.request_path, json=params):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
+        self.handler.do_post(self.feature_id, self.field_id)
+
+    testing_config.sign_in('user7@example.com', 123567890)
+    with register.app.test_request_context(self.request_path, json=params):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
+        self.handler.do_post(self.feature_id, self.field_id)
+
+    testing_config.sign_in('user@google.com', 123567890)
+    with register.app.test_request_context(self.request_path, json=params):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
+        self.handler.do_post(self.feature_id, self.field_id)
+
+  @mock.patch('internals.approval_defs.get_approvers')
+  def test_post__update(self, mock_get_approvers):
+    """Handler adds comment and updates approval value."""
+    mock_get_approvers.return_value = ['owner1@example.com']
+    testing_config.sign_in('owner1@example.com', 123567890)
+    params = {'state': models.Approval.NEED_INFO}
+    with register.app.test_request_context(self.request_path, json=params):
+      actual = self.handler.do_post(self.feature_id, self.field_id)
+
+    self.assertEqual(actual, {'message': 'Done'})
+    updated_approvals = models.Approval.get_approvals(self.feature_id)
+    self.assertEqual(1, len(updated_approvals))
+    appr = updated_approvals[0]
+    self.assertEqual(appr.feature_id, self.feature_id)
+    self.assertEqual(appr.field_id, 1)
+    self.assertEqual(appr.set_by, 'owner1@example.com')
+    self.assertEqual(appr.state, models.Approval.NEED_INFO)
+    updated_comments = models.Comment.get_comments(
+        self.feature_id, self.field_id)
+    cmnt = updated_comments[0]
+    self.assertEqual(None, cmnt.content)
+    self.assertEqual(models.Approval.APPROVED, cmnt.old_approval_state)
+    self.assertEqual(models.Approval.NEED_INFO, cmnt.new_approval_state)
+
+  def test_post__comment_only(self):
+    """Handler adds a comment only."""
+    testing_config.sign_in('owner2@example.com', 123567890)
+    params = {'comment': 'Congratulations'}
+    with register.app.test_request_context(self.request_path, json=params):
+      actual = self.handler.do_post(self.feature_id, self.field_id)
+
+    self.assertEqual(actual, {'message': 'Done'})
+    updated_approvals = models.Approval.get_approvals(self.feature_id)
+    self.assertEqual(1, len(updated_approvals))
+    appr = updated_approvals[0]
+    self.assertEqual(appr.feature_id, self.feature_id)
+    self.assertEqual(appr.field_id, 1)
+    self.assertEqual(appr.set_by, 'owner1@example.com')  # Unchanged
+    self.assertEqual(appr.state, models.Approval.APPROVED)  # Unchanged
+    updated_comments = models.Comment.get_comments(
+        self.feature_id, self.field_id)
+    cmnt = updated_comments[0]
+    self.assertEqual('Congratulations', cmnt.content)
+    self.assertIsNone(cmnt.old_approval_state)
+    self.assertIsNone(cmnt.new_approval_state)

--- a/api/register.py
+++ b/api/register.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import settings
 from api import accounts_api
 from api import approvals_api
+from api import comments_api
 from api import cues_api
 from api import features_api
 from api import stars_api
@@ -37,7 +38,8 @@ app = basehandlers.FlaskApplication([
     ('/features/<int:feature_id>', features_api.FeaturesAPI),
     ('/features/<int:feature_id>/approvals/<int:field_id>',
      approvals_api.ApprovalsAPI),
-    # ('/features/<int:feature_id>/approvals/<int:field_id>/comments', TODO),
+    ('/features/<int:feature_id>/approvals/<int:field_id>/comments',
+     comments_api.CommentsAPI),
 
     ('/login', login_api.LoginAPI),
     ('/logout', logout_api.LogoutAPI),

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -107,7 +107,7 @@ class BaseHandler(flask.views.MethodView):
     val = self.get_param(
         name, default=default, required=required, validator=validator,
         allowed=allowed)
-    if type(val) != int:
+    if val and type(val) != int:
       self.abort(400, msg='Parameter %r was not an int' % name)
     return val
 

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -170,6 +170,13 @@ class BaseHandlerTests(unittest.TestCase):
     actual = self.handler.get_int_param('missing', default=3)
     self.assertEqual(3, actual)
 
+    actual = self.handler.get_int_param('missing', required=False)
+    self.assertIsNone(actual)
+
+    actual = self.handler.get_int_param(
+        'missing', required=False, validator=lambda x: x % 2 == 1)
+    self.assertIsNone(actual)
+
     with self.assertRaises(werkzeug.exceptions.BadRequest):
       self.handler.get_int_param('foo')
     mock_abort.assert_called_once_with(

--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -166,6 +166,18 @@ class ChromeStatusClient {
     return this.doDelete('/accounts/' + accountId);
     // TODO: catch((error) => { display message }
   }
+
+  // Review comments
+
+  getComments(featureId, fieldId) {
+    return this.doGet(`/features/${featureId}/approvals/${fieldId}/comments`);
+  }
+
+  postComment(featureId, fieldId, state, comment) {
+    return this.doPost(
+        `/features/${featureId}/approvals/${fieldId}/comments`,
+        {state, comment});
+  }
 };
 
 exports.ChromeStatusClient = ChromeStatusClient;


### PR DESCRIPTION
This should resolve issue #1180.

In this PR:
+ Add Comment class to models.py.
+ Implement api/comments_api.py to handle getting all review comments for an approval, and posting a new comment that may have comment text and/or an approval value.  Also register the new API class and implement unit tests.
+ Implement some JS methods in csClient to call the python API.
+ Fix get_int_param() in basehandlers.py to allow an int parameter to return None when optional, and update the unit tests.