### PR TITLE
Add fields for DevTrial milestones.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -948,11 +948,11 @@ class Feature(DictModel):
 
     # Stash existing values when entity is created so we can diff property
     # values later in put() to know what's changed. https://stackoverflow.com/a/41344898
-    
+
     for prop_name, prop in self._properties.iteritems():
       old_val = getattr(self, prop_name, None)
       setattr(self, '_old_' + prop_name, old_val)
-      
+
 
   def __notify_feature_subscribers_of_changes(self, is_update):
     """Async notifies subscribers of new features and property changes to features by
@@ -1051,6 +1051,12 @@ class Feature(DictModel):
   all_platforms_descr = ndb.StringProperty()
   wpt = ndb.BooleanProperty()
   wpt_descr = ndb.StringProperty()
+  dt_milestone_desktop_start = ndb.IntegerProperty()
+  dt_milestone_android_start = ndb.IntegerProperty()
+  dt_milestone_ios_start = ndb.IntegerProperty()
+  dt_milestone_webview_start = ndb.IntegerProperty()
+  # Note: There are no dt end milestones because a dev trail implicitly
+  # ends when the feature ships or is abandoned.
 
   visibility = ndb.IntegerProperty(required=False)  # Deprecated
 

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -391,6 +391,22 @@ class FeatureEditStage(basehandlers.FlaskHandler):
     if self.touched('devtrial_instructions'):
       feature.devtrial_instructions = self.parse_link('devtrial_instructions')
 
+    if self.touched('dt_milestone_desktop_start'):
+      feature.dt_milestone_desktop_start = self.parse_int(
+          'dt_milestone_desktop_start')
+
+    if self.touched('dt_milestone_android_start'):
+      feature.dt_milestone_android_start = self.parse_int(
+          'dt_milestone_android_start')
+
+    if self.touched('dt_milestone_ios_start'):
+      feature.dt_milestone_ios_start = self.parse_int(
+          'dt_milestone_ios_start')
+
+    if self.touched('dt_milestone_webview_start'):
+      feature.dt_milestone_webview_start = self.parse_int(
+          'dt_milestone_webview_start')
+
     if self.touched('flag_name'):
       feature.flag_name = self.form.get('flag_name')
 

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -642,6 +642,33 @@ ALL_FIELDS = {
             'https://github.com/WICG/idle-detection/blob/main/HOWTO.md'
             '">Example 2</a>.')),
 
+    'dt_milestone_desktop_start': forms.IntegerField(
+        required=False, label='DevTrail on desktop',
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
+        help_text=('First milestone that will allow developers to try out '
+                   'this feature on desktop platforms by setting a flag.')),
+
+    'dt_milestone_android_start': forms.IntegerField(
+        required=False, label='DevTrail on Android',
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
+        help_text=('First milestone that will allow developers to try out '
+                   'this feature on iOS by setting a flag.  '
+                   'Set this only if different from desktop milestone.')),
+
+    'dt_milestone_ios_start': forms.IntegerField(
+        required=False, label='DevTrial on iOS (RARE)',
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
+        help_text=('First milestone that will allow developers to try out '
+                   'this feature on iOS by setting a flag.  '
+                   'Set this only if different from desktop milestone.')),
+
+    'dt_milestone_webview_start': forms.IntegerField(
+        required=False, label='DevTrial on Webview',
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
+        help_text=('First milestone that will allow developers to try out '
+                   'this feature on Webview by setting a flag.  '
+                   'Set this only if different from desktop milestone.')),
+
     'flag_name': forms.CharField(
         label='Flag name', required=False,
         help_text='Name of the flag that enables this feature.'),
@@ -734,8 +761,9 @@ Any_DevTrial = define_form_class_using_shared_fields(
 
 ImplStatus_DevTrial = define_form_class_using_shared_fields(
     'ImplStatus_InDevTrial',
-    ('shipped_milestone', 'shipped_android_milestone',
-     'shipped_ios_milestone', 'flag_name'))
+    ('dt_milestone_desktop_start', 'dt_milestone_android_start',
+     'dt_milestone_ios_start', 'dt_milestone_webview_start',
+     'flag_name'))
 
 
 NewFeature_EvalReadinessToShip = define_form_class_using_shared_fields(
@@ -903,6 +931,8 @@ Flat_DevTrial = define_form_class_using_shared_fields(
      # TODO(jrobbins): UA support signals section
 
      # Implementation
+     'dt_milestone_desktop_start', 'dt_milestone_android_start',
+     'dt_milestone_ios_start', 'dt_milestone_webview_start',
      'flag_name'))
   # TODO(jrobbins): api overview link
 
@@ -1010,6 +1040,8 @@ DISPLAY_FIELDS_IN_STAGES = {
         'debuggability',
         'all_platforms', 'all_platforms_descr', 'wpt', 'wpt_descr',
         'sample_links', 'devrel', 'ready_for_trial_url',
+        'dt_milestone_desktop_start', 'dt_milestone_android_start',
+        'dt_milestone_ios_start', 'dt_milestone_webview_start',
         'flag_name'),
     models.INTENT_IMPLEMENT_SHIP: make_display_specs(
         'launch_bug_url',

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -645,29 +645,26 @@ ALL_FIELDS = {
     'dt_milestone_desktop_start': forms.IntegerField(
         required=False, label='DevTrail on desktop',
         widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=('First milestone that will allow developers to try out '
+        help_text=('First milestone that allows developers to try '
                    'this feature on desktop platforms by setting a flag.')),
 
     'dt_milestone_android_start': forms.IntegerField(
         required=False, label='DevTrail on Android',
         widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=('First milestone that will allow developers to try out '
-                   'this feature on iOS by setting a flag.  '
-                   'Set this only if different from desktop milestone.')),
+        help_text=('First milestone that allows developers to try '
+                   'this feature on iOS by setting a flag.')),
 
     'dt_milestone_ios_start': forms.IntegerField(
         required=False, label='DevTrial on iOS (RARE)',
         widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=('First milestone that will allow developers to try out '
-                   'this feature on iOS by setting a flag.  '
-                   'Set this only if different from desktop milestone.')),
+        help_text=('First milestone that allows developers to try '
+                   'this feature on iOS by setting a flag.')),
 
     'dt_milestone_webview_start': forms.IntegerField(
         required=False, label='DevTrial on Webview',
         widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=('First milestone that will allow developers to try out '
-                   'this feature on Webview by setting a flag.  '
-                   'Set this only if different from desktop milestone.')),
+        help_text=('First milestone that allows developers to try '
+                   'this feature on Webview by setting a flag.')),
 
     'flag_name': forms.CharField(
         label='Flag name', required=False,

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -423,13 +423,17 @@ ALL_FIELDS = {
         required=False, label='OT desktop start',
         widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
         help_text=('First desktop milestone that will support an origin '
-                   'trial of this feature.')),
+                   'trial of this feature.  '
+                   'Setting this automatically sets the android '
+                   'milestone, unless they are different.')),
 
     'ot_milestone_desktop_end': forms.IntegerField(
         required=False, label='OT desktop end',
         widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
         help_text=('Last desktop milestone that will support an origin '
-                   'trial of this feature.')),
+                   'trial of this feature.  '
+                   'Setting this automatically sets the android '
+                   'milestone, unless they are different.')),
 
     'ot_milestone_android_start': forms.IntegerField(
         required=False, label='OT android start',
@@ -646,7 +650,9 @@ ALL_FIELDS = {
         required=False, label='DevTrail on desktop',
         widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
         help_text=('First milestone that allows developers to try '
-                   'this feature on desktop platforms by setting a flag.')),
+                   'this feature on desktop platforms by setting a flag.  '
+                   'Setting this automatically sets android and webview '
+                   'milestones, unless they are different.')),
 
     'dt_milestone_android_start': forms.IntegerField(
         required=False, label='DevTrail on Android',

--- a/static/js-src/admin/feature_form.js
+++ b/static/js-src/admin/feature_form.js
@@ -3,7 +3,7 @@
 
   const fields = document.querySelectorAll('input, textarea');
   for (let i = 0; i < fields.length; ++i) {
-    fields[i].addEventListener('blur', (e) => {
+    fields[i].addEventListener('input', (e) => {
       e.target.classList.add('interacted');
     });
   }
@@ -25,4 +25,27 @@
   document.addEventListener('DOMContentLoaded', function() {
     document.body.classList.remove('loading');
   });
+
+  // Copy field SRC to DST if SRC is edited and DST was empty and
+  // has not been edited.
+  const COPY_ON_EDIT = [
+    ['dt_milestone_desktop_start', 'dt_milestone_android_start'],
+    ['dt_milestone_desktop_start', 'dt_milestone_webview_start'],
+    // Don't autofill dt_milestone_ios_start because it is rare.
+    ['ot_milestone_desktop_start', 'ot_milestone_android_start'],
+    ['ot_milestone_desktop_end', 'ot_milestone_android_end'],
+  ];
+
+  for (let [srcId, dstId] of COPY_ON_EDIT) {
+    let srcEl = document.getElementById('id_' + srcId);
+    let dstEl = document.getElementById('id_' + dstId);
+    if (srcEl && dstEl && srcEl.value == dstEl.value) {
+      srcEl.addEventListener('input', (e) => {
+        if (!dstEl.classList.contains('interacted')) {
+          dstEl.value = srcEl.value;
+          dstEl.classList.add('copied');
+        }
+      });
+    }
+  }
 })();

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -229,13 +229,23 @@
   {% endif %}
 
   {% if feature.ot_milestone_desktop_start %}
-    <tr><td>OriginTrial first</td>
+    <tr><td>OriginTrial desktop first</td>
     <td>{{feature.ot_milestone_desktop_start}}</td></tr>
   {% endif %}
 
   {% if feature.ot_milestone_desktop_end %}
-    <tr><td>OriginTrial last</td>
+    <tr><td>OriginTrial desktop last</td>
     <td>{{feature.ot_milestone_desktop_end}}</td></tr>
+  {% endif %}
+
+  {% if feature.ot_milestone_android_start %}
+    <tr><td>OriginTrial android first</td>
+    <td>{{feature.ot_milestone_android_start}}</td></tr>
+  {% endif %}
+
+  {% if feature.ot_milestone_android_end %}
+    <tr><td>OriginTrial android last</td>
+    <td>{{feature.ot_milestone_android_end}}</td></tr>
   {% endif %}
 
   {% if feature.shipped_milestone %}

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -204,6 +204,64 @@
    {% endif %}
 {% endif %}
 
+
+<br><br><h4>Estimated milestones</h4>
+<table>
+
+  {% if feature.dt_milestone_desktop_start %}
+    <tr><td>DevTrial on desktop</td>
+    <td>{{feature.dt_milestone_desktop_start}}</td></tr>
+  {% endif %}
+
+  {% if feature.dt_milestone_andorid_start %}
+    <tr><td>DevTrial on android</td>
+    <td>{{feature.dt_milestone_android_start}}</td></tr>
+  {% endif %}
+
+  {% if feature.dt_milestone_ios_start %}
+    <tr><td>DevTrial on iOS</td>
+    <td>{{feature.dt_milestone_ios_start}}</td></tr>
+  {% endif %}
+
+  {% if feature.dt_milestone_webview_start %}
+    <tr><td>DevTrial on Webview</td>
+    <td>{{feature.dt_milestone_webview_start}}</td></tr>
+  {% endif %}
+
+  {% if feature.ot_milestone_desktop_start %}
+    <tr><td>OriginTrial first</td>
+    <td>{{feature.ot_milestone_desktop_start}}</td></tr>
+  {% endif %}
+
+  {% if feature.ot_milestone_desktop_end %}
+    <tr><td>OriginTrial last</td>
+    <td>{{feature.ot_milestone_desktop_end}}</td></tr>
+  {% endif %}
+
+  {% if feature.shipped_milestone %}
+    <tr><td>Shipping on desktop</td>
+    <td>{{feature.shipped_milestone}}</td></tr>
+  {% endif %}
+
+  {% if feature.shipped_android_milestone %}
+    <tr><td>Shipping on Android</td>
+    <td>{{feature.shipped_android_milestone}}</td></tr>
+  {% endif %}
+
+  {% if feature.shipped_ios_milestone %}
+    <tr><td>Shipping on iOS</td>
+    <td>{{feature.shipped_ios_milestone}}</td></tr>
+  {% endif %}
+
+  {% if feature.shipped_webview_milestone %}
+    <tr><td>Shipping on Webview</td>
+    <td>{{feature.shipped_webview_milestone}}</td></tr>
+  {% endif %}
+
+</table>
+
+
+
 <br><br><h4>Link to entry on the {{APP_TITLE}}</h4>
 <a href="{{default_url}}">{{default_url}}</a>
 


### PR DESCRIPTION
In this CL:
 + In models.py: Define fields for the start milestone of a devtrial on each platform.
 + In guideforms.py: Define django form fields for those milestones, and add those fields to the devtrials stage form, the flat form, and the feature detail page.
 + In guide.py: Process the new milestone values when edited.
 + In intent_to_implement.html: Add a new section with a table for all milestones.

Note, this PR does not include logic to display the devtrails in the feature list or releases page, or the features_v2.json feed.