### PR TITLE
Adjust logging level for py3.

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -46,15 +46,16 @@ SEND_EMAIL = False  # Just log email
 DEV_MODE = os.environ['SERVER_SOFTWARE'].startswith('Development')
 UNIT_TEST_MODE = os.environ['SERVER_SOFTWARE'].startswith('test')
 
+if not UNIT_TEST_MODE:
+  # Configure logging to print INFO lines so that they are captured
+  # when written to stdout on GAE py3.
+  logging.basicConfig(level=logging.INFO)
+
 #setting GOOGLE_CLOUD_PROJECT manually in dev mode
 if DEV_MODE or UNIT_TEST_MODE:
   APP_ID = os.environ.get('GOOGLE_CLOUD_PROJECT', 'dev')
 else:
   APP_ID = os.environ['GOOGLE_CLOUD_PROJECT']
-
-  # Configure logging to print INFO lines so that they are captured
-  # when written to stdout on GAE py3.
-  logging.basicConfig(level=logging.INFO)
 
 SITE_URL = 'http://%s.appspot.com/' % APP_ID
 CLOUD_TASKS_REGION = 'us-central1'

--- a/settings.py
+++ b/settings.py
@@ -4,9 +4,6 @@ from __future__ import print_function
 import logging
 import os
 
-# Configure logging to print INFO lines so that they are captured
-# when written to stdout on GAE py3.
-#logging.basicConfig(level=logging.INFO)
 
 #Hack to get custom tags working django 1.3 + python27.
 INSTALLED_APPS = (
@@ -54,6 +51,10 @@ if DEV_MODE or UNIT_TEST_MODE:
   APP_ID = os.environ.get('GOOGLE_CLOUD_PROJECT', 'dev')
 else:
   APP_ID = os.environ['GOOGLE_CLOUD_PROJECT']
+
+  # Configure logging to print INFO lines so that they are captured
+  # when written to stdout on GAE py3.
+  logging.basicConfig(level=logging.INFO)
 
 SITE_URL = 'http://%s.appspot.com/' % APP_ID
 CLOUD_TASKS_REGION = 'us-central1'

--- a/settings.py
+++ b/settings.py
@@ -4,6 +4,9 @@ from __future__ import print_function
 import logging
 import os
 
+# Configure logging to print INFO lines so that they are captured
+# when written to stdout on GAE py3.
+#logging.basicConfig(level=logging.INFO)
 
 #Hack to get custom tags working django 1.3 + python27.
 INSTALLED_APPS = (


### PR DESCRIPTION
Try a super-simple way to get logging to work well enough for GAE py3.

The standard logging library will write to stdout, and GAE captures any lines written to stdout as log entries.  They are not nested under the request and they do not have severity info parsed, but it is good enough for debugging.

This line is needed because the standard python logging library defaults to only outputting log entries with severity WARN or higher, but we want INFO to match how it worked under py2.  It is not set when running unit tests to avoid excessive output.