### PR TITLE
Added the dropdown in narrow viewports

### DIFF
--- a/static/elements/chromedash-banner.js
+++ b/static/elements/chromedash-banner.js
@@ -27,6 +27,7 @@ class ChromedashBanner extends LitElement {
         color: var(--warning-color);
         border-radius: var(--border-radius);
         padding: var(--content-padding);
+        width:100%;
       }
     `];
   }

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -299,10 +299,12 @@ footer {
 #column-container {
    display: flex;
    align-items: stretch;
+   flex-direction: row;
  }
 
 #drawer-column {
   padding: 1em 2em 1em 1em;
+  margin-left: 8px;
 }
 
 #content-column {
@@ -364,8 +366,8 @@ footer {
   }
 
 
-  #drawer-column {
-    display: none;
+  #column-container {
+    flex-direction: column;
   }
   #content-column {
     padding-left: var(--content-padding-half);

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -173,12 +173,13 @@ limitations under the License.
 
       <div id="content">
         <div id="spinner"><img src="/static/img/ring.svg"></div>
+        <chromedash-banner message="{{banner_message}}"
+                               timestamp="{{banner_time}}"></chromedash-banner>
         <div id="column-container">
           <div id="drawer-column">{% block drawer %}{% endblock %}</div>
           <div id="content-column">
             <div id="horizontal-sub-nav">{% block horizontalsubnav %}{% endblock %}</div>
-            <chromedash-banner message="{{banner_message}}"
-                               timestamp="{{banner_time}}"></chromedash-banner>
+            
             {% block subheader %}{% endblock %}
             {% block content %}{% endblock %}
           </div>


### PR DESCRIPTION
Merging this should close #1242 
Review Requested:- @jrobbins 

This PR is a follow up to #1325. As suggested by @jrobbins, this PR displays the `Filter By` dropdown field above the search box but below the banner. It now looks like the following:- 

On Wide ViewPorts:-
![1](https://user-images.githubusercontent.com/44562091/119220171-cd178280-bb06-11eb-8ab4-73fbffd24fcd.jpg)

On Narrow ViewPorts:-
![2](https://user-images.githubusercontent.com/44562091/119220255-42835300-bb07-11eb-927a-2fbc46c58ade.jpg)


