### PR TITLE
Detect intent emails to create pending approval entities.

### DIFF
--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -37,19 +37,24 @@ ApprovalFieldDef = collections.namedtuple(
     'name, description, field_id, rule, approvers')
 
 PrototypeApproval = ApprovalFieldDef(
-    'Intent to prototype approval',
+    'Intent to prototype',
     'One API Owner must approve your intent',
     1, ONE_LGTM, API_OWNERS_URL)
 
 ExperimentApproval = ApprovalFieldDef(
-    'Intent to experiment approval',
+    'Intent to experiment',
     'One API Owner must approve your intent',
     2, ONE_LGTM, API_OWNERS_URL)
 
+ExtendExperimentApproval = ApprovalFieldDef(
+    'Intent to extend experiment',
+    'One API Owner must approve your intent',
+    3, ONE_LGTM, API_OWNERS_URL)
+
 ShipApproval = ApprovalFieldDef(
-    'Intent to ship approval',
+    'Intent to ship',
     'Three API Owners must approve your intent',
-    3, THREE_LGTM, API_OWNERS_URL)
+    4, THREE_LGTM, API_OWNERS_URL)
 
 APPROVAL_FIELDS_BY_ID = {
     afd.field_id: afd

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -13,13 +13,72 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import division
-from __future__ import print_function
-
+import re
 import logging
 
 import settings
 from framework import basehandlers
+from internals import approval_defs
+from internals import models
+
+
+def detect_field(subject):
+  """Look for key words in the subject line that indicate intent type.
+
+  These should detect recent actual intent threads as seen in the blink-dev
+  archive: https://groups.google.com/a/chromium.org/g/blink-dev.
+  """
+  subject = subject.lower().strip()
+  if subject.startswith('[blink-dev]'):
+    subject = subject[len('[blink-dev]'):]
+  while subject.startswith('re: '):
+    subject = subject[len('re: ')]
+  subject = subject.strip()
+
+  if (subject.startswith('intent to ship') or
+      subject.startswith('intent to prototype and ship')):
+    return approval_defs.ShipApproval
+
+  if subject.startswith('intent to prototype'):
+    return approval_defs.PrototypeApproval
+
+  if (subject.startswith('intent to experiment') or
+      subject.startswith('intent to continue experiment') or
+      subject.startswith('intent to extend experiment') or
+      subject.startswith('intent to extend origin')):
+    return approval_defs.ExperimentApproval
+
+  # TODO(jrobbins): deprecate and remove
+  # TODO(jrobbins): deprecation trials
+
+  return None
+
+
+CHROMESTATUS_LINK_RE = re.compile(
+    r'Link to entry on the Chrome Platform Status:?\s+'
+    r'https://www.chromestatus.com/feature/(\d+)', re.I)
+
+
+def detect_feature_id(body):
+  """Look for the link to a chromestatus entry."""
+  match = CHROMESTATUS_LINK_RE.search(body)
+  if match:
+    return int(match.group(1))
+  return None
+
+
+THREAD_LINK_RE = re.compile(
+    r'To view this discussion on the web visit\s+'
+    r'(https://groups.google.com/a/chromium.org/d/msgid/blink-dev/'
+    r'\S+)[.]')
+
+
+def detect_thread_url(body):
+  """Look for the link to the thread in the blink-dev archive."""
+  match = THREAD_LINK_RE.search(body)
+  if match:
+    return match.group(1)
+  return None
 
 
 class IntentEmailHandler(basehandlers.FlaskHandler):
@@ -42,12 +101,59 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
                  'Body:        %r\n',
                  from_addr, subject, in_reply_to, body)
 
-    # TODO(jrobbins): Write code to parse out:
-    # 1. The type of intent.
-    # 2. The feature ID number
-    # 3. Any clear "LGTM"s
-    # And retrieve model objects for the feature and the sending user.
-    # Set the thread URL on the feature.
-    # Set an LGTM if appropriate.
+    approval_field = detect_field(subject)
+    if not approval_field:
+      logging.info('This does not appear to be an intent')
+      return {'message': 'Not an intent'}
 
+    feature_id = detect_feature_id(body)
+    if not feature_id:
+      logging.info('Could not find feature ID')
+      return {'message': 'No feature ID'}
+    feature = models.Feature.get_by_id(feature_id)
+    if not feature:
+      logging.info('Could not retrieve feature')
+      return {'message': 'Feature not found'}
+
+    thread_url = detect_thread_url(body)
+
+    self.set_intent_thread_url(feature, approval_field, thread_url)
+    self.create_approvals(feature_id, approval_field, from_addr, body)
     return {'message': 'Done'}
+
+  def set_intent_thread_url(self, feature, approval_field, thread_url):
+    """If the feature has no previous thread URL for this intent, set it."""
+    if not thread_url:
+      return
+
+    if (approval_field == approval_defs.PrototypeApproval and
+        not feature.intent_to_implement_url):
+      feature.intent_to_implement_url = thread_url
+      feature.put()
+
+    # TODO(jrobbins): Ready-for-trial threads
+
+    if (approval_field == approval_defs.ExperimentApproval and
+        not feature.intent_to_experiment_url):
+      feature.intent_to_experiment_url = thread_url
+      feature.put()
+
+    if (approval_field == approval_defs.ShipApproval and
+        not feature.intent_to_ship_url):
+      feature.intent_to_ship_url = thread_url
+      feature.put()
+
+  def create_approvals(self, feature_id, approval_field, from_addr, body):
+    """Store either a NEEDS_REVIEW or an APPROVED approval value."""
+    # Case 1: This is a new intent thread
+    existing_approvals = models.Approval.get_approvals(
+        feature_id=feature_id, field_id=approval_field.field_id)
+    if not existing_approvals:
+      models.Approval.set_approval(
+          feature_id, approval_field.field_id,
+          models.Approval.NEEDS_REVIEW, from_addr)
+
+    # Case 2: This is an existing intent thread
+    # TODO(jrobbins): Detect LGTMs in body, verify that sender has permission,
+    # set an approval value, and clear the original NEEDS_REVIEW if
+    # the approval rule (1 or 3 LTGMs) is satisfied.

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -30,26 +30,31 @@ def detect_field(subject):
   """
   subject = subject.lower().strip()
   if subject.startswith('[blink-dev]'):
-    subject = subject[len('[blink-dev]'):]
-  while subject.startswith('re: '):
-    subject = subject[len('re: ')]
-  subject = subject.strip()
+    subject = subject[len('[blink-dev]'):].strip()
+  while subject.startswith('re:'):
+    subject = subject[len('re:'):].strip()
 
   if (subject.startswith('intent to ship') or
-      subject.startswith('intent to prototype and ship')):
+      subject.startswith('intent to prototype and ship') or
+      subject.startswith('intent to implement and ship') or
+      subject.startswith('intent to deprecate and remove') or
+      subject.startswith('intent to remove')):
     return approval_defs.ShipApproval
 
-  if subject.startswith('intent to prototype'):
+  if (subject.startswith('intent to prototype') or
+      subject.startswith('intent to implement') or
+      subject.startswith('intent to deprecate')):
     return approval_defs.PrototypeApproval
 
   if (subject.startswith('intent to experiment') or
-      subject.startswith('intent to continue experiment') or
-      subject.startswith('intent to extend experiment') or
-      subject.startswith('intent to extend origin')):
+      subject.startswith('request for deprecation trial')):
     return approval_defs.ExperimentApproval
 
-  # TODO(jrobbins): deprecate and remove
-  # TODO(jrobbins): deprecation trials
+  if (subject.startswith('intent to continue experiment') or
+      subject.startswith('intent to extend experiment') or
+      subject.startswith('intent to continue origin') or
+      subject.startswith('intent to extend origin')):
+    return approval_defs.ExtendExperimentApproval
 
   return None
 

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -18,9 +18,76 @@ import flask
 import werkzeug
 
 from internals import models
+from internals import approval_defs
 from internals import detect_intent
 
 test_app = flask.Flask(__name__)
+
+
+class FunctionTest(testing_config.CustomTestCase):
+
+  def test_detect_field(self):
+    """We can detect intent thread type by subject line."""
+    test_data = {
+      approval_defs.PrototypeApproval: [
+          'Intent to Prototype: Something cool',
+          'intent to prototype: something cool',
+          'Intent to Prototype request for Something cool',
+        ],
+      approval_defs.ExperimentApproval: [
+          'Intent to Experiment: Something cool',
+          'intent to experiment: something cool',
+          'Intent to experiment on Something cool',
+          'Intent to Continue Experiment: Something cool',
+          'Intent to Extend Experiment: Something cool',
+          'Intent to Continue Experiment: Something cool',
+      ],
+      approval_defs.ShipApproval: [
+          'Intent to Ship: Something cool',
+          'intent to ship: something cool',
+          'Intent to ship request for Something cool',
+        ],
+      None: [
+          'Status of something cool',
+          '[meta] Are Intent to Prototype threads too long?',
+          'PSA: We are making changes',
+          'Why is feature so cool?',
+          'Save the date for BlinkOn',
+        ],
+     }
+
+    for expected, subjects in test_data.items():
+      for subject in subjects:
+        with self.subTest(subject=subject):
+          actual = detect_intent.detect_field(subject)
+          self.assertEqual(expected, actual)
+
+  def test_detect_feature_id(self):
+    """We can parse the feature ID from a link inthe body."""
+    body = (
+        'blah blah blah\n'
+        'Link to entry on the Chrome Platform Status\n'
+        'https://www.chromestatus.com/feature/5144822362931200\n'
+        'blah blah blah')
+    self.assertEqual(
+        5144822362931200,
+        detect_intent.detect_feature_id(body))
+
+  def test_detect_thread_url(self):
+    """We can parse the thread archive link from the body footer."""
+    footer = (
+        'You received this message because you are subscribed to the Google '
+        'Groups "blink-dev" group.\n'
+        'To unsubscribe from this group and stop receiving emails from it,'
+        'send an email to blink-dev+unsubscribe@chromium.org.\n'
+        'To view this discussion on the web visit https://groups.google.com'
+        '/a/chromium.org/d/msgid/blink-dev/CAMO6jDPGfXfE5z6hJcWO112zX3We'
+        '-oNTb%2BZjiJk%2B6RNb9%2Bv05w%40mail.gmail.com.')
+    self.assertEqual(
+        ('https://groups.google.com'
+         '/a/chromium.org/d/msgid/blink-dev/CAMO6jDPGfXfE5z6hJcWO112zX3We'
+         '-oNTb%2BZjiJk%2B6RNb9%2Bv05w%40mail.gmail.com'),
+        detect_intent.detect_thread_url(footer))
 
 
 class IntentEmailHandlerTest(testing_config.CustomTestCase):
@@ -34,15 +101,27 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
     self.feature_id = self.feature_1.key.integer_id()
 
     self.request_path = '/tasks/detect-intent'
+
+    self.entry_link = (
+        '\nLink to entry on the Chrome Platform Status\n'
+        'https://www.chromestatus.com/feature/%d\n' % self.feature_id)
+    self.footer = (
+        '\n--\n'
+        'instructions...\n'
+        '---\n'
+        'To view this discussion on the web visit '
+        'https://groups.google.com/a/chromium.org/d/msgid/blink-dev/fake.')
     self.json_data = {
         'from_addr': 'user@example.com',
         'subject': 'Intent to Ship: Featurename',
-        'body': 'Please review',
+        'body': 'Please review. ' + self.entry_link + self.footer,
         }
     self.handler = detect_intent.IntentEmailHandler()
 
   def tearDown(self):
     self.feature_1.key.delete()
+    for appr in models.Approval.query().fetch(None):
+      appr.key.delete()
 
   def test_process_post_data__normal(self):
     """When everything is perfect, we record the intent thread."""
@@ -50,6 +129,15 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
         self.request_path, json=self.json_data):
       actual = self.handler.process_post_data()
 
-    # TODO(jrobbins): Add checks after detect_intent is written.
-
     self.assertEqual(actual, {'message': 'Done'})
+
+    created_approvals = list(models.Approval.query().fetch(None))
+    self.assertEqual(1, len(created_approvals))
+    appr = created_approvals[0]
+    self.assertEqual(self.feature_id, appr.feature_id)
+    self.assertEqual(approval_defs.ShipApproval.field_id, appr.field_id)
+    self.assertEqual(models.Approval.NEEDS_REVIEW, appr.state)
+    self.assertEqual('user@example.com', appr.set_by)
+    self.assertEqual(
+        self.feature_1.intent_to_ship_url,
+        'https://groups.google.com/a/chromium.org/d/msgid/blink-dev/fake')

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -31,6 +31,7 @@ class FunctionTest(testing_config.CustomTestCase):
     test_data = {
       approval_defs.PrototypeApproval: [
           'Intent to Prototype: Something cool',
+          'Re: Re:Intent to Prototype: Something cool',
           'intent to prototype: something cool',
           'Intent to Prototype request for Something cool',
         ],
@@ -38,6 +39,8 @@ class FunctionTest(testing_config.CustomTestCase):
           'Intent to Experiment: Something cool',
           'intent to experiment: something cool',
           'Intent to experiment on Something cool',
+      ],
+      approval_defs.ExtendExperimentApproval: [
           'Intent to Continue Experiment: Something cool',
           'Intent to Extend Experiment: Something cool',
           'Intent to Continue Experiment: Something cool',


### PR DESCRIPTION
This resolves issue #1172.

In this PR:
+ Match the email subject line to well-known patterns to detect the type of intent.
+ Search the email body for a link to chromestatus, which tells us the Feature entry ID.
+ Search the email body for a footer link to the blink-dev thread archive
+ If the feature entry does not already have a thread URL for that type of intent, set it.
+ If the feature entry has not already had a review for that type of intent, start it off with a NEEDS_REVIEW entry, which will make the feature show up on the MyFeatures page.