### PR TITLE
Fix Gecko views link href in intents.

### DIFF
--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -85,7 +85,7 @@
 
     <br><br><i>Gecko</i>: {{feature.browsers.ff.view.text}}
     {% if feature.browsers.ff.view.url %}
-      (<a href="{{feature.browsers.ff.views.url}}">{{feature.browsers.ff.view.url}}</a>)
+      (<a href="{{feature.browsers.ff.view.url}}">{{feature.browsers.ff.view.url}}</a>)
     {% endif %}
     {% if feature.browsers.ff.view.notes %}
      {{feature.browsers.ff.view.notes|urlize}}


### PR DESCRIPTION
This fixes issue #1512.

The cause was a typo in a field name used in a django template.  With the bad field name, the link's href was treated as '', which created a link that was treated as a self-link to the page that shows the intent email content. 

This problem was not detected sooner because we do not have unit tests for templates.