### PR TITLE
Update privacy link to skip a redirect.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -14,7 +14,6 @@ indexes:
 - kind: "Feature"
   properties:
   - name: "shipped_milestone"
-  - name: "shipped_android_milestone"
     direction: desc
   - name: "name"
 - kind: "Feature"

--- a/index.yaml
+++ b/index.yaml
@@ -14,12 +14,12 @@ indexes:
 - kind: "Feature"
   properties:
   - name: "shipped_milestone"
+  - name: "shipped_android_milestone"
     direction: desc
   - name: "name"
 - kind: "Feature"
   properties:
   - name: "shipped_milestone"
-  - name: "shipped_android_milestone"
     direction: desc
   - name: "name"
 - kind: "AnimatedProperty"

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -6,7 +6,7 @@
      <a href="https://github.com/GoogleChrome/chromium-dashboard/issues"
         target="_blank" rel="noopener"
        >File an issue</a>
-     <a href="https://www.google.com/policies/privacy/"
+     <a href="https://policies.google.com/privacy"
         target="_blank" rel="noopener"
         >Privacy</a>
   </div>


### PR DESCRIPTION
While working through our system test spreadsheet, I was doing the row about footer links and I noticed that the URL we were using takes the user through an interstitial page.   So, I just used the destination URL.