### PR TITLE
Refine our use of CSP.

### DIFF
--- a/framework/csp.py
+++ b/framework/csp.py
@@ -30,6 +30,11 @@ USE_NONCE_ONLY_POLICY = True  # Recommended
 REPORT_URI = '/csp'
 NONCE_LENGTH = 30
 
+# Note: This is an addition beyond the reference csp.py example code.
+HOST_SOURCES = [
+    'https://www.gstatic.com',
+    ]
+
 DEFAULT_POLICY = {
     # Disallow base tags.
     'base-uri': ["'none'"],
@@ -45,7 +50,7 @@ DEFAULT_POLICY = {
         # Fallback. Ignored in presence of strict-dynamic.
         'https:',
         'http:'
-    ],
+    ] + HOST_SOURCES,
 }
 
 # This is a stricter version of the DEFAULT_POLICY.
@@ -59,7 +64,7 @@ NONCE_ONLY_POLICY = {
     'script-src': [
         # Fallback. Ignored in presence of a nonce (which is added below).
         "'unsafe-inline'"
-    ],
+    ] + HOST_SOURCES,
 }
 
 HEADER_KEY_ENFORCE = 'Content-Security-Policy'

--- a/static/js-src/feature-page.js
+++ b/static/js-src/feature-page.js
@@ -42,6 +42,14 @@ if (navigator.share) {
   });
 }
 
+const shareFeatureEl = document.querySelector('#share-feature');
+if (shareFeatureEl) {
+  shareFeatureEl.addEventListener('click', function() {
+    shareFeature();
+  });
+}
+
+
 // Show the star icon if the user has starred this feature.
 window.csClient.getStars().then((subscribedFeatures) => {
   const iconEl = document.querySelector('.pushicon');
@@ -56,6 +64,13 @@ const starWhenSignedOutEl = document.querySelector('#star-when-signed-out');
 if (starWhenSignedOutEl) {
   starWhenSignedOutEl.addEventListener('click', function(e) {
     window.promptSignIn(e);
+  });
+}
+
+const starWhenSignedInEl = document.querySelector('#star-when-signed-in');
+if (starWhenSignedInEl) {
+  starWhenSignedInEl.addEventListener('click', function() {
+    subscribeToFeature(Number(FEATURE_ID));
   });
 }
 

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -125,13 +125,9 @@ limitations under the License.
   </script>
 
   <script src="https://unpkg.com/@webcomponents/webcomponentsjs/webcomponents-loader.js"
-          defer nonce="{{nonce}}"></script>
-  <script type="module" nonce="{{nonce}}">
-    WebComponents.waitFor(() => {
-      return import('/static/dist/components.js');
-    });
-  </script>
-
+          nonce="{{nonce}}"></script>
+  <script type="module" nonce="{{nonce}}" defer
+          src="/static/dist/components.js"></script>
   {% block preload %}{% endblock %}
 
   {% block rss %}{% endblock%}

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -24,9 +24,8 @@
   <div style="float:right">
   {% if user %}
     <span class="tooltip" title="Receive an email notification when there are updates">
-      <a href="#" data-tooltip>
+      <a href="#" data-tooltip id="star-when-signed-in">
         <iron-icon icon="chromestatus:star-border"
-                    onclick="subscribeToFeature({{ feature.id }})"
                     class="pushicon"></iron-icon>
       </a>
     </span>
@@ -44,8 +43,8 @@
     </a>
   </span>
   <span class="tooltip no-web-share" title="Share this feature">
-    <a href="#" data-tooltip>
-      <iron-icon icon="chromestatus:share" onclick="shareFeature()"></iron-icon>
+    <a href="#" data-tooltip id="share-feature">
+      <iron-icon icon="chromestatus:share"></iron-icon>
     </a>
   </span>
   {% if user.can_edit %}


### PR DESCRIPTION
Based on reviewing logs of our CSP reports, I made the following changes:
+ In csp.py, add gstatic.com to our script-src directive because script from there is dynamically loaded by the charting library. 
+ In the HTML templates, convert a couple of previously missed onclick="" attributes to addEventListener in a separate JS file.
+ Change the way that we load web components to avoid a dynamic import statement.  Such a statement cannot have a nonce, and I don't like the idea of allowing dynamic imports in the CSP policy.  This way of loading the components is potentially a little slower because we block on loading the polyfill code, but I see it as only taking about 42ms to retrieve and it is cacheable.

I tested in chrome, safari, and firefox and I see no reports of CSP violations.  So, if we deploy this and monitor the logs for another week then we can probably start enforcing our CSP policy rather than just using reporting mode.