### PR TITLE
Fix nonce type to be a string.

### DIFF
--- a/framework/csp.py
+++ b/framework/csp.py
@@ -74,7 +74,8 @@ HEADER_KEY_REPORT_ONLY = 'Content-Security-Policy-Report-Only'
 def get_nonce():
   """Returns a random nonce."""
   length = NONCE_LENGTH
-  return base64.b64encode(os.urandom(length * 2))[:length]
+  b_nonce = base64.b64encode(os.urandom(length * 2))[:length]
+  return b_nonce.decode()
 
 
 def get_default_policy(nonce=None):

--- a/framework/csp_test.py
+++ b/framework/csp_test.py
@@ -50,16 +50,18 @@ class CspTest(unittest.TestCase):
   @mock.patch('framework.csp.USE_NONCE_ONLY_POLICY', False)
   def test_get_default_policy__strict(self):
     """We can get the regular strict policy."""
-    policy = csp.get_default_policy(nonce=12345)
+    policy = csp.get_default_policy(nonce='12345')
     self.assertCountEqual(csp.DEFAULT_POLICY.keys(), policy.keys())
     self.assertIn('strict-dynamic', policy['script-src'])
+    self.assertIn("'nonce-12345'", policy['script-src'])
 
   @mock.patch('framework.csp.USE_NONCE_ONLY_POLICY', True)
   def test_get_default_policy__strict(self):
     """We can get the even stricter nonce-only policy."""
-    policy = csp.get_default_policy(nonce=12345)
+    policy = csp.get_default_policy(nonce='12345')
     self.assertCountEqual(csp.NONCE_ONLY_POLICY.keys(), policy.keys())
     self.assertNotIn('strict-dynamic', policy['script-src'])
+    self.assertIn("'nonce-12345'", policy['script-src'])
 
   @mock.patch('framework.csp.REPORT_ONLY', False)
   def test_get_csp_header_key__enforced(self):
@@ -88,7 +90,7 @@ class CspTest(unittest.TestCase):
   @mock.patch('framework.csp.REPORT_ONLY', True)
   def test_get_headers(self):
     """We can get a complete header dict."""
-    actual = csp.get_headers(12345)
+    actual = csp.get_headers('12345')
     self.assertIn('12345', actual[csp.HEADER_KEY_REPORT_ONLY])
 
 


### PR DESCRIPTION
None of the JS was loading because it was all failing CSP checks.  We use a nonce to indicate that our JS code is really ours.  That nonce should be a string.  But in py3 it was a bytes object, so we need to decode().