### PR TITLE
Make “debuggability” field required

### DIFF
--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -506,7 +506,7 @@ ALL_FIELDS = {
                    'the Request for Deprecation Trial email thread.')),
 
     'debuggability': forms.CharField(
-        label='Debuggability', required=False,
+        label='Debuggability', required=True,
         widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
         help_text=
         ('Description of the DevTools debugging support for your feature. '


### PR DESCRIPTION
Now that #1375 landed, there is clear guidance for feature owners on how to assess debuggability. In cases where debuggability is already covered through existing DevTools functionality, it’s valuable for feature owners to explicitly state that rather than leaving the field empty.

Issue: #1372