### PR TITLE
Use urlfetch directly in py2 code.

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -1,7 +1,3 @@
-
-
-
-
 import os
 import sys
 import importlib
@@ -16,11 +12,3 @@ vendor.add(lib_path) # add third party libs to "lib" folder.
 # Add libraries to pkg_resources working set to find the distribution.
 import pkg_resources
 pkg_resources.working_set.add_entry(lib_path)
-
-# This is needed to use the requests library in python 2.7.
-# https://cloud.google.com/appengine/docs/standard/python/issue-requests#requests
-if (sys.version_info < (3, 0)):
-  import requests_toolbelt.adapters.appengine  # noqa: E402
-  # Use the App Engine Requests adapter. This makes sure that Requests uses
-  # URLFetch.
-  requests_toolbelt.adapters.appengine.monkeypatch()

--- a/internals/sendemail.py
+++ b/internals/sendemail.py
@@ -18,10 +18,10 @@ import json
 import logging
 import re
 import urllib
-import requests
 import rfc822
 
 from google.appengine.api import mail
+from google.appengine.api import urlfetch
 from google.appengine.ext.webapp.mail_handlers import BounceNotification
 
 import settings
@@ -145,8 +145,9 @@ def call_py3_task_handler(handler_path, task_dict):
   # AppEngine automatically sets header X-Appengine-Inbound-Appid,
   # and that header is stripped from external requests.  So,
   # require_task_header() can check for it to authenticate.
-  handler_response = requests.request(
-      'POST', handler_url, data=request_body, allow_redirects=False)
+  handler_response = urlfetch.fetch(
+      url=handler_url, payload=request_body, method=urlfetch.POST,
+      follow_redirects=False)
 
   logging.info('request_response is %r', handler_response)
   return handler_response

--- a/internals/sendemail_py2test.py
+++ b/internals/sendemail_py2test.py
@@ -20,6 +20,7 @@ import mock
 import unittest
 
 from google.appengine.api import mail
+from google.appengine.api import urlfetch
 
 import settings
 from internals import sendemail
@@ -198,17 +199,17 @@ class FunctionTest(unittest.TestCase):
         ['a@b.com', 'e.g-h@i-j.k-L.com'],
         sendemail._extract_addrs(header_val))
 
-  @mock.patch('requests.request')
-  def test_call_py3_task_handler(self, mock_request):
+  @mock.patch('google.appengine.api.urlfetch.fetch')
+  def test_call_py3_task_handler(self, mock_fetch):
     """Our py2 code can make a request to our py3 code."""
-    mock_request.return_value = 'mock response'
+    mock_fetch.return_value = 'mock response'
 
     actual = sendemail.call_py3_task_handler('/path', {'a': 1})
 
     self.assertEqual('mock response', actual)
-    mock_request.assert_called_once_with(
-        'POST', 'http://localhost:8080/path',
-        data=b'{"a": 1}', allow_redirects=False)
+    mock_fetch.assert_called_once_with(
+        url='http://localhost:8080/path', method=urlfetch.POST,
+        payload=b'{"a": 1}', follow_redirects=False)
 
 
 def MakeMessage(header_list, body):

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,5 @@ itsdangerous==1.1.0
 
 # Required for porting Python2 to Python3
 requests==2.25.1
-requests-toolbelt==0.9.1  # backward compatability while still on py2.
 
 # See also: requirements.dev.txt


### PR DESCRIPTION
This should resolve the problem that we talked about today.

I don't know exactly why our call to requests.request() was failing to go through urlfetch.fetch() and thus failing to add the X-AppEngine-App-Id header.  However, this change eliminates any possibility of making the request without using urlfetch because it references urlfetch explicitly.

This change also allows us to take out a little bit of the py2/3 complexity in appengine_config.py and one line from requirements.txt.  The remaining py2 code we have is not py2-waiting-to-be-upgraded-to-py3, it is just plain py2.