### PR TITLE
Tell dev_appserver to start datastore emulator

### DIFF
--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -7,5 +7,6 @@
 # The directory in which this script resides.
 readonly BASEDIR=$(dirname $BASH_SOURCE)
 
-dev_appserver.py -A cr-status --enable_console=1 --datastore_emulator_port=15606 \
+dev_appserver.py -A cr-status --enable_console=1 \
+  --support_datastore_emulator=1 --datastore_emulator_port=15606 \
   $BASEDIR/../app.yaml $BASEDIR/../notifier.yaml


### PR DESCRIPTION
Based on some previous discussions and the instructions in the README.md file, I thought that 'npm start' was supposed to cause dev_appserver to start the emulator automatically.  However, that was not working for me until I added this option.