### PR TITLE
Try logging to stdout

### DIFF
--- a/api/accounts_api.py
+++ b/api/accounts_api.py
@@ -16,11 +16,10 @@
 from __future__ import division
 from __future__ import print_function
 
-import logging
-
 from google.cloud import ndb
 
 from framework import basehandlers
+from framework import logging
 from framework import permissions
 from framework import ramcache
 from internals import models

--- a/api/approvals_api.py
+++ b/api/approvals_api.py
@@ -16,9 +16,8 @@
 from __future__ import division
 from __future__ import print_function
 
-import logging
-
 from framework import basehandlers
+from framework import logging
 from framework import permissions
 from internals import approval_defs
 from internals import models

--- a/api/channels_api.py
+++ b/api/channels_api.py
@@ -16,10 +16,10 @@
 from __future__ import division
 from __future__ import print_function
 
-import logging
 import json
 
 from framework import basehandlers
+from framework import logging
 from framework import ramcache
 import requests
 

--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -16,9 +16,8 @@
 from __future__ import division
 from __future__ import print_function
 
-import logging
-
 from framework import basehandlers
+from framework import logging
 from framework import permissions
 from internals import approval_defs
 from internals import models

--- a/api/cues_api.py
+++ b/api/cues_api.py
@@ -16,9 +16,8 @@
 from __future__ import division
 from __future__ import print_function
 
-import logging
-
 from framework import basehandlers
+from framework import logging
 from internals import models
 
 # We only accept known cue name strings.

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -16,9 +16,8 @@
 from __future__ import division
 from __future__ import print_function
 
-import logging
-
 from framework import basehandlers
+from framework import logging
 from framework import permissions
 from framework import ramcache
 from framework import users
@@ -37,7 +36,7 @@ class FeaturesAPI(basehandlers.APIHandler):
       try:
         milestone = int(self.request.args.get('milestone'))
         feature_list = models.Feature.get_in_milestone(
-          show_unlisted=show_unlisted_features, 
+          show_unlisted=show_unlisted_features,
           milestone=milestone)
       except ValueError:
         self.abort(400, msg='Invalid  Milestone')

--- a/api/login_api.py
+++ b/api/login_api.py
@@ -16,14 +16,12 @@
 from __future__ import division
 from __future__ import print_function
 
-import logging
-
 from google.oauth2 import id_token
 from google.auth.transport import requests
 from flask import session
 
-
 from framework import basehandlers
+from framework import logging
 import settings
 
 class LoginAPI(basehandlers.APIHandler):

--- a/api/logout_api.py
+++ b/api/logout_api.py
@@ -16,14 +16,12 @@
 from __future__ import division
 from __future__ import print_function
 
-import logging
-
 from google.oauth2 import id_token
 from google.auth.transport import requests
 from flask import session
 
-
 from framework import basehandlers
+from framework import logging
 # from framework import permissions
 # from framework import ramcache
 # from internals import models
@@ -34,4 +32,3 @@ class LogoutAPI(basehandlers.APIHandler):
   def do_post(self):
     session.clear()
     return {'message': 'Done'}
-

--- a/api/metricsdata.py
+++ b/api/metricsdata.py
@@ -20,12 +20,12 @@ __author__ = 'ericbidelman@chromium.org (Eric Bidelman)'
 
 import datetime
 import json
-import logging
 
 # from google.appengine.api import users
 from framework import users
 
 from framework import basehandlers
+from framework import logging
 from internals import models
 from framework import ramcache
 import settings

--- a/api/stars_api.py
+++ b/api/stars_api.py
@@ -16,9 +16,8 @@
 from __future__ import division
 from __future__ import print_function
 
-import logging
-
 from framework import basehandlers
+from framework import logging
 from internals import models
 from internals import notifier
 

--- a/api/token_refresh_api.py
+++ b/api/token_refresh_api.py
@@ -16,9 +16,8 @@
 from __future__ import division
 from __future__ import print_function
 
-import logging
-
 from framework import basehandlers
+from framework import logging
 from framework import xsrf
 from internals import models
 

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -17,7 +17,6 @@ from __future__ import division
 from __future__ import print_function
 
 import json
-import logging
 import os
 import re
 
@@ -29,6 +28,7 @@ from google.cloud import ndb
 
 import settings
 from framework import csp
+from framework import logging
 from framework import permissions
 from framework import ramcache
 from framework import secrets
@@ -149,6 +149,7 @@ class APIHandler(BaseHandler):
 
   def get(self, *args, **kwargs):
     """Handle an incoming HTTP GET request."""
+    print('started the GET handler')
     headers = self.get_headers()
     ramcache.check_for_distributed_invalidation()
     handler_data = self.do_get(*args, **kwargs)
@@ -315,6 +316,7 @@ class FlaskHandler(BaseHandler):
 
   def get(self, *args, **kwargs):
     """GET handlers can render templates, return JSON, or do redirects."""
+    print('started the GET handler')
     ramcache.check_for_distributed_invalidation()
     handler_data = self.get_template_data(*args, **kwargs)
 

--- a/framework/cloud_tasks_helpers.py
+++ b/framework/cloud_tasks_helpers.py
@@ -19,12 +19,11 @@ from __future__ import print_function
 # This code is based on a file from Monorail:
 # https://chromium.googlesource.com/infra/infra/+/master/appengine/monorail/framework/cloud_tasks_helpers.py
 
-import logging
 import json
-
 import requests
-
 import settings
+
+from framework import logging
 
 if not settings.UNIT_TEST_MODE:
   import grpc  # See requirements.dev.txt.
@@ -58,7 +57,7 @@ class LocalCloudTasksClient(object):
     target_url = 'http://localhost:8080' + uri
     body = task.get('app_engine_http_request').get('body')
     logging.info('Making request to %r', target_url)
-    handler_response = requests.request('POST', 
+    handler_response = requests.request('POST',
         target_url, data=body, allow_redirects=False,
         # This header can only be set on internal requests, not by users.
         headers={'X-AppEngine-QueueName': 'default'})

--- a/framework/csp.py
+++ b/framework/csp.py
@@ -18,12 +18,12 @@ from __future__ import print_function
 
 import base64
 import copy
-import logging
 import os
 import six
 
 import flask
 
+from framework import logging
 
 REPORT_ONLY = True
 USE_NONCE_ONLY_POLICY = True  # Recommended

--- a/framework/logging.py
+++ b/framework/logging.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+from __future__ import print_function
+
+import datetime
+import os
+
+# We cannot import settings.py because it imports this file.
+DEV_MODE = os.environ['SERVER_SOFTWARE'].startswith('Development')
+UNIT_TEST_MODE = os.environ['SERVER_SOFTWARE'].startswith('test')
+
+
+def _log(severity, format_str, args):
+  message = format_str % args
+  if DEV_MODE or UNIT_TEST_MODE:
+    now = datetime.datetime.now()
+    timestr = now.strftime('%Y-%m-%d %H:%M:%S')
+    milli = int(now.microsecond / 1000)
+    line = '%-8s %s,%03d: %s' % (severity, timestr, milli, message)
+    print(line)
+  else:
+    # AppEngine adds the data and time automatically.
+    # Severity is always Error, but we don't care.
+    print(message)
+
+
+def debug(format_str, *args):
+  _log('DEBUG', format_str, args)
+
+
+def info(format_str, *args):
+  _log('INFO', format_str, args)
+
+
+def warning(format_str, *args):
+  _log('WARMING', format_str, args)
+
+
+def error(format_str, *args):
+  _log('ERROR', format_str, args)
+
+
+def critical(format_str, *args):
+  _log('CRITICAL', format_str, args)
+
+# Note: we do not support logging.exception().

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -16,9 +16,9 @@
 from __future__ import division
 from __future__ import print_function
 
-import logging
 import flask
 
+from framework import logging
 from framework import users
 from internals import models
 

--- a/framework/ramcache.py
+++ b/framework/ramcache.py
@@ -47,7 +47,7 @@ Unlike memcache, this RAM cache has no concept of expiration time.  So,
 whenever a cached value would become invalid, it must be invalidated.
 """
 
-import logging
+from framework import logging
 import time as time_module
 from google.cloud import ndb
 
@@ -161,7 +161,7 @@ class SharedInvalidate(ndb.Model):
     SINGLETON_KEY = ndb.Key(
       'SharedInvalidateParent', PARENT_ENTITY_ID,
       'SharedInvalidate', SINGLETON_ENTITY_ID)
-  
+
   last_processed_timestamp = None
 
   updated = ndb.DateTimeProperty(auto_now=True)

--- a/framework/secrets.py
+++ b/framework/secrets.py
@@ -18,13 +18,13 @@ from __future__ import print_function
 
 import base64
 import hmac
-import logging
 import random
 import string
 import time
 
 from google.cloud import ndb
 
+from framework import logging
 
 # For random key generation
 RANDOM_KEY_LENGTH = 128

--- a/framework/utils.py
+++ b/framework/utils.py
@@ -19,10 +19,10 @@ from __future__ import print_function
 import calendar
 import datetime
 import flask
-import logging
 import time
 import traceback
 
+from framework import logging
 # from google.appengine.api import users
 from framework import users
 

--- a/framework/xsrf.py
+++ b/framework/xsrf.py
@@ -18,12 +18,12 @@ from __future__ import print_function
 
 import base64
 import hmac
-import logging
 import random
 import string
 import time
 
 from framework import constants
+from framework import logging
 from framework import secrets
 
 

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -18,9 +18,9 @@ from __future__ import print_function
 
 import base64
 import collections
-import logging
 import requests
 
+from framework import logging
 from framework import ramcache
 
 CACHE_EXPIRATION = 60 * 60  # One hour

--- a/internals/fetchmetrics.py
+++ b/internals/fetchmetrics.py
@@ -19,11 +19,11 @@ from __future__ import print_function
 import base64
 import datetime
 import json
-import logging
 from xml.dom import minidom
 import requests
 
 from framework import basehandlers
+from framework import logging
 from framework import ramcache
 from framework import utils
 from internals import models

--- a/internals/models.py
+++ b/internals/models.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 import collections
 import datetime
 import json
-import logging
 import re
 import time
 
@@ -27,6 +26,7 @@ from google.cloud import ndb
 
 # from google.appengine.ext.db import djangoforms
 from google.appengine.api import mail
+from framework import logging
 from framework import ramcache
 import requests
 from google.appengine.api import users as gae_users

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -19,12 +19,12 @@ from __future__ import print_function
 __author__ = 'ericbidelman@chromium.org (Eric Bidelman)'
 
 import collections
-import logging
 import datetime
 import json
 import os
 import re
 
+from framework import logging
 from framework import ramcache
 from google.cloud import ndb
 from google.appengine.api import mail

--- a/pages/blink_handler.py
+++ b/pages/blink_handler.py
@@ -20,11 +20,11 @@ __author__ = 'ericbidelman@chromium.org (Eric Bidelman)'
 
 import collections
 import json
-import logging
 import os
 import yaml
 
 from framework import basehandlers
+from framework import logging
 from framework import permissions
 from internals import models
 import settings

--- a/pages/featuredetail.py
+++ b/pages/featuredetail.py
@@ -17,10 +17,10 @@ from __future__ import division
 from __future__ import print_function
 
 import json
-import logging
 
 import settings
 from framework import basehandlers
+from framework import logging
 from pages import guideforms
 from internals import models
 from internals import processes

--- a/pages/featurelist.py
+++ b/pages/featurelist.py
@@ -17,10 +17,10 @@ from __future__ import division
 from __future__ import print_function
 
 import json
-import logging
 
 import settings
 from framework import basehandlers
+from framework import logging
 from framework import permissions
 from framework import utils
 from internals import models

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -19,13 +19,13 @@ from __future__ import print_function
 import datetime
 import flask
 import json
-import logging
 import os
 import re
 import sys
 from django import forms
 
 # Appengine imports.
+from framework import logging
 from framework import ramcache
 # TODO(jrobbins): phase out gae_users
 from google.appengine.api import users as gae_users

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -16,11 +16,11 @@ from __future__ import print_function
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from django import forms
 from django.core.validators import validate_email
 import string
 
+from framework import logging
 # from google.appengine.api import users
 from framework import users
 

--- a/pages/metrics.py
+++ b/pages/metrics.py
@@ -17,9 +17,9 @@ from __future__ import division
 from __future__ import print_function
 
 import json
-import logging
 
 import settings
+from framework import logging
 from framework import basehandlers
 from framework import utils
 from pages import guideforms

--- a/pages/samples.py
+++ b/pages/samples.py
@@ -17,10 +17,10 @@ from __future__ import division
 from __future__ import print_function
 
 import json
-import logging
 
 import settings
 from framework import basehandlers
+from framework import logging
 from framework import utils
 from internals import models
 

--- a/pages/schedule.py
+++ b/pages/schedule.py
@@ -19,9 +19,9 @@ from __future__ import print_function
 __author__ = 'ericbidelman@chromium.org (Eric Bidelman)'
 
 import json
-import logging
 import os
 
+from framework import logging
 from framework import permissions
 from framework import ramcache
 import requests

--- a/pages/users.py
+++ b/pages/users.py
@@ -21,12 +21,12 @@ __author__ = 'ericbidelman@chromium.org (Eric Bidelman)'
 
 #import datetime
 import json
-import logging
 import os
 
 import flask
 
 from framework import basehandlers
+from framework import loggging
 from framework import permissions
 from internals import models
 import settings

--- a/settings.py
+++ b/settings.py
@@ -1,9 +1,8 @@
 from __future__ import division
 from __future__ import print_function
 
-import logging
 import os
-
+from framework import logging
 
 #Hack to get custom tags working django 1.3 + python27.
 INSTALLED_APPS = (


### PR DESCRIPTION
I couldn't figure out what was happening with Cloud Logging.

On reading the AppEngine py2 to py3 upgrade guide again, I notice that there is an alternative available in both py2 and py3, which is simply to write to stdout.    That has some disadvantages in that it loses the source file and line number, and everything seems to get logged at the warning level.  However, it is really simple, so maybe we could just try it for now and come back to it once we are on py3.  I tested it on staging and it seems to nest the log lines under the requests.