### PR TITLE
Fix dt_milestone_android_start

### DIFF
--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -652,7 +652,7 @@ ALL_FIELDS = {
         required=False, label='DevTrail on Android',
         widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
         help_text=('First milestone that allows developers to try '
-                   'this feature on iOS by setting a flag.')),
+                   'this feature on Android by setting a flag.')),
 
     'dt_milestone_ios_start': forms.IntegerField(
         required=False, label='DevTrial on iOS (RARE)',

--- a/templates/estimated-milestones-table.html
+++ b/templates/estimated-milestones-table.html
@@ -1,4 +1,4 @@
-{% if feature.shipped_milestone or feature.ot_milestone_desktop_end or feature.ot_milestone_desktop_start or feature.dt_milestone_desktop_start or feature.shipped_android_milestone or feature.ot_milestone_android_end or feature.ot_milestone_android_start or feature.dt_milestone_andorid_start or feature.shipped_ios_milestone or feature.dt_milestone_ios_start or feature.shipped_webview_milestone or feature.dt_milestone_webview_start %}
+{% if feature.shipped_milestone or feature.ot_milestone_desktop_end or feature.ot_milestone_desktop_start or feature.dt_milestone_desktop_start or feature.shipped_android_milestone or feature.ot_milestone_android_end or feature.ot_milestone_android_start or feature.dt_milestone_android_start or feature.shipped_ios_milestone or feature.dt_milestone_ios_start or feature.shipped_webview_milestone or feature.dt_milestone_webview_start %}
 
   <table>
 
@@ -37,7 +37,7 @@
       <td>{{feature.ot_milestone_android_start}}</td></tr>
     {% endif %}
 
-    {% if feature.dt_milestone_andorid_start %}
+    {% if feature.dt_milestone_android_start %}
       <tr><td>DevTrial on android</td>
       <td>{{feature.dt_milestone_android_start}}</td></tr>
     {% endif %}


### PR DESCRIPTION
Currently "DevTrial on android" is not printed in "Ready for Trial"
mail because of the typo in estimated-milestones-table.html.
And the help_text in guideforms.py is not correct.

This PR fixes them.