### PR TITLE
Eliminated references to GAE users.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -29,7 +29,6 @@ from google.cloud import ndb
 from google.appengine.api import mail
 from framework import ramcache
 import requests
-from google.appengine.api import users as gae_users
 from framework import users
 
 from framework import cloud_tasks_helpers
@@ -394,8 +393,6 @@ class DictModel(ndb.Model):
         output[key] = {'lat': value.lat, 'lon': value.lon}
       elif isinstance(value, ndb.Model):
         output[key] = to_dict(value)
-      elif isinstance(value, gae_users.User):
-        output[key] = value.email()
       elif isinstance(value, ndb.model.User):
         output[key] = value.email()
       else:

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -22,9 +22,8 @@ import testing_config  # Must be imported before the module under test.
 import flask
 import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
+from google.cloud import ndb
 
-# TODO(jrobbins): phase out gae_users.
-from google.appengine.api import users as gae_users
 from framework import users
 
 from internals import models
@@ -38,8 +37,10 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.feature_1 = models.Feature(
         name='feature one', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1,
-        created_by=gae_users.User(email='creator@example.com'),
-        updated_by=gae_users.User(email='editor@example.com'),
+        created_by=ndb.User(
+            email='creator@example.com', _auth_domain='gmail.com'),
+        updated_by=ndb.User(
+            email='editor@example.com', _auth_domain='gmail.com'),
         blink_components=['Blink'])
     self.feature_1.put()
     self.component_1 = models.BlinkComponent(name='Blink')
@@ -57,8 +58,10 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.feature_2 = models.Feature(
         name='feature two', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1,
-        created_by=gae_users.User(email='creator@example.com'),
-        updated_by=gae_users.User(email='editor@example.com'),
+        created_by=ndb.User(
+            email='creator@example.com', _auth_domain='gmail.com'),
+        updated_by=ndb.User(
+            email='editor@example.com', _auth_domain='gmail.com'),
         blink_components=['Blink'])
     self.feature_2.put()
 


### PR DESCRIPTION
This PR replaces references to gae_users with ndb.User.

I did not find documentation on what the _auth_domain field should be, however I see in all our production data that I checked it has the value "gmail.com".

I deployed this to staging to verify that existing Feature entities can be read and updated. 