### PR TITLE
Fix a test failure in api/.

### DIFF
--- a/api/accounts_api_test.py
+++ b/api/accounts_api_test.py
@@ -88,8 +88,8 @@ class AccountsAPITest(testing_config.CustomTestCase):
     testing_config.sign_in('admin@example.com', 123567890)
 
     json_data = {'isAdmin': False}  # No email
-    with register.app.test_request_context(self.request_path):
-      with self.assertRaises(werkzeug.exceptions.BadRequest, json=json_data):
+    with register.app.test_request_context(self.request_path, json=json_data):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_post()
 
     new_appuser = (models.AppUser.query(models.AppUser.email == 'new@example.com').get())


### PR DESCRIPTION
I think this was a long standing defect in the code that has nothing to do with python 2 or 3.
I guess the python2 version of the flask library had a wildcard for these keywords, while it is checked more strictly in py3.
