### PR TITLE
Fix docs & samples links on /feature/ pages

### DIFF
--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -34,7 +34,7 @@
   <br><br><h4>Specification</h4>
   {{feature.standards.spec|urlize}}
 
-  {% if feature.doc_links %}
+  {% if feature.resources && feature.resources.docs %}
     <br><br><h4>Design docs</h4>
     {% for link in feature.resources.docs %}
       <br><a href="{{link}}">{{link}}</a>
@@ -190,9 +190,9 @@
 {% endif %}
 
 {% if 'sample_links' in sections_to_show %}
-   {% if feature.sample_links %}
+   {% if feature.resources && feature.resources.samples %}
      <br><br><h4>Sample links</h4>
-     {% for link in feature.sample_links %}
+     {% for link in feature.resources.samples %}
        <br><a href="{{link}}">{{link}}</a>
      {% endfor %}
    {% endif %}

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -92,9 +92,9 @@
     </section>
     {% endif %}
 
-    {% if feature.sample_links %}
+    {% if feature.resources && feature.resources.samples %}
     <section id="demo">
-      <h3>{% if feature.sample_links|length == 1 %}Demo{% else %}Demos{% endif %}</h3>
+      <h3>{% if feature.resources.samples|length == 1 %}Demo{% else %}Demos{% endif %}</h3>
       <ul>
         {% for sample_link in feature.resources.samples %}
         <li><a href="{{ sample_link }}">{{ sample_link }}</a></li>
@@ -103,7 +103,7 @@
     </section>
     {% endif %}
 
-    {% if feature.doc_links %}
+    {% if feature.resources && feature.resources.docs %}
     <section id="documentation">
       <h3>Documentation</h3>
       <ul>


### PR DESCRIPTION
It looks like #1443 introduced some changes to account for a new data schema, but there are a couple of places that did not get updated to account for the fact that `feature.doc_links` and `feature.sample_links` is now `feature.resources.docs` and `feature.resources.samples`.

This PR remediates that, ensuring that the docs and samples links show up on the standalone feature pages (and the `intent_to_implement.html` template).

Please note that I haven't run a local copy of this project in a while, so I haven't actually tested these changes out—please confirm that the change works before merging!