### PR TITLE
Show spec_link itself rather than old specification field enum.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -258,15 +258,6 @@ EDITORS_DRAFT = 4
 PUBLIC_DISCUSSION = 5
 NO_STD_OR_DISCUSSION = 6
 
-STANDARDIZATION = {
-  DEFACTO_STD: 'De-facto standard',
-  ESTABLISHED_STD: 'Established standard',
-  WORKING_DRAFT: 'Working draft or equivalent',
-  EDITORS_DRAFT: "Editor's draft",
-  PUBLIC_DISCUSSION: 'Public discussion',
-  NO_STD_OR_DISCUSSION: 'No public standards discussion',
-  }
-
 DEV_STRONG_POSITIVE = 1
 DEV_POSITIVE = 2
 DEV_MIXED_SIGNALS = 3
@@ -290,7 +281,6 @@ PROPERTY_NAMES_TO_ENUM_DICTS = {
     'impl_status_chrome': IMPLEMENTATION_STATUS,
     'security_review_status': REVIEW_STATUS_CHOICES,
     'privacy_review_status': REVIEW_STATUS_CHOICES,
-    'standardization': STANDARDIZATION,
     'ff_views': VENDOR_VIEWS,
     'ie_views': VENDOR_VIEWS,
     'safari_views': VENDOR_VIEWS,
@@ -597,10 +587,6 @@ class Feature(DictModel):
       }
       d['standards'] = {
         'spec': d.pop('spec_link', None),
-        'status': {
-          'text': STANDARDIZATION[self.standardization],
-          'val': d.pop('standardization', None),
-        },
       }
       d['tag_review_status'] = REVIEW_STATUS_CHOICES[self.tag_review_status]
       d['security_review_status'] = REVIEW_STATUS_CHOICES[
@@ -711,8 +697,6 @@ class Feature(DictModel):
                        'text': VENDOR_VIEWS[self.ie_views]}
       d['safari_views'] = {'value': self.safari_views,
                            'text': VENDOR_VIEWS[self.safari_views]}
-      d['standardization'] = {'value': self.standardization,
-                              'text': STANDARDIZATION[self.standardization]}
       d['web_dev_views'] = {'value': self.web_dev_views,
                             'text': WEB_DEV_VIEWS[self.web_dev_views]}
 
@@ -1055,7 +1039,7 @@ class Feature(DictModel):
   visibility = ndb.IntegerProperty(required=False)  # Deprecated
 
   # Standards details.
-  standardization = ndb.IntegerProperty(required=True)
+  standardization = ndb.IntegerProperty(required=True)  # Deprecated
   spec_link = ndb.StringProperty()
   api_spec = ndb.BooleanProperty(default=False)
   spec_mentors = ndb.StringProperty(repeated=True)

--- a/pages/featurelist.py
+++ b/pages/featurelist.py
@@ -66,9 +66,6 @@ class FeatureListHandler(basehandlers.FlaskHandler):
     template_data['WEB_DEV_VIEWS'] = json.dumps([
       {'key': k, 'val': v} for k,v in
       models.WEB_DEV_VIEWS.iteritems()])
-    template_data['STANDARDS_VALS'] = json.dumps([
-      {'key': k, 'val': v} for k,v in
-      models.STANDARDIZATION.iteritems()])
 
     return template_data
 

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -169,13 +169,6 @@ ALL_FIELDS = {
          'success of this feature, such as a link to the UseCounter(s) you '
          'have set up.')),
 
-    'standardization': forms.ChoiceField(
-        required=False, label='Standardization',
-        choices=models.STANDARDIZATION.items(),
-        initial=models.EDITORS_DRAFT,
-        help_text=("The standardization status of the API. In bodies that don't "
-                   "use this nomenclature, use the closest equivalent.")),
-
     'unlisted': forms.BooleanField(
       required=False, initial=False,
       help_text=('Check this box for draft features that should not appear '
@@ -963,7 +956,7 @@ def make_display_specs(*shared_field_names):
           for field_name in shared_field_names]
 
 
-DEPRECATED_FIELDS = ['standardization']
+DEPRECATED_FIELDS = []
 
 DISPLAY_IN_FEATURE_HIGHLIGHTS = [
     'name', 'summary',

--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -8,7 +8,6 @@ import './chromedash-color-status';
 import style from '../css/elements/chromedash-feature.css';
 import sharedStyle from '../css/shared.css';
 
-const MAX_STANDARDS_VAL = 6;
 const MAX_VENDOR_VIEW = 7;
 const MAX_WEBDEV_VIEW = 6;
 
@@ -441,17 +440,12 @@ class ChromedashFeature extends LitElement {
                     .max="${MAX_WEBDEV_VIEW}"></chromedash-color-status>
                 <iron-icon icon="chromestatus:accessibility"></iron-icon>
               </span>
-              <span class="standardization view">
-                <chromedash-color-status class="bottom"
-                    .value="${this.feature.standards.status.val}"
-                    .max="${MAX_STANDARDS_VAL}"></chromedash-color-status>
-                ${this.feature.standards.spec ? html`
+             ${this.feature.standards.spec ? html`
+                <span class="standardization view">
                   <a href="${this.feature.standards.spec}"
-                     target="_blank">${this.feature.standards.status.text}</a>
-                  ` : html`
-                  <label>${this.feature.standards.status.text}</label>
-                  `}
-              </span>
+                     target="_blank">Spec</a>
+                </span>` :
+               nothing}
             </div>
             <div style="font-size:smaller">
               After a feature ships in Chrome, the values listed here are not

--- a/static/elements/chromedash-legend.js
+++ b/static/elements/chromedash-legend.js
@@ -4,6 +4,9 @@ import '@polymer/iron-icon';
 import './chromedash-color-status';
 import SHARED_STYLES from '../css/shared.css';
 
+// This element implements the help dialog that appears when the user
+// clicks on the '?' icon near the search field.
+
 class ChromedashLegend extends LitElement {
   static get properties() {
     return {
@@ -147,7 +150,7 @@ class ChromedashLegend extends LitElement {
         <p>Colors indicate the "interoperability risk" for a given feature. The
           risk increases as
           <chromedash-color-status value="0"
-              .max="${this.views.vendors.length}"></chromedash-color-status> → 
+              .max="${this.views.vendors.length}"></chromedash-color-status> →
           <chromedash-color-status .value="${this.views.vendors.length}"
               .max="${this.views.vendors.length}"></chromedash-color-status>, and the
           color meaning differs for browser vendors, web developers, and the
@@ -174,18 +177,6 @@ class ChromedashLegend extends LitElement {
                                            .max="${this.views.webdevs.length}">
                                            </chromedash-color-status>
                   <span>${webdev.val}</span></li>
-                `)}
-            </ul>
-          </div>
-          <div>
-            <p>Standards values</p>
-            <ul>
-              ${this.views.standards.map((standard) => html`
-                <li>
-                  <chromedash-color-status .value="${standard.key}"
-                                           .max="${this.views.standards.length}">
-                                           </chromedash-color-status>
-                  <span>${standard.val}</span></li>
                 `)}
             </ul>
           </div>

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -118,7 +118,7 @@
     <section id="specification">
       <h3>Specification</h3>
       <p><a href="{{feature.spec_link}}" target="_blank" rel="noopener"
-            >{{feature.standardization.text}}</a></p>
+            >{{feature.spec_link}}</a></p>
     </section>
     {% endif %}
 

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -161,7 +161,7 @@
     </section>
 
     <section id="consensus">
-      <h3>Consensus &amp; Standardization</h3>
+      <h3>Consensus</h3>
       <div style="font-size:smaller;">After a feature ships in Chrome, the values listed here are not guaranteed to be up to date.</div>
       <br>
       <ul>

--- a/templates/features.html
+++ b/templates/features.html
@@ -59,11 +59,10 @@
   <script nonce="{{nonce}}">
     (function() {
       'use strict';
-      // Get values from server. used in /static/js/features-page.js
+      // Get values from server. used in /static/js-src/features-page.js
       const VIEWS = {
         vendors: {{VENDOR_VIEWS|safe}},
         webdevs: {{WEB_DEV_VIEWS|safe}},
-        standards: {{STANDARDS_VALS|safe}}
       };
       {% inline_file "/static/js/features-page.min.js" %}
     })();


### PR DESCRIPTION
This should resolve issue #1366.

IIRC, the standardization field was deprecated because the status of a standardization effort is too nuanced to accurately represent with a simple enum.  Instead, users really need to click through to the spec link and just for themselves what the status of that effort is.

I think the reason that this change was half done before was because I didn't understand all the ways that this enum was used in the UI until digging through it today.

In this CL:
+ Delete the STANDARDIZATION enum from models.py.
+ Mark the DB field as deprecated (we don't delete it because we don't want accidentally reuse the same name).
+ Remove the standardization enum name and int from the JSON representation of features
+ Remove the standardization section from the search help dialog
+ Change the little standardization color block on the expanded feature card from displaying the standardization status enum to just saying "Spec" if there is a spec_link.
+ Change a section heading on the feature detail page from "Consensus &amp; Standardization" to just "Consensus" because the spec link is already displayed under a separate "Specification" heading.