### PR TITLE
Fill in milestone when there is a gap between stable, beta, or dev.

### DIFF
--- a/static/elements/chromedash-metadata.js
+++ b/static/elements/chromedash-metadata.js
@@ -119,8 +119,10 @@ class ChromedashMetadata extends LitElement {
       this._className = 'betaisdev';
     }
 
-    for (let i = this._channels.stable - 1; i >= 1; i--) {
-      this._versions.push(i);
+    for (let i = this._channels.canary - 1; i >= 1; i--) {
+      if (!this._versions.includes(i)) {
+        this._versions.push(i);
+      }
     }
     const noActiveDev = this.implStatuses[this.status.NO_ACTIVE_DEV - 1].val;
     this._versions.push(noActiveDev);

--- a/static/elements/chromedash-schedule.js
+++ b/static/elements/chromedash-schedule.js
@@ -28,6 +28,13 @@ const TEMPLATE_CONTENT = {
     dateText: 'coming',
     featureHeader: 'Features planned in this release',
   },
+  gap: {
+    channelLabel: '',
+    h1Class: '',
+    downloadUrl: null,
+    dateText: 'coming',
+    featureHeader: 'Features planned in this release',
+  },
 };
 
 const REMOVED_STATUS = ['Removed'];
@@ -40,12 +47,14 @@ class ChromedashSchedule extends LitElement {
   constructor() {
     super();
     this.starredFeatures = new Set();
+    this.columns = ['stable', 'beta', 'dev'];
   }
 
   static get properties() {
     return {
       // Assigned in schedule-apge.js, value from Django
       channels: {attribute: false},
+      columns: {attribute: false},
       showBlink: {attribute: false}, // Set by code in schedule-page.js
       signedin: {type: Boolean},
       loginUrl: {type: String},
@@ -116,15 +125,20 @@ class ChromedashSchedule extends LitElement {
     if (!this.channels) {
       return html``;
     }
+
     return html`
-      ${['stable', 'beta', 'dev'].map((type) => html`
+      ${this.columns.map((type) => html`
         <section class="release ${this.showBlink ? nothing : 'no-components'}">
           <div class="layout vertical center">
             <h1 class="channel_label">${TEMPLATE_CONTENT[type].channelLabel}</h1>
             <h1 class="chrome_version layout horizontal center ${TEMPLATE_CONTENT[type].h1Class}">
               <span class="chrome-logo"></span>
-              <a href="${TEMPLATE_CONTENT[type].downloadUrl}" title="${TEMPLATE_CONTENT[type].downloadTitle}"
-                 target="_blank">Chrome ${this.channels[type].version}</a>
+               ${TEMPLATE_CONTENT[type].downloadUrl ? html`
+                 <a href="${TEMPLATE_CONTENT[type].downloadUrl}"
+                    title="${TEMPLATE_CONTENT[type].downloadTitle}"
+                    target="_blank">Chrome ${this.channels[type].version}</a>`
+                 : html`
+                 Chrome ${this.channels[type].version}`}
             </h1>
           </div>
           ${SHOW_DATES && this.channels[type].earliest_beta ? html`
@@ -140,7 +154,7 @@ class ChromedashSchedule extends LitElement {
                 <span class="release-stable">( ${this._computeDate(this.channels[type].stable_date)} )</span>
               </h3>
             </div>
-          ` : nothing}
+          ` : html`<div style="border-bottom: 1px solid #e6e6e6; height: 7em"></div>`}
           <div class="features_list">
             <div class="features_header">${TEMPLATE_CONTENT[type].featureHeader}:</div>
 

--- a/static/js-src/schedule-page.js
+++ b/static/js-src/schedule-page.js
@@ -17,13 +17,25 @@ async function init() {
 
   // Prepare data for chromedash-schedule
   const features = await featuresPromise;
-  ['stable', 'beta', 'dev'].forEach((channel) => {
+  let columns = ['stable', 'beta', 'dev'];
+
+  // If there is a gap between stable, beta, or dev then display "gap" column.
+  if (CHANNELS['beta'].version > CHANNELS['stable'].version + 1) {
+    CHANNELS['gap'] = {version: CHANNELS['stable'].version + 1};
+    columns = ['stable', 'gap', 'beta'];
+  } else if (CHANNELS['dev'].version > CHANNELS['beta'].version + 1) {
+    CHANNELS['gap'] = {version: CHANNELS['beta'].version + 1};
+    columns = ['stable', 'beta', 'gap'];
+  }
+
+  columns.forEach((channel) => {
     CHANNELS[channel].components = mapFeaturesToComponents(features.filter(f =>
       f.browsers.chrome.status.milestone_str === CHANNELS[channel].version));
   });
 
   const scheduleEl = document.querySelector('chromedash-schedule');
   scheduleEl.channels = CHANNELS;
+  scheduleEl.columns = columns;
 
   window.csClient.getStars().then((starredFeatureIds) => {
     scheduleEl.starredFeatures = new Set(starredFeatureIds);


### PR DESCRIPTION
This should resolve issue #1496.

For the version filter menu: start at canary and count down, avoiding duplicates.  This makes the menu look like: "95 dev, 94 beta, 92 stable, 93, 91, 90, 89, ..." which kind of makes sense.  It is not ideal, but I don't expect this case to happen very often.  The current implementation uses CSS nth-child() stuff to add those labels so it would be a hassle to add logic.  Eventually we will redo the filter menus.

For the schedule page: instead of hardcoding the columns, use a variable that is normally ['stable', 'beta', 'dev'].  Then, change that to ['stable', 'gap', 'beta'] or ['stable', 'beta', 'gap'] when we detect that a milestone has been skipped.  This is kind of hacky.  A better fix can be made to the "upcoming" page because it has a different approach.