### PR TITLE
Use background highlights on Upcoming page.

### DIFF
--- a/static/elements/chromedash-upcoming-milestone-card.js
+++ b/static/elements/chromedash-upcoming-milestone-card.js
@@ -144,8 +144,9 @@ class ChromedashUpcomingMilestoneCard extends LitElement {
 
   _cardFeatureItemTemplate(f, shippingType) {
     return html `
-    <li data-feature-id="${f.id}">
-      <a href="/feature/${f.id}" @mouseenter="${this.highlight}" class="${f.id == this.highlightFeature ? 'highlight' : ''}">${f.name}</a>
+    <li data-feature-id="${f.id}"
+        class="${f.id == this.highlightFeature ? 'highlight' : ''}">
+      <a href="/feature/${f.id}" @mouseenter="${this.highlight}">${f.name}</a>
       <span class="icon_row">
         ${this.originTrialStatus.includes(shippingType) ? html`
         <span class="tooltip" title="Origin Trial">
@@ -191,7 +192,7 @@ class ChromedashUpcomingMilestoneCard extends LitElement {
         `}
       </span>
     </li>
-    
+
     `;
   }
 
@@ -230,7 +231,7 @@ class ChromedashUpcomingMilestoneCard extends LitElement {
       ${this._widthStyle()}
       <section class="release ${this.showShippingType ? '' : 'no-components'}">
         ${this._cardHeaderTemplate()}
-        ${this._cardFeatureListTemplate()}    
+        ${this._cardFeatureListTemplate()}
       </section>
     `;
   }

--- a/static/sass/elements/chromedash-upcoming-milestone-card.scss
+++ b/static/sass/elements/chromedash-upcoming-milestone-card.scss
@@ -38,12 +38,12 @@ iron-icon {
     cursor: pointer;
   }
 }
-  
+
 .main-toolbar .toolbar-content {
   max-width: 100%; // override.
   width: 100%;
 }
-  
+
 .chrome_version {
   font-size: 45px;
   margin: $content-padding / 2 0 $content-padding 0;
@@ -135,7 +135,7 @@ iron-icon {
   }
 
   li {
-    padding: $content-padding / 2 0;
+    padding: $content-padding / 2;
     font-weight: 500;
     display: flex;
     justify-content: space-between;
@@ -164,11 +164,5 @@ iron-icon {
 }
 
 .highlight {
-  font-weight: bold;
-  font-size: large;
-  color: orangered;
-}
-
-li a:hover {
-  color: orangered;
+  background: var(--light-accent-color);
 }


### PR DESCRIPTION
In this PR:
* Use a background color for highlighting rather than changing font size and color
* Highlight the feature `<li>` element rather than just the `<a>` element so that the highlighted regions will have a more consistent size
* Use a little padding on all four sides of the `<li>` element so that the text is not right up against the edge of the highlighted area