### PR TITLE
Refactor dialog management into a separate webelement.

### DIFF
--- a/static/components.js
+++ b/static/components.js
@@ -17,6 +17,7 @@ import './elements/chromedash-accordion';
 import './elements/chromedash-banner';
 import './elements/chromedash-callout';
 import './elements/chromedash-color-status';
+import './elements/chromedash-dialog';
 import './elements/chromedash-feature';
 import './elements/chromedash-feature-detail';
 import './elements/chromedash-feature-table';

--- a/static/elements/chromedash-dialog.js
+++ b/static/elements/chromedash-dialog.js
@@ -26,12 +26,10 @@ class ChromedashDialog extends LitElement {
         align-items: center;
         justify-content: center;
       }
-      :host(:not([opened])), [hidden] {
+      :host(:not([opened])) {
         display: none;
-        visibility: hidden;
       }
-      :host([closeOnOutsideClick]),
-      :host([closeOnOutsideClick]) .dialog::backdrop {
+      :host, .dialog::backdrop {
         /* TODO(zhangtiff): Deprecate custom backdrop in favor of native
         * browser backdrop.
         */
@@ -65,25 +63,6 @@ class ChromedashDialog extends LitElement {
     `;
   }
 
-  render() {
-    return html`
-      <dialog class="dialog" role="dialog" @cancel=${this._cancelHandler}>
-        <div class="dialog-content">
-          <button id="close-icon" @click=${this.close}>
-             <iron-icon icon="chromestatus:close"></iron-icon>
-          </button>
-          <slot></slot>
-        </div>
-      </dialog>
-    `;
-  }
-
-  static get properties() {
-    return {
-      opened: {type: Boolean, reflect: true},
-    };
-  }
-
   constructor() {
     super();
     this.opened = false;
@@ -94,13 +73,13 @@ class ChromedashDialog extends LitElement {
     super.connectedCallback();
     this.addEventListener('click', (evt) => {
       if (!this.opened) return;
-      const hasDialog = evt.composedPath().find(
-        (node) => {
-          return node.classList && node.classList.contains('dialog-content');
-        }
+      // A click outside the dialog box will close the dialog.
+      const clickIsOutsideDialog = !evt.composedPath().find(
+        (node) => node.classList && node.classList.contains('dialog-content')
       );
-      if (hasDialog) return;
-      this.close();
+      if (clickIsOutsideDialog) {
+        this.close();
+      }
     });
     window.addEventListener('keydown', this._boundKeydownHandler, true);
   }
@@ -152,6 +131,19 @@ class ChromedashDialog extends LitElement {
         dialog.setAttribute('open', undefined);
       }
     }
+  }
+
+  render() {
+    return html`
+      <dialog class="dialog" role="dialog" @cancel=${this._cancelHandler}>
+        <div class="dialog-content">
+          <button id="close-icon" @click=${this.close}>
+             <iron-icon icon="chromestatus:close"></iron-icon>
+          </button>
+          <slot></slot>
+        </div>
+      </dialog>
+    `;
   }
 }
 

--- a/static/elements/chromedash-dialog.js
+++ b/static/elements/chromedash-dialog.js
@@ -1,0 +1,159 @@
+import {LitElement, css, html} from 'lit-element';
+import '@polymer/iron-icon';
+
+// This is a simplfied version of chops-dialog:
+// https://source.chromium.org/chromium/infra/infra/+/main:appengine/monorail/static_src/elements/chops/chops-dialog/chops-dialog.js
+
+class ChromedashDialog extends LitElement {
+  static get properties() {
+    return {
+      opened: {type: Boolean, reflect: true},
+    };
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        position: fixed;
+        z-index: 9999;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        overflow: auto;
+        background-color: rgba(0,0,0,0.4);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      :host(:not([opened])), [hidden] {
+        display: none;
+        visibility: hidden;
+      }
+      :host([closeOnOutsideClick]),
+      :host([closeOnOutsideClick]) .dialog::backdrop {
+        /* TODO(zhangtiff): Deprecate custom backdrop in favor of native
+        * browser backdrop.
+        */
+        cursor: pointer;
+      }
+      .dialog {
+        background: none;
+        border: 0;
+        max-width: 90%;
+      }
+      .dialog-content {
+        /* This extra div is here because otherwise the browser can't
+        * differentiate between a click event that hits the dialog element or
+        * its backdrop pseudoelement.
+        */
+        box-sizing: border-box;
+        background: white;
+        padding: 1em 16px;
+        cursor: default;
+        box-shadow: 0px 3px 20px 0px hsla(0, 0%, 0%, 0.4);
+        width: var(--dialog-width-param);
+        max-width: var(--dialog-max-width-param, 100%);
+      }
+      #close-icon {
+        background: transparent;
+        border: 0;
+        float: right;
+        cursor: pointer;
+      }
+
+    `;
+  }
+
+  render() {
+    return html`
+      <dialog class="dialog" role="dialog" @cancel=${this._cancelHandler}>
+        <div class="dialog-content">
+          <button id="close-icon" @click=${this.close}>
+             <iron-icon icon="chromestatus:close"></iron-icon>
+          </button>
+          <slot></slot>
+        </div>
+      </dialog>
+    `;
+  }
+
+  static get properties() {
+    return {
+      opened: {type: Boolean, reflect: true},
+    };
+  }
+
+  constructor() {
+    super();
+    this.opened = false;
+    this._boundKeydownHandler = this._keydownHandler.bind(this);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('click', (evt) => {
+      if (!this.opened) return;
+      const hasDialog = evt.composedPath().find(
+        (node) => {
+          return node.classList && node.classList.contains('dialog-content');
+        }
+      );
+      if (hasDialog) return;
+      this.close();
+    });
+    window.addEventListener('keydown', this._boundKeydownHandler, true);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('keydown', this._boundKeydownHandler,
+      true);
+  }
+
+  updated(changedProperties) {
+    if (changedProperties.has('opened')) {
+      this._openedChanged(this.opened);
+    }
+  }
+
+  _keydownHandler(event) {
+    if (!this.opened) return;
+    if (event.key === 'Escape') {
+      this.close();
+    }
+  }
+
+  close() {
+    this.opened = false;
+  }
+
+  open() {
+    this.opened = true;
+  }
+
+  _cancelHandler() {
+    this.close();
+  }
+
+  _openedChanged(opened) {
+    const dialog = this.shadowRoot.querySelector('dialog');
+    if (!dialog) return;
+    if (opened) {
+      if (dialog.showModal) {
+        dialog.showModal();
+      } else {
+        dialog.setAttribute('open', 'true');
+      }
+    } else {
+      if (dialog.close) {
+        dialog.close();
+      } else {
+        dialog.setAttribute('open', undefined);
+      }
+    }
+  }
+}
+
+
+customElements.define('chromedash-dialog', ChromedashDialog);

--- a/static/elements/chromedash-legend.js
+++ b/static/elements/chromedash-legend.js
@@ -1,7 +1,7 @@
 import {LitElement, css, html} from 'lit-element';
 import {nothing} from 'lit-html';
-import '@polymer/iron-icon';
 import './chromedash-color-status';
+import './chromedash-dialog';
 import SHARED_STYLES from '../css/shared.css';
 
 class ChromedashLegend extends LitElement {
@@ -16,51 +16,6 @@ class ChromedashLegend extends LitElement {
     return [
       SHARED_STYLES,
       css`
-      :host {
-        position: fixed;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        visibility: hidden;
-      }
-
-      :host::after {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        z-index: -1;
-        content: '';
-        transition: opacity 300ms;
-        background: #000;
-        opacity: 0;
-        pointer-events: none;
-        will-change: opacity;
-      }
-
-      :host([opened]) {
-        visibility: visible;
-        z-index: 1;
-      }
-
-      :host([opened])::after {
-        opacity: 0.6;
-      }
-
-      #overlay {
-        background: #fff;
-        padding: 16px;
-        position: relative;
-        width: 100%;
-        height: 100%;
-        overflow: auto;
-      }
-
       h3 {
         border-bottom: var(--heading-underbar);
         padding: 0 !important;
@@ -102,15 +57,6 @@ class ChromedashLegend extends LitElement {
         margin-top: 5px;
       }
 
-      .close {
-        background: transparent;
-        border: 0;
-        position: absolute;
-        top: var(--content-padding-half);
-        right: var(--content-padding-half);
-        cursor: pointer;
-      }
-
       @media only screen and (min-width: 701px) {
         #overlay {
           width: 80vw;
@@ -120,9 +66,12 @@ class ChromedashLegend extends LitElement {
     `];
   }
 
-  toggle() {
-    this.opened = !this.opened;
-    document.body.style.overflow = this.opened ? 'opened' : '';
+  open() {
+    this.shadowRoot.querySelector('chromedash-dialog').open();
+  }
+
+  close() {
+    this.shadowRoot.querySelector('chromedash-dialog').close();
   }
 
   render() {
@@ -130,7 +79,7 @@ class ChromedashLegend extends LitElement {
       return nothing;
     }
     return html`
-      <div id="overlay">
+      <chromedash-dialog>
         <h3>About the data</h3>
         <section class="content-wrapper">
           <p class="description">What you're looking at is a mostly
@@ -139,15 +88,12 @@ class ChromedashLegend extends LitElement {
           added. Features marked "No active development" are being considered or
           have yet to be started. Features marked "In development" are currently
           being worked on.</p>
-          <button class="close buttons" @click=${this.toggle}>
-            <iron-icon icon="chromestatus:close"></iron-icon>
-          </button>
         </section>
         <h3>Color legend</h3>
         <p>Colors indicate the "interoperability risk" for a given feature. The
           risk increases as
           <chromedash-color-status value="0"
-              .max="${this.views.vendors.length}"></chromedash-color-status> → 
+              .max="${this.views.vendors.length}"></chromedash-color-status> →
           <chromedash-color-status .value="${this.views.vendors.length}"
               .max="${this.views.vendors.length}"></chromedash-color-status>, and the
           color meaning differs for browser vendors, web developers, and the
@@ -217,7 +163,7 @@ class ChromedashLegend extends LitElement {
             </li>
           </ul>
         </section>
-      </div>
+      </chromedash-dialog>
     `;
   }
 }

--- a/static/js-src/features-page.js
+++ b/static/js-src/features-page.js
@@ -99,5 +99,5 @@ legendEl.views = VIEWS;
 
 document.querySelector('.legend-button').addEventListener('click', (e) => {
   e.preventDefault();
-  legendEl.toggle();
+  legendEl.open();
 });


### PR DESCRIPTION
The purpose of this refactoring is to make it easier to add other dialog boxes to the app.

This produces no visible change in the UI.
However now the Escape key or a click outside the dialog will close the "legend" dialog box.
