### PR TITLE
Use toast rather than alert().

### DIFF
--- a/static/elements/chromedash-roadmap.js
+++ b/static/elements/chromedash-roadmap.js
@@ -92,7 +92,7 @@ class ChromedashRoadmap extends LitElement {
         this.requestUpdate('lastPastFetchedOn', oldVal);
       }).catch(() => {
         const toastEl = document.querySelector('chromedash-toast');
-        toastEl.showMessage('Some error occurred. Please refresh the page or try again later.');
+        toastEl.showMessage('Some errors occurred. Please refresh the page or try again later.');
       });
     }
   }


### PR DESCRIPTION
On staging I found that if I navigated to the roadmap page and then quickly navigated away, it would show two alerts that temporarily blocked the navigation away.  I believe that this is because pending requests are being canceled which is treated like an error response.  Using the toast element is a nicer way to show an error message, and it is non-blocking.  When I tried this code on staging, the toast was not noticeable.

I considered also listening for the beforeunload event, but this change achieves the goal I wanted with less code. 