### PR TITLE
Some easy pylint fixes.

### DIFF
--- a/api/accounts_api.py
+++ b/api/accounts_api.py
@@ -42,7 +42,8 @@ class AccountsAPI(basehandlers.APIHandler):
   def create_account(self, email, is_admin):
     """Create and store a new account entity."""
     # Don't add a duplicate email address.
-    user = models.AppUser.query(models.AppUser.email == email).get(keys_only=True)
+    user = models.AppUser.query(
+        models.AppUser.email == email).get(keys_only=True)
     if not user:
       user = models.AppUser(email=str(email))
       user.is_admin = is_admin

--- a/api/accounts_api_test.py
+++ b/api/accounts_api_test.py
@@ -54,7 +54,8 @@ class AccountsAPITest(testing_config.CustomTestCase):
     self.assertEqual('new@example.com', actual_json['email'])
     self.assertFalse(actual_json['is_admin'])
 
-    new_appuser = (models.AppUser.query(models.AppUser.email == 'new@example.com').get())
+    new_appuser = (models.AppUser.query(
+        models.AppUser.email == 'new@example.com').get())
     self.assertEqual('new@example.com', new_appuser.email)
     self.assertFalse(new_appuser.is_admin)
 
@@ -68,7 +69,8 @@ class AccountsAPITest(testing_config.CustomTestCase):
     self.assertEqual('new_admin@example.com', actual_json['email'])
     self.assertTrue(actual_json['is_admin'])
 
-    new_appuser = (models.AppUser.query(models.AppUser.email == 'new_admin@example.com').get())
+    new_appuser = models.AppUser.query(
+        models.AppUser.email == 'new_admin@example.com').get()
     self.assertEqual('new_admin@example.com', new_appuser.email)
     self.assertTrue(new_appuser.is_admin)
 
@@ -80,7 +82,8 @@ class AccountsAPITest(testing_config.CustomTestCase):
       with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.do_post(self.appuser_id)
 
-    new_appuser = (models.AppUser.query(models.AppUser.email == 'new@example.com').get())
+    new_appuser = models.AppUser.query(
+        models.AppUser.email == 'new@example.com').get()
     self.assertIsNone(new_appuser)
 
   def test_create__invalid(self):
@@ -92,7 +95,8 @@ class AccountsAPITest(testing_config.CustomTestCase):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_post()
 
-    new_appuser = (models.AppUser.query(models.AppUser.email == 'new@example.com').get())
+    new_appuser = models.AppUser.query(
+        models.AppUser.email == 'new@example.com').get()
     self.assertIsNone(new_appuser)
 
   def test_create__duplicate(self):

--- a/api/channels_api.py
+++ b/api/channels_api.py
@@ -97,7 +97,8 @@ class ChannelsAPI(basehandlers.APIHandler):
 
   def do_get(self):
     # Query-string parameters 'start' and 'end' are provided
-    if self.request.args.get('start') is not None and self.request.args.get('end') is not None:
+    if (self.request.args.get('start') is not None and
+        self.request.args.get('end') is not None):
       try:
         start = int(self.request.args.get('start'))
         end = int(self.request.args.get('end'))
@@ -108,7 +109,7 @@ class ChannelsAPI(basehandlers.APIHandler):
         self.abort(400, msg='Invalid  Start and End Values provided')
     else:
       channels = construct_chrome_channels_details()
-    
+
     return channels
 
   # TODO(jrobbins): do_post

--- a/api/cues_api.py
+++ b/api/cues_api.py
@@ -37,7 +37,7 @@ class CuesAPI(basehandlers.APIHandler):
   def do_post(self):
     """Dismisses a cue card for the signed in user."""
     cue = self.get_param('cue', allowed=ALLOWED_CUES)
-    user = self.get_current_user(required=True)
+    unused_user = self.get_current_user(required=True)
 
     models.UserPref.dismiss_cue(cue)
     # Callers don't use the JSON response for this API call.

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -94,7 +94,7 @@ class FeaturesAPITestDelete(testing_config.CustomTestCase):
 
     revised_feature = models.Feature.get_by_id(self.feature_id)
     self.assertFalse(revised_feature.deleted)
-  
+
 
 class FeaturesAPITestGet(testing_config.CustomTestCase):
 
@@ -125,8 +125,8 @@ class FeaturesAPITestGet(testing_config.CustomTestCase):
     with register.app.test_request_context(self.request_path):
       actual_response = self.handler.do_get()
 
-    # Comparing only the total number of features and name of the feature 
-    # as certain fields like `updated` cannot be compared 
+    # Comparing only the total number of features and name of the feature
+    # as certain fields like `updated` cannot be compared
     self.assertEqual(1, len(actual_response))
     self.assertEqual('feature one', actual_response[0]['name'])
 
@@ -137,7 +137,7 @@ class FeaturesAPITestGet(testing_config.CustomTestCase):
 
     # No signed-in user
     with register.app.test_request_context(self.request_path):
-      actual_response = self.handler.do_get() 
+      actual_response = self.handler.do_get()
     self.assertEqual(0, len(actual_response))
 
     # Signed-in user with no permissions
@@ -215,6 +215,7 @@ class FeaturesAPITestGet(testing_config.CustomTestCase):
     """Invalid value of milestone should not be processed."""
 
     # Feature is present in milestone
-    with register.app.test_request_context(self.request_path+'?milestone=chromium'):
+    with register.app.test_request_context(
+        self.request_path + '?milestone=chromium'):
       actual_response = self.handler.do_get()
     mock_abort.assert_called_once_with(400, description='Invalid  Milestone')

--- a/api/login_api.py
+++ b/api/login_api.py
@@ -34,7 +34,7 @@ class LoginAPI(basehandlers.APIHandler):
     message = "Unable to Authenticate"
 
     try:
-      idinfo = id_token.verify_oauth2_token(
+      unused_idinfo = id_token.verify_oauth2_token(
           token, requests.Request(),
           settings.GOOGLE_SIGN_IN_CLIENT_ID)
       # userid = idinfo['sub']
@@ -44,6 +44,5 @@ class LoginAPI(basehandlers.APIHandler):
       # print(idinfo['email'], file=sys.stderr)
     except ValueError:
       message = "Invalid token"
-      pass
 
     return {'message': message}

--- a/api/metricsdata.py
+++ b/api/metricsdata.py
@@ -79,7 +79,8 @@ class TimelineHandler(basehandlers.FlaskHandler):
     # does not make sense, filter out everything before the 2017-10-26 switch.
     # See https://github.com/GoogleChrome/chromium-dashboard/issues/414
     if self.MODEL_CLASS == models.AnimatedProperty:
-      query = query.filter(self.MODEL_CLASS.date >= datetime.datetime(2017, 10, 26))
+      query = query.filter(
+          self.MODEL_CLASS.date >= datetime.datetime(2017, 10, 26))
     return query
 
   def get_template_data(self):
@@ -147,7 +148,8 @@ class FeatureHandler(basehandlers.FlaskHandler):
     # That operation is fast and makes most of the iterations
     # of the main loop become in-RAM operations.
     batch_datapoints_query = self.MODEL_CLASS.query()
-    batch_datapoints_query = batch_datapoints_query.order(-self.MODEL_CLASS.date)
+    batch_datapoints_query = batch_datapoints_query.order(
+        -self.MODEL_CLASS.date)
     batch_datapoints_list = batch_datapoints_query.fetch(5000)
     logging.info('batch query found %r recent datapoints',
                  len(batch_datapoints_list))
@@ -189,7 +191,8 @@ class FeatureHandler(basehandlers.FlaskHandler):
 
     else:
       properties = ramcache.get(self.CACHE_KEY)
-      logging.info('looked at cache %r and found %r', self.CACHE_KEY, properties)
+      logging.info(
+          'looked at cache %r and found %r', self.CACHE_KEY, properties)
       if properties is None:
         logging.info('Loading properties from datastore')
         properties = self.__query_metrics_for_properties()
@@ -238,10 +241,10 @@ class FeatureBucketsHandler(basehandlers.FlaskHandler):
   def get_template_data(self, prop_type):
     if prop_type == 'cssprops':
       properties = sorted(
-          list(models.CssPropertyHistogram.get_all().items()), key=lambda x:x[1])
+          models.CssPropertyHistogram.get_all().items(), key=lambda x:x[1])
     else:
       properties = sorted(
-          list(models.FeatureObserverHistogram.get_all().items()), key=lambda x:x[1])
+          models.FeatureObserverHistogram.get_all().items(), key=lambda x:x[1])
 
     return properties
 

--- a/api/stars_api.py
+++ b/api/stars_api.py
@@ -47,6 +47,7 @@ class StarsAPI(basehandlers.APIHandler):
     starred = self.get_bool_param('starred', default=True)
     user = self.get_current_user(required=True)
 
-    notifier.FeatureStar.set_star(user.email(), feature.key.integer_id(), starred)
+    notifier.FeatureStar.set_star(
+        user.email(), feature.key.integer_id(), starred)
     # Callers don't use the JSON response for this API call.
     return {'message': 'Done'}

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -375,7 +375,8 @@ class APIHandlerTests(testing_config.CustomTestCase):
         'valid body token', 'user@example.com')
 
   @mock.patch('framework.basehandlers.APIHandler.validate_token')
-  def test_require_signed_in_and_xsrf_token__OK_header(self, mock_validate_token):
+  def test_require_signed_in_and_xsrf_token__OK_header(
+      self, mock_validate_token):
     """User is signed in and has a token in the request header."""
     testing_config.sign_in('user@example.com', 111)
     headers = {'X-Xsrf-Token': 'valid header token'}

--- a/framework/csp_test.py
+++ b/framework/csp_test.py
@@ -42,7 +42,7 @@ class CspTest(unittest.TestCase):
   def test_get_nonce(self):
     """Many different nonce values are all different."""
     nonces = []
-    for i in range(1000):
+    for _ in range(1000):
       nonces.append(csp.get_nonce())
 
     self.assertEqual(len(nonces), len(set(nonces)))
@@ -51,14 +51,14 @@ class CspTest(unittest.TestCase):
   def test_get_default_policy__strict(self):
     """We can get the regular strict policy."""
     policy = csp.get_default_policy(nonce=12345)
-    self.assertCountEqual(list(csp.DEFAULT_POLICY.keys()), list(policy.keys()))
+    self.assertCountEqual(csp.DEFAULT_POLICY.keys(), policy.keys())
     self.assertIn('strict-dynamic', policy['script-src'])
 
   @mock.patch('framework.csp.USE_NONCE_ONLY_POLICY', True)
   def test_get_default_policy__strict(self):
     """We can get the even stricter nonce-only policy."""
     policy = csp.get_default_policy(nonce=12345)
-    self.assertCountEqual(list(csp.NONCE_ONLY_POLICY.keys()), list(policy.keys()))
+    self.assertCountEqual(csp.NONCE_ONLY_POLICY.keys(), policy.keys())
     self.assertNotIn('strict-dynamic', policy['script-src'])
 
   @mock.patch('framework.csp.REPORT_ONLY', False)

--- a/framework/ramcache_test.py
+++ b/framework/ramcache_test.py
@@ -109,7 +109,8 @@ class SharedInvalidateTests(testing_config.CustomTestCase):
   def assertTimestampWasUpdated(self, start_time):
 
     singleton = None
-    entities = ramcache.SharedInvalidate.query(ancestor=ramcache.SharedInvalidate.PARENT_KEY).fetch(1)
+    entities = ramcache.SharedInvalidate.query(
+        ancestor=ramcache.SharedInvalidate.PARENT_KEY).fetch(1)
     if entities:
       singleton = entities[0]
 

--- a/framework/secrets_test.py
+++ b/framework/secrets_test.py
@@ -33,7 +33,7 @@ class SecretsFunctionsTest(testing_config.CustomTestCase):
   def test_make_random_key__distinct(self):
     """The random keys are different."""
     key_set = set()
-    for i in range(1000):
+    for _ in range(1000):
       key_set.add(secrets.make_random_key())
     self.assertEqual(1000, len(key_set))
 

--- a/framework/users.py
+++ b/framework/users.py
@@ -8,16 +8,18 @@ import settings
 class User(object):
     """Provides the email address, nickname, and ID for a user.
 
-    A nickname is a human-readable string that uniquely identifies a Google user,
-    akin to a username. For some users, this nickname is an email address, but for
-    other users, a different nickname is used.
+    A nickname is a human-readable string that uniquely identifies a
+    Google user, akin to a username. For some users, this nickname is
+    an email address, but for other users, a different nickname is
+    used.
 
     A user is a Google Accounts user.
 
-    `federated_identity` and `federated_provider` are decommissioned and should
-    not be used.
+    `federated_identity` and `federated_provider` are decommissioned
+    and should not be used.
 
     This class is based on google.appengine.api.users.User class
+
     """
 
 
@@ -54,9 +56,10 @@ class User(object):
     def nickname(self):
         """Returns the user's nickname.
 
-        The nickname will be a unique, human readable identifier for this user with
-        respect to this application. It will be an email address for some users,
-        and part of the email address for some users.
+        The nickname will be a unique, human readable identifier for
+        this user with respect to this application. It will be an
+        email address for some users, and part of the email address
+        for some users.
 
         Returns:
         The nickname of the user as a string.
@@ -80,8 +83,8 @@ class User(object):
         """Obtains the user ID of the user.
 
         Returns:
-        A permanent unique identifying string or `None`. If the email address was
-        set explicity, this will return `None`.
+        A permanent unique identifying string or `None`. If the email
+        address was set explicity, this will return `None`.
         """
         return self.__user_id
 
@@ -90,8 +93,8 @@ class User(object):
         """Obtains the user's authentication domain.
 
         Returns:
-        A string containing the authentication domain. This method is internal and
-        should not be used by client applications.
+        A string containing the authentication domain. This method is
+        internal and should not be used by client applications.
         """
         return self.__auth_domain
 
@@ -100,8 +103,8 @@ class User(object):
         """Decommissioned, don't use.
 
         Returns:
-        A string containing the federated identity of the user. If the user is not
-        a federated user, `None` is returned.
+        A string containing the federated identity of the user. If the
+        user is not a federated user, `None` is returned.
         """
         return self.__federated_identity
 
@@ -110,8 +113,8 @@ class User(object):
         """Decommissioned, don't use.
 
         Returns:
-        A string containing the federated provider. If the user is not a federated
-        user, `None` is returned.
+        A string containing the federated provider. If the user is not
+        a federated user, `None` is returned.
         """
         return self.__federated_provider
 
@@ -148,11 +151,11 @@ class User(object):
             return cmp((self.__email, self.__auth_domain),
                         (other.__email, other.__auth_domain))
 
-    def get_current_user():
-        """Retrieves information associated with the user that is making a request.
+    def get_current_user(self):
+        """Retrieves information associated with the requesting user.
 
         Returns:
-
+        The current user object.
         """
         try:
             return User()
@@ -160,20 +163,22 @@ class User(object):
             return None
 
 
-    def is_current_user_admin():
+    def is_current_user_admin(self):
         """Specifies whether the user making a request is an application admin.
 
-        Because administrator status is not persisted in the datastore,
-        `is_current_user_admin()` is a separate function rather than a member function
-        of the `User` class. The status only exists for the user making the current
-        request.
+        Because administrator status is not persisted in the
+        datastore, `is_current_user_admin()` is a separate function
+        rather than a member function of the `User` class. The status
+        only exists for the user making the current request.
 
         Returns:
-        `True` if the user is an administrator; all other user types return `False`.
+        `True` if the user is an administrator; all other user types
+        return `False`.
         """
 
-        # This environment variable was set by GAE based on a GAE session cookie.
-        # With Google Sign-In, it will probably never be present. Hence, currently is always False
+        # This env variable was set by GAE based on a GAE session cookie.
+        # With Google Sign-In, it will probably never be present.
+        # Hence, currently is always False
         # TODO (jrobbins): Implement this method
         return (os.environ.get('USER_IS_ADMIN', '0')) == '1'
 

--- a/framework/xsrf.py
+++ b/framework/xsrf.py
@@ -68,7 +68,8 @@ def generate_token(user_email, token_time=None):
   """
   token_time = token_time or int(time.time())
   token_time = str(token_time).encode()
-  digester = hmac.new(secrets.get_xsrf_secret().encode(), digestmod=hashlib.sha256)
+  digester = hmac.new(secrets.get_xsrf_secret().encode(),
+                      digestmod=hashlib.sha256)
   digester.update(user_email.encode() if user_email else b'')
   digester.update(DELIMITER)
   digester.update(token_time)

--- a/internals/fetchmetrics.py
+++ b/internals/fetchmetrics.py
@@ -45,7 +45,8 @@ CAPSTONE_BUCKET_ID = -1
 @utils.retry(3, delay=30, backoff=2)
 def _FetchMetrics(url):
   if settings.PROD or settings.STAGING:
-    # follow_redirects=False according to https://cloud.google.com/appengine/docs/python/appidentity/#asserting_identity_to_other_app_engine_apps
+    # follow_redirects=False according to
+    # https://cloud.google.com/appengine/docs/python/appidentity/#asserting_identity_to_other_app_engine_apps
     # GAE request limit is 60s, but it could go longer due to start-up latency.
     logging.info('Requesting metrics from: %r', url)
     return requests.request('GET', url, timeout=120.0, allow_redirects=False)
@@ -251,7 +252,8 @@ class HistogramsHandler(basehandlers.FlaskHandler):
     # Save bucket ids for each histogram type, FeatureObserver and
     # MappedCSSProperties.
     for histogram_id in list(self.MODEL_CLASS.keys()):
-      enum = [enum for enum in enum_tags if enum.attributes['name'].value == histogram_id][0]
+      enum = [enum for enum in enum_tags
+              if enum.attributes['name'].value == histogram_id][0]
       for child in enum.getElementsByTagName('int'):
         self._SaveData({
           'bucket_id': child.attributes['value'].value,

--- a/internals/fetchmetrics_test.py
+++ b/internals/fetchmetrics_test.py
@@ -108,7 +108,7 @@ class YesterdayHandlerTest(testing_config.CustomTestCase):
     expected_calls = [
         mock.call(datetime.date(2021, 1, day))
         for day in [19, 18, 17, 16, 15]
-        for query in fetchmetrics.UMA_QUERIES]
+        for unused_query in fetchmetrics.UMA_QUERIES]
     mock_FetchAndSaveData.assert_has_calls(expected_calls)
 
   @mock.patch('internals.fetchmetrics.UmaQuery.FetchAndSaveData')
@@ -124,7 +124,7 @@ class YesterdayHandlerTest(testing_config.CustomTestCase):
     self.assertEqual('Success', actual_response)
     expected_calls = [
         mock.call(datetime.date(2021, 1, 20))
-        for query in fetchmetrics.UMA_QUERIES]
+        for unused_query in fetchmetrics.UMA_QUERIES]
     mock_FetchAndSaveData.assert_has_calls(expected_calls)
 
 

--- a/internals/models.py
+++ b/internals/models.py
@@ -411,15 +411,19 @@ class BlinkComponent(DictModel):
 
   @property
   def subscribers(self):
-    return FeatureOwner.query(FeatureOwner.blink_components == self.key).order(FeatureOwner.name).fetch(None)
+    q = FeatureOwner.query(FeatureOwner.blink_components == self.key)
+    q = q.order(FeatureOwner.name)
+    return q.fetch(None)
 
   @property
   def owners(self):
-    return FeatureOwner.query(FeatureOwner.primary_blink_components == self.key).order(FeatureOwner.name).fetch(None)
+    q = FeatureOwner.query(FeatureOwner.primary_blink_components == self.key)
+    q = q.order(FeatureOwner.name)
+    return q.fetch(None)
 
   @classmethod
   def fetch_all_components(self, update_cache=False):
-    """Returns the list of blink components from live endpoint if unavailable in the cache."""
+    """Returns the list of blink components."""
     key = 'blinkcomponents'
 
     components = ramcache.get(key)
@@ -431,7 +435,8 @@ class BlinkComponent(DictModel):
         components = sorted(json.loads(result.content))
         ramcache.set(key, components)
       else:
-        logging.error('Fetching blink components returned: %s' % result.status_code)
+        logging.error('Fetching blink components returned: %s' %
+                      result.status_code)
 
     if not components:
       components = sorted(hack_components.HACK_BLINK_COMPONENTS)
@@ -490,9 +495,11 @@ class Feature(DictModel):
   DEFAULT_CACHE_KEY = 'features'
 
   def __init__(self, *args, **kwargs):
-    # Initialise Feature.blink_components with a default value
-    if 'name' in kwargs:        # If name is present in kwargs then it would mean constructor is being called for creating a
-                                # new feature rather than for fetching an existing feature.
+    # Initialise Feature.blink_components with a default value.  If
+    # name is present in kwargs then it would mean constructor is
+    # being called for creating a new feature rather than for fetching
+    # an existing feature.
+    if 'name' in kwargs:
       if 'blink_components' not in kwargs:
         kwargs['blink_components'] = [BlinkComponent.DEFAULT_COMPONENT]
 
@@ -521,7 +528,8 @@ class Feature(DictModel):
 
       if (str(desktop_milestone) == str(milestone) or status == str(milestone)):
         return i
-      elif (desktop_milestone == None and str(android_milestone) == str(milestone)):
+      elif (desktop_milestone == None and
+            str(android_milestone) == str(milestone)):
         return i
 
     return -1
@@ -534,7 +542,9 @@ class Feature(DictModel):
       win_versions = omaha_data[0]['versions']
 
       # Find the latest canary major version from the list of windows versions.
-      canary_versions = [x for x in win_versions if x.get('channel') and x.get('channel').startswith('canary')]
+      canary_versions = [
+          x for x in win_versions
+          if x.get('channel') and x.get('channel').startswith('canary')]
       LATEST_VERSION = int(canary_versions[0].get('version').split('.')[0])
 
       milestones = list(range(1, LATEST_VERSION + 1))
@@ -750,7 +760,7 @@ class Feature(DictModel):
     d['doc_links'] = '\r\n'.join(self.doc_links)
     d['sample_links'] = '\r\n'.join(self.sample_links)
     d['search_tags'] = ', '.join(self.search_tags)
-    d['blink_components'] = self.blink_components[0] #TODO: support more than one component.
+    d['blink_components'] = self.blink_components[0]
     d['devrel'] = ', '.join(self.devrel)
     d['i2e_lgtms'] = ', '.join(self.i2e_lgtms)
     d['i2s_lgtms'] = ', '.join(self.i2s_lgtms)
@@ -820,7 +830,8 @@ class Feature(DictModel):
         if unformatted_feature.deleted:
           return None
         feature = unformatted_feature.format_for_template()
-        feature['updated_display'] = unformatted_feature.updated.strftime("%Y-%m-%d")
+        feature['updated_display'] = (
+            unformatted_feature.updated.strftime("%Y-%m-%d"))
         feature['new_crbug_url'] = unformatted_feature.new_crbug_url()
         ramcache.set(KEY, feature)
 
@@ -842,7 +853,8 @@ class Feature(DictModel):
       unformatted_feature = future.get_result()
       if unformatted_feature and not unformatted_feature.deleted:
         feature = unformatted_feature.format_for_template()
-        feature['updated_display'] = unformatted_feature.updated.strftime("%Y-%m-%d")
+        feature['updated_display'] = (
+            unformatted_feature.updated.strftime("%Y-%m-%d"))
         feature['new_crbug_url'] = unformatted_feature.new_crbug_url()
         ramcache.set(KEY, feature)
         result_dict[unformatted_feature.key.integer_id()] = feature
@@ -909,7 +921,9 @@ class Feature(DictModel):
 
       shipping_features.extend(android_only_shipping_features)
 
-      shipping_features = [f for f in shipping_features if (IN_DEVELOPMENT < f.impl_status_chrome < NO_LONGER_PURSUING)]
+      shipping_features = [
+          f for f in shipping_features
+          if (IN_DEVELOPMENT < f.impl_status_chrome < NO_LONGER_PURSUING)]
 
       def getSortingMilestone(feature):
         feature._sort_by_milestone = (feature.shipped_milestone or
@@ -965,7 +979,8 @@ class Feature(DictModel):
     all_features[IMPLEMENTATION_STATUS[ORIGIN_TRIAL]] = []
     all_features[IMPLEMENTATION_STATUS[BEHIND_A_FLAG]] = []
 
-    logging.info('Getting chronological feature list in milestone %d', milestone)
+    logging.info('Getting chronological feature list in milestone %d',
+                 milestone)
     # Start each query asynchronously in parallel.
     q = Feature.query()
     q = q.order(Feature.name)
@@ -1016,7 +1031,8 @@ class Feature(DictModel):
     desktop_dev_trial_features = desktop_dev_trial_features_future.result()
     android_dev_trial_features = android_dev_trial_features_future.result()
 
-    # Push feature to list corresponding to the implementation status of feature in queried milestone
+    # Push feature to list corresponding to the implementation status of
+    # feature in queried milestone
     for feature in desktop_shipping_features:
       if feature.impl_status_chrome == ENABLED_BY_DEFAULT:
         all_features[IMPLEMENTATION_STATUS[ENABLED_BY_DEFAULT]].append(feature)
@@ -1026,12 +1042,14 @@ class Feature(DictModel):
         all_features[IMPLEMENTATION_STATUS[REMOVED]].append(feature)
       elif feature.impl_status_chrome == INTERVENTION:
         all_features[IMPLEMENTATION_STATUS[INTERVENTION]].append(feature)
-      elif feature.feature_type == FEATURE_TYPE_DEPRECATION_ID and Feature.dt_milestone_desktop_start != None:
+      elif (feature.feature_type == FEATURE_TYPE_DEPRECATION_ID and
+            Feature.dt_milestone_desktop_start != None):
           all_features[IMPLEMENTATION_STATUS[DEPRECATED]].append(feature)
       elif feature.feature_type == FEATURE_TYPE_INCUBATE_ID:
           all_features[IMPLEMENTATION_STATUS[ENABLED_BY_DEFAULT]].append(feature)
 
-    # Push feature to list corresponding to the implementation status of feature in queried milestone
+    # Push feature to list corresponding to the implementation status
+    # of feature in queried milestone
     for feature in android_only_shipping_features:
       if feature.impl_status_chrome == ENABLED_BY_DEFAULT:
         all_features[IMPLEMENTATION_STATUS[ENABLED_BY_DEFAULT]].append(feature)
@@ -1039,7 +1057,8 @@ class Feature(DictModel):
         all_features[IMPLEMENTATION_STATUS[DEPRECATED]].append(feature)
       elif feature.impl_status_chrome == REMOVED:
         all_features[IMPLEMENTATION_STATUS[REMOVED]].append(feature)
-      elif feature.feature_type == FEATURE_TYPE_DEPRECATION_ID and Feature.dt_milestone_android_start != None:
+      elif (feature.feature_type == FEATURE_TYPE_DEPRECATION_ID and
+            Feature.dt_milestone_android_start != None):
           all_features[IMPLEMENTATION_STATUS[DEPRECATED]].append(feature)
       elif feature.feature_type == FEATURE_TYPE_INCUBATE_ID:
           all_features[IMPLEMENTATION_STATUS[ENABLED_BY_DEFAULT]].append(feature)
@@ -1083,7 +1102,8 @@ class Feature(DictModel):
     if feature_list is None or update_cache:
       # Get all shipping features. Ordered by shipping milestone (latest first).
       q = Feature.query()
-      q = q.filter(Feature.impl_status_chrome.IN([ENABLED_BY_DEFAULT, ORIGIN_TRIAL, INTERVENTION]))
+      q = q.filter(Feature.impl_status_chrome.IN([
+          ENABLED_BY_DEFAULT, ORIGIN_TRIAL, INTERVENTION]))
       q = q.order(-Feature.impl_status_chrome)
       q = q.order(-Feature.shipped_milestone)
       q = q.order(Feature.name)
@@ -1136,15 +1156,17 @@ class Feature(DictModel):
   def stash_values(self):
 
     # Stash existing values when entity is created so we can diff property
-    # values later in put() to know what's changed. https://stackoverflow.com/a/41344898
+    # values later in put() to know what's changed.
+    # https://stackoverflow.com/a/41344898
 
     for prop_name, prop in list(self._properties.items()):
       old_val = getattr(self, prop_name, None)
       setattr(self, '_old_' + prop_name, old_val)
 
   def __notify_feature_subscribers_of_changes(self, is_update):
-    """Async notifies subscribers of new features and property changes to features by
-       posting to a task queue."""
+    """Async notifies subscribers of new features and property changes to
+       features by posting to a task queue.
+    """
     # Diff values to see what properties have changed.
     changed_props = []
     for prop_name, prop in list(self._properties.items()):
@@ -1209,7 +1231,8 @@ class Feature(DictModel):
   intent_to_ship_url = ndb.StringProperty()
   ready_for_trial_url = ndb.StringProperty()
   intent_to_experiment_url = ndb.StringProperty()
-  i2e_lgtms = ndb.StringProperty(repeated=True)  # Currently, only one is needed.
+  # Currently, only one is needed.
+  i2e_lgtms = ndb.StringProperty(repeated=True)
   i2s_lgtms = ndb.StringProperty(repeated=True)
 
   # Chromium details.
@@ -1527,16 +1550,20 @@ class FeatureOwner(DictModel):
         return self.put()
     return None
 
-  def remove_from_component_subscribers(self, component_name, remove_as_owner=False):
-    """Removes the user from the list of Blink component subscribers or as the owner
-       of the component."""
+  def remove_from_component_subscribers(
+      self, component_name, remove_as_owner=False):
+    """Removes the user from the list of Blink component subscribers or as
+       the owner of the component.
+    """
     c = BlinkComponent.get_by_name(component_name)
     if c:
       if remove_as_owner:
-        self.primary_blink_components = list_without_component(self.primary_blink_components, c)
+        self.primary_blink_components = (
+            list_without_component(self.primary_blink_components, c))
       else:
         self.blink_components = list_without_component(self.blink_components, c)
-        self.primary_blink_components = list_without_component(self.primary_blink_components, c)
+        self.primary_blink_components = (
+            list_without_component(self.primary_blink_components, c))
       return self.put()
     return None
 
@@ -1553,7 +1580,8 @@ class FeatureOwner(DictModel):
     return None
 
   def remove_as_component_owner(self, component_name):
-    return self.remove_from_component_subscribers(component_name, remove_as_owner=True)
+    return self.remove_from_component_subscribers(
+        component_name, remove_as_owner=True)
 
 
 class HistogramModel(ndb.Model):

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -128,7 +128,8 @@ def apply_subscription_rules(feature, changes):
 
 def make_email_tasks(feature, is_update=False, changes=[]):
   """Return a list of task dicts to notify users of feature changes."""
-  feature_watchers = models.FeatureOwner.query(models.FeatureOwner.watching_all_features == True).fetch(None)
+  feature_watchers = models.FeatureOwner.query(
+      models.FeatureOwner.watching_all_features == True).fetch(None)
 
   email_html = format_email_body(is_update, feature, changes)
   if is_update:

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -75,7 +75,8 @@ class EmailFormattingTest(testing_config.CustomTestCase):
         False, self.feature_1, [])
     self.assertIn('Blink', body_html)
     self.assertIn('creator@example.com added', body_html)
-    self.assertIn('www.chromestatus.com/feature/%d' % self.feature_1.key.integer_id(),
+    self.assertIn('www.chromestatus.com/feature/%d' %
+                  self.feature_1.key.integer_id(),
                   body_html)
     self.assertNotIn('watcher_1,', body_html)
 
@@ -92,7 +93,8 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     body_html = notifier.format_email_body(
         True, self.feature_1, self.changes)
     self.assertIn('test_prop', body_html)
-    self.assertIn('www.chromestatus.com/feature/%d' % self.feature_1.key.integer_id(),
+    self.assertIn('www.chromestatus.com/feature/%d' %
+                  self.feature_1.key.integer_id(),
                   body_html)
     self.assertIn('test old value', body_html)
     self.assertIn('test new value', body_html)

--- a/pages/blink_handler.py
+++ b/pages/blink_handler.py
@@ -40,8 +40,10 @@ class PopulateSubscribersHandler(basehandlers.FlaskHandler):
     f = file('%s/data/devrel_team.yaml' % settings.ROOT_DIR, 'r')
     for profile in yaml.load_all(f):
       blink_components = profile.get('blink_components', [])
-      blink_components = [models.BlinkComponent.get_by_name(name).key for name in blink_components]
-      blink_components = [f for f in blink_components if f] # Filter out None values
+      blink_components = [
+          models.BlinkComponent.get_by_name(name).key
+          for name in blink_components]
+      blink_components = [f for f in blink_components if f]
 
       user = models.FeatureOwner(
         name=str(profile['name']),
@@ -67,7 +69,8 @@ class BlinkHandler(basehandlers.FlaskHandler):
 
   TEMPLATE_PATH = 'admin/blink.html'
 
-  def __update_subscribers_list(self, add=True, user_id=None, blink_component=None, primary=False):
+  def __update_subscribers_list(
+      self, add=True, user_id=None, blink_component=None, primary=False):
     if not user_id or not blink_component:
       return False
 
@@ -142,22 +145,29 @@ class SubscribersHandler(basehandlers.FlaskHandler):
 
   @permissions.require_admin_site
   def get_template_data(self):
-    users = models.FeatureOwner.query().order(models.FeatureOwner.name).fetch(None)
+    users = models.FeatureOwner.query().order(
+        models.FeatureOwner.name).fetch(None)
     feature_list = models.Feature.get_chronological()
 
     milestone = self.request.args.get('milestone') or None
     if milestone:
       milestone = int(milestone)
-      feature_list = [f for f in feature_list if (f['shipped_milestone'] or f['shipped_android_milestone']) == milestone]
+      feature_list = [
+          f for f in feature_list
+          if (f['shipped_milestone'] or
+              f['shipped_android_milestone']) == milestone]
 
     list_features_per_owner = 'showFeatures' in self.request.args
     for user in users:
       # user.subscribed_components = [key.get() for key in user.blink_components]
-      user.owned_components = [key.get() for key in user.primary_blink_components]
+      user.owned_components = [
+          key.get() for key in user.primary_blink_components]
       for component in user.owned_components:
         component.features = []
         if list_features_per_owner:
-          component.features = [f for f in feature_list if component.name in f['blink_components']]
+          component.features = [
+              f for f in feature_list
+              if component.name in f['blink_components']]
 
     details = construct_chrome_channels_details()
 

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -368,7 +368,8 @@ class FeatureEditStage(basehandlers.FlaskHandler):
           'shipped_webview_milestone')
 
     if self.touched('shipped_opera_milestone'):
-      feature.shipped_opera_milestone = self.parse_int('shipped_opera_milestone')
+      feature.shipped_opera_milestone = (
+          self.parse_int('shipped_opera_milestone'))
 
     if self.touched('shipped_opera_android'):
       feature.shipped_opera_android_milestone = self.parse_int(

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -101,7 +101,7 @@ ALL_FIELDS = {
         help_text=('Select the most specific category. If unsure, '
                    'leave as "%s".' % models.FEATURE_CATEGORIES[models.MISC]),
         initial=models.MISC,
-        choices=sorted(list(models.FEATURE_CATEGORIES.items()), key=lambda x: x[1])),
+        choices=sorted(models.FEATURE_CATEGORIES.items(), key=lambda x: x[1])),
 
     'feature_type': forms.ChoiceField(
         required=False,
@@ -239,8 +239,8 @@ ALL_FIELDS = {
     'intent_to_implement_url': forms.URLField(
         required=False, label='Intent to Prototype link',
         widget=forms.URLInput(attrs={'placeholder': 'https://'}),
-        help_text=('After you have started the "Intent to Prototype" discussion '
-                   'thread, link to it here.')),
+        help_text=('After you have started the "Intent to Prototype" '
+                   ' discussion thread, link to it here.')),
 
     'intent_to_ship_url': forms.URLField(
         required=False, label='Intent to Ship link',
@@ -257,8 +257,8 @@ ALL_FIELDS = {
     'intent_to_experiment_url': forms.URLField(
         required=False, label='Intent to Experiment link',
         widget=forms.URLInput(attrs={'placeholder': 'https://'}),
-        help_text=('After you have started the "Intent to Experiment" discussion '
-                   'thread, link to it here.')),
+        help_text=('After you have started the "Intent to Experiment" '
+                   ' discussion thread, link to it here.')),
 
     'r4dt_url': forms.URLField(  # Sets intent_to_experiment_url in DB
         required=False, label='Request for Deprecation Trial link',

--- a/pages/metrics.py
+++ b/pages/metrics.py
@@ -60,7 +60,7 @@ class FeaturePopularityHandler(basehandlers.FlaskHandler):
   def get_template_data(self, bucket_id=None):
     # Note: bucket_id is not used, but the JS looks in the URL to get it.
     properties = sorted(
-        list(models.FeatureObserverHistogram.get_all().items()), key=lambda x:x[1])
+        models.FeatureObserverHistogram.get_all().items(), key=lambda x:x[1])
     template_data = {
         'FEATUREOBSERVER_BUCKETS': json.dumps(
             properties, separators=(',',':')),

--- a/pages/schedule.py
+++ b/pages/schedule.py
@@ -96,7 +96,8 @@ def construct_chrome_channels_details():
 class ScheduleHandler(basehandlers.FlaskHandler):
 
   TEMPLATE_PATH = 'schedule.html'
-  # TODO(shivamag00): fetch data from Channels API and Features API using JS instead of passing it here
+  # TODO(shivamag00): fetch data from Channels API and Features API
+  # using JS instead of passing it here
 
   def get_template_data(self):
     template_data = {

--- a/pages/users.py
+++ b/pages/users.py
@@ -38,8 +38,7 @@ class UserListHandler(basehandlers.FlaskHandler):
 
   @permissions.require_admin_site
   def get_template_data(self):
-    users = models.AppUser.query().fetch(None) # TODO(ericbidelman): ramcache this.
-
+    users = models.AppUser.query().fetch(None)
     user_list = [user.format_for_template() for user in users]
 
     logging.info('user_list is %r', user_list)

--- a/scripts/fix_data.py
+++ b/scripts/fix_data.py
@@ -6,15 +6,17 @@
 #
 # Copyright 2017 Google Inc. All Rights Reserved.
 
-"""When new UMA data is collected without a corresponding histogram in the db, the
-entry is saved with a property_name === 'ERROR'. The histogram buckets are updated
-by a nightly cron job (/cron/histograms), but sometimes changes to the enums.xml
-can cause data not make it into a proper bucket. This script finds the invalid.
+"""When new UMA data is collected without a corresponding histogram in
+the db, the entry is saved with a property_name === 'ERROR'. The
+histogram buckets are updated by a nightly cron job
+(/cron/histograms), but sometimes changes to the enums.xml can cause
+data not make it into a proper bucket. This script finds the invalid.
 entities in the datastore and corrects their bucket_id.
 
 How to use:
 Copy and paste this script into the interactive GAE console. If there are
 deadline errors, run it a few times until there's no more.
+
 """
 
 from internals import models


### PR DESCRIPTION
This clears up some easy pylint warnings:
* Wrap long lines
* Rename a few unused variables that are meant to be unused
* Remove a couple of calls to list() where they are not needed and they made the line too long
* One or two others