### PR TITLE
Add heading property to chromedash-dialog.

### DIFF
--- a/static/elements/chromedash-dialog.js
+++ b/static/elements/chromedash-dialog.js
@@ -7,6 +7,7 @@ import '@polymer/iron-icon';
 class ChromedashDialog extends LitElement {
   static get properties() {
     return {
+      heading: {type: String},
       opened: {type: Boolean, reflect: true},
     };
   }
@@ -40,6 +41,10 @@ class ChromedashDialog extends LitElement {
         border: 0;
         max-width: 90%;
       }
+      #heading {
+        margin-top: 0;
+        font-weight: normal;
+      }
       .dialog-content {
         /* This extra div is here because otherwise the browser can't
         * differentiate between a click event that hits the dialog element or
@@ -65,6 +70,7 @@ class ChromedashDialog extends LitElement {
 
   constructor() {
     super();
+    this.heading = '';
     this.opened = false;
     this._boundKeydownHandler = this._keydownHandler.bind(this);
   }
@@ -140,6 +146,7 @@ class ChromedashDialog extends LitElement {
           <button id="close-icon" @click=${this.close}>
              <iron-icon icon="chromestatus:close"></iron-icon>
           </button>
+          <h2 id="heading">${this.heading}</h2>
           <slot></slot>
         </div>
       </dialog>


### PR DESCRIPTION
Previously our dialog boxes just showed the child nodes of the <chromedash-dialog> element as the entire contents.  Everything was below the "X" icon, so it was impossible to use the very first line of the dialog box.

This change allows us to specify a heading that is shown at the top of the dialog box in a way that looks good with the "X" icon to close the dialog.  The rest of the contents are displayed as before.