### PR TITLE
Enforce xsrf protections

### DIFF
--- a/api/token_refresh_api_test.py
+++ b/api/token_refresh_api_test.py
@@ -56,7 +56,6 @@ class TokenRefreshAPITest(unittest.TestCase):
       with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.post()
 
-  @unittest.skip('TODO(jrobbins): enable after next release')
   def test_post__missing(self):
     """We reject token requests that do not include a previous token."""
     testing_config.sign_in('user@example.com', 111)
@@ -65,7 +64,6 @@ class TokenRefreshAPITest(unittest.TestCase):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.post()
 
-  @unittest.skip('TODO(jrobbins): enable after next release')
   @mock.patch('api.token_refresh_api.TokenRefreshAPI.validate_token')
   def test_post__bad(self, mock_validate_token):
     """We reject token requests that have a bad token."""

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -232,13 +232,11 @@ class APIHandler(BaseHandler):
       except werkzeug.exceptions.BadRequest:
         pass  # Raised when the request has no body.
     if not token:
-      # TODO(jrobbins): start enforcing in next release
-      logging.info("would do self.abort(400, msg='Missing XSRF token')")
+      self.abort(400, msg='Missing XSRF token')
     try:
       self.validate_token(token, user.email())
     except xsrf.TokenIncorrect:
-      # TODO(jrobbins): start enforcing in next release
-      logging.info("would do self.abort(400, msg='Invalid XSRF token')")
+      self.abort(400, msg='Invalid XSRF token')
 
 
 class FlaskHandler(BaseHandler):
@@ -368,14 +366,12 @@ class FlaskHandler(BaseHandler):
       return
     token = self.form.get('token')
     if not token:
-      # TODO(jrobbins): start enforcing in next release
-      logging.info("would do self.abort(400, msg='Missing XSRF token')")
+      self.abort(400, msg='Missing XSRF token')
     user = self.get_current_user(required=True)
     try:
       xsrf.validate_token(token, user.email())
     except xsrf.TokenIncorrect:
-      # TODO(jrobbins): start enforcing in next release
-      logging.info("would do self.abort(400, msg='Invalid XSRF token')")
+      self.abort(400, msg='Invalid XSRF token')
 
   def require_task_header(self):
     """Abort if this is not a Google Cloud Tasks request."""

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -364,7 +364,9 @@ class FlaskHandler(BaseHandler):
     """Every UI form submission must have a XSRF token."""
     if settings.UNIT_TEST_MODE or self.IS_INTERNAL_HANDLER:
       return
-    token = self.form.get('token')
+    token = self.request.headers.get('X-Xsrf-Token')
+    if not token:
+      token = self.form.get('token')
     if not token:
       self.abort(400, msg='Missing XSRF token')
     user = self.get_current_user(required=True)

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -386,7 +386,6 @@ class APIHandlerTests(unittest.TestCase):
     mock_validate_token.assert_called_once_with(
         'valid header token', 'user@example.com')
 
-  @unittest.skip('TODO(jrobbins): enable after next release')
   @mock.patch('framework.basehandlers.APIHandler.validate_token')
   def test_require_signed_in_and_xsrf_token__missing(self, mock_validate_token):
     """User is signed in but missing a token."""
@@ -397,7 +396,6 @@ class APIHandlerTests(unittest.TestCase):
         self.handler.require_signed_in_and_xsrf_token()
     mock_validate_token.assert_not_called()
 
-  @unittest.skip('TODO(jrobbins): enable after next release')
   @mock.patch('framework.basehandlers.APIHandler.validate_token')
   def test_require_signed_in_and_xsrf_token__bad(self, mock_validate_token):
     """User is signed in but missing a token."""
@@ -613,7 +611,6 @@ class FlaskHandlerTests(unittest.TestCase):
     with test_app.test_request_context('/test', data=form_data):
       self.handler.require_xsrf_token()
 
-  @unittest.skip('TODO(jrobbins): enable after next release')
   @mock.patch('settings.UNIT_TEST_MODE', False)
   def test_require_xsrf_token__missing(self):
     """We reject a POST with a missing token."""
@@ -623,11 +620,15 @@ class FlaskHandlerTests(unittest.TestCase):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.require_xsrf_token()
 
-  @unittest.skip('TODO(jrobbins): enable after next release')
   @mock.patch('settings.UNIT_TEST_MODE', False)
-  def test_require_xsrf_token__wrong(self):
+  @mock.patch('framework.basehandlers.BaseHandler.get_current_user')
+  def test_require_xsrf_token__wrong(self, mock_get_current_user):
     """We reject a POST with a incorrect token."""
     testing_config.sign_in('user1@example.com', 111)
+    # Also mock get_current_user because it will not use the usual
+    # unit test configuration if we have UNIT_TEST_MODE == False.
+    mock_get_current_user.return_value = users.User('user1@example.com', 111)
+    # Form has a token intended for a different user.
     form_data = {'token': xsrf.generate_token('user2@example.com')}
     with test_app.test_request_context('/test', data=form_data):
       with self.assertRaises(werkzeug.exceptions.BadRequest):

--- a/templates/admin/blink.html
+++ b/templates/admin/blink.html
@@ -160,7 +160,14 @@ document.querySelector('#components_list').addEventListener('click', function(e)
   fetch('/admin/blink', {
     method: removeUser ? 'PUT' : 'POST',
     credentials: 'include',
-    body: JSON.stringify({userId, componentName, primary: toggleAsOwner})
+    headers: {
+        'X-Xsrf-Token': window.csClient.token,
+    },
+    body: JSON.stringify({
+        userId,
+        componentName,
+        primary: toggleAsOwner
+    })
   })
   .then(resp => resp.json())
   .then(json => {


### PR DESCRIPTION
For several weeks now, we've been sending out XSRF tokens and checking them without raising errors.  A review of the logs shows on valid requests that logged missing or invalid XSRF tokens.  So, I think we are ready to start enforcing them as requirements on requests.

In this PR:
+ Reject requests that have missing or bad tokens rathe than just logging them
+ Update unit tests
+ Update the admin page for editing blink component owners.  It was not sending tokens in XHR requests. 