### PR TITLE
Migration to Cloud NDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ env_variables:
   DJANGO_SETTINGS_MODULE: 'settings'
   DJANGO_SECRET: 'this-is-a-secret'
   DATASTORE_EMULATOR_HOST: 'localhost:15606'
-  DATASTORE_PROJECT_ID: 'chromestatus'
-  DATASTORE_USE_PROJECT_ID_AS_APP_ID: true
 ```
 
 ### Developing

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Create a file named `env_vars.yaml` in the root directory and fill it with:
 env_variables:
   DJANGO_SETTINGS_MODULE: 'settings'
   DJANGO_SECRET: 'this-is-a-secret'
+  DATASTORE_EMULATOR_HOST: 'localhost:15606'
+  DATASTORE_PROJECT_ID: 'chromestatus'
 ```
 
 ### Developing

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ env_variables:
   DJANGO_SECRET: 'this-is-a-secret'
   DATASTORE_EMULATOR_HOST: 'localhost:15606'
   DATASTORE_PROJECT_ID: 'chromestatus'
+  DATASTORE_USE_PROJECT_ID_AS_APP_ID: true
 ```
 
 ### Developing

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -455,7 +455,10 @@ def FlaskApplication(routes, pattern_base='', debug=False):
   
   app = flask.Flask(__name__)
   app.wsgi_app = ndb_wsgi_middleware(app.wsgi_app)
-  app.secret_key = secrets.get_session_secret()  # For flask.session
+  
+  client = ndb.Client()
+  with client.context():
+    app.secret_key = secrets.get_session_secret()  # For flask.session
 
   for i, rule in enumerate(routes):
     pattern = rule[0]

--- a/framework/secrets.py
+++ b/framework/secrets.py
@@ -49,8 +49,8 @@ class Secrets(ndb.Model):
   def _get_or_make_singleton(cls):
     needs_save = False
     singleton = None
-    with client.context():
-      existing = Secrets.query().fetch(1)
+    existing = Secrets.query().fetch(1)
+
     if existing:
       singleton = existing[0]
 

--- a/framework/secrets.py
+++ b/framework/secrets.py
@@ -24,7 +24,9 @@ import string
 import time
 
 from google.appengine.ext import db
+from google.cloud import ndb
 
+client = ndb.Client()
 
 # For random key generation
 RANDOM_KEY_LENGTH = 128
@@ -37,17 +39,18 @@ def make_random_key(length=RANDOM_KEY_LENGTH, chars=RANDOM_KEY_CHARACTERS):
   return ''.join(chars)
 
 
-class Secrets(db.Model):
+class Secrets(ndb.Model):
   """A server-side-only value that we use to generate security tokens."""
 
-  xsrf_secret = db.StringProperty()
-  session_secret = db.StringProperty()
+  xsrf_secret = ndb.StringProperty()
+  session_secret = ndb.StringProperty()
 
   @classmethod
   def _get_or_make_singleton(cls):
     needs_save = False
     singleton = None
-    existing = Secrets.all().fetch(1)
+    with client.context():
+      existing = Secrets.query().fetch(1)
     if existing:
       singleton = existing[0]
 

--- a/internals/models.py
+++ b/internals/models.py
@@ -993,18 +993,18 @@ class Feature(DictModel):
   star_count = ndb.IntegerProperty(default=0)
   search_tags = ndb.StringProperty(repeated=True)
   comments = ndb.StringProperty()
-  # owner = ndb.ListProperty(ndb.Email)
+  # owner = db.ListProperty(db.Email)
   owner = ndb.StringProperty(repeated=True)
   footprint = ndb.IntegerProperty()  # Deprecated
 
   # Tracability to intent discussion threads
-  # intent_to_implement_url = ndb.LinkProperty()
+  # intent_to_implement_url = db.LinkProperty()
   intent_to_implement_url = ndb.StringProperty()
-  # intent_to_ship_url = ndb.LinkProperty()
-  # ready_for_trial_url = ndb.LinkProperty()
-  # intent_to_experiment_url = ndb.LinkProperty()
-  # i2e_lgtms = ndb.ListProperty(ndb.Email)  # Currently, only one is needed.
-  # i2s_lgtms = ndb.ListProperty(ndb.Email)
+  # intent_to_ship_url = db.LinkProperty()
+  # ready_for_trial_url = db.LinkProperty()
+  # intent_to_experiment_url = db.LinkProperty()
+  # i2e_lgtms = db.ListProperty(db.Email)  # Currently, only one is needed.
+  # i2s_lgtms = db.ListProperty(db.Email)
   intent_to_ship_url = ndb.StringProperty()
   ready_for_trial_url = ndb.StringProperty()
   intent_to_experiment_url = ndb.StringProperty()
@@ -1012,15 +1012,15 @@ class Feature(DictModel):
   i2s_lgtms = ndb.StringProperty(repeated=True)
 
   # Chromium details.
-  # bug_url = ndb.LinkProperty()
-  # launch_bug_url = ndb.LinkProperty()
-  # initial_public_proposal_url = ndb.LinkProperty()
+  # bug_url = db.LinkProperty()
+  # launch_bug_url = db.LinkProperty()
+  # initial_public_proposal_url = db.LinkProperty()
   bug_url = ndb.StringProperty()
   launch_bug_url = ndb.StringProperty()
   initial_public_proposal_url = ndb.StringProperty()
-  # blink_components = ndb.StringListProperty(required=True, default=[BlinkComponent.DEFAULT_COMPONENT])
+  # blink_components = db.StringListProperty(required=True, default=[BlinkComponent.DEFAULT_COMPONENT])
   blink_components = ndb.StringProperty(repeated=True)
-  # devrel = ndb.ListProperty(db.Email)
+  # devrel = db.ListProperty(db.Email)
   devrel = ndb.StringProperty(repeated=True)
 
   impl_status_chrome = ndb.IntegerProperty(required=True)

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -31,6 +31,7 @@ from framework import ramcache
 from google.appengine.api import users as gae_users
 from framework import users
 from google.appengine.ext import db
+from google.cloud import ndb
 
 from framework import basehandlers
 from framework import permissions

--- a/pages/users.py
+++ b/pages/users.py
@@ -27,6 +27,7 @@ import os
 # App Engine imports.
 from google.appengine.api import users
 from google.appengine.ext import db
+from google.cloud import ndb
 
 import flask
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,7 @@ itsdangerous==1.1.0
 # Required for porting Python2 to Python3
 requests==2.25.1
 requests-toolbelt==0.9.1  # backward compatability while still on py2.
+google-cloud-ndb
+
 
 # See also: requirements.dev.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ enum34==1.1.10
 grpc-google-iam-v1==0.12.3
 google-api-core==1.22.0
 pytz==2020.1
-google-auth==1.20.1
+google-auth==1.24.0
 setuptools==44.1.1
 six==1.15.0
 urllib3==1.26.5

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -7,5 +7,5 @@
 # The directory in which this script resides.
 readonly BASEDIR=$(dirname $BASH_SOURCE)
 
-dev_appserver.py -A cr-status --enable_console=1 \
+dev_appserver.py -A cr-status --enable_console=1 --datastore_emulator_port=15606 \
   $BASEDIR/../app.yaml $BASEDIR/../notifier.yaml


### PR DESCRIPTION
Merging this will close #1075 and #1076 

This PR is not supposed to be merged at this stage !!!

The PR will replace DB Client Library with Cloud NDB library which is required for migration to Python 3.

Some Important points to note:-
- Cloud NDB seems to be working fine in the interactive console of Cloud Datastore Emulator and is able to return the existing data created using DB Client Library.
- The order of release of the storage client libraries is - `DB Client Library` (oldest), `App Engine NDB Library` and `Cloud NDB library` (latest). We are migrating, directly from `DB Client Library` to `Cloud NDB Library`. 
- There are many changes that were introduced in `App Engine NDB Library`. E.g. Many `property types`, that were present in `DB Client Library` are not present in `App Engine NDB Library`. As `Cloud NDB library` is successor of `App Engine NDB library`, these changes are also present in `Cloud NDB Library`. 
- Deploying and running this PR on local machine, at this stage, will result in `BadArgumentError: Could not import googledatastore. This library must be installed with version >= 6.0.0 to use the Cloud Datastore API.` It may seem counter-intuitive but this error is raised because of the syntax changes introduced in `App Engine NDB Library` ( and as a result, `Cloud NDB library` also). Over the next few days, I will try to remove these syntax errors.

Note:

- This [link](https://cloud.google.com/appengine/docs/standard/python/ndb/db_to_ndb) contains the differences between `DB Client Library` and `App Engine NDB Library`