### PR TITLE
Web Page title on edit feature page will display the Feature name

### DIFF
--- a/templates/guide/edit.html
+++ b/templates/guide/edit.html
@@ -1,5 +1,5 @@
 {% extends "_base.html" %}
-
+{% block page_title %}{{ feature.name }} - {% endblock %}
 {% block css %}
 <link rel="stylesheet" href="/static/css/forms.css">
 <link rel="stylesheet" href="/static/css/guide.css">


### PR DESCRIPTION
Merging this should close #1336 

The web page title for edit features page will be displayed in the following format when deployed on production server.
`Feature Name - Chrome Platform Status`

Review Requested:- @jrobbins 