### PR TITLE
Made Drawer Column responsive

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -432,12 +432,19 @@ footer {
     margin: 0;
   }
 
+  //Vertical Sub-Nav should not be visible in narrow view ports
+  .metric-nav{display: none}
+  #drawer-column{padding: 0em;}
+
 }
 
-//Horizontal Properties Row should be visible only in narrow view ports
+//Horizontal Sub-Nav should not be visible in wider view ports
 @media only screen and (min-width: 700px){
   #horizontal-sub-nav{display: none}
+  
 }
+
+
 
 // When banner doesn't block navigation buttons.
 @media only screen and (min-width: 1100px) {

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -158,8 +158,6 @@ limitations under the License.
         <div id="column-container">
           <div id="drawer-column">{% block drawer %}{% endblock %}</div>
           <div id="content-column">
-            <div id="horizontal-sub-nav">{% block horizontalsubnav %}{% endblock %}</div>
-            
             {% block subheader %}{% endblock %}
             {% block content %}{% endblock %}
           </div>

--- a/templates/metrics/css/_css_metric_nav.html
+++ b/templates/metrics/css/_css_metric_nav.html
@@ -1,3 +1,4 @@
+<!-- For Wider View Ports with larger screen size -->
 <ul class="metric-nav">
   <h3>All properties</h3>
   <li><a href="/metrics/css/popularity">Stack rank</a></li>
@@ -6,3 +7,28 @@
   <li><a href="/metrics/css/animated">Stack rank</a></li>
   <li><a href="/metrics/css/timeline/animated">Timeline</a></li>
 </ul>
+
+<!-- For Narror ViewPorts with small screen size -->
+<div id="horizontal-sub-nav">
+  <table>
+    <tr>
+      <nav class="data-panel">
+        <td>View All Properties As:</td>
+        <td>
+          <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a> |
+          <a href="/metrics/css/popularity"  class="sub-nav-links">Stack Rank</a>
+        </td>
+      </nav>
+    </tr>
+  
+    <tr>
+      <nav class="data-panel">
+        <td>View Animated Properties As:</td>
+        <td>
+          <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a> |
+          <a href="/metrics/css/animated"  class="sub-nav-links">Stack Rank</a>
+        </td>
+      </nav>
+    </tr>
+  </table>
+</div>

--- a/templates/metrics/css/animated.html
+++ b/templates/metrics/css/animated.html
@@ -9,30 +9,6 @@
   {% include "metrics/css/_css_metric_nav.html" %}
 {% endblock %}
 
-{% block horizontalsubnav %}
-<table>
-  <tr>
-    <nav class="data-panel">
-      <td>View All Properties As:</td>
-      <td>
-        <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a> |
-        <a href="/metrics/css/popularity"  class="sub-nav-links">Stack Rank</a>
-      </td>
-    </nav>
-  </tr>
-
-  <tr>
-    <nav class="data-panel">
-      <td>View Animated Properties As:</td>
-      <td>
-        <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a> |
-        <a href="/metrics/css/animated"  class="sub-nav-links">Stack Rank</a>
-      </td>
-    </nav>
-  </tr>
-</table>
-{% endblock %}
-
 {% block subheader %}
 <div id="subheader">
   <h2>CSS usage metrics &gt; animated properties > stack rank</h2>

--- a/templates/metrics/css/popularity.html
+++ b/templates/metrics/css/popularity.html
@@ -9,29 +9,6 @@
   {% include "metrics/css/_css_metric_nav.html" %}
 {% endblock %}
 
-{% block horizontalsubnav %}
-<table>
-  <tr>
-    <nav class="data-panel">
-      <td>View All Properties As:</td>
-      <td>
-        <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a> |
-        <a href="/metrics/css/popularity"  class="sub-nav-links">Stack Rank</a>
-      </td>
-    </nav>
-  </tr>
-
-  <tr>
-    <nav class="data-panel">
-      <td>View Animated Properties As:</td>
-      <td>
-        <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a> |
-        <a href="/metrics/css/animated"  class="sub-nav-links">Stack Rank</a>
-      </td>
-    </nav>
-  </tr>
-</table>
-{% endblock %}
 
 {% block subheader %}
 <div id="subheader">

--- a/templates/metrics/css/timeline/animated.html
+++ b/templates/metrics/css/timeline/animated.html
@@ -13,30 +13,6 @@
   {% include "metrics/css/_css_metric_nav.html" %}
 {% endblock %}
 
-{% block horizontalsubnav %}
-<table>
-  <tr>
-    <nav class="data-panel">
-      <td>View All Properties As:</td>
-      <td>
-        <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a> |
-        <a href="/metrics/css/popularity"  class="sub-nav-links">Stack Rank</a>
-      </td>
-    </nav>
-  </tr>
-
-  <tr>
-    <nav class="data-panel">
-      <td>View Animated Properties As:</td>
-      <td>
-        <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a> |
-        <a href="/metrics/css/animated"  class="sub-nav-links">Stack Rank</a>
-      </td>
-    </nav>
-  </tr>
-</table>
-{% endblock %}
-
 {% block subheader %}
 <div id="subheader">
   <h2>CSS usage metrics &gt; animated properties > timeline</h2>

--- a/templates/metrics/css/timeline/popularity.html
+++ b/templates/metrics/css/timeline/popularity.html
@@ -13,30 +13,6 @@
   {% include "metrics/css/_css_metric_nav.html" %}
 {% endblock %}
 
-{% block horizontalsubnav %}
-<table>
-  <tr>
-    <nav class="data-panel">
-      <td>View All Properties As:</td>
-      <td>
-        <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a> |
-        <a href="/metrics/css/popularity"  class="sub-nav-links">Stack Rank</a>
-      </td>
-    </nav>
-  </tr>
-
-  <tr>
-    <nav class="data-panel">
-      <td>View Animated Properties As:</td>
-      <td>
-        <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a> |
-        <a href="/metrics/css/animated"  class="sub-nav-links">Stack Rank</a>
-      </td>
-    </nav>
-  </tr>
-</table>
-{% endblock %}
-
 {% block subheader %}
 <div id="subheader">
   <h2>CSS usage metrics &gt; all properties > timeline</h2>

--- a/templates/metrics/feature/_feature_metric_nav.html
+++ b/templates/metrics/feature/_feature_metric_nav.html
@@ -5,9 +5,16 @@
 </ul>
 
 <div id="horizontal-sub-nav">
-  <nav class="data-panel">
-    View As:<a href="/metrics/feature/timeline/popularity" class="sub-nav-links">Timeline</a> |
-    <a href="/metrics/feature/popularity"  class="sub-nav-links">Stack Rank</a>
-  </nav>
+  <table>
+    <tr>
+      <nav class="data-panel">
+        <td>View As:</td>
+        <td>
+          <a href="/metrics/feature/timeline/popularity" class="sub-nav-links">Timeline</a> |
+          <a href="/metrics/feature/popularity"  class="sub-nav-links">Stack Rank</a>
+        </td>
+      </nav>
+    </tr>
+  </table>
 </div>
 

--- a/templates/metrics/feature/_feature_metric_nav.html
+++ b/templates/metrics/feature/_feature_metric_nav.html
@@ -3,3 +3,11 @@
   <li><a href="/metrics/feature/popularity">Stack rank</a></li>
   <li><a href="/metrics/feature/timeline/popularity">Timeline</a></li>
 </ul>
+
+<div id="horizontal-sub-nav">
+  <nav class="data-panel">
+    View As:<a href="/metrics/feature/timeline/popularity" class="sub-nav-links">Timeline</a> |
+    <a href="/metrics/feature/popularity"  class="sub-nav-links">Stack Rank</a>
+  </nav>
+</div>
+

--- a/templates/metrics/feature/popularity.html
+++ b/templates/metrics/feature/popularity.html
@@ -9,13 +9,6 @@
   {% include "metrics/feature/_feature_metric_nav.html" %}
 {% endblock %}
 
-{% block horizontalsubnav %}
-<nav class="data-panel">
-  View As:<a href="/metrics/feature/timeline/popularity" class="sub-nav-links">Timeline</a> |
-  <a href="/metrics/feature/popularity"  class="sub-nav-links">Stack Rank</a>
-</nav>
-{% endblock %}
-
 {% block subheader %}
 <div id="subheader">
   <h2>HTML &amp; JavaScript usage &gt; all features > stack rank</h2>

--- a/templates/metrics/feature/timeline/popularity.html
+++ b/templates/metrics/feature/timeline/popularity.html
@@ -13,12 +13,7 @@
   {% include "metrics/feature/_feature_metric_nav.html" %}
 {% endblock %}
 
-{% block horizontalsubnav %}
-<nav class="data-panel">
-  View As:<a href="/metrics/feature/timeline/popularity" class="sub-nav-links">Timeline</a> |
-  <a href="/metrics/feature/popularity"  class="sub-nav-links">Stack Rank</a>
-</nav>
-{% endblock %}
+
 
 {% block subheader %}
 <div id="subheader">


### PR DESCRIPTION
Merging this should close #1345 

In this PR,

- The HTML code for vertical navigation menu and the horizontal navigation menu is moved to `templates/metrics/css/_css_metric_nav.html` for CSS properties and `templates/metrics/feature/_feature_metric_nav.html` for JavaScript features. Consequently, the block `horizontalsubnav` has been removed. This also keeps the HTML code for navigation menus together unlike the previous approach.
- The vertical navigation menu will be only displayed in wider view ports using CSS Media Query.
- The horizontal navigation menu will be only displayed in narrow view ports using CSS Media Query.

**Review Requested** - @jrobbins 