### PR TITLE
Set approval by specifying featureId in URL only.

### DIFF
--- a/api/approvals_api.py
+++ b/api/approvals_api.py
@@ -39,12 +39,12 @@ class ApprovalsAPI(basehandlers.APIHandler):
         }
     return data
 
-  def do_post(self):
+  def do_post(self, feature_id=None):
     """Set an approval value for the specified feature."""
     field_id = self.get_int_param('fieldId')
     new_state = self.get_int_param(
-        'state', validator= models.Approval.is_valid_state)
-    feature = self.get_specified_feature()
+        'state', validator=models.Approval.is_valid_state)
+    feature = self.get_specified_feature(feature_id=feature_id)
     user = self.get_current_user(required=True)
 
     approvers = approval_defs.get_approvers(field_id)

--- a/internals/models.py
+++ b/internals/models.py
@@ -844,6 +844,8 @@ class Feature(DictModel):
 
       if feature is None or update_cache:
         futures.append(Feature.get_by_id_async(feature_id))
+      else:
+        result_dict[feature_id] = feature
 
     for future in futures:
       unformatted_feature = future.get_result()

--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -192,7 +192,8 @@ class ChromeStatusClient {
   setApproval(featureId, fieldId, state) {
     return this.doPost(
         `/features/${featureId}/approvals`,
-        {featureId, fieldId, state});
+        {fieldId: Number(fieldId),
+          state: Number(state)});
   }
 
   getComments(featureId, fieldId) {


### PR DESCRIPTION
Previously in cs-client when setting an approval, the featureId was specified in both the URL and in the POST data.  Having the ID in the URL is more aligned with REST API design.  Having it duplicated in the POST data was a mistake because it leaves open the possibility that the two values might somehow disagree.

We have a method to retrieve a list of features by their ID numbers.  It had a defect which caused features found in ramcache to be omitted from the result.

In this PR:
* In cs-client, pass the featureId only in the URL.  Also, ensure that the other numbers are passed as numbers rather than strings.
* In the approvals_api request hander, treat feature_id as a URL parameter and use it to load the requested feature.
* Fix the logic for cache hits in get_by_ids() and add unit tests.