### PR TITLE
Add indexes needed for /upcoming page

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -14,13 +14,40 @@ indexes:
 - kind: "Feature"
   properties:
   - name: "shipped_milestone"
+  - name: "shipped_android_milestone"
     direction: desc
   - name: "name"
 - kind: "Feature"
   properties:
   - name: "shipped_milestone"
-  - name: "shipped_android_milestone"
     direction: desc
+  - name: "name"
+- kind: "Feature"
+  properties:
+  - name: "shipped_milestone"
+  - name: "name"
+- kind: "Feature"
+  properties:
+  - name: "shipped_android_milestone"
+  - name: "shipped_milestone"
+  - name: "name"
+- kind: "Feature"
+  properties:
+  - name: "ot_milestone_desktop_start"
+  - name: "name"
+- kind: "Feature"
+  properties:
+  - name: "ot_milestone_android_start"
+  - name: "ot_milestone_desktop_start"
+  - name: "name"
+- kind: "Feature"
+  properties:
+  - name: "dt_milestone_desktop_start"
+  - name: "name"
+- kind: "Feature"
+  properties:
+  - name: "dt_milestone_android_start"
+  - name: "dt_milestone_desktop_start"
   - name: "name"
 - kind: "AnimatedProperty"
   properties:
@@ -96,10 +123,6 @@ indexes:
   - name: "sample_links"
   - name: "updated"
     direction: desc
-- kind: "Feature"
-  properties:
-  - name: "shipped_milestone"
-  - name: "name"
 - kind: "Feature"
   properties:
   - name: "shipped_milestone"

--- a/scripts/deploy_indexes.sh
+++ b/scripts/deploy_indexes.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Deploys the datastore indexes to App Engine.
+#
+# Note: This script should be used in place of using appcfg.py update directly
+# to update the application on App Engine.
+
+
+appName=${1:-cr-status}
+usage="Usage: deploy_indexes.sh cr-status-staging"
+
+# The directory in which this script resides.
+readonly BASEDIR=$(dirname $BASH_SOURCE)
+
+$BASEDIR/oauthtoken.sh deploy
+gcloud app deploy \
+  --project $appName \
+  $BASEDIR/../index.yaml


### PR DESCRIPTION
Added entries to index.yaml that are needed for queries done by the new /upcoming page.  And, a simple script to run the command to deploy them when needed.