### PR TITLE
Reland: Update privacy link to skip a redirect.

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -6,7 +6,7 @@
      <a href="https://github.com/GoogleChrome/chromium-dashboard/issues"
         target="_blank" rel="noopener"
        >File an issue</a>
-     <a href="https://www.google.com/policies/privacy/"
+     <a href="https://policies.google.com/privacy"
         target="_blank" rel="noopener"
         >Privacy</a>
   </div>


### PR DESCRIPTION
This is was previously reviewed, reverted, and now relanded.  I accidentally included a file that was not intended to be in the original PR.