### PR TITLE
New upcoming page

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -77,6 +77,10 @@ handlers:
   script: pages.featurelist.app
   secure: always
 
+- url: /upcoming
+  script: pages.upcoming.app
+  secure: always
+
 - url: /features/schedule
   script: pages.schedule.app
   secure: always

--- a/pages/upcoming.py
+++ b/pages/upcoming.py
@@ -1,0 +1,111 @@
+from __future__ import division
+from __future__ import print_function
+
+# -*- coding: utf-8 -*-
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__author__ = 'ericbidelman@chromium.org (Eric Bidelman)'
+
+import json
+import logging
+import os
+
+from framework import permissions
+from framework import ramcache
+import requests
+# from google.appengine.api import users
+from framework import users
+
+from framework import basehandlers
+from internals import models
+import settings
+from internals import fetchchannels
+
+SCHEDULE_CACHE_TIME = 60 * 60  # 1 hour
+
+# TODO(shivamag00): remove these methods and use Channels API instead
+def fetch_chrome_release_info(version):
+  key = 'chromerelease|%s' % version
+
+  data = ramcache.get(key)
+  if data is None:
+    url = ('https://chromiumdash.appspot.com/fetch_milestone_schedule?'
+           'mstone=%s' % version)
+    result = requests.get(url, timeout=60)
+    if result.status_code == 200:
+      try:
+        logging.info('result.content is:\n%s', result.content)
+        result_json = json.loads(result.content)
+        if 'mstones' in result_json:
+          data = result_json['mstones'][0]
+          del data['owners']
+          del data['feature_freeze']
+          del data['ldaps']
+          ramcache.set(key, data, time=SCHEDULE_CACHE_TIME)
+      except ValueError:
+        pass  # Handled by next statement
+
+    if not data:
+      data = {
+          'stable_date': None,
+          'earliest_beta': None,
+          'latest_beta': None,
+          'mstone': version,
+          'version': version,
+      }
+      # Note: we don't put placeholder data into ramcache.
+
+  return data
+
+def construct_chrome_channels_details():
+  omaha_data = fetchchannels.get_omaha_data()
+  channels = {}
+  win_versions = omaha_data[0]['versions']
+
+  for v in win_versions:
+    channel = v['channel']
+    major_version = int(v['version'].split('.')[0])
+    channels[channel] = fetch_chrome_release_info(major_version)
+    channels[channel]['version'] = major_version
+
+  # Adjust for the brief period after next miletone gets promted to stable/beta
+  # channel and their major versions are the same.
+  if channels['stable']['version'] == channels['beta']['version']:
+    new_beta_version = channels['stable']['version'] + 1
+    channels['beta'] = fetch_chrome_release_info(new_beta_version)
+    channels['beta']['version'] = new_beta_version
+    new_dev_version = channels['beta']['version'] + 1
+    channels['dev'] = fetch_chrome_release_info(new_dev_version)
+    channels['dev']['version'] = new_dev_version
+
+  return channels
+
+
+class UpcomingHandler(basehandlers.FlaskHandler):
+
+  TEMPLATE_PATH = 'upcoming.html'
+  # TODO(shivamag00): fetch data from Channels API and Features API using JS instead of passing it here
+
+  def get_template_data(self):
+    template_data = {
+      'channels': json.dumps(construct_chrome_channels_details(),
+                             indent=4)
+    }
+    return template_data
+
+
+app = basehandlers.FlaskApplication([
+  ('/upcoming', UpcomingHandler),
+], debug=settings.DEBUG)

--- a/pages/upcoming.py
+++ b/pages/upcoming.py
@@ -2,7 +2,7 @@ from __future__ import division
 from __future__ import print_function
 
 # -*- coding: utf-8 -*-
-# Copyright 2017 Google Inc.
+# Copyright 2021 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
 # you may not use this file except in compliance with the License.
@@ -16,94 +16,17 @@ from __future__ import print_function
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__author__ = 'ericbidelman@chromium.org (Eric Bidelman)'
-
-import json
-import logging
-import os
-
-from framework import permissions
-from framework import ramcache
-import requests
-# from google.appengine.api import users
-from framework import users
+__author__ = 'shivam.agrawal.2000@gmail.com (Shivam Agarwal)'
 
 from framework import basehandlers
-from internals import models
 import settings
-from internals import fetchchannels
-
-SCHEDULE_CACHE_TIME = 60 * 60  # 1 hour
-
-# TODO(shivamag00): remove these methods and use Channels API instead
-def fetch_chrome_release_info(version):
-  key = 'chromerelease|%s' % version
-
-  data = ramcache.get(key)
-  if data is None:
-    url = ('https://chromiumdash.appspot.com/fetch_milestone_schedule?'
-           'mstone=%s' % version)
-    result = requests.get(url, timeout=60)
-    if result.status_code == 200:
-      try:
-        logging.info('result.content is:\n%s', result.content)
-        result_json = json.loads(result.content)
-        if 'mstones' in result_json:
-          data = result_json['mstones'][0]
-          del data['owners']
-          del data['feature_freeze']
-          del data['ldaps']
-          ramcache.set(key, data, time=SCHEDULE_CACHE_TIME)
-      except ValueError:
-        pass  # Handled by next statement
-
-    if not data:
-      data = {
-          'stable_date': None,
-          'earliest_beta': None,
-          'latest_beta': None,
-          'mstone': version,
-          'version': version,
-      }
-      # Note: we don't put placeholder data into ramcache.
-
-  return data
-
-def construct_chrome_channels_details():
-  omaha_data = fetchchannels.get_omaha_data()
-  channels = {}
-  win_versions = omaha_data[0]['versions']
-
-  for v in win_versions:
-    channel = v['channel']
-    major_version = int(v['version'].split('.')[0])
-    channels[channel] = fetch_chrome_release_info(major_version)
-    channels[channel]['version'] = major_version
-
-  # Adjust for the brief period after next miletone gets promted to stable/beta
-  # channel and their major versions are the same.
-  if channels['stable']['version'] == channels['beta']['version']:
-    new_beta_version = channels['stable']['version'] + 1
-    channels['beta'] = fetch_chrome_release_info(new_beta_version)
-    channels['beta']['version'] = new_beta_version
-    new_dev_version = channels['beta']['version'] + 1
-    channels['dev'] = fetch_chrome_release_info(new_dev_version)
-    channels['dev']['version'] = new_dev_version
-
-  return channels
-
 
 class UpcomingHandler(basehandlers.FlaskHandler):
 
   TEMPLATE_PATH = 'upcoming.html'
-  # TODO(shivamag00): fetch data from Channels API and Features API using JS instead of passing it here
 
   def get_template_data(self):
-    template_data = {
-      'channels': json.dumps(construct_chrome_channels_details(),
-                             indent=4)
-    }
-    return template_data
+    return {}
 
 
 app = basehandlers.FlaskApplication([

--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -194,6 +194,16 @@ class ChromeStatusClient {
         `/features/${featureId}/approvals/${fieldId}/comments`,
         {state, comment});
   }
+
+  // Features API
+  getFeaturesInMilestone(milestone) {
+    return this.doGet(`/features?milestone?=${milestone}`);
+  }
+
+  // Channels API
+  getChannels() {
+    return this.doGet('/channels');
+  }
 };
 
 exports.ChromeStatusClient = ChromeStatusClient;

--- a/static/js-src/upcoming-page.js
+++ b/static/js-src/upcoming-page.js
@@ -1,11 +1,8 @@
 // Start fetching right away.
-const FEATURES_API_URL = '/api/v0/features';
-const CHANNELS_API_URL = '/api/v0/channels';
 const channelsArray = ['stable', 'beta', 'dev'];
 
-const channelsPromise = fetch(CHANNELS_API_URL)
-  .then((res) => res.text())
-  .then((res) => JSON.parse(res.substring(5)));
+const channelsPromise = window.csClient.getChannels();
+
 
 document.querySelector('.show-blink-checkbox').addEventListener('change', e => {
   e.stopPropagation();
@@ -23,10 +20,7 @@ async function init() {
   let featuresPromise = {};
 
   channelsArray.forEach((channel) => {
-    let queryStringUrl = `${FEATURES_API_URL}?milestone=${channels[channel].version}`;
-    featuresPromise[channel] = fetch(queryStringUrl)
-      .then((res) => res.text())
-      .then((res) => JSON.parse(res.substring(5))); // Ignore XSSI prefix
+    featuresPromise[channel] = window.csClient.getFeaturesInMilestone(channels[channel].version);
   });
 
   const features = {};

--- a/static/js-src/upcoming-page.js
+++ b/static/js-src/upcoming-page.js
@@ -1,6 +1,14 @@
 // Start fetching right away.
-const url = '/features.json';
-const featuresPromise = fetch(url).then((res) => res.json());
+const urlFeatures = '/api/v0/features';
+const urlChannels = '/api/v0/channels';
+
+const featuresPromise = fetch(urlFeatures)
+  .then((res) => res.text())
+  .then((res) => JSON.parse(res.substring(5))); // Ignore XSSI prefix
+
+const channelsPromise = fetch(urlChannels)
+  .then((res) => res.text())
+  .then((res) => JSON.parse(res.substring(5)));
 
 document.querySelector('.show-blink-checkbox').addEventListener('change', e => {
   e.stopPropagation();
@@ -17,6 +25,8 @@ async function init() {
 
   // Prepare data for chromedash-schedule
   const features = await featuresPromise;
+  const CHANNELS = await channelsPromise;
+
   ['stable', 'beta', 'dev'].forEach((channel) => {
     CHANNELS[channel].components = mapFeaturesToComponents(features.filter(f =>
       f.browsers.chrome.status.milestone_str === CHANNELS[channel].version));

--- a/static/js-src/upcoming-page.js
+++ b/static/js-src/upcoming-page.js
@@ -1,0 +1,73 @@
+// Start fetching right away.
+const url = '/features.json';
+const featuresPromise = fetch(url).then((res) => res.json());
+
+document.querySelector('.show-blink-checkbox').addEventListener('change', e => {
+  e.stopPropagation();
+  document.querySelector('chromedash-schedule').showBlink = e.target.checked;
+});
+
+const header = document.querySelector('app-header-layout app-header');
+if (header) {
+  header.fixed = false;
+}
+
+async function init() {
+  document.body.classList.remove('loading');
+
+  // Prepare data for chromedash-schedule
+  const features = await featuresPromise;
+  ['stable', 'beta', 'dev'].forEach((channel) => {
+    CHANNELS[channel].components = mapFeaturesToComponents(features.filter(f =>
+      f.browsers.chrome.status.milestone_str === CHANNELS[channel].version));
+  });
+
+  const scheduleEl = document.querySelector('chromedash-schedule');
+  scheduleEl.channels = CHANNELS;
+
+  window.csClient.getStars().then((starredFeatureIds) => {
+    scheduleEl.starredFeatures = new Set(starredFeatureIds);
+  });
+}
+
+function mapFeaturesToComponents(features) {
+  let set = new Set();
+  features.forEach(f => set.add(...f.browsers.chrome.blink_components));
+
+  const featuresMappedToComponents = {};
+  features.forEach(f => {
+    const components = f.browsers.chrome.blink_components;
+    components.forEach(component => {
+      if (!featuresMappedToComponents[component]) {
+        featuresMappedToComponents[component] = [];
+      }
+      featuresMappedToComponents[component].push(f);
+    });
+  });
+
+  for (let [, feautreList] of Object.entries(featuresMappedToComponents)) {
+    sortFeaturesByName(feautreList);
+  }
+
+  return featuresMappedToComponents;
+}
+
+
+/**
+ *  @param {!Array<!Object>} features
+ */
+function sortFeaturesByName(features) {
+  features.sort((a, b) => {
+    a = a.name.toLowerCase();
+    b = b.name.toLowerCase();
+    if (a < b) {
+      return -1;
+    }
+    if (a > b) {
+      return 1;
+    }
+    return 0;
+  });
+}
+
+init();

--- a/static/js-src/upcoming-page.js
+++ b/static/js-src/upcoming-page.js
@@ -46,9 +46,6 @@ async function init() {
 }
 
 function mapFeaturesToComponents(features) {
-  let set = new Set();
-  features.forEach(f => set.add(...f.browsers.chrome.blink_components));
-
   const featuresMappedToComponents = {};
   features.forEach(f => {
     const components = f.browsers.chrome.blink_components;

--- a/static/sass/upcoming.scss
+++ b/static/sass/upcoming.scss
@@ -1,0 +1,24 @@
+@import "vars";
+@import "layout";
+
+body[data-path*='features/schedule'] {
+  --app-drawer-width: 0;
+
+  app-drawer {
+    display: none;
+  }
+
+  #spinner {
+    display: none;
+  }
+
+}
+
+.hide-blink-checkbox {
+  margin-right: 8px;
+}
+
+#subheader {
+  max-width: 100%;
+  justify-content: center;
+}

--- a/templates/upcoming.html
+++ b/templates/upcoming.html
@@ -1,0 +1,41 @@
+{% extends "_base.html" %}
+{% load inline_file %}
+
+{% block css %}
+  <style>{% inline_file "/static/css/upcoming.css" %}</style>
+{% endblock %}
+
+{% block subheader %}
+  <div id="subheader">
+    <!--<h2>Chrome release timeline</h2>-->
+    <div style="flex:1">
+      <h3>Release timeline</h3>
+      <!-- p class="description">Please note, all dates are estimates and are subject to change.</p -->
+    </div>
+    <!-- <paper-toggle-button> doesn't working here. Related links:
+      https://github.com/PolymerElements/paper-toggle-button/pull/132 -->
+    <label><input type="checkbox" class="show-blink-checkbox">Show Blink components</label>
+  </div>
+{% endblock %}
+
+{% block content %}
+  <section id="releases-section">
+    <chromedash-schedule
+      {% if user %}signedin{% endif %}
+      {# TODO(jrobbins): Fix to work with google sign-in #}
+      loginurl="#"
+    ></chromedash-schedule>
+  </section>
+{% endblock %}
+
+{% block js %}
+  <script nonce="{{nonce}}">
+    (function() {
+      'use strict';
+      // Variables used in schedule.js
+      const CHANNELS = {{channels|safe}};
+
+      {% inline_file "/static/js/upcoming-page.min.js" %}
+    })();
+  </script>
+{% endblock %}

--- a/templates/upcoming.html
+++ b/templates/upcoming.html
@@ -32,8 +32,6 @@
   <script nonce="{{nonce}}">
     (function() {
       'use strict';
-      // Variables used in schedule.js
-      const CHANNELS = {{channels|safe}};
 
       {% inline_file "/static/js/upcoming-page.min.js" %}
     })();


### PR DESCRIPTION
Review Requested: @jrobbins 

Merging this should close #1415 

In this PR,

- Created a new page 'upcoming' which can be accessed by visiting '/upcoming'
- The new upcoming page shows schedule like the old releases page but uses Channels API and features API
- The features are fetched separately for each milestone.