### PR TITLE
Remove request to get blink components via firebase.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -23,7 +23,6 @@ import time
 from google.cloud import ndb
 
 from framework import ramcache
-import requests
 from framework import users
 
 from framework import cloud_tasks_helpers
@@ -399,8 +398,6 @@ class DictModel(ndb.Model):
 class BlinkComponent(DictModel):
 
   DEFAULT_COMPONENT = 'Blink'
-  COMPONENTS_URL = 'https://blinkcomponents-b48b5.firebaseapp.com'
-  COMPONENTS_ENDPOINT = '%s/blinkcomponents' % COMPONENTS_URL
 
   name = ndb.StringProperty(required=True, default=DEFAULT_COMPONENT)
   created = ndb.DateTimeProperty(auto_now_add=True)
@@ -425,15 +422,9 @@ class BlinkComponent(DictModel):
 
     components = ramcache.get(key)
     if components is None or update_cache:
-      components = []
-      url = self.COMPONENTS_ENDPOINT + '?cache-buster=%s' % time.time()
-      result = requests.get(url, timeout=60)
-      if result.status_code == 200:
-        components = sorted(json.loads(result.content))
-        ramcache.set(key, components)
-      else:
-        logging.error('Fetching blink components returned: %s' %
-                      result.status_code)
+      # TODO(jrobbins): Re-implement fetching the list of blink components
+      # by getting it via the monorail API.
+      pass
 
     if not components:
       components = sorted(hack_components.HACK_BLINK_COMPONENTS)


### PR DESCRIPTION
Remove some old code that hit a backend on firebase that gave a list of Monorail components.  This backend started being flakey in Jan 2020 and at some point completely stopped working (error message "Runtime nodejs6 is no longer available").  Since Jan 2020, we have used a hard-coded list of components in hack_components.py as a fallback.  We don't have the source code to the firebase app or admin access to it.

Monorail does offer an API, and we should use it in the future to get other info related to tracking issue for the features in our system.  So, it would make sense to get the list of components via that API too.
