### PR TITLE
Remove Webview DT from the UI.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -1255,6 +1255,8 @@ class Feature(DictModel):
   dt_milestone_desktop_start = ndb.IntegerProperty()
   dt_milestone_android_start = ndb.IntegerProperty()
   dt_milestone_ios_start = ndb.IntegerProperty()
+  # Webview DT is currently not offered in the UI because there is no way
+  # to set flags.
   dt_milestone_webview_start = ndb.IntegerProperty()
   # Note: There are no dt end milestones because a dev trail implicitly
   # ends when the feature ships or is abandoned.

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -659,12 +659,6 @@ ALL_FIELDS = {
         help_text=('First milestone that allows developers to try '
                    'this feature on iOS by setting a flag.')),
 
-    'dt_milestone_webview_start': forms.IntegerField(
-        required=False, label='DevTrial on Webview',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=('First milestone that allows developers to try '
-                   'this feature on Webview by setting a flag.')),
-
     'flag_name': forms.CharField(
         label='Flag name', required=False,
         help_text='Name of the flag that enables this feature.'),
@@ -758,7 +752,7 @@ Any_DevTrial = define_form_class_using_shared_fields(
 ImplStatus_DevTrial = define_form_class_using_shared_fields(
     'ImplStatus_InDevTrial',
     ('dt_milestone_desktop_start', 'dt_milestone_android_start',
-     'dt_milestone_ios_start', 'dt_milestone_webview_start',
+     'dt_milestone_ios_start',
      'flag_name'))
 
 
@@ -930,7 +924,7 @@ Flat_DevTrial = define_form_class_using_shared_fields(
 
      # Implementation
      'dt_milestone_desktop_start', 'dt_milestone_android_start',
-     'dt_milestone_ios_start', 'dt_milestone_webview_start',
+     'dt_milestone_ios_start',
      'flag_name'))
   # TODO(jrobbins): api overview link
 
@@ -1040,7 +1034,7 @@ DISPLAY_FIELDS_IN_STAGES = {
         'all_platforms', 'all_platforms_descr', 'wpt', 'wpt_descr',
         'sample_links', 'devrel', 'ready_for_trial_url',
         'dt_milestone_desktop_start', 'dt_milestone_android_start',
-        'dt_milestone_ios_start', 'dt_milestone_webview_start',
+        'dt_milestone_ios_start',
         'flag_name'),
     models.INTENT_IMPLEMENT_SHIP: make_display_specs(
         'launch_bug_url',

--- a/templates/estimated-milestones-table.html
+++ b/templates/estimated-milestones-table.html
@@ -1,4 +1,4 @@
-{% if feature.shipped_milestone or feature.ot_milestone_desktop_end or feature.ot_milestone_desktop_start or feature.dt_milestone_desktop_start or feature.shipped_android_milestone or feature.ot_milestone_android_end or feature.ot_milestone_android_start or feature.dt_milestone_android_start or feature.shipped_ios_milestone or feature.dt_milestone_ios_start or feature.shipped_webview_milestone or feature.dt_milestone_webview_start %}
+{% if feature.shipped_milestone or feature.ot_milestone_desktop_end or feature.ot_milestone_desktop_start or feature.dt_milestone_desktop_start or feature.shipped_android_milestone or feature.ot_milestone_android_end or feature.ot_milestone_android_start or feature.dt_milestone_android_start or feature.shipped_ios_milestone or feature.dt_milestone_ios_start or feature.shipped_webview_milestone %}
 
   <table>
 
@@ -63,11 +63,6 @@
     {% if feature.shipped_webview_milestone %}
       <tr><td>Shipping on Webview</td>
       <td>{{feature.shipped_webview_milestone}}</td></tr>
-    {% endif %}
-
-    {% if feature.dt_milestone_webview_start %}
-      <tr><td>DevTrial on Webview</td>
-      <td>{{feature.dt_milestone_webview_start}}</td></tr>
     {% endif %}
 
   </table>


### PR DESCRIPTION
If there is no need for a webview devtrial milestone right now, we can hide it from the UI.
We can always add it back again.