### PR TITLE
Add help link to footer.

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,5 +1,8 @@
 <footer>
   <div>
+     <a href="https://github.com/GoogleChrome/chromium-dashboard/wiki/"
+        target="_blank" rel="noopener"
+        >Help</a>
      <a href="https://groups.google.com/a/chromium.org/forum/#!newtopic/blink-dev"
         target="_blank" rel="noopener"
         >Discuss</a>


### PR DESCRIPTION
This adds a footer link labeled "Help" that goes to the home page of our project wiki.

I already added a FAQ page to the wiki with a single question about deleting features.  The combination of this PR and that wiki edit should address the request raised last week by a user on our mailing list.