### PR TITLE
Add standard_maturity field.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -182,6 +182,7 @@ REVIEW_STATUS_CHOICES = {
     REVIEW_NA: 'Not applicable',
     }
 
+
 FOOTPRINT_CHOICES = {
   MAJOR_NEW_API: ('A major new independent API (e.g. adding many '
                   'independent concepts with many methods/properties/objects)'),
@@ -267,6 +268,22 @@ STANDARDIZATION = {
   NO_STD_OR_DISCUSSION: 'No public standards discussion',
   }
 
+UNKNOWN_STD = 1
+PROPOSAL_STD = 2
+INCUBATION_STD = 3
+WORKINGDRAFT_STD = 4
+STANDARD_STD = 5
+
+STANDARD_MATURITY_CHOICES = {
+  UNKNOWN_STD: 'Unknown standards status - check spec link for status',
+  PROPOSAL_STD: 'Proposal in a personal repository, no adoption from community',
+  INCUBATION_STD: 'Specification being incubated in a Community Group',
+  WORKINGDRAFT_STD: ('Specification currently under development in a '
+                     'Working Group'),
+  STANDARD_STD: ('Final published standard: Recommendation, Living Standard, '
+                 'Candidate Recommendation, or similar final form'),
+}
+
 DEV_STRONG_POSITIVE = 1
 DEV_POSITIVE = 2
 DEV_MIXED_SIGNALS = 3
@@ -290,6 +307,7 @@ PROPERTY_NAMES_TO_ENUM_DICTS = {
     'impl_status_chrome': IMPLEMENTATION_STATUS,
     'security_review_status': REVIEW_STATUS_CHOICES,
     'privacy_review_status': REVIEW_STATUS_CHOICES,
+    'standard_maturity': STANDARD_MATURITY_CHOICES,
     'standardization': STANDARDIZATION,
     'ff_views': VENDOR_VIEWS,
     'ie_views': VENDOR_VIEWS,
@@ -627,6 +645,10 @@ class Feature(DictModel):
           'text': STANDARDIZATION[self.standardization],
           'val': d.pop('standardization', None),
         },
+        'maturity': {
+          'text': STANDARD_MATURITY_CHOICES.get(self.standard_maturity),
+          'val': d.pop('standard_maturity', None),
+        },
       }
       d['tag_review_status'] = REVIEW_STATUS_CHOICES[self.tag_review_status]
       d['security_review_status'] = REVIEW_STATUS_CHOICES[
@@ -942,7 +964,7 @@ class Feature(DictModel):
     all_features.extend(desktop_shipping_features)
     all_features.extend(android_only_shipping_features)
 
-    # Feature list must be first sorted by implementation status and then by name. 
+    # Feature list must be first sorted by implementation status and then by name.
     # The implementation may seem to be counter-intuitive using sort() method.
     all_features.sort(key=lambda f: f.name)
     all_features.sort(key=lambda f: f.impl_status_chrome)
@@ -959,7 +981,7 @@ class Feature(DictModel):
 
     return allowed_feature_list
 
-  
+
   @classmethod
   def get_shipping_samples(self, limit=None, update_cache=False):
     cache_key = '%s|%s|%s' % (Feature.DEFAULT_CACHE_KEY, 'samples', limit)
@@ -1130,7 +1152,8 @@ class Feature(DictModel):
   visibility = ndb.IntegerProperty(required=False)  # Deprecated
 
   # Standards details.
-  standardization = ndb.IntegerProperty(required=True)
+  standardization = ndb.IntegerProperty(required=True)  # Deprecated
+  standard_maturity = ndb.IntegerProperty(required=True, default=UNKNOWN_STD)
   spec_link = ndb.StringProperty()
   api_spec = ndb.BooleanProperty(default=False)
   spec_mentors = ndb.StringProperty(repeated=True)

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -294,6 +294,9 @@ class FeatureEditStage(basehandlers.FlaskHandler):
     if self.touched('spec_link'):
       feature.spec_link = self.parse_link('spec_link')
 
+    if self.touched('standard_maturity'):
+      feature.standard_maturity = self.parse_int('standard_maturity')
+
     if self.touched('api_spec'):
       feature.api_spec = self.form.get('api_spec') == 'on'
 

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -169,12 +169,14 @@ ALL_FIELDS = {
          'success of this feature, such as a link to the UseCounter(s) you '
          'have set up.')),
 
-    'standardization': forms.ChoiceField(
-        required=False, label='Standardization',
-        choices=models.STANDARDIZATION.items(),
-        initial=models.EDITORS_DRAFT,
-        help_text=("The standardization status of the API. In bodies that don't "
-                   "use this nomenclature, use the closest equivalent.")),
+    # 'standardization' is deprecated
+
+    'standard_maturity': forms.ChoiceField(
+        required=False, label='Standard maturity',
+        choices=models.STANDARD_MATURITY_CHOICES.items(),
+        initial=models.PROPOSAL_STD,
+        help_text=('How far along is the standard that this '
+                   'feature implements?')),
 
     'unlisted': forms.BooleanField(
       required=False, initial=False,
@@ -712,7 +714,7 @@ ImplStatus_Incubate = define_form_class_using_shared_fields(
 
 NewFeature_Prototype = define_form_class_using_shared_fields(
     'NewFeature_Prototype',
-    ('spec_link', 'api_spec', 'spec_mentors',
+    ('spec_link', 'standard_maturity', 'api_spec', 'spec_mentors',
      'intent_to_implement_url', 'comments'))
   # TODO(jrobbins): advise user to request a tag review
 
@@ -740,7 +742,8 @@ ImplStatus_DevTrial = define_form_class_using_shared_fields(
 
 NewFeature_EvalReadinessToShip = define_form_class_using_shared_fields(
     'NewFeature_EvalReadinessToShip',
-    ('doc_links', 'tag_review', 'spec_link', 'interop_compat_risks',
+    ('doc_links', 'tag_review', 'spec_link',
+     'standard_maturity', 'interop_compat_risks',
      'safari_views', 'safari_views_link', 'safari_views_notes',
      'ff_views', 'ff_views_link', 'ff_views_notes',
      'ie_views', 'ie_views_link', 'ie_views_notes',
@@ -792,7 +795,7 @@ Any_Ship = define_form_class_using_shared_fields(
 Existing_Prototype = define_form_class_using_shared_fields(
     'Existing_Prototype',
     ('owner', 'blink_components', 'motivation', 'explainer_links',
-     'spec_link', 'api_spec', 'bug_url', 'launch_bug_url',
+     'spec_link', 'standard_maturity', 'api_spec', 'bug_url', 'launch_bug_url',
      'intent_to_implement_url', 'comments'))
 
 
@@ -806,7 +809,7 @@ Existing_OriginTrial = define_form_class_using_shared_fields(
 
 PSA_Implement = define_form_class_using_shared_fields(
     'Any_Implement',
-    ('spec_link', 'comments'))
+    ('spec_link', 'standard_maturity', 'comments'))
   # TODO(jrobbins): advise user to request a tag review
 
 
@@ -883,7 +886,8 @@ Flat_Identify = define_form_class_using_shared_fields(
 Flat_Implement = define_form_class_using_shared_fields(
     'Flat_Implement',
     (# Standardization
-     'spec_link', 'api_spec', 'spec_mentors', 'intent_to_implement_url'))
+     'spec_link', 'standard_maturity', 'api_spec', 'spec_mentors',
+     'intent_to_implement_url'))
 
 
 Flat_DevTrial = define_form_class_using_shared_fields(
@@ -997,7 +1001,8 @@ DISPLAY_FIELDS_IN_STAGES = {
         'initial_public_proposal_url', 'explainer_links',
         'requires_embedder_support'),
     models.INTENT_IMPLEMENT: make_display_specs(
-        'spec_link', 'api_spec', 'spec_mentors', 'intent_to_implement_url'),
+        'spec_link', 'standard_maturity', 'api_spec', 'spec_mentors',
+        'intent_to_implement_url'),
     models.INTENT_EXPERIMENT: make_display_specs(
         'devtrial_instructions', 'doc_links',
         'interop_compat_risks',

--- a/static/elements/chromedash-feature-detail.js
+++ b/static/elements/chromedash-feature-detail.js
@@ -104,6 +104,12 @@ class ChromedashFeatureDetail extends LitElement {
   getFieldValue(fieldDef) {
     const fieldId = fieldDef[0];
     let value = this.feature[fieldId];
+    if (fieldId == 'spec_link') {
+      value = this.feature.standards.spec;
+    }
+    if (fieldId == 'standard_maturity') {
+      value = this.feature.standards.maturity;
+    }
     if (value && value.text) {
       value = value.text;
     }


### PR DESCRIPTION
This should partially resolve issue #1366.

In this PR:
+ models.py define a new field standard_maturity and associated enum values and add it to the format_for_template dict.
+ guideforms.py define a django form field for standard_maturity and add the field to various forms and the feature detail page.
+ guide.py process the submitted value for standard_maturity.
+ chromedash-feature-detail.js add logic to access field that are not at the top level of the format_for_template dict.

In a follow-up PR, I will change the logic that generates the feature cards and the top of the feature detail page to use this instead of the old standardization field.