### PR TITLE
Implement pending-approval-by:me query.

### DIFF
--- a/api/approvals_api.py
+++ b/api/approvals_api.py
@@ -31,7 +31,8 @@ class ApprovalsAPI(basehandlers.APIHandler):
   def do_get(self, feature_id, field_id=None):
     """Return a list of all approval values on the given feature."""
     # Note: We assume that anyone may view approvals.
-    approvals = models.Approval.get_approvals(feature_id, field_id=field_id)
+    approvals = models.Approval.get_approvals(
+        feature_id=feature_id, field_id=field_id)
     dicts = [av.format_for_template(add_id=False) for av in approvals]
     data = {
         'approvals': dicts,

--- a/api/approvals_api_test.py
+++ b/api/approvals_api_test.py
@@ -200,7 +200,8 @@ class ApprovalsAPITest(testing_config.CustomTestCase):
       actual = self.handler.do_post()
 
     self.assertEqual(actual, {'message': 'Done'})
-    updated_approvals = models.Approval.get_approvals(self.feature_id)
+    updated_approvals = models.Approval.get_approvals(
+        feature_id=self.feature_id)
     self.assertEqual(1, len(updated_approvals))
     appr = updated_approvals[0]
     self.assertEqual(appr.feature_id, self.feature_id)

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -146,7 +146,8 @@ class CommentsAPITest(testing_config.CustomTestCase):
       actual = self.handler.do_post(self.feature_id, self.field_id)
 
     self.assertEqual(actual, {'message': 'Done'})
-    updated_approvals = models.Approval.get_approvals(self.feature_id)
+    updated_approvals = models.Approval.get_approvals(
+        feature_id=self.feature_id)
     self.assertEqual(1, len(updated_approvals))
     appr = updated_approvals[0]
     self.assertEqual(appr.feature_id, self.feature_id)
@@ -170,7 +171,8 @@ class CommentsAPITest(testing_config.CustomTestCase):
       actual = self.handler.do_post(self.feature_id, self.field_id)
 
     self.assertEqual(actual, {'message': 'Done'})
-    updated_approvals = models.Approval.get_approvals(self.feature_id)
+    updated_approvals = models.Approval.get_approvals(
+        feature_id=self.feature_id)
     self.assertEqual(1, len(updated_approvals))
     appr = updated_approvals[0]
     self.assertEqual(appr.feature_id, self.feature_id)

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -13,14 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import base64
 import collections
 import logging
 import requests
 
+from framework import permissions
 from framework import ramcache
 
 CACHE_EXPIRATION = 60 * 60  # One hour
@@ -95,6 +93,18 @@ def get_approvers(field_id):
     return owners
 
   return afd.approvers
+
+
+def fields_approvable_by(user):
+  """Return a set of field IDs that the user is allowed to approve."""
+  if permissions.can_admin_site(user):
+    return set(APPROVAL_FIELDS_BY_ID.keys())
+
+  email = user.email()
+  approvable_ids = {
+      field_id for field_id in APPROVAL_FIELDS_BY_ID
+      if email in get_approvers(field_id)}
+  return approvable_ids
 
 
 def is_valid_field_id(field_id):

--- a/internals/models.py
+++ b/internals/models.py
@@ -1,6 +1,3 @@
-
-
-
 # -*- coding: utf-8 -*-
 # Copyright 2020 Google Inc.
 #
@@ -1326,7 +1323,7 @@ class Approval(DictModel):
   """Describes the current state of one approval on a feature."""
 
   NEEDS_REVIEW = 0
-  # NA = 1  Reserved for FLT
+  NA = 1
   # REVIEW_REQUESTED = 2  Reserved for FLT
   REVIEW_STARTED = 3
   NEED_INFO = 4
@@ -1334,12 +1331,12 @@ class Approval(DictModel):
   NOT_APPROVED = 6
   APPROVAL_VALUES = {
       NEEDS_REVIEW: 'needs_review',
-      # NA: 'na',
+      NA: 'na',
       # REVIEW_REQUESTED: 'review_requested',
       REVIEW_STARTED: 'review_started',
       NEED_INFO: 'need_info',
       APPROVED: 'approved',
-      NOT_APPROVED: 'not_approved'
+      NOT_APPROVED: 'not_approved',
   }
 
   feature_id = ndb.IntegerProperty(required=True)
@@ -1349,12 +1346,16 @@ class Approval(DictModel):
   set_by = ndb.StringProperty(required=True)
 
   @classmethod
-  def get_approvals(cls, feature_id, field_id=None, set_by=None):
+  def get_approvals(
+      cls, feature_id=None, field_id=None, states=None, set_by=None):
     """Return the requested approvals."""
     query = Approval.query()
-    query = query.filter(Approval.feature_id == feature_id)
+    if feature_id is not None:
+      query = query.filter(Approval.feature_id == feature_id)
     if field_id is not None:
       query = query.filter(Approval.field_id == field_id)
+    if states is not None:
+      query = query.filter(Approval.state.IN(states))
     if set_by is not None:
       query = query.filter(Approval.set_by == set_by)
     approvals = query.fetch(None)
@@ -1373,7 +1374,7 @@ class Approval(DictModel):
 
     now = datetime.datetime.now()
     existing_list = cls.get_approvals(
-        feature_id, field_id=field_id, set_by=set_by_email)
+        feature_id=feature_id, field_id=field_id, set_by=set_by_email)
     if existing_list:
       existing = existing_list[0]
       existing.set_on = now

--- a/internals/search.py
+++ b/internals/search.py
@@ -13,20 +13,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import logging
 
 from framework import users
+from internals import approval_defs
 from internals import models
 from internals import notifier
 
 
+PENDING_STATES = [
+    models.Approval.NEEDS_REVIEW, models.Approval.REVIEW_STARTED,
+    models.Approval.NEED_INFO]
+
 def process_pending_approval_me_query():
   """Return a list of features needing approval by current user."""
-  # TODO(jrobbins): write this
-  return []
+  user = users.get_current_user()
+  if not user:
+    return []
+
+  approvable_fields_ids = approval_defs.fields_approvable_by(user)
+  pending_approvals = models.Approval.get_approvals(states=PENDING_STATES)
+  logging.info('pending_approvals is %r', pending_approvals)
+  pending_approvals = [pa for pa in pending_approvals
+                       if pa.field_id in approvable_fields_ids]
+  pending_approvals.sort(key=lambda pa: pa.set_on)
+
+  # De-duplicate feature_ids while maintaining set_on order.
+  feature_ids = []
+  seen = set()
+  for pa in pending_approvals:
+    if pa.feature_id not in seen:
+      seen.add(pa.feature_id)
+      feature_ids.append(pa.feature_id)
+
+  features = models.Feature.get_by_ids(feature_ids)
+
+  return features
 
 
 def process_starred_me_query():


### PR DESCRIPTION
This is a step toward implementing the MyFeatures page for API Owners.

The search query "pending-approval-by:me" returns a list of features that have an approval record that has a pending value (e.g., NEEDS_REVIEW), iff the current user has permission to set an approval record for that feature.

In this PR:
+ In search.py: Implement most of the query logic
+ In models.py: Generalize get_approvals() to make feature_id optional and add states=[] parameter.
+ Update callers in other files now that feature_id is a keyword parameter.
+ Add unit tests