### PR TITLE
Fix FeatureOwner order() property and improve performance of /admin/blink

### DIFF
--- a/templates/admin/blink.html
+++ b/templates/admin/blink.html
@@ -61,9 +61,9 @@
       <div class="owners_list layout horizontal center">
         <div>
           <div class="column_header">Receives email updates:</div>
-          <select multiple disabled id="owner_list_{{forloop.counter}}" size="{{c.subscribers|length}}">
-            {% for s in c.subscribers %}
-              <option class="owner_name {% if s.name in c.primaries %}component_owner{% endif %}"
+          <select multiple disabled id="owner_list_{{forloop.counter}}" size="{{c.computed_subscribers|length}}">
+            {% for s in c.computed_subscribers %}
+              <option class="owner_name {% if s.name in c.computed_owners %}component_owner{% endif %}"
                       value="{{s.id}}">{{s.name}}: {{s.email}}</option>
             {% endfor %}
           </select>
@@ -72,7 +72,7 @@
           <div>
             <select class="owner_candidates">
               <option selected disabled>Select owner to add/remove</option>
-              {% for s in subscribers %}
+              {% for s in possible_subscribers %}
                 <option class="owner_name" value="{{s.id}}" data-email="{{s.email}}">{{s.name}}</option>
               {% endfor %}
             </select><br>


### PR DESCRIPTION
This PR makes two improvements to blink_handlers.py:

(1) Correct the sort order field name for the list of possible subscribers.
  This had originally been specified as 'name', and then your recent upgrade to GAE NDB changed it to models.BlinkComponent.name, which works, but models.FeatureOwner.name is more correct.

(2) Eliminate queries done in loops that made the page very slow to load on the prod site.  
  - There was a loop in python code that where c.owner did a query, and that is done over 700 times.
  - In the HTML template there was a reference to c.subscribers that also did a query and that was done over 700 times
  - The new code uses the list of possible_subscribers that is already fetched and loops over those entities in python code with no additional queries.