### PR TITLE
Remove testbed and replace sign_in() and sign_out()

### DIFF
--- a/pages/featurelist_test.py
+++ b/pages/featurelist_test.py
@@ -56,6 +56,7 @@ class FeaturesJsonHandlerTest(TestWithFeature):
 
   def test_get_template_data(self):
     """User can get a JSON feed of all features."""
+    testing_config.sign_in('user@example.com', 111)
     with featurelist.app.test_request_context(self.request_path):
       json_data = self.handler.get_template_data()
 

--- a/testing_config.py
+++ b/testing_config.py
@@ -47,6 +47,7 @@ os.environ['SERVER_SOFTWARE'] = 'test ' + os.environ.get('SERVER_SOFTWARE', '')
 os.environ['CURRENT_VERSION_ID'] = 'test.123'
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 os.environ['DATASTORE_EMULATOR_HOST'] = 'localhost:15606'
+os.environ['APPLICATION_ID'] = 'testing'
 
 
 from framework import cloud_tasks_helpers

--- a/testing_config.py
+++ b/testing_config.py
@@ -22,7 +22,7 @@ import unittest
 
 app_engine_path = os.environ.get('APP_ENGINE_PATH', '')
 if not app_engine_path:
-  app_engine_path = '/usr/local/google/home/kyleju/google-cloud-sdk/platform/google_appengine'
+  app_engine_path = '/usr/lib/google-cloud-sdk/platform/google_appengine'
 if not os.path.exists(app_engine_path):
   # app_engine_path for GitHub Action CI.
   app_engine_path = '/home/runner/google-cloud-sdk/platform/google_appengine'

--- a/testing_config.py
+++ b/testing_config.py
@@ -22,7 +22,7 @@ import unittest
 
 app_engine_path = os.environ.get('APP_ENGINE_PATH', '')
 if not app_engine_path:
-  app_engine_path = '/usr/lib/google-cloud-sdk/platform/google_appengine'
+  app_engine_path = '/usr/local/google/home/kyleju/google-cloud-sdk/platform/google_appengine'
 if not os.path.exists(app_engine_path):
   # app_engine_path for GitHub Action CI.
   app_engine_path = '/home/runner/google-cloud-sdk/platform/google_appengine'
@@ -41,37 +41,12 @@ from google.appengine.ext import vendor
 vendor.add(lib_path) # add third party libs to "lib" folder.
 
 from google.cloud import ndb
-from google.appengine.ext import testbed
 
 os.environ['DJANGO_SECRET'] = 'test secret'
 os.environ['SERVER_SOFTWARE'] = 'test ' + os.environ.get('SERVER_SOFTWARE', '')
 os.environ['CURRENT_VERSION_ID'] = 'test.123'
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 os.environ['DATASTORE_EMULATOR_HOST'] = 'localhost:15606'
- 
-
-ourTestbed = testbed.Testbed()
-
-def setUpOurTestbed():
-  # needed because endpoints expects a . in this value
-  ourTestbed.setup_env(current_version_id='testbed.version')
-  ourTestbed.activate()
-
-  # Can't use init_all_stubs() because PIL isn't in wheel.
-  ourTestbed.init_app_identity_stub()
-  ourTestbed.init_blobstore_stub()
-  ourTestbed.init_capability_stub()
-  ourTestbed.init_files_stub()
-  ourTestbed.init_logservice_stub()
-  ourTestbed.init_mail_stub()
-  ourTestbed.init_search_stub()
-  ourTestbed.init_urlfetch_stub()
-  ourTestbed.init_user_stub()
-
-# Normally this would be done in the setUp() methods of individual test files,
-# but we need it to be done before importing any application code because
-# models.py makes GAE API calls to in code that runs during loading.
-setUpOurTestbed()
 
 
 from framework import cloud_tasks_helpers
@@ -113,17 +88,17 @@ class Blank(object):
 
 def sign_out():
   """Set env variables to represent a signed out user."""
-  ourTestbed.setup_env(
-      user_email='', user_id='', user_is_admin='0', overwrite=True)
-
+  os.environ['USER_EMAIL'] = ''
+  os.environ['USER_ID'] = ''
+  os.environ['USER_IS_ADMIN'] = '0'
+  os.environ['AUTH_DOMAIN'] = '1'
 
 def sign_in(user_email, user_id):
   """Set env variables to represent a signed out user."""
-  ourTestbed.setup_env(
-      user_email=user_email,
-      user_id=str(user_id),
-      user_is_admin='0',  # This was for GAE user admin, we use AppUser.
-      overwrite=True)
+  os.environ['USER_EMAIL'] = user_email
+  os.environ['USER_ID'] = str(user_id)
+  os.environ['USER_IS_ADMIN'] = '0'
+  os.environ['AUTH_DOMAIN'] = '0'
 
 
 class CustomTestCase(unittest.TestCase):


### PR DESCRIPTION
Part one of #1077

Hacked the setup by adding `os.environ['AUTH_DOMAIN'] = '1'`. Without this line, any tests related to `from google.appengine.api import users as gae_users` will fail.