### PR TITLE
Fix and simplify project installation.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "http2push"]
-	path = http2push
-	url = https://github.com/GoogleChrome/http2push-gae

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Chrome Platform Status
 
 ### Get the code
 
-    git clone --recursive https://github.com/GoogleChrome/chromium-dashboard
+    git clone https://github.com/GoogleChrome/chromium-dashboard
 
 ### Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
+
+# Libraries that we use directly.
 Django==1.11.29
 mock==3.0.5
 funcsigs
 Flask==1.1.2
-
 google-cloud-tasks==1.5.0
 
 # Required by google-cloud-tasks
@@ -21,6 +22,15 @@ idna==2.10
 pyasn1-modules==0.2.8
 cachetools==3.1.1
 rsa==4.5
+
+# These are some libraries used indirectly below.  Pin them to versions that
+# work on python 2.7.
+# TODO(jrobbins): Eliminate these once we are on py3.
+Jinja2==2.11.3
+MarkupSafe==1.1.1
+Werkzeug==1.0.1
+click==7.1.2
+itsdangerous==1.1.0
 
 # Required for porting Python2 to Python3
 requests==2.25.1


### PR DESCRIPTION
I tried a fresh install today and hit some problems due to libraries that no longer support py2.7 in their default version.  So, I am specifying specific versions for more things in requirements.txt.

Also, there was a git sub-module used to check out code from a different project.  This is not currently used.  I believe that it was needed for push notifications.  But, we now use email instead of push notifications.