### PR TITLE
Make footer fixed on very long pages.

### DIFF
--- a/static/sass/features/features.scss
+++ b/static/sass/features/features.scss
@@ -53,10 +53,12 @@ chromedash-featurelist {
 }
 
 @media only screen and (min-width: 701px) {
-  #content {
-    &::after {
-      width: $max-content-width;
-    }
+
+  footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
   }
 }
 

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -93,7 +93,6 @@ app-header-layout {
   flex: 1;
 }
 
-
 .main-toolbar {
   display: flex;
   position: relative;
@@ -103,14 +102,6 @@ app-header-layout {
 header {
   display: flex;
   align-items: baseline;
-}
-
-footer {
-  display: flex;
-  align-items: center;
-}
-
-header {
   user-select: none;
   background: var(--card-background);
   border-bottom: var(--card-border);
@@ -214,6 +205,7 @@ footer {
   flex-direction: column;
   justify-content: center;
   text-align: center;
+  align-items: center;
   margin-top: 2em;
   padding: var(--content-padding-half);
 

--- a/static/sass/metrics.scss
+++ b/static/sass/metrics.scss
@@ -31,6 +31,16 @@
   }
 }
 
+@media only screen and (min-width: 701px) {
+
+  footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+  }
+}
+
 @media only screen and (max-width: 700px) {
   #subheader {
     margin: $content-padding 0;

--- a/static/sass/theme.scss
+++ b/static/sass/theme.scss
@@ -112,5 +112,5 @@
   --toast-color: var(--md-gray-50);
   --toast-action-color: var(--md-orange-200);
 
-  --footer-background: transparent;
+  --footer-background: var(--page-background);
 }


### PR DESCRIPTION
This should resolve issue #1096.

Footer links are infrequently used, so I don't want them to always be taking up screen real estate on pages like the Guide UI.  However, having the footer be position:relative on a few pages is a pain because the pages are very long.  I think the right long-term fix is to make those pages not so long, however in the near term we can make the footer fixed (always displayed) on just those pages.

In this PR:
* Add CSS to make the footer fixed position to the CSS files for the feature list and metrics list pages.  These rules are inside a media condition for desktop devices because we don't want to dedicate screen space to the footer on mobile devices.
* Combine some existing CSS rules
* Delete an ::after rule that does not seem to be needed.
