### PR TITLE
Allow required int parameters to have zero value.

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -86,7 +86,7 @@ class BaseHandler(flask.views.MethodView):
     """Get the specified JSON parameter."""
     json_body = self.request.get_json(force=True, silent=True) or {}
     val = json_body.get(name, default)
-    if required and not val:
+    if required and val is None:
       self.abort(400, msg='Missing parameter %r' % name)
     if val and validator and not validator(val):
       self.abort(400, msg='Invalid value for parameter %r' % name)

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -160,11 +160,14 @@ class BaseHandlerTests(testing_config.CustomTestCase):
   @mock.patch('flask.request')
   def test_get_int_param(self, mock_request, mock_abort):
     """We can get an int, or abort."""
-    mock_request.get_json.return_value = {'x': 1, 'foo': 'bar'}
+    mock_request.get_json.return_value = {'x': 1, 'y': 0, 'foo': 'bar'}
     mock_abort.side_effect = werkzeug.exceptions.BadRequest
 
     actual = self.handler.get_int_param('x')
     self.assertEqual(1, actual)
+
+    actual = self.handler.get_int_param('y')
+    self.assertEqual(0, actual)
 
     actual = self.handler.get_int_param('missing', default=3)
     self.assertEqual(3, actual)


### PR DESCRIPTION
We used to check if a required POST parameter had a truth-y value according to python logic rules.  However, that caused zeros to be treated as missing values.  So, with this change we only check if the value is None.