### PR TITLE
Update fetching of API OWNERS from new URL.

### DIFF
--- a/api/approvals_api_test.py
+++ b/api/approvals_api_test.py
@@ -168,8 +168,10 @@ class ApprovalsAPITest(unittest.TestCase):
       with self.assertRaises(werkzeug.exceptions.NotFound):
         self.handler.do_post()
 
-  def test_post__forbidden(self):
+  @mock.patch('internals.approval_defs.get_approvers')
+  def test_post__forbidden(self, mock_get_approvers):
     """Handler rejects requests from anon users and non-approvers."""
+    mock_get_approvers.return_value = ['owner1@example.com']
     params = {'featureId': self.feature_id, 'fieldId': 1,
               'state': models.Approval.NEED_INFO}
 

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -70,7 +70,7 @@ def fetch_owners(url):
     logging.error('Got response %r', response)
     raise ValueError('Could not get OWNERS file')
 
-  decoded = base64.b64decode(response.content)
+  decoded = base64.b64decode(response.content).decode()
   for line in decoded.split('\n'):
     logging.info('got line: '  + line)
     if '#' in line:

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -16,6 +16,7 @@
 from __future__ import division
 from __future__ import print_function
 
+import base64
 import collections
 import logging
 import requests
@@ -28,9 +29,8 @@ CACHE_EXPIRATION = 60 * 60  # One hour
 ONE_LGTM = 'One LGTM'
 THREE_LGTM = 'Three LGTMs'
 API_OWNERS_URL = (
-    'https://source.chromium.org/chromium/chromium/src/+/'
-    # TODO(jrobbins): branch name will change soon
-    'master:third_party/blink/API_OWNERS')
+    'https://chromium.googlesource.com/chromium/src/+/'
+    'main/third_party/blink/API_OWNERS?format=TEXT')
 
 ApprovalFieldDef = collections.namedtuple(
     'ApprovalField',
@@ -70,7 +70,9 @@ def fetch_owners(url):
     logging.error('Got response %r', response)
     raise ValueError('Could not get OWNERS file')
 
-  for line in response.iter_lines():
+  decoded = base64.b64decode(response.content)
+  for line in decoded.split('\n'):
+    logging.info('got line: '  + line)
     if '#' in line:
       line = line[:line.index('#')]
     line = line.strip()

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -15,6 +15,7 @@
 from __future__ import division
 from __future__ import print_function
 
+import base64
 import requests
 import testing_config  # Must be imported before the module under test.
 import unittest
@@ -33,17 +34,18 @@ class FetchOwnersTest(unittest.TestCase):
   @mock.patch('requests.get')
   def test__normal(self, mock_get):
     """We can fetch and parse an OWNERS file.  And reuse cached value."""
+    file_contents = (
+        '# Blink API owners are responsible for ...\n'
+        '#\n'
+        '# See https://www.chromium.org/blink#new-features for details.\n'
+        'owner1@example.com\n'
+        'owner2@example.com\n'
+        'owner3@example.com\n'
+        '\n')
+    encoded = base64.b64encode(file_contents)
     mock_get.return_value = testing_config.Blank(
         status_code=200,
-        iter_lines=lambda: [
-            '# This is an owners file',
-            'owner1@example.com',
-            '  owner2@example.com   ',
-            '# if those two are not available',
-            'owner3@example.com  # use URGENT in subject line',
-            '- - nothing below this line - -',
-            '']
-        )
+        content=encoded)
 
     actual = approval_defs.fetch_owners('https://example.com')
     again = approval_defs.fetch_owners('https://example.com')

--- a/internals/fetchmetrics.py
+++ b/internals/fetchmetrics.py
@@ -16,6 +16,7 @@
 from __future__ import division
 from __future__ import print_function
 
+import base64
 import datetime
 import json
 import logging
@@ -241,13 +242,13 @@ class HistogramsHandler(basehandlers.FlaskHandler):
 
   def get_template_data(self):
     # Attempt to fetch enums mapping file.
-    result = requests.get(HISTOGRAMS_URL, timeout=60)
+    response = requests.get(HISTOGRAMS_URL, timeout=60)
 
-    if (result.status_code != 200):
+    if (response.status_code != 200):
       logging.error('Unable to retrieve chromium histograms mapping file.')
       return
 
-    histograms_content = result.content.decode('base64')
+    histograms_content = base64.b64decode(response.content).decode()
     dom = minidom.parseString(histograms_content)
 
     # The enums.xml file looks like this:


### PR DESCRIPTION
I previously had an old URL for fetching the API_OWNERS file.  
Also, the gitiles server now seems to serve format=TEXT as a base64 encode file, so we need to decode it.