### PR TITLE
Fix application of query order.

### DIFF
--- a/api/metricsdata.py
+++ b/api/metricsdata.py
@@ -95,7 +95,7 @@ class TimelineHandler(basehandlers.FlaskHandler):
 
     if not datapoints:
       query = self.make_query(bucket_id)
-      query.order(self.MODEL_CLASS.date)
+      query = query.order(self.MODEL_CLASS.date)
       datapoints = query.fetch(None) # All matching results.
 
       # Remove outliers if percentage is not between 0-1.
@@ -145,7 +145,7 @@ class FeatureHandler(basehandlers.FlaskHandler):
     # That operation is fast and makes most of the iterations
     # of the main loop become in-RAM operations.
     batch_datapoints_query = self.MODEL_CLASS.query()
-    batch_datapoints_query.order(-self.MODEL_CLASS.date)
+    batch_datapoints_query = batch_datapoints_query.order(-self.MODEL_CLASS.date)
     batch_datapoints_list = batch_datapoints_query.fetch(5000)
     logging.info('batch query found %r recent datapoints',
                  len(batch_datapoints_list))


### PR DESCRIPTION
The DB and NDB query objects are immutable and adding a new filter or setting the query order returns a new query object, which we need to keep in a variable.

This looks like a long-standing defect that has been in our code for at least 9 months.  However, the recent upgrade from DB to NDB to Cloud NDB may have made the defect more visible.  Other wrong results may have been show often, but they happened to not be very different in value from the correct results.