### PR TITLE
Create py2 test target for internals.sendemail_test

### DIFF
--- a/.github/workflows/ci_py2.yml
+++ b/.github/workflows/ci_py2.yml
@@ -1,0 +1,44 @@
+name: Continuous Integration py2
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  python2_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: set up Python2
+        uses: actions/setup-python@v2
+        with:
+          python-version: '2.8'
+
+      - name: pre-installation
+        run: |
+          # Remove existing google-cloud-sdk packages in Ubuntu.
+          sudo rm -rf /usr/lib/google-cloud-sdk
+          curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-353.0.0-linux-x86_64.tar.gz | tar -zx > /dev/null
+          # Substitute the downloaded google-cloud-sdk packages, due to https://stackoverflow.com/questions/42697026/install-google-cloud-components-error-from-gcloud-command.
+          sudo mv google-cloud-sdk /usr/lib/
+          sudo gcloud components update
+          sudo gcloud components install app-engine-python beta cloud-datastore-emulator app-engine-python-extras
+          gcloud config set project cr-status-staging
+          gcloud version
+
+      - name: installation
+        run: |
+          npm install -g gulp
+          npm ci
+          python -m pip install -t lib -r requirements.txt --upgrade
+          python -m pip install --no-deps -r requirements.dev.txt
+
+      - name: lint
+        run: npm run lint
+
+      - name: test
+        run: python -m unittest discover -p '*_py2test.py'
+
+      - name: build
+        run: npm run build

--- a/.github/workflows/ci_py2.yml
+++ b/.github/workflows/ci_py2.yml
@@ -13,7 +13,7 @@ jobs:
       - name: set up Python2
         uses: actions/setup-python@v2
         with:
-          python-version: '2.8'
+          python-version: '2.7'
 
       - name: pre-installation
         run: |

--- a/internals/sendemail_py2test.py
+++ b/internals/sendemail_py2test.py
@@ -17,11 +17,8 @@ from __future__ import print_function
 
 import collections
 import json
-import testing_config  # Must be imported before the module under test.
-
-import flask
+import testing_config_py2  # Must be imported before the module under test.
 import mock
-import werkzeug.exceptions  # Flask HTTP stuff.
 
 from google.appengine.api import mail
 
@@ -29,7 +26,7 @@ import settings
 from internals import models
 from internals import sendemail
 
-class OutboundEmailHandlerTest(testing_config.CustomTestCase):
+class OutboundEmailHandlerTest(unittest.TestCase):
 
   def setUp(self):
     self.handler = sendemail.OutboundEmailHandler()
@@ -105,7 +102,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
     self.assertEqual({'message': 'Done'}, actual_response)
 
 
-class BouncedEmailHandlerTest(testing_config.CustomTestCase):
+class BouncedEmailHandlerTest(unittest.TestCase):
 
   def setUp(self):
     self.handler = sendemail.BouncedEmailHandler()
@@ -131,7 +128,7 @@ class BouncedEmailHandlerTest(testing_config.CustomTestCase):
         notify_as_starrer=False)
     starrer_3_pref.put()
 
-    bounce_message = testing_config.Blank(
+    bounce_message = testing_config_py2.Blank(
         original={'to': 'starrer_3@example.com',
                   'from': 'sender',
                   'subject': 'subject',
@@ -157,7 +154,7 @@ class BouncedEmailHandlerTest(testing_config.CustomTestCase):
     """When we get a bounce, we create the UserPrefs for that user."""
     # Note, no existing UserPref for starrer_4.
 
-    bounce_message = testing_config.Blank(
+    bounce_message = testing_config_py2.Blank(
         original={'to': 'starrer_4@example.com',
                   'from': 'sender',
                   'subject': 'subject',

--- a/testing_config_py2.py
+++ b/testing_config_py2.py
@@ -1,0 +1,61 @@
+from __future__ import division
+from __future__ import print_function
+
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import sys
+import unittest
+
+app_engine_path = os.environ.get('APP_ENGINE_PATH', '')
+if not app_engine_path:
+  app_engine_path = '/usr/lib/google-cloud-sdk/platform/google_appengine'
+if not os.path.exists(app_engine_path):
+  # app_engine_path for GitHub Action CI.
+  app_engine_path = '/usr/local/google/home/kyleju/google-cloud-sdk/platform/google_appengine'
+if os.path.exists(app_engine_path):
+  sys.path.insert(0, app_engine_path)
+else:
+  print('Could not find appengine, please set APP_ENGINE_PATH',
+        file=sys.stderr)
+  sys.exit(1)
+
+import dev_appserver
+dev_appserver.fix_sys_path()
+
+lib_path = os.path.join(os.path.dirname(__file__), 'lib')
+from google.appengine.ext import vendor
+vendor.add(lib_path) # add third party libs to "lib" folder.
+
+os.environ['DJANGO_SECRET'] = 'test secret'
+os.environ['SERVER_SOFTWARE'] = 'test ' + os.environ.get('SERVER_SOFTWARE', '')
+os.environ['CURRENT_VERSION_ID'] = 'test.123'
+os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
+os.environ['APPLICATION_ID'] = 'testing'
+
+
+class Blank(object):
+  """Simple class that assigns all named args to attributes.
+  Tip: supply a lambda to define a method.
+  """
+  def __init__(self, **kwargs):
+    vars(self).update(kwargs)
+  def __repr__(self):
+    return '%s(%s)' % (self.__class__.__name__, str(vars(self)))
+  def __eq__(self, other):
+    if other is None:
+      return False
+    return vars(self) == vars(other)

--- a/testing_config_py2.py
+++ b/testing_config_py2.py
@@ -23,9 +23,6 @@ import unittest
 app_engine_path = os.environ.get('APP_ENGINE_PATH', '')
 if not app_engine_path:
   app_engine_path = '/usr/lib/google-cloud-sdk/platform/google_appengine'
-if not os.path.exists(app_engine_path):
-  # app_engine_path for GitHub Action CI.
-  app_engine_path = '/usr/local/google/home/kyleju/google-cloud-sdk/platform/google_appengine'
 if os.path.exists(app_engine_path):
   sys.path.insert(0, app_engine_path)
 else:


### PR DESCRIPTION
- Rename internals/sendemail_test.py to internals/sendemail_py2test.py and exclude it from `Continuous Integration / python_tests (pull_request)`

- Create a separate python2 test target on CI

- Duplicate the testing_config.py file and remove `ndb` dependencies for the py2 test