### PR TITLE
Remove calls to set up parts of testbed that are no longer supported.

### DIFF
--- a/testing_config.py
+++ b/testing_config.py
@@ -53,20 +53,19 @@ def setUpOurTestbed():
   # needed because endpoints expects a . in this value
   ourTestbed.setup_env(current_version_id='testbed.version')
   ourTestbed.activate()
+
   # Can't use init_all_stubs() because PIL isn't in wheel.
   ourTestbed.init_app_identity_stub()
   ourTestbed.init_blobstore_stub()
   ourTestbed.init_capability_stub()
-  ourTestbed.init_channel_stub()
   ourTestbed.init_datastore_v3_stub()
   ourTestbed.init_files_stub()
   ourTestbed.init_logservice_stub()
   ourTestbed.init_mail_stub()
-  ourTestbed.init_modules_stub()
   ourTestbed.init_search_stub()
   ourTestbed.init_urlfetch_stub()
   ourTestbed.init_user_stub()
-  ourTestbed.init_xmpp_stub()
+
 
 # Normally this would be done in the setUp() methods of individual test files,
 # but we need it to be done before importing any application code because


### PR DESCRIPTION
I just started getting errors:
AttributeError: 'Testbed' object has no attribute 'init_channel_stub'
even though this code is copied from Monorail and has been working for us for a year without changes.
I think what happened is that my Google Cloud SDK got updated.
When I checked the docs for Testbed, I see that init_channel_stub and these others is not listed.  We don't use any of those features so we don't need to stub them out, and they probably don't even exist in the current SDK.
https://cloud.google.com/appengine/docs/standard/python/tools/localunittesting

Note: we still can't use init_all_stubs() because the imagine processing stub requires a PIL library to be installed locally and we don't want to add that dependency.