### PR TITLE
Add My Features tab and indicate active tab.

### DIFF
--- a/static/elements/chromedash-myfeatures.js
+++ b/static/elements/chromedash-myfeatures.js
@@ -1,6 +1,7 @@
-import {LitElement, html} from 'lit-element';
+import {LitElement, css, html} from 'lit-element';
 import {nothing} from 'lit-html';
-import '@polymer/iron-icon';
+import SHARED_STYLES from '../css/shared.css';
+
 
 class ChromedashMyFeatures extends LitElement {
   static get properties() {
@@ -18,6 +19,16 @@ class ChromedashMyFeatures extends LitElement {
     this.starredFeatures = new Set();
     this.canEdit = false;
     this.canApprove = false;
+  }
+
+  static get styles() {
+    return [
+      SHARED_STYLES,
+      css`
+        chromedash-accordion {
+          padding: 0 var(--content-padding);
+        }
+      `];
   }
 
   // Handles the Star-Toggle event fired by any one of the child components

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -100,7 +100,12 @@ app-header-layout {
   padding: 0;
 }
 
-header, footer {
+header {
+  display: flex;
+  align-items: baseline;
+}
+
+footer {
   display: flex;
   align-items: center;
 }
@@ -129,6 +134,7 @@ header {
       padding: var(--content-padding-half) var(--content-padding);
       color: var(--nav-link-color);
       white-space: nowrap;
+      border-bottom: var(--nav-link-border);
 
       &:hover {
         color: black;
@@ -138,6 +144,15 @@ header {
       &.disabled {
         opacity: 0.5;
         pointer-events: none;
+      }
+    }
+
+    .active {
+      color: var(--nav-link-active-color);
+      border-bottom: var(--nav-link-active-border);
+
+      a {
+        color: var(--nav-link-active-color);
       }
     }
 
@@ -215,7 +230,7 @@ footer {
 }
 
 .sub-nav-links {
-  padding-left: var(--content-padding-quarter); 
+  padding-left: var(--content-padding-quarter);
   padding-right: var(--content-padding-quarter);
 }
 
@@ -445,7 +460,7 @@ footer {
 //Horizontal Sub-Nav should not be visible in wider view ports
 @media only screen and (min-width: 700px){
   #horizontal-sub-nav{display: none}
-  
+
 }
 
 

--- a/static/sass/theme.scss
+++ b/static/sass/theme.scss
@@ -62,6 +62,9 @@
   --nav-link-color: var(--md-gray-700-alpha);
   --nav-link-font-size: 16px;
   --nav-link-hover-background: var(--md-gray-100-alpha);
+  --nav-link-border: 2px solid transparent;
+  --nav-link-active-color: var(--md-blue-900);
+  --nav-link-active-border: 2px solid var(--nav-link-active-color);
 
   --leftnav-link-color: var(--md-blue-900);
   --leftnav-selected-color: var(--md-blue-900);

--- a/templates/header.html
+++ b/templates/header.html
@@ -54,8 +54,8 @@
   </nav>
 </header>
 
-{% if user %}
-  <script nonce="{{nonce}}">
+<script nonce="{{nonce}}">
+  {% if user %}
     const signOutEl = document.querySelector('#sign-out-link');
     if (signOutEl) {
         signOutEl.addEventListener('click', (e) => {
@@ -63,13 +63,13 @@
             signOut();
         });
     }
+  {% endif %}
 
-    const maintabsEl = document.querySelector('#maintabs');
-    for (let tabEl of maintabs.children) {
-        const path = tabEl.getAttribute('href');
-        if (window.location.pathname.startsWith(path)) {
-            tabEl.classList.add('active');
-        }
-    }
-  </script>
-{% endif %}
+  const maintabsEl = document.querySelector('#maintabs');
+  for (let tabEl of maintabs.children) {
+      const path = tabEl.getAttribute('href');
+      if (window.location.pathname.startsWith(path)) {
+          tabEl.classList.add('active');
+      }
+  }
+</script>

--- a/templates/header.html
+++ b/templates/header.html
@@ -8,11 +8,13 @@
   <nav>
     <div class="flex-container flex-container-outer">
 
-      <div class="flex-container flex-container-inner-first">
+      <div id="maintabs" class="flex-container flex-container-inner-first">
         <a class="flex-item" href="/roadmap">Roadmap</a>
-        {# TODO(jrobbins): link to myfeatures #}
+        {% if user %}
+          <a class="flex-item" href="/myfeatures">My features</a>
+        {% endif %}
         <a class="flex-item" href="/features">All features</a>
-        <div class="nav-dropdown-container flex-item">
+        <div class="nav-dropdown-container flex-item" href="/metrics">
           <a class="nav-dropdown-trigger flex-item-inner">Stats
             <iron-icon icon="chromestatus:arrow-drop-down"></iron-icon>
           </a>
@@ -60,6 +62,14 @@
             e.preventDefault();
             signOut();
         });
+    }
+
+    const maintabsEl = document.querySelector('#maintabs');
+    for (let tabEl of maintabs.children) {
+        const path = tabEl.getAttribute('href');
+        if (window.location.pathname.startsWith(path)) {
+            tabEl.classList.add('active');
+        }
     }
   </script>
 {% endif %}


### PR DESCRIPTION
This adds a top-tab navigation link to the myfeatures page, essentially launching the page.
The tab is only shown when the user is signed in.

In this PR:
+ Add the top tab link to /myfeatures
+ Change the CSS to indicate the active tab, in the spirit of the MD spec:
  https://material.io/components/tabs#anatomy
  "To differentiate an active tab from an inactive tab, apply an underline and color change to the active tab’s text and icon."
+ Add a little bit of JS to add the "active" CSS class to the active tab, if any.
+ Also, add a little space between the sections of the myfeatures page