### PR TITLE
20210923 fix dev mode detection

### DIFF
--- a/pages/featurelist.py
+++ b/pages/featurelist.py
@@ -18,7 +18,6 @@
 
 import json
 import logging
-import os
 
 import settings
 from framework import basehandlers

--- a/pages/featurelist.py
+++ b/pages/featurelist.py
@@ -18,6 +18,7 @@
 
 import json
 import logging
+import os
 
 import settings
 from framework import basehandlers

--- a/settings.py
+++ b/settings.py
@@ -43,7 +43,7 @@ PROD = False
 STAGING = False
 DEBUG = True
 SEND_EMAIL = False  # Just log email
-DEV_MODE = os.environ['GAE_ENV'].startswith('localdev')
+DEV_MODE = os.environ.get('GAE_ENV', '').startswith('localdev')
 UNIT_TEST_MODE = os.environ['SERVER_SOFTWARE'].startswith('test')
 
 if not UNIT_TEST_MODE:

--- a/settings.py
+++ b/settings.py
@@ -43,7 +43,7 @@ PROD = False
 STAGING = False
 DEBUG = True
 SEND_EMAIL = False  # Just log email
-DEV_MODE = os.environ['SERVER_SOFTWARE'].startswith('Development')
+DEV_MODE = os.environ['GAE_ENV'].startswith('localdev')
 UNIT_TEST_MODE = os.environ['SERVER_SOFTWARE'].startswith('test')
 
 if not UNIT_TEST_MODE:

--- a/settings.py
+++ b/settings.py
@@ -43,7 +43,8 @@ PROD = False
 STAGING = False
 DEBUG = True
 SEND_EMAIL = False  # Just log email
-DEV_MODE = os.environ.get('GAE_ENV', '').startswith('localdev')
+DEV_MODE = (os.environ['SERVER_SOFTWARE'].startswith('Development') or
+            os.environ.get('GAE_ENV', '').startswith('localdev'))
 UNIT_TEST_MODE = os.environ['SERVER_SOFTWARE'].startswith('test')
 
 if not UNIT_TEST_MODE:


### PR DESCRIPTION
The py3 environment has a different way to indicate when our code is running on a local server.   We check both ways so that DEV_MODE can be used in both py2 and py3.