### PR TITLE
Fix the display of some feature details.

### DIFF
--- a/static/elements/chromedash-feature-detail.js
+++ b/static/elements/chromedash-feature-detail.js
@@ -104,14 +104,35 @@ class ChromedashFeatureDetail extends LitElement {
   getFieldValue(fieldDef) {
     const fieldId = fieldDef[0];
     let value = this.feature[fieldId];
-    if (fieldId == 'spec_link') {
-      value = this.feature.standards.spec;
-    }
-    if (fieldId == 'standard_maturity') {
-      value = this.feature.standards.maturity;
-    }
-    if (value && value.text) {
-      value = value.text;
+    const fieldIdMapping = {
+      spec_link: 'standards.spec',
+      standard_maturity: 'standards.maturity.text',
+      sample_links: 'resources.samples',
+      docs_links: 'resources.docs',
+      bug_url: 'browsers.chrome.bug',
+      blink_components: 'browsers.chrome.blink_components',
+      devrel: 'browsers.chrome.devrel',
+      prefixed: 'browsers.chrome.prefixed',
+      impl_status_chrome: 'browsers.chrome.status.text',
+      shipped_milestone: 'browsers.chrome.desktop',
+      shipped_android_milestone: 'browsers.chrome.android',
+      shipped_webview_milestone: 'browsers.chrome.webview',
+      shipped_ios_milestone: 'browsers.chrome.ios',
+      ff_views: 'browsers.ff.views.text',
+      ff_views_link: 'browsers.ff.views.url',
+      safari_views: 'browsers.safari.views.text',
+      safari_views_link: 'browsers.safari.views.url',
+      webdev_views: 'browsers.webdev.views.text',
+      webdev_views_link: 'browsers.webdev.views.url',
+    };
+    if (fieldIdMapping[fieldId]) {
+      value = this.feature;
+      console.log(fieldIdMapping[fieldId]);
+      for (let step of fieldIdMapping[fieldId].split('.')) {
+        if (value) {
+          value = value[step];
+        }
+      }
     }
     return value;
   }

--- a/static/elements/chromedash-feature-detail.js
+++ b/static/elements/chromedash-feature-detail.js
@@ -127,7 +127,6 @@ class ChromedashFeatureDetail extends LitElement {
     };
     if (fieldIdMapping[fieldId]) {
       value = this.feature;
-      console.log(fieldIdMapping[fieldId]);
       for (let step of fieldIdMapping[fieldId].split('.')) {
         if (value) {
           value = value[step];


### PR DESCRIPTION
This fixes a defect that I noticed when comparing the milestone visualization to the details at the bottom of the feature details page.

The problem is that list of detailed fields is specified using flat field names, e.g., `standards_maturity`, whereas the feature_json object that is passed to this web element has a nested structure that includes both human-readable and enum integer values.  Since the naming schemes don't match, the JS code simply skips those rows in the detailed field list.

The solution I used here is to define a mapping from the flat field names to the nested JSON object path. 