### PR TITLE
Fix another XML feed defect and add tests.

### DIFF
--- a/framework/utils.py
+++ b/framework/utils.py
@@ -107,7 +107,8 @@ def render_atom_feed(request, title, data):
       language=u'en'
   )
   for f in data:
-    pubdate = datetime.datetime.strptime(str(f['updated'][:19]),
+    updated = f['updated']['when']
+    pubdate = datetime.datetime.strptime(str(updated[:19]),
                                          '%Y-%m-%d  %H:%M:%S')
     feed.add_item(
         title=unicode(f['name']),

--- a/internals/models.py
+++ b/internals/models.py
@@ -613,6 +613,7 @@ class Feature(DictModel):
     if self.safari_views == PUBLIC_SKEPTICISM:
       self.safari_views = OPPOSED
 
+  # TODO(jrobbins): Eliminate format version 1.
   def format_for_template(self, version=2):
     self.migrate_views()
     d = self.to_dict()

--- a/pages/featurelist.py
+++ b/pages/featurelist.py
@@ -102,7 +102,7 @@ class FeatureListXMLHandler(basehandlers.FlaskHandler):
           limit=max_items,
           filterby=filterby,
           order='-updated',
-          version=1)
+          version=2)
 
     return utils.render_atom_feed(self.request, 'Features', feature_list)
 


### PR DESCRIPTION
Update more of the RSS feed generation logic to work with version=2.

I should have caught this defect at the same time that I made my other recent fix, but I didn't realize we were lacking test coverage there, and my local data didn't have any matching features.  So, I have added a test.

I believe that we can phase out version=1 now because it is not used anywhere, however I will do that in a separate PR to keep each PR focused.