### PR TITLE
Decode response from uma-export.

### DIFF
--- a/internals/fetchmetrics.py
+++ b/internals/fetchmetrics.py
@@ -97,7 +97,7 @@ class UmaQuery(object):
           url, result.status_code))
       return (None, result.status_code)
 
-    json_content = result.content.split('\n', 1)[1]
+    json_content = result.content.decode().split('\n', 1)[1]
     j = json.loads(json_content)
     if 'r' not in j:
       logging.info(


### PR DESCRIPTION
We didn't notice this before because the code never reached this point due to failure to authenticate to the uma-export backend.