### PR TITLE
Fix tests in pages/ and internals/.

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -380,8 +380,8 @@ class FlaskHandler(BaseHandler):
   def split_input(self, field_name, delim='\\r?\\n'):
     """Split the input lines, strip whitespace, and skip blank lines."""
     input_text = flask.request.form.get(field_name) or ''
-    return filter(bool, [
-        x.strip() for x in re.split(delim, input_text)])
+    return [x.strip() for x in re.split(delim, input_text)
+            if x]
 
   def split_emails(self, param_name):
     """Split one input field and construct objects for ndb.StringProperty()."""

--- a/internals/fetchmetrics.py
+++ b/internals/fetchmetrics.py
@@ -261,9 +261,9 @@ class HistogramsHandler(basehandlers.FlaskHandler):
     # Save bucket ids for each histogram type, FeatureObserver and
     # MappedCSSProperties.
     for histogram_id in self.MODEL_CLASS.keys():
-      enum = filter(
+      enum = list(filter(
           lambda enum: enum.attributes['name'].value == histogram_id,
-          enum_tags)[0]
+          enum_tags))[0]
       for child in enum.getElementsByTagName('int'):
         self._SaveData({
           'bucket_id': child.attributes['value'].value,

--- a/internals/models.py
+++ b/internals/models.py
@@ -500,7 +500,7 @@ class Feature(DictModel):
 
   @classmethod
   def _first_of_milestone(self, feature_list, milestone, start=0):
-    for i in xrange(start, len(feature_list)):
+    for i in range(start, len(feature_list)):
       f = feature_list[i]
       if (str(f['shipped_milestone']) == str(milestone) or
           f['impl_status_chrome'] == str(milestone)):
@@ -513,7 +513,7 @@ class Feature(DictModel):
 
   @classmethod
   def _first_of_milestone_v2(self, feature_list, milestone, start=0):
-    for i in xrange(start, len(feature_list)):
+    for i in range(start, len(feature_list)):
       f = feature_list[i]
       desktop_milestone = f['browsers']['chrome'].get('desktop', None)
       android_milestone = f['browsers']['chrome'].get('android', None)
@@ -537,7 +537,7 @@ class Feature(DictModel):
       canary_versions = [x for x in win_versions if x.get('channel') and x.get('channel').startswith('canary')]
       LATEST_VERSION = int(canary_versions[0].get('version').split('.')[0])
 
-      milestones = range(1, LATEST_VERSION + 1)
+      milestones = list(range(1, LATEST_VERSION + 1))
       milestones.reverse()
       versions = [
         IMPLEMENTATION_STATUS[PROPOSED],

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -270,8 +270,8 @@ class FeatureEditStageTest(testing_config.CustomTestCase):
   def test_post__non_allowed(self):
     """Non-allowed cannot edit features, gets a 403."""
     testing_config.sign_in('user1@example.com', 1234567890)
-    with guide.app.test_request_context(self.request_path):
-      with self.assertRaises(werkzeug.exceptions.Forbidden, method='POST'):
+    with guide.app.test_request_context(self.request_path, method='POST'):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.process_post_data(
             self.feature_1.key.integer_id(), self.stage)
 


### PR DESCRIPTION
The main causes of these failures were either:
* Long-standing careless defects in the way that we created test HTTP requests
* Py3 standard library changes: xrange to range, and the fact that range and filter return iterators now.