### PR TITLE
Speed up the roadmap page by querying in parallel and caching

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -924,6 +924,12 @@ class Feature(DictModel):
     if milestone == None:
       return None
 
+    cache_key = '%s|%s|%s|%s' % (
+        Feature.DEFAULT_CACHE_KEY, 'milestone', show_unlisted, milestone)
+    cached_allowed_features_by_type = ramcache.get(cache_key)
+    if cached_allowed_features_by_type:
+      return cached_allowed_features_by_type
+
     all_features = {}
     all_features[IMPLEMENTATION_STATUS[ENABLED_BY_DEFAULT]] = []
     all_features[IMPLEMENTATION_STATUS[DEPRECATED]] = []
@@ -933,10 +939,55 @@ class Feature(DictModel):
     all_features[IMPLEMENTATION_STATUS[BEHIND_A_FLAG]] = []
 
     logging.info('Getting chronological feature list in milestone %d', milestone)
+    # Start each query asynchronously in parallel.
     q = Feature.query()
     q = q.order(Feature.name)
     q = q.filter(Feature.shipped_milestone == milestone)
-    desktop_shipping_features = q.fetch(None)
+    desktop_shipping_features_future = q.fetch_async(None)
+
+    # Features with an android shipping milestone but no desktop milestone.
+    q = Feature.query()
+    q = q.order(Feature.name)
+    q = q.filter(Feature.shipped_android_milestone == milestone)
+    q = q.filter(Feature.shipped_milestone == None)
+    android_only_shipping_features_future = q.fetch_async(None)
+
+    # Features that are in origin trial (Desktop) in this milestone
+    q = Feature.query()
+    q = q.order(Feature.name)
+    q = q.filter(Feature.ot_milestone_desktop_start == milestone)
+    desktop_origin_trial_features_future = q.fetch_async(None)
+
+    # Features that are in origin trial (Android) in this milestone
+    q = Feature.query()
+    q = q.order(Feature.name)
+    q = q.filter(Feature.ot_milestone_android_start == milestone)
+    q = q.filter(Feature.ot_milestone_desktop_start == None)
+    android_origin_trial_features_future = q.fetch_async(None)
+
+    # Features that are in dev trial (Desktop) in this milestone
+    q = Feature.query()
+    q = q.order(Feature.name)
+    q = q.filter(Feature.dt_milestone_desktop_start == milestone)
+    desktop_dev_trial_features_future = q.fetch_async(None)
+
+    # Features that are in dev trial (Android) in this milestone
+    q = Feature.query()
+    q = q.order(Feature.name)
+    q = q.filter(Feature.dt_milestone_android_start == milestone)
+    q = q.filter(Feature.dt_milestone_desktop_start == None)
+    android_dev_trial_features_future = q.fetch_async(None)
+
+    # Wait for all futures to complete.
+    desktop_shipping_features = desktop_shipping_features_future.result()
+    android_only_shipping_features = (
+        android_only_shipping_features_future.result())
+    desktop_origin_trial_features = (
+        desktop_origin_trial_features_future.result())
+    android_origin_trial_features = (
+        android_origin_trial_features_future.result())
+    desktop_dev_trial_features = desktop_dev_trial_features_future.result()
+    android_dev_trial_features = android_dev_trial_features_future.result()
 
     # Push feature to list corresponding to the implementation status of feature in queried milestone
     for feature in desktop_shipping_features:
@@ -953,13 +1004,6 @@ class Feature(DictModel):
       elif feature.feature_type == FEATURE_TYPE_INCUBATE_ID:
           all_features[IMPLEMENTATION_STATUS[ENABLED_BY_DEFAULT]].append(feature)
 
-    # Features with an android shipping milestone but no desktop milestone.
-    q = Feature.query()
-    q = q.order(Feature.name)
-    q = q.filter(Feature.shipped_android_milestone == milestone)
-    q = q.filter(Feature.shipped_milestone == None)
-    android_only_shipping_features = q.fetch(None)
-
     # Push feature to list corresponding to the implementation status of feature in queried milestone
     for feature in android_only_shipping_features:
       if feature.impl_status_chrome == ENABLED_BY_DEFAULT:
@@ -973,53 +1017,35 @@ class Feature(DictModel):
       elif feature.feature_type == FEATURE_TYPE_INCUBATE_ID:
           all_features[IMPLEMENTATION_STATUS[ENABLED_BY_DEFAULT]].append(feature)
 
-    # Features that are in origin trial (Desktop) in this milestone
-    q = Feature.query()
-    q = q.order(Feature.name)
-    q = q.filter(Feature.ot_milestone_desktop_start == milestone)
-    desktop_origin_trial_features = q.fetch(None)
     for feature in desktop_origin_trial_features:
       all_features[IMPLEMENTATION_STATUS[ORIGIN_TRIAL]].append(feature)
 
-    # Features that are in origin trial (Android) in this milestone
-    q = Feature.query()
-    q = q.order(Feature.name)
-    q = q.filter(Feature.ot_milestone_android_start == milestone)
-    q = q.filter(Feature.ot_milestone_desktop_start == None)
-    android_origin_trial_features = q.fetch(None)
     for feature in android_origin_trial_features:
       all_features[IMPLEMENTATION_STATUS[ORIGIN_TRIAL]].append(feature)
 
-    # Features that are in dev trial (Desktop) in this milestone
-    q = Feature.query()
-    q = q.order(Feature.name)
-    q = q.filter(Feature.dt_milestone_desktop_start == milestone)
-    desktop_dev_trial_features = q.fetch(None)
     for feature in desktop_dev_trial_features:
       all_features[IMPLEMENTATION_STATUS[BEHIND_A_FLAG]].append(feature)
 
-    # Features that are in dev trial (Android) in this milestone
-    q = Feature.query()
-    q = q.order(Feature.name)
-    q = q.filter(Feature.dt_milestone_android_start == milestone)
-    q = q.filter(Feature.dt_milestone_desktop_start == None)
-    android_dev_trial_features = q.fetch(None)
     for feature in android_dev_trial_features:
       all_features[IMPLEMENTATION_STATUS[BEHIND_A_FLAG]].append(feature)
 
-    feature_list = {}
-    allowed_feature_list = {}
+    features_by_type = {}
+    allowed_features_by_type = {}
 
-    # Constructor the proper format.
+    # Construct results as: {type: [json_feature, ...], ...}.
     for shippingType in all_features:
       all_features[shippingType].sort(key=lambda f: f.name)
-      all_features[shippingType] = [f for f in all_features[shippingType] if not f.deleted]
-      feature_list[shippingType] = [f.format_for_template() for f in all_features[shippingType]]
-      allowed_feature_list[shippingType] = [
-        f for f in feature_list[shippingType]
+      all_features[shippingType] = [
+          f for f in all_features[shippingType] if not f.deleted]
+      features_by_type[shippingType] = [
+          f.format_for_template() for f in all_features[shippingType]]
+      allowed_features_by_type[shippingType] = [
+        f for f in features_by_type[shippingType]
         if show_unlisted or not f['unlisted']]
 
-    return allowed_feature_list
+    ramcache.set(cache_key, allowed_features_by_type)
+
+    return allowed_features_by_type
 
   @classmethod
   def get_shipping_samples(self, limit=None, update_cache=False):

--- a/internals/models_test.py
+++ b/internals/models_test.py
@@ -173,6 +173,12 @@ class FeatureTest(testing_config.CustomTestCase):
         enabled_by_default)
     self.assertEqual(6, len(actual))
 
+    cache_key = '%s|%s|%s|%s' % (
+        models.Feature.DEFAULT_CACHE_KEY, 'milestone', False, 1)
+    cached_result = ramcache.get(cache_key)
+    self.assertEqual(cached_result, actual)
+
+
   def test_get_in_milestone__unlisted(self):
     """Unlisted features should not be listed for users who can't edit."""
     self.feature_2.unlisted = True
@@ -220,6 +226,17 @@ class FeatureTest(testing_config.CustomTestCase):
     self.assertEqual(
         1,
         len(actual['Removed']))
+
+  def test_get_in_milestone__cached(self):
+    """If there is something in the cache, we use it."""
+    cache_key = '%s|%s|%s|%s' % (
+        models.Feature.DEFAULT_CACHE_KEY, 'milestone', False, 1)
+    ramcache.set(cache_key, 'fake feature dict')
+
+    actual = models.Feature.get_in_milestone(milestone=1)
+    self.assertEqual(
+        'fake feature dict',
+        actual)
 
 
 class ApprovalTest(testing_config.CustomTestCase):


### PR DESCRIPTION
This PR reduces the latency on requests to `/api/v0/features?milestone=<number>`.

On staging for a cache hit, the time is reduced from 400-500ms to 140-200ms.  A roughly 60% speedup.
On prod for a cache miss, the time is reduced from 400-700ms to 250-450ms. A roughly 40% speedup.
On prod for a cache miss, the time is reduced from 400-700ms to 120-400ms. A roughly 50% speedup.
The absolute number of ms saved on the page load is 200-300ms and does feel faster.
Scrolling to past or future releases is also a little faster, which fells more responsive when the user clicks rapidly.

In this PR:
+ In `models.Feature.get_in_milestone()`, move all the queries closer to the top of the function, and make them all use fetch_async().  After all the queries have been started, wait for them all to finish.
+ Add a check for cached results at the top of that function and set the cached results at the bottom.
+ Rename some of the result variables to clarify the structure of those values.
