### PR TITLE
Add field requires_embedder_support.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -1038,6 +1038,7 @@ class Feature(DictModel):
   shipped_android_milestone = ndb.IntegerProperty()
   shipped_ios_milestone = ndb.IntegerProperty()
   shipped_webview_milestone = ndb.IntegerProperty()
+  requires_embedder_support = ndb.BooleanProperty(default=False)
 
   # DevTrial details.
   devtrial_instructions = ndb.StringProperty()

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -79,6 +79,8 @@ STAGE_FORMS = {
 
 
 IMPL_STATUS_FORMS = {
+    models.INTENT_INCUBATE:
+        (None, guideforms.ImplStatus_Incubate),
     models.INTENT_EXPERIMENT:
         (models.BEHIND_A_FLAG, guideforms.ImplStatus_DevTrial),
     models.INTENT_EXTEND_TRIAL:
@@ -208,7 +210,8 @@ class FeatureEditStage(basehandlers.FlaskHandler):
     # For now, checkboxes are always considered "touched", if they are
     # present on the form.
     # TODO(jrobbins): Simplify this after next deployment.
-    checkboxes = ('unlisted', 'all_platforms', 'wpt', 'prefixed', 'api_spec')
+    checkboxes = ('unlisted', 'all_platforms', 'wpt', 'prefixed', 'api_spec',
+                  'requires_embedder_support')
     if param_name in checkboxes:
       form_fields_str = self.form.get('form_fields')
       if form_fields_str:
@@ -378,6 +381,10 @@ class FeatureEditStage(basehandlers.FlaskHandler):
     if self.touched('ot_milestone_android_end'):
       feature.ot_milestone_android_end = self.parse_int(
           'ot_milestone_android_end')
+
+    if self.touched('requires_embedder_support'):
+      feature.requires_embedder_support = (
+          self.form.get('requires_embedder_support') == 'on')
 
     if self.touched('devtrial_instructions'):
       feature.devtrial_instructions = self.parse_link('devtrial_instructions')

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -627,6 +627,15 @@ ALL_FIELDS = {
         widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
         help_text=SHIPPED_WEBVIEW_HELP_TXT),
 
+    'requires_embedder_support': forms.BooleanField(
+      required=False, initial=False,
+      help_text=('Will this feature require support in //chrome?  '
+                 'If so, other embedders will need to make corresponding '
+                 'changes.  Please add a row to this '
+                 '<a href="https://docs.google.com/spreadsheets/d/'
+                 '1QV4SW4JBG3IyLzaonohUhim7nzncwK4ioop2cgUYevw/edit#gid=0'
+                 '" target="_blank">tracking spreadsheet</a>.')),
+
     'devtrial_instructions': forms.URLField(
         required=False, label='DevTrial instructions',
         widget=forms.URLInput(attrs={'placeholder': 'https://'}),
@@ -699,6 +708,11 @@ NewFeature_Incubate = define_form_class_using_shared_fields(
     'NewFeature_Incubate',
     ('motivation', 'initial_public_proposal_url', 'explainer_links',
      'bug_url', 'launch_bug_url', 'comments'))
+
+ImplStatus_Incubate = define_form_class_using_shared_fields(
+    'ImplStatus_Incubate',
+    ('requires_embedder_support',
+     ))
 
 
 NewFeature_Prototype = define_form_class_using_shared_fields(
@@ -865,7 +879,10 @@ Flat_Identify = define_form_class_using_shared_fields(
     'Flat_Identify',
     (# Standardization
     # TODO(jrobbins): display deprecation_motivation instead when deprecating.
-     'motivation', 'initial_public_proposal_url', 'explainer_links'))
+     'motivation', 'initial_public_proposal_url', 'explainer_links',
+
+     # Implementtion
+    'requires_embedder_support'))
 
 
 Flat_Implement = define_form_class_using_shared_fields(
@@ -982,7 +999,8 @@ DISPLAY_FIELDS_IN_STAGES = {
         'category', 'feature_type', 'intent_stage',
         ),
     models.INTENT_INCUBATE: make_display_specs(
-        'initial_public_proposal_url', 'explainer_links'),
+        'initial_public_proposal_url', 'explainer_links',
+        'requires_embedder_support'),
     models.INTENT_IMPLEMENT: make_display_specs(
         'spec_link', 'api_spec', 'spec_mentors', 'intent_to_implement_url'),
     models.INTENT_EXPERIMENT: make_display_specs(

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -179,6 +179,9 @@
 <br><br><h4>Flag name</h4>
 {{feature.flag_name}}
 
+<br><br><h4>Requires code in //chrome?</h4>
+{{feature.requires_embedder_support}}
+
 {% if feature.bug_url %}
   <br><br><h4>Tracking bug</h4>
   <a href="{{feature.bug_url}}">{{feature.bug_url}}</a>


### PR DESCRIPTION
This should resolve issue #1338.

In this PR:
+ Add requires_embedder_support boolean field in models.py.
+ Add that field to a new form for the implementation aspect of the Start Incubating stage.
+ Add that field to the flat editing page, feature detail page, and intent email templates.