### PR TITLE
Add feature name to other edit page titles.

### DIFF
--- a/templates/admin/features/launch.html
+++ b/templates/admin/features/launch.html
@@ -1,6 +1,8 @@
 {% extends "_base.html" %}
 {% load inline_file %}
 
+{% block page_title %}{{ feature.name }} - {% endblock %}
+
 {% block css %}
 <!-- <link rel="stylesheet" href="/static/css/forms.css"> -->
 <!-- <link rel="stylesheet" href="/static/css/features/launch.css"> -->

--- a/templates/guide/editall.html
+++ b/templates/guide/editall.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block page_title %}{{ feature.name }} - {% endblock %}
 
 {% block css %}
 <link rel="stylesheet" href="/static/css/forms.css">

--- a/templates/guide/stage.html
+++ b/templates/guide/stage.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block page_title %}{{ feature.name }} - {% endblock %}
 
 {% block css %}
 <link rel="stylesheet" href="/static/css/forms.css">


### PR DESCRIPTION
This is a follow-up to https://github.com/GoogleChrome/chromium-dashboard/pull/1340
that does the same thing on related editing pages and the intent email preview page.
