### PR TITLE
Added support for scrolling to previous releases

### DIFF
--- a/static/elements/chromedash-upcoming.js
+++ b/static/elements/chromedash-upcoming.js
@@ -119,7 +119,7 @@ class ChromedashUpcoming extends LitElement {
 
     let nextMilestones;
     let milestoneNumsArray = [];
-    const cardsToFetchInAdvance = 3;
+    const cardsToFetchInAdvance = 3; // number of milestones to fetch while fetching for the first time
 
     // promise to fetch next milestones
     // if fetching first time, fetch next cardsToFetchInAdvance milestones, else fetch only the next milestone.
@@ -130,9 +130,10 @@ class ChromedashUpcoming extends LitElement {
         milestoneNumsArray.push(this._lastFutureFetchedOn+1+i);
       }
     } else {
-      nextMilestones = window.csClient.getSpecifiedChannels(this._lastFutureFetchedOn+3+1,
-        this._lastFutureFetchedOn+3+1);
-      milestoneNumsArray.push(this._lastFutureFetchedOn+3+1);
+      nextMilestones = window.csClient.
+        getSpecifiedChannels(this._lastFutureFetchedOn+cardsToFetchInAdvance+1,
+          this._lastFutureFetchedOn+cardsToFetchInAdvance+1);
+      milestoneNumsArray.push(this._lastFutureFetchedOn+cardsToFetchInAdvance+1);
     }
 
     // promise to fetch features in next milestones

--- a/static/js-src/upcoming-page.js
+++ b/static/js-src/upcoming-page.js
@@ -3,10 +3,6 @@ const channelsArray = ['stable', 'beta', 'dev'];
 
 const channelsPromise = window.csClient.getChannels();
 
-let cardsToFetchInAdvance;
-let cardsToDisplay;
-
-
 document.querySelector('.show-blink-checkbox').addEventListener('change', e => {
   e.stopPropagation();
   document.querySelector('chromedash-upcoming').showShippingType = e.target.checked;
@@ -32,7 +28,6 @@ async function init() {
     features[channel] = await featuresPromise[channel];
   }
 
-
   // Remove the loading sign once the data has been fetched from the APIs
   document.body.classList.remove('loading');
 
@@ -41,14 +36,11 @@ async function init() {
     channels[channel].features = features[channel];
   });
 
-
   upcomingEl.channels = channels;
   upcomingEl.lastFutureFetchedOn = channels[channelsArray[1]].version;
   upcomingEl.lastPastFetchedOn = channels[channelsArray[1]].version;
   let cardsDisplayed = upcomingEl.computeItems();
   upcomingEl.lastMilestoneVisible = channels[channelsArray[cardsDisplayed-1]].version;
-  cardsToFetchInAdvance = upcomingEl.cardsToFetchInAdvance;
-  cardsToDisplay = upcomingEl.computeItems();
 
   window.csClient.getStars().then((starredFeatureIds) => {
     upcomingEl.starredFeatures = new Set(starredFeatureIds);
@@ -57,10 +49,11 @@ async function init() {
 
 // Slide to newer or older version
 function move(e) {
-  let container = document.querySelector('chromedash-upcoming');
-  let divWidth = container.shadowRoot.querySelector('chromedash-upcoming-milestone-card').cardWidth;
-  let margin = 8;
-  let change = divWidth+margin*2;
+  const container = document.querySelector('chromedash-upcoming');
+  const divWidth = container.shadowRoot
+    .querySelector('chromedash-upcoming-milestone-card').cardWidth;
+  const margin = 8;
+  const change = divWidth + margin * 2;
   container.classList.add('animate');
 
   if (container.lastFutureFetchedOn) {
@@ -77,11 +70,12 @@ function move(e) {
     }
 
     // Fetch when second last card is displayed
-    if (container.lastMilestoneVisible - container.lastFutureFetchedOn == cardsToFetchInAdvance) {
-      container.lastFutureFetchedOn += cardsToFetchInAdvance;
+    if (container.lastMilestoneVisible - container.lastFutureFetchedOn > 1) {
+      container.lastFutureFetchedOn += 1;
     }
-    if (container.lastPastFetchedOn - container.lastMilestoneVisible == 4 - cardsToDisplay) {
-      container.lastPastFetchedOn -= cardsToFetchInAdvance;
+
+    if (container.lastPastFetchedOn - container.lastMilestoneVisible == 0) {
+      container.lastPastFetchedOn -= 1;
     }
   }
 }

--- a/static/js-src/upcoming-page.js
+++ b/static/js-src/upcoming-page.js
@@ -3,8 +3,8 @@ const channelsArray = ['stable', 'beta', 'dev'];
 
 const channelsPromise = window.csClient.getChannels();
 
-let jumpSlideWidth = 0;
 let cardsToFetchInAdvance;
+let cardsToDisplay;
 
 
 document.querySelector('.show-blink-checkbox').addEventListener('change', e => {
@@ -43,10 +43,12 @@ async function init() {
 
 
   upcomingEl.channels = channels;
-  upcomingEl.lastFetchedOn = channels[channelsArray[1]].version;
+  upcomingEl.lastFutureFetchedOn = channels[channelsArray[1]].version;
+  upcomingEl.lastPastFetchedOn = channels[channelsArray[1]].version;
   let cardsDisplayed = upcomingEl.computeItems();
   upcomingEl.lastMilestoneVisible = channels[channelsArray[cardsDisplayed-1]].version;
   cardsToFetchInAdvance = upcomingEl.cardsToFetchInAdvance;
+  cardsToDisplay = upcomingEl.computeItems();
 
   window.csClient.getStars().then((starredFeatureIds) => {
     upcomingEl.starredFeatures = new Set(starredFeatureIds);
@@ -59,23 +61,27 @@ function move(e) {
   let divWidth = container.shadowRoot.querySelector('chromedash-upcoming-milestone-card').cardWidth;
   let margin = 8;
   let change = divWidth+margin*2;
+  container.classList.add('animate');
 
-  if (container.lastFetchedOn) {
+  if (container.lastFutureFetchedOn) {
     if (e.target.id == 'next-button') {
-      jumpSlideWidth -= change; // move to newer version
-      container.style.marginLeft = jumpSlideWidth + 'px';
+      container.jumpSlideWidth -= change; // move to newer version
+      container.style.marginLeft = container.jumpSlideWidth + 'px';
       container.lastMilestoneVisible += 1;
     } else {
-      if (jumpSlideWidth < 0) {
-        jumpSlideWidth += change; // move to older version
-        container.style.marginLeft = jumpSlideWidth + 'px';
+      if (container.jumpSlideWidth < 0) {
+        container.jumpSlideWidth += change; // move to older version
+        container.style.marginLeft = container.jumpSlideWidth + 'px';
         container.lastMilestoneVisible -= 1;
       }
     }
 
     // Fetch when second last card is displayed
-    if (container.lastMilestoneVisible - container.lastFetchedOn == cardsToFetchInAdvance) {
-      container.lastFetchedOn += cardsToFetchInAdvance;
+    if (container.lastMilestoneVisible - container.lastFutureFetchedOn == cardsToFetchInAdvance) {
+      container.lastFutureFetchedOn += cardsToFetchInAdvance;
+    }
+    if (container.lastPastFetchedOn - container.lastMilestoneVisible == 4 - cardsToDisplay) {
+      container.lastPastFetchedOn -= cardsToFetchInAdvance;
     }
   }
 }

--- a/static/sass/elements/chromedash-upcoming.scss
+++ b/static/sass/elements/chromedash-upcoming.scss
@@ -5,5 +5,4 @@
   display: inline-flex;
   padding: 0 0em $content-padding * 5;
   margin-right: $content-padding * -1;
-  transition: margin 1s ease;
 }

--- a/static/sass/upcoming.scss
+++ b/static/sass/upcoming.scss
@@ -40,6 +40,10 @@ body[data-path*='upcoming'] {
   padding-bottom: $content-padding;
 }
 
+.animate {
+  transition: margin .75s ease;
+}
+
 @media only screen and (min-width: 701px) {
 
   #content-column {

--- a/static/sass/upcoming.scss
+++ b/static/sass/upcoming.scss
@@ -41,7 +41,7 @@ body[data-path*='upcoming'] {
 }
 
 .animate {
-  transition: margin .75s ease;
+  transition: margin .4s ease;
 }
 
 @media only screen and (min-width: 701px) {

--- a/templates/upcoming.html
+++ b/templates/upcoming.html
@@ -25,7 +25,7 @@
       <button id="next-button" aria-label="Button to move to later release">Next</button>
     </div>
 
-    <chromedash-upcoming
+    <chromedash-upcoming class="animate"
       {% if user %}signedin{% endif %}
       {# TODO(jrobbins): Fix to work with google sign-in #}
       loginurl="#"


### PR DESCRIPTION
Review Requested:- @jrobbins 

In this PR,

- Added support for scrolling to previous release.
- While scrolling to future milestones, first 3 future milestones on loading of the page but subsequently fetch 1 milestone at a time. This would result in a better UX as decreased fetching time will enable faster scrolling.  