### PR TITLE
Rearrange main tabs as step toward site redesign.

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -9,9 +9,9 @@
     <div class="flex-container flex-container-outer">
 
       <div class="flex-container flex-container-inner-first">
-        <a class="flex-item" href="/features">All features</a>
         <a class="flex-item" href="/features/schedule">Releases</a>
-        <a class="flex-item" href="/samples" class="features">Samples</a>
+        {# TODO(jrobbins): link to myfeatures #}
+        <a class="flex-item" href="/features">All features</a>
         <div class="nav-dropdown-container flex-item">
           <a class="nav-dropdown-trigger flex-item-inner">Stats
             <iron-icon icon="chromestatus:arrow-drop-down"></iron-icon>


### PR DESCRIPTION
This is a first step toward launching the new site information architecture as described in the "Big board and my features" proposal.

We have a ways to go on implementing the "My features" page, but I'd like to get users exposed to the new tab ordering and the removal of the samples page.