### PR TITLE
Update loading primary_blink_components to NDB.

### DIFF
--- a/pages/blink_handler.py
+++ b/pages/blink_handler.py
@@ -145,8 +145,8 @@ class SubscribersHandler(basehandlers.FlaskHandler):
 
     list_features_per_owner = 'showFeatures' in self.request.args
     for user in users:
-      # user.subscribed_components = [models.BlinkComponent.get(key) for key in user.blink_components]
-      user.owned_components = [models.BlinkComponent.get(key) for key in user.primary_blink_components]
+      # user.subscribed_components = [key.get() for key in user.blink_components]
+      user.owned_components = [key.get() for key in user.primary_blink_components]
       for component in user.owned_components:
         component.features = []
         if list_features_per_owner:


### PR DESCRIPTION
This looks like one call to load a datastore entity that was missed when upgrading from the old DB API to the GAE NDB API.  It caused an error on the rarely used /admin/subscribers page.