### PR TITLE
Start strictly enforcing CSP

### DIFF
--- a/framework/csp.py
+++ b/framework/csp.py
@@ -25,7 +25,7 @@ import six
 import flask
 
 
-REPORT_ONLY = True
+REPORT_ONLY = False
 USE_NONCE_ONLY_POLICY = True  # Recommended
 REPORT_URI = '/csp'
 NONCE_LENGTH = 30

--- a/static/elements/chromedash-userlist.js
+++ b/static/elements/chromedash-userlist.js
@@ -6,7 +6,6 @@ import {nothing} from 'lit-html';
 class ChromedashUserlist extends LitElement {
   static get properties() {
     return {
-      actionPath: {type: String},
       users: {attribute: false},
     };
   }
@@ -91,7 +90,7 @@ class ChromedashUserlist extends LitElement {
 
   render() {
     return html`
-      <form id="form" name="user_form" method="POST" action="${this.actionPath}" onsubmit="return false;">
+      <form id="form" name="user_form" method="POST">
         <div>
           <input type="email" placeholder="Email address" name="email"
                  required>

--- a/templates/admin/users/new.html
+++ b/templates/admin/users/new.html
@@ -13,9 +13,7 @@
 {% block content %}
 <section>
 
-  <chromedash-userlist
-    actionPath="/admin/users/create"
-    ></chromedeash-userlist>
+  <chromedash-userlist></chromedeash-userlist>
 
 </section>
 {% endblock %}


### PR DESCRIPTION
This is a follow-up to
https://github.com/GoogleChrome/chromium-dashboard/pull/1347

In the logs, I do see CSP violations being reported, but I can't reproduce them.  If we get reports from users of functionality not working, then we can simply reverse this setting.

Also in this PR: deleted unused actionPath and onsubmit from the form to add users.