### PR TITLE
Remove a reference to GAE users.

### DIFF
--- a/pages/users.py
+++ b/pages/users.py
@@ -25,7 +25,6 @@ import logging
 import os
 
 # App Engine imports.
-from google.appengine.api import users
 from google.appengine.ext import ndb
 
 import flask
@@ -34,6 +33,8 @@ from framework import basehandlers
 from framework import permissions
 from internals import models
 import settings
+
+LOGIN_PAGE_URL = '/features?loginStatus=False'
 
 
 class UserListHandler(basehandlers.FlaskHandler):
@@ -60,7 +61,7 @@ class SettingsHandler(basehandlers.FlaskHandler):
   def get_template_data(self):
     user_pref = models.UserPref.get_signed_in_user_pref()
     if not user_pref:
-      return flask.redirect(users.create_login_url(flask.request.path))
+      return flask.redirect(LOGIN_PAGE_URL)
 
     template_data = {
         'user_pref': user_pref,


### PR DESCRIPTION
This follows the pattern that you established for dealing with a page view that requires the user to be signed in.   With the old GAE users library we could redirect them to a sign-in page, but with Google Sign-In we will redirect them to the /features page and ask them to sign in.