### PR TITLE
On the upcoming page, always group features by launch type.

### DIFF
--- a/static/elements/chromedash-upcoming-milestone-card.js
+++ b/static/elements/chromedash-upcoming-milestone-card.js
@@ -7,7 +7,6 @@ class ChromedashUpcomingMilestoneCard extends LitElement {
   static get properties() {
     return {
       // Assigned in schedule-apge.js, value from Django
-      showShippingType: {type: Boolean},
       starredFeatures: {type: Object},
       highlightFeature: {type: Number},
       templateContent: {type: Object},
@@ -26,7 +25,7 @@ class ChromedashUpcomingMilestoneCard extends LitElement {
   constructor() {
     super();
     this.starredFeatures = new Set();
-    this.noFeatureString = 'NO FEATURE HAS BEEN PLANNED IN THIS RELEASE YET';
+    this.noFeatureString = 'NO FEATURES ARE PLANNED FOR THIS MILESTONE YET';
   }
 
   /**
@@ -135,7 +134,7 @@ class ChromedashUpcomingMilestoneCard extends LitElement {
       <div class="milestone_info layout horizontal center-center">
         <h3>
           <span class="channel_label">Stable</span> ${this._computeDaysUntil(this.channel.stable_date)}
-          <span class="release-stable">( ${this._computeDate(this.channel.stable_date)} )</span>
+          <span class="release-stable">(${this._computeDate(this.channel.stable_date)})</span>
         </h3>
       </div>
       ` : nothing}
@@ -191,7 +190,7 @@ class ChromedashUpcomingMilestoneCard extends LitElement {
         `}
       </span>
     </li>
-    
+
     `;
   }
 
@@ -228,9 +227,9 @@ class ChromedashUpcomingMilestoneCard extends LitElement {
   render() {
     return html`
       ${this._widthStyle()}
-      <section class="release ${this.showShippingType ? '' : 'no-components'}">
+      <section class="release">
         ${this._cardHeaderTemplate()}
-        ${this._cardFeatureListTemplate()}    
+        ${this._cardFeatureListTemplate()}
       </section>
     `;
   }

--- a/static/elements/chromedash-upcoming.js
+++ b/static/elements/chromedash-upcoming.js
@@ -57,7 +57,6 @@ class ChromedashUpcoming extends LitElement {
     return {
       // Assigned in upcoming-page.js,
       channels: {attribute: false},
-      showShippingType: {attribute: false},
       signedIn: {type: Boolean},
       loginUrl: {type: String},
       starredFeatures: {type: Object}, // will contain a set of starred features
@@ -276,11 +275,10 @@ class ChromedashUpcoming extends LitElement {
           .cardWidth=${this.cardWidth}
           .highlightFeature=${this.highlightFeature}
           ?signedin=${this.signedIn}
-          ?showShippingType=${this.showShippingType}
           @star-toggle-event=${this.handleStarToggle}
           @highlight-feature-event=${this.handleHighlightEvent}
         >
-        </chromedash-upcoming-milestone-card>        
+        </chromedash-upcoming-milestone-card>
       `)}
 
       ${['stable', 'beta', 'dev'].map((type) => html`
@@ -296,11 +294,10 @@ class ChromedashUpcoming extends LitElement {
           .cardWidth=${this.cardWidth}
           .highlightFeature=${this.highlightFeature}
           ?signedin=${this.signedIn}
-          ?showShippingType=${this.showShippingType}
           @star-toggle-event=${this.handleStarToggle}
           @highlight-feature-event=${this.handleHighlightEvent}
         >
-        </chromedash-upcoming-milestone-card>        
+        </chromedash-upcoming-milestone-card>
       `)}
 
       ${this.futureMilestoneArray.map((milestone) => html`
@@ -316,11 +313,10 @@ class ChromedashUpcoming extends LitElement {
           .cardWidth=${this.cardWidth}
           .highlightFeature=${this.highlightFeature}
           ?signedin=${this.signedIn}
-          ?showShippingType=${this.showShippingType}
           @star-toggle-event=${this.handleStarToggle}
           @highlight-feature-event=${this.handleHighlightEvent}
         >
-        </chromedash-upcoming-milestone-card>        
+        </chromedash-upcoming-milestone-card>
       `)}
     `;
   }

--- a/static/js-src/upcoming-page.js
+++ b/static/js-src/upcoming-page.js
@@ -3,11 +3,6 @@ const channelsArray = ['stable', 'beta', 'dev'];
 
 const channelsPromise = window.csClient.getChannels();
 
-document.querySelector('.show-blink-checkbox').addEventListener('change', e => {
-  e.stopPropagation();
-  document.querySelector('chromedash-upcoming').showShippingType = e.target.checked;
-});
-
 const header = document.querySelector('app-header-layout app-header');
 if (header) {
   header.fixed = false;

--- a/templates/upcoming.html
+++ b/templates/upcoming.html
@@ -12,9 +12,6 @@
       <h3>Release timeline</h3>
       <!-- p class="description">Please note, all dates are estimates and are subject to change.</p -->
     </div>
-    <!-- <paper-toggle-button> doesn't working here. Related links:
-      https://github.com/PolymerElements/paper-toggle-button/pull/132 -->
-    <label><input type="checkbox" class="show-blink-checkbox">Show Shipping Type</label>
   </div>
 {% endblock %}
 
@@ -33,7 +30,7 @@
     ></chromedash-upcoming>
 
     <div class="timeline-controls">
-      
+
     </div>
   </section>
 {% endblock %}


### PR DESCRIPTION
The old schedule page had an option to group by blink component.  That was not super-useful, so it was unchecked by default.  That choice was copied over onto the new upcoming page, but it should be removed.

On the upcoming page, we want to clearly show what kind of launch is happening for each feature in each milestone.  So, we should always group feature by launch type.  We don't need the option to have features shown in a list without the grouping.

Also, tweak the wording for the message when a milestone has nothing in it yet.