### PR TITLE
Only trap BadRequest in DEV, not PROD.

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -453,9 +453,10 @@ def FlaskApplication(routes, pattern_base='', debug=False):
         view_func=handler_class.as_view(classname),
         defaults=defaults)
 
-  # Note: debug parameter is not used because the following accomplishes
-  # what we need it to do.
-  app.config["TRAP_BAD_REQUEST_ERRORS"] = True  # Needed to log execptions
+  # The following causes flask to print a stack trace and return 500
+  # when we are running locally and a handler raises a BadRequest exception.
+  # In production, it will return a status 400.
+  app.config["TRAP_BAD_REQUEST_ERRORS"] = settings.DEV_MODE
   # Flask apps also have a debug setting that can be used to auto-reload
   # template source code, but we use django for that.
 


### PR DESCRIPTION
We have someone out on the internet sending POST requests without an XSRF token.   (The requests themselves are apparently someone probing for common WordPress vulnerabilities).   Most are 404, but the '/' URL is one that we handle. Our request handling logic correctly does self.abort(400) in this case because the POST request does not include an XSRF token.

In production, these rejected requests are getting a response code 500.  We don't care what response the attacker gets, but each 500 shows up on the Cloud Console Error Handling page, and App Engine error charts, which is not desired.

This Flask behavior is intended to support local debugging and is controlled by app.config["TRAP_BAD_REQUEST_ERRORS"].  So, we'll just set it to True when running locally.