### PR TITLE
When an intent review is complete, make it no longer pending.

### DIFF
--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import base64
+import datetime
 import requests
 import testing_config  # Must be imported before the module under test.
 import unittest
@@ -79,7 +77,7 @@ MOCK_APPROVALS_BY_ID = {
     2: approval_defs.ApprovalFieldDef(
         'Intent to optimize',
         'You need permission to optimize',
-        2, approval_defs.ONE_LGTM, 'https://example.com'),
+        2, approval_defs.THREE_LGTM, 'https://example.com'),
 }
 
 
@@ -114,3 +112,83 @@ class IsValidFieldIdTest(unittest.TestCase):
     self.assertTrue(approval_defs.is_valid_field_id(1))
     self.assertTrue(approval_defs.is_valid_field_id(2))
     self.assertFalse(approval_defs.is_valid_field_id(3))
+
+
+class IsApprovedTest(unittest.TestCase):
+
+  def setUp(self):
+    feature_1_id = 123456
+    self.appr_nr = models.Approval(
+        feature_id=feature_1_id, field_id=1,
+        state=models.Approval.NEEDS_REVIEW,
+        set_on=datetime.datetime.now(),
+        set_by='one@example.com')
+    self.appr_no = models.Approval(
+        feature_id=feature_1_id, field_id=1,
+        state=models.Approval.NOT_APPROVED,
+        set_on=datetime.datetime.now(),
+        set_by='two@example.com')
+    self.appr_yes = models.Approval(
+        feature_id=feature_1_id, field_id=1,
+        state=models.Approval.APPROVED,
+        set_on=datetime.datetime.now(),
+        set_by='three@example.com')
+
+  @mock.patch('internals.approval_defs.APPROVAL_FIELDS_BY_ID',
+              MOCK_APPROVALS_BY_ID)
+  def test_is_approved(self):
+    """We know if an approval rule has been satisfied."""
+
+    # Field requires 1 LGTM
+    self.assertFalse(approval_defs.is_approved([], 1))
+    self.assertFalse(approval_defs.is_approved([self.appr_nr], 1))
+    self.assertFalse(approval_defs.is_approved([self.appr_no], 1))
+    self.assertTrue(approval_defs.is_approved([self.appr_yes], 1))
+    self.assertFalse(approval_defs.is_approved([self.appr_nr, self.appr_no], 1))
+    self.assertFalse(approval_defs.is_approved(
+        [self.appr_nr, self.appr_no, self.appr_yes], 1))
+    self.assertTrue(approval_defs.is_approved([self.appr_nr, self.appr_yes], 1))
+
+    # Field requires 3 LGTMs
+    self.assertFalse(approval_defs.is_approved([], 2))
+    self.assertFalse(approval_defs.is_approved([self.appr_nr], 2))
+    self.assertFalse(approval_defs.is_approved([self.appr_no], 2))
+    self.assertFalse(approval_defs.is_approved([self.appr_yes], 2))
+    self.assertFalse(approval_defs.is_approved([self.appr_nr, self.appr_no], 2))
+    self.assertFalse(approval_defs.is_approved(
+        [self.appr_nr, self.appr_no, self.appr_yes], 2))
+    self.assertFalse(approval_defs.is_approved([self.appr_nr, self.appr_yes], 2))
+
+    self.assertTrue(approval_defs.is_approved(
+        [self.appr_yes, self.appr_yes, self.appr_yes], 2))
+    self.assertFalse(approval_defs.is_approved(
+        [self.appr_yes, self.appr_yes, self.appr_yes, self.appr_no], 2))
+
+  @mock.patch('internals.approval_defs.APPROVAL_FIELDS_BY_ID',
+              MOCK_APPROVALS_BY_ID)
+  def test_is_resolved(self):
+    """We know if an approval request has been resolved."""
+    # Field requires 1 LGTM
+    self.assertFalse(approval_defs.is_resolved([], 1))
+    self.assertFalse(approval_defs.is_resolved([self.appr_nr], 1))
+    self.assertTrue(approval_defs.is_resolved([self.appr_no], 1))
+    self.assertTrue(approval_defs.is_resolved([self.appr_yes], 1))
+    self.assertTrue(approval_defs.is_resolved([self.appr_nr, self.appr_no], 1))
+    self.assertTrue(approval_defs.is_resolved(
+        [self.appr_nr, self.appr_no, self.appr_yes], 1))
+    self.assertTrue(approval_defs.is_resolved([self.appr_nr, self.appr_yes], 1))
+
+    # Field requires 3 LGTMs
+    self.assertFalse(approval_defs.is_resolved([], 2))
+    self.assertFalse(approval_defs.is_resolved([self.appr_nr], 2))
+    self.assertTrue(approval_defs.is_resolved([self.appr_no], 2))
+    self.assertFalse(approval_defs.is_resolved([self.appr_yes], 2))
+    self.assertTrue(approval_defs.is_resolved([self.appr_nr, self.appr_no], 2))
+    self.assertTrue(approval_defs.is_resolved(
+        [self.appr_nr, self.appr_no, self.appr_yes], 2))
+    self.assertFalse(approval_defs.is_resolved([self.appr_nr, self.appr_yes], 2))
+
+    self.assertTrue(approval_defs.is_resolved(
+        [self.appr_yes, self.appr_yes, self.appr_yes], 2))
+    self.assertTrue(approval_defs.is_resolved(
+        [self.appr_yes, self.appr_yes, self.appr_yes, self.appr_no], 2))

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -120,7 +120,7 @@ class IsApprovedTest(unittest.TestCase):
     feature_1_id = 123456
     self.appr_nr = models.Approval(
         feature_id=feature_1_id, field_id=1,
-        state=models.Approval.NEEDS_REVIEW,
+        state=models.Approval.REVIEW_REQUESTED,
         set_on=datetime.datetime.now(),
         set_by='one@example.com')
     self.appr_no = models.Approval(

--- a/internals/models.py
+++ b/internals/models.py
@@ -1395,7 +1395,7 @@ class Approval(DictModel):
   def clear_request(cls, feature_id, field_id):
     """After the review requirement has been satisfied, remove the request."""
     review_requests = cls.get_approvals(
-        feature_id=feature_id, field_id=field_id, states=[cls.NEEDS_REVIEW])
+        feature_id=feature_id, field_id=field_id, states=[cls.REVIEW_REQUESTED])
     for rr in review_requests:
       rr.key.delete()
 

--- a/internals/models.py
+++ b/internals/models.py
@@ -1391,6 +1391,13 @@ class Approval(DictModel):
         set_on=now, set_by=set_by_email)
     new_appr.put()
 
+  @classmethod
+  def clear_request(cls, feature_id, field_id):
+    """After the review requirement has been satisfied, remove the request."""
+    review_requests = cls.get_approvals(
+        feature_id=feature_id, field_id=field_id, states=[cls.NEEDS_REVIEW])
+    for rr in review_requests:
+      rr.key.delete()
 
 
 class Comment(DictModel):

--- a/internals/models_test.py
+++ b/internals/models_test.py
@@ -339,7 +339,8 @@ class ApprovalTest(testing_config.CustomTestCase):
     self.feature_1.put()
     self.feature_1_id = self.feature_1.key.integer_id()
     self.appr_1 = models.Approval(
-        feature_id=self.feature_1_id, field_id=1, state=2,
+        feature_id=self.feature_1_id, field_id=1,
+        state=models.Approval.REVIEW_STARTED,
         set_on=datetime.datetime.now(),
         set_by='one@example.com')
     self.appr_1.put()
@@ -358,7 +359,8 @@ class ApprovalTest(testing_config.CustomTestCase):
     actual = models.Approval.get_approvals(field_id=1)
     self.assertEqual(1, len(actual))
 
-    actual = models.Approval.get_approvals(states={2, 3})
+    actual = models.Approval.get_approvals(
+        states={models.Approval.REVIEW_STARTED, models.Approval.NEED_INFO})
     self.assertEqual(1, len(actual))
 
     actual = models.Approval.get_approvals(set_by='one@example.com')
@@ -379,6 +381,18 @@ class ApprovalTest(testing_config.CustomTestCase):
     self.assertEqual(
         2,
         len(models.Approval.query().fetch(None)))
+
+  def test_clear_request(self):
+    """We can clear a review request so that it is no longer pending."""
+    self.appr_1.state = models.Approval.NEEDS_REVIEW
+    self.appr_1.put()
+
+    models.Approval.clear_request(self.feature_1_id, 1)
+
+    remaining_apprs = models.Approval.get_approvals(
+        feature_id=self.feature_1_id, field_id=1,
+        states=[models.Approval.NEEDS_REVIEW])
+    self.assertEqual([], remaining_apprs)
 
 
 class CommentTest(testing_config.CustomTestCase):

--- a/internals/models_test.py
+++ b/internals/models_test.py
@@ -385,14 +385,14 @@ class ApprovalTest(testing_config.CustomTestCase):
 
   def test_clear_request(self):
     """We can clear a review request so that it is no longer pending."""
-    self.appr_1.state = models.Approval.NEEDS_REVIEW
+    self.appr_1.state = models.Approval.REVIEW_REQUESTED
     self.appr_1.put()
 
     models.Approval.clear_request(self.feature_1_id, 1)
 
     remaining_apprs = models.Approval.get_approvals(
         feature_id=self.feature_1_id, field_id=1,
-        states=[models.Approval.NEEDS_REVIEW])
+        states=[models.Approval.REVIEW_REQUESTED])
     self.assertEqual([], remaining_apprs)
 
 


### PR DESCRIPTION
Each feature can have a list of associated approval values which are grouped by approval field (e.g., prototype, experiment, ship).  When an intent email thread is detected, a NEEDS_REVIEW value is added to indicate the start of that review process.  When viewing the My Features page, the list of pending reviews is generated by searching for NEEDS_REVIEW approval values.

This change implements the end of the review process.  When users have added enough APPROVED or NOT_APPROVED values, then we detect that fact and delete the original NEEDS_REVIEW value.  This makes that item no longer appear on the My Features page (until it starts the review of a later intent with a different field id).

In this PR:
* Implement boolean methods `is_approved()` and `is_resolved()`.
* Implement a models.py method `clear_request()` to delete the relevant NEEDS_REVIEW entity.
* Add logic to approvals_api.py to `check is_resolved()` and call `clear_request()`.
