### PR TITLE
Avoid "gapi not defined" JS error.

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -42,12 +42,11 @@
               <span class="gSignInIcon"></span>
           </div>
         </div>
-        <script nonce="{{nonce}}">startApp();</script>
       {% endif %}
       </div>
     </div>
 
-    
+
 
 
   </nav>


### PR DESCRIPTION
While debugging another problem, I noticed that the JS console includes lines saying "gapi not defined".   I believe that this is because this line runs startApp() before gapi is loaded.  I don't think that this <script> is needed at all since startApp() is run as part of the gapi loading.