### PR TITLE
Set up GCL for python3

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,8 +45,6 @@ from pages import schedule
 from pages import users
 import settings
 
-logging.basicConfig(level=logging.INFO)
-
 
 metrics_chart_routes = [
     ('/data/timeline/cssanimated', metricsdata.AnimatedTimelineHandler),

--- a/main.py
+++ b/main.py
@@ -46,6 +46,13 @@ from pages import users
 import settings
 
 
+# Sets up Cloud Logging client library.
+if not settings.UNIT_TEST_MODE and not settings.DEV_MODE:
+  import google.cloud.logging
+  client = google.cloud.logging.Client()
+  client.get_default_handler()
+  client.setup_logging()
+
 metrics_chart_routes = [
     ('/data/timeline/cssanimated', metricsdata.AnimatedTimelineHandler),
     ('/data/timeline/csspopularity', metricsdata.PopularityTimelineHandler),
@@ -56,6 +63,7 @@ metrics_chart_routes = [
     ('/data/featurepopularity', metricsdata.FeatureObserverPopularityHandler),
     ('/data/blink/<string:prop_type>', metricsdata.FeatureBucketsHandler),
 ]
+
 
 # TODO(jrobbins): Advance this to v1 once we have it fleshed out
 API_BASE = '/api/v0'

--- a/main.py
+++ b/main.py
@@ -64,7 +64,6 @@ metrics_chart_routes = [
     ('/data/blink/<string:prop_type>', metricsdata.FeatureBucketsHandler),
 ]
 
-
 # TODO(jrobbins): Advance this to v1 once we have it fleshed out
 API_BASE = '/api/v0'
 api_routes = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ funcsigs
 Flask==1.1.2
 google-cloud-tasks==1.5.0
 google-cloud-ndb
-google-cloud-logging==1.14.0
+google-cloud-logging
 
 # Required by google-cloud-tasks
 googleapis-common-protos==1.52.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ funcsigs
 Flask==1.1.2
 google-cloud-tasks==1.5.0
 google-cloud-ndb
+google-cloud-logging==1.14.0
 
 # Required by google-cloud-tasks
 googleapis-common-protos==1.52.0

--- a/settings.py
+++ b/settings.py
@@ -47,13 +47,6 @@ DEV_MODE = (os.environ['SERVER_SOFTWARE'].startswith('Development') or
             os.environ.get('GAE_ENV', '').startswith('localdev'))
 UNIT_TEST_MODE = os.environ['SERVER_SOFTWARE'].startswith('test')
 
-# Sets up Cloud Logging client library.
-if not UNIT_TEST_MODE and not DEV_MODE:
-  import google.cloud.logging
-  client = google.cloud.logging.Client()
-  client.get_default_handler()
-  client.setup_logging()
-
 #setting GOOGLE_CLOUD_PROJECT manually in dev mode
 if DEV_MODE or UNIT_TEST_MODE:
   APP_ID = os.environ.get('GOOGLE_CLOUD_PROJECT', 'dev')

--- a/settings.py
+++ b/settings.py
@@ -47,10 +47,12 @@ DEV_MODE = (os.environ['SERVER_SOFTWARE'].startswith('Development') or
             os.environ.get('GAE_ENV', '').startswith('localdev'))
 UNIT_TEST_MODE = os.environ['SERVER_SOFTWARE'].startswith('test')
 
-if not UNIT_TEST_MODE:
-  # Configure logging to print INFO lines so that they are captured
-  # when written to stdout on GAE py3.
-  logging.basicConfig(level=logging.INFO)
+# Sets up Cloud Logging client library.
+if not UNIT_TEST_MODE and not DEV_MODE:
+  import google.cloud.logging
+  client = google.cloud.logging.Client()
+  client.get_default_handler()
+  client.setup_logging()
 
 #setting GOOGLE_CLOUD_PROJECT manually in dev mode
 if DEV_MODE or UNIT_TEST_MODE:


### PR DESCRIPTION
Fix #1359. Use [the recommended approach](https://cloud.google.com/appengine/docs/standard/python/migrate-to-python3/migrate-to-cloud-logging#key_differences), attaching Python logging module with AppEngineHandler as the root handler. 

Severity levels and nested request entries are only available after deploy to the Python 3 runtime.