### PR TITLE
Outline the implementation of the approvals dialog

### DIFF
--- a/static/components.js
+++ b/static/components.js
@@ -14,6 +14,7 @@ import '@polymer/paper-styles/color.js';
 // chromedash components
 import './elements/icons';
 import './elements/chromedash-accordion';
+import './elements/chromedash-approvals-dialog';
 import './elements/chromedash-banner';
 import './elements/chromedash-callout';
 import './elements/chromedash-color-status';

--- a/static/elements/chromedash-approvals-dialog.js
+++ b/static/elements/chromedash-approvals-dialog.js
@@ -1,0 +1,42 @@
+import {LitElement, css, html} from 'lit-element';
+import './chromedash-dialog';
+import SHARED_STYLES from '../css/shared.css';
+
+class ChromedashApprovalsDialog extends LitElement {
+  static get properties() {
+    return {
+      signedInUser: {type: String},
+      featureId: {type: Number},
+      canApprove: {type: Boolean},
+    };
+  }
+
+  constructor() {
+    super();
+    this.signedInUser = ''; // email address
+    this.canApprove = false;
+  }
+
+  static get styles() {
+    return [
+      SHARED_STYLES,
+      css`
+      `];
+  }
+
+  openWithFeature(featureId) {
+    this.featureId = featureId;
+    this.shadowRoot.querySelector('chromedash-dialog').open();
+  }
+
+  render() {
+    const heading = 'TODO: Feature name';
+    return html`
+      <chromedash-dialog heading="${heading}">
+        TODO: dialog content
+      </chromedash-dialog>
+    `;
+  }
+}
+
+customElements.define('chromedash-approvals-dialog', ChromedashApprovalsDialog);

--- a/static/elements/chromedash-feature-table.js
+++ b/static/elements/chromedash-feature-table.js
@@ -119,7 +119,7 @@ class ChromedashFeatureTable extends LitElement {
         @click="${() => this.openApprovalsDialog(feature.id)}"
         title="Review approvals">
         <iron-icon icon="chromestatus:approval"></iron-icon>
-      </span>
+      </a>
     `;
   }
 
@@ -128,7 +128,7 @@ class ChromedashFeatureTable extends LitElement {
       <a href="/guide/edit/${feature.id}" class="tooltip"
         title="Edit feature">
         <iron-icon icon="chromestatus:create"></iron-icon>
-      </span>
+      </a>
     `;
   }
 

--- a/static/elements/chromedash-feature-table.js
+++ b/static/elements/chromedash-feature-table.js
@@ -87,7 +87,7 @@ class ChromedashFeatureTable extends LitElement {
 
     // handled in chromedash-myfeatures.js
     this._fireEvent('star-toggle-event', {
-      feature: featureId,
+      featureId: featureId,
       doStar: newStarred,
     });
   }
@@ -106,14 +106,17 @@ class ChromedashFeatureTable extends LitElement {
     return nothing;
   }
 
-  openApprovalsDialog(feature) {
-    alert('TODO show approvals for ' + feature.id);
+  openApprovalsDialog(featureId) {
+    // handled in chromedash-myfeatures.js
+    this._fireEvent('open-approvals-event', {
+      featureId: featureId,
+    });
   }
 
   renderApprovalsIcon(feature) {
     return html`
       <a href="#" class="tooltip"
-        @click="${() => this.openApprovalsDialog(feature)}"
+        @click="${() => this.openApprovalsDialog(feature.id)}"
         title="Review approvals">
         <iron-icon icon="chromestatus:approval"></iron-icon>
       </span>

--- a/static/elements/chromedash-myfeatures.js
+++ b/static/elements/chromedash-myfeatures.js
@@ -66,7 +66,7 @@ class ChromedashMyFeatures extends LitElement {
 
         <chromedash-feature-table
           query="${query}"
-          ?signedIn=${this.signedInUser}
+          ?signedIn=${Boolean(this.signedInUser)}
           ?canEdit=${this.canEdit}
           ?canApprove=${this.canApprove}
           .starredFeatures=${this.starredFeatures}

--- a/templates/myfeatures.html
+++ b/templates/myfeatures.html
@@ -13,12 +13,11 @@
 {% block content %}
 
 <chromedash-myfeatures
-  {% if user %} signedin {% endif %}
+  {% if user %} signedinuser="{{user.email}}" {% endif %}
   {% if user.can_edit %} canedit {% endif %}
   {% if user.can_approve %} canapprove {% endif %}
   >
 </chromedash-myfeatures>
-
 
 {% endblock %}
 


### PR DESCRIPTION
This replaces a previous alert("TODO") with a real dialog box that still says "TODO".

In this CL:
* Defined a custom element chromedash-approvals-dialog that wraps a chromedash-dialog element.
* For now, that dialog just says "TODO".
* Generate an event when the approvals-stamp icon is clicked, and handle that event by opening the dialog.
* Pass only the feature ID in that event because we will reuse this dialog on pages where only the ID is available.
* Change from using a signedIn boolean to a signedInUser email address string.  The full implementation of the dialog will need the string.
* Fix a couple of mismatched HTML tags that were caught by JS lint.