### PR TITLE
Separate standards maturity status from spec link.

### DIFF
--- a/templates/feature.html
+++ b/templates/feature.html
@@ -118,8 +118,12 @@
     <section id="specification">
       <h3>Specification</h3>
       <p><a href="{{feature.standards.spec}}" target="_blank" rel="noopener"
-            title="{{feature.standards.maturity.text}}"
-            >{{feature.standards.maturity.short_text}}</a></p>
+            >Specification link</a></p>
+      <br>
+      <p>
+        <label>Status:</label>
+        {{feature.standards.maturity.text}}
+      </p>
     </section>
     {% endif %}
 


### PR DESCRIPTION
This should resolve issue #1504. 

In this PR:
* Create a separate link for the specification and use the link text "Specification link".  (Normally I would not include the word "link" in link text, but this appears directly under the heading "Specification" which would otherwise look redundant.)
* Display the standards maturity status on its own line, using the full version of the text rather than the short version.