### PR TITLE
Show a message when a feature has no milestones

### DIFF
--- a/templates/estimated-milestones-table.html
+++ b/templates/estimated-milestones-table.html
@@ -1,63 +1,71 @@
-<table>
+{% if feature.shipped_milestone or feature.ot_milestone_desktop_end or feature.ot_milestone_desktop_start or feature.dt_milestone_desktop_start or feature.shipped_android_milestone or feature.ot_milestone_android_end or feature.ot_milestone_android_start or feature.dt_milestone_andorid_start or feature.shipped_ios_milestone or feature.dt_milestone_ios_start or feature.shipped_webview_milestone or feature.dt_milestone_webview_start %}
 
-  {% if feature.shipped_milestone %}
-    <tr><td>Shipping on desktop</td>
-    <td>{{feature.shipped_milestone}}</td></tr>
-  {% endif %}
+  <table>
 
-  {% if feature.ot_milestone_desktop_end %}
-    <tr><td>OriginTrial desktop last</td>
-    <td>{{feature.ot_milestone_desktop_end}}</td></tr>
-  {% endif %}
+    {% if feature.shipped_milestone %}
+      <tr><td>Shipping on desktop</td>
+      <td>{{feature.shipped_milestone}}</td></tr>
+    {% endif %}
 
-  {% if feature.ot_milestone_desktop_start %}
-    <tr><td>OriginTrial desktop first</td>
-    <td>{{feature.ot_milestone_desktop_start}}</td></tr>
-  {% endif %}
+    {% if feature.ot_milestone_desktop_end %}
+      <tr><td>OriginTrial desktop last</td>
+      <td>{{feature.ot_milestone_desktop_end}}</td></tr>
+    {% endif %}
 
-  {% if feature.dt_milestone_desktop_start %}
-    <tr><td>DevTrial on desktop</td>
-    <td>{{feature.dt_milestone_desktop_start}}</td></tr>
-  {% endif %}
+    {% if feature.ot_milestone_desktop_start %}
+      <tr><td>OriginTrial desktop first</td>
+      <td>{{feature.ot_milestone_desktop_start}}</td></tr>
+    {% endif %}
 
-  {% if feature.shipped_android_milestone %}
-    <tr><td>Shipping on Android</td>
-    <td>{{feature.shipped_android_milestone}}</td></tr>
-  {% endif %}
+    {% if feature.dt_milestone_desktop_start %}
+      <tr><td>DevTrial on desktop</td>
+      <td>{{feature.dt_milestone_desktop_start}}</td></tr>
+    {% endif %}
 
-  {% if feature.ot_milestone_android_end %}
-    <tr><td>OriginTrial android last</td>
-    <td>{{feature.ot_milestone_android_end}}</td></tr>
-  {% endif %}
+    {% if feature.shipped_android_milestone %}
+      <tr><td>Shipping on Android</td>
+      <td>{{feature.shipped_android_milestone}}</td></tr>
+    {% endif %}
 
-  {% if feature.ot_milestone_android_start %}
-    <tr><td>OriginTrial android first</td>
-    <td>{{feature.ot_milestone_android_start}}</td></tr>
-  {% endif %}
+    {% if feature.ot_milestone_android_end %}
+      <tr><td>OriginTrial android last</td>
+      <td>{{feature.ot_milestone_android_end}}</td></tr>
+    {% endif %}
 
-  {% if feature.dt_milestone_andorid_start %}
-    <tr><td>DevTrial on android</td>
-    <td>{{feature.dt_milestone_android_start}}</td></tr>
-  {% endif %}
+    {% if feature.ot_milestone_android_start %}
+      <tr><td>OriginTrial android first</td>
+      <td>{{feature.ot_milestone_android_start}}</td></tr>
+    {% endif %}
 
-  {% if feature.shipped_ios_milestone %}
-    <tr><td>Shipping on iOS</td>
-    <td>{{feature.shipped_ios_milestone}}</td></tr>
-  {% endif %}
+    {% if feature.dt_milestone_andorid_start %}
+      <tr><td>DevTrial on android</td>
+      <td>{{feature.dt_milestone_android_start}}</td></tr>
+    {% endif %}
 
-  {% if feature.dt_milestone_ios_start %}
-    <tr><td>DevTrial on iOS</td>
-    <td>{{feature.dt_milestone_ios_start}}</td></tr>
-  {% endif %}
+    {% if feature.shipped_ios_milestone %}
+      <tr><td>Shipping on iOS</td>
+      <td>{{feature.shipped_ios_milestone}}</td></tr>
+    {% endif %}
 
-  {% if feature.shipped_webview_milestone %}
-    <tr><td>Shipping on Webview</td>
-    <td>{{feature.shipped_webview_milestone}}</td></tr>
-  {% endif %}
+    {% if feature.dt_milestone_ios_start %}
+      <tr><td>DevTrial on iOS</td>
+      <td>{{feature.dt_milestone_ios_start}}</td></tr>
+    {% endif %}
 
-  {% if feature.dt_milestone_webview_start %}
-    <tr><td>DevTrial on Webview</td>
-    <td>{{feature.dt_milestone_webview_start}}</td></tr>
-  {% endif %}
+    {% if feature.shipped_webview_milestone %}
+      <tr><td>Shipping on Webview</td>
+      <td>{{feature.shipped_webview_milestone}}</td></tr>
+    {% endif %}
 
-</table>
+    {% if feature.dt_milestone_webview_start %}
+      <tr><td>DevTrial on Webview</td>
+      <td>{{feature.dt_milestone_webview_start}}</td></tr>
+    {% endif %}
+
+  </table>
+
+{% else %}
+
+  <p>No milestones specified</p>
+
+{% endif %}


### PR DESCRIPTION
This should resolve issue #1507.

This change impacts that feature change notification emails and also the intent email text that feature owners are supposed to copy and paste.  When a feature has no milestones specified, there will now be a message that says "No milestones specified".