### PR TITLE
Trying single threading to avoid CPU contention

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,7 +1,11 @@
 runtime: python27
-threadsafe: true
+threadsafe: false
 api_version: 1
 instance_class: F4
+
+automatic_scaling:
+  min_idle_instances: 1
+  max_pending_latency: 0.2s
 
 # default_expiration: "30s"
 


### PR DESCRIPTION
I have a theory that our current timeouts and general inconsistent latency on datastore queries is because of CPU contention while decoding (somewhat) large result sets.  This change should precent contention by basically spinning up more GAE instances, and using each GAE instance for only one HTTP request at a time.

This change should have no user visible effect, other than more consistent latency on cache misses. 