### PR TITLE
Update help text for current page structure.

### DIFF
--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -44,16 +44,11 @@ class MultiEmailField(forms.Field):
 
 SHIPPED_HELP_TXT = (
     'First milestone to ship with this status. Applies to: Enabled by '
-    'default, Behind a flag, Origin trial, Browser Intervention, and '
-    'Deprecated. If the flag is \'test\' rather than \'experimental\' set '
-    'status to In development. If the flag is for an origin trial set status '
-    'to Origin trial.')
+    'default, Browser Intervention, Deprecated and Removed.')
 
 SHIPPED_WEBVIEW_HELP_TXT = ('First milestone to ship with this status. '
                             'Applies to Enabled by default, Browser '
-                            'Intervention, and Deprecated.\n\n NOTE: for '
-                            'statuses In developer trial and Origin trial this '
-                            'MUST be blank.')
+                            'Intervention, Deprecated, and Removed.')
 
 SUMMARY_PLACEHOLDER_TXT = (
   'NOTE: This text describes this feature in the eventual beta release post '
@@ -425,17 +420,13 @@ ALL_FIELDS = {
         required=False, label='OT desktop start',
         widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
         help_text=('First desktop milestone that will support an origin '
-                   'trial of this feature.  '
-                   'Setting this automatically sets the android '
-                   'milestone, unless they are different.')),
+                   'trial of this feature.')),
 
     'ot_milestone_desktop_end': forms.IntegerField(
         required=False, label='OT desktop end',
         widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
         help_text=('Last desktop milestone that will support an origin '
-                   'trial of this feature.  '
-                   'Setting this automatically sets the android '
-                   'milestone, unless they are different.')),
+                   'trial of this feature.')),
 
     'ot_milestone_android_start': forms.IntegerField(
         required=False, label='OT android start',
@@ -655,9 +646,7 @@ ALL_FIELDS = {
         required=False, label='DevTrail on desktop',
         widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
         help_text=('First milestone that allows developers to try '
-                   'this feature on desktop platforms by setting a flag.  '
-                   'Setting this automatically sets android and webview '
-                   'milestones, unless they are different.')),
+                   'this feature on desktop platforms by setting a flag.')),
 
     'dt_milestone_android_start': forms.IntegerField(
         required=False, label='DevTrail on Android',


### PR DESCRIPTION
Milestone help text is still written for a single set of milestone fields. This PR corrects that.