### PR TITLE
Use an ancestor query in ramcache for strong consistency.

### DIFF
--- a/framework/ramcache.py
+++ b/framework/ramcache.py
@@ -165,7 +165,10 @@ class SharedInvalidate(db.Model):
   @classmethod
   def invalidate(cls):
     """Tell this and other appengine instances to invalidate their caches."""
-    singleton = cls.get(cls.SINGLETON_KEY)
+    singleton = None
+    entities = cls.all().ancestor(cls.PARENT_KEY).fetch(1)
+    if entities:
+      singleton = entities[0]
     if not singleton:
       singleton = SharedInvalidate(key=cls.SINGLETON_KEY)
     singleton.put()  # automatically sets singleton.updated to now.


### PR DESCRIPTION
In the old DB library, strong consistency can be achieved by specifying a read policy or by doing an ancestor query.  In the not-as-old NDB library that we want to upgrade to, only the ancestor query is supported.  So, try using that approach in DB so that we can prove that it works in practice.