### PR TITLE
Fix defect in read-only display of approval values.

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -164,16 +164,16 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
       feature.put()
 
   def create_approvals(self, feature_id, approval_field, from_addr, body):
-    """Store either a NEEDS_REVIEW or an APPROVED approval value."""
+    """Store either a REVIEW_REQUESTED or an APPROVED approval value."""
     # Case 1: This is a new intent thread
     existing_approvals = models.Approval.get_approvals(
         feature_id=feature_id, field_id=approval_field.field_id)
     if not existing_approvals:
       models.Approval.set_approval(
           feature_id, approval_field.field_id,
-          models.Approval.NEEDS_REVIEW, from_addr)
+          models.Approval.REVIEW_REQUESTED, from_addr)
 
     # Case 2: This is an existing intent thread
     # TODO(jrobbins): Detect LGTMs in body, verify that sender has permission,
-    # set an approval value, and clear the original NEEDS_REVIEW if
+    # set an approval value, and clear the original REVIEW_REQUESTED if
     # the approval rule (1 or 3 LTGMs) is satisfied.

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -150,7 +150,7 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
     appr = created_approvals[0]
     self.assertEqual(self.feature_id, appr.feature_id)
     self.assertEqual(approval_defs.ShipApproval.field_id, appr.field_id)
-    self.assertEqual(models.Approval.NEEDS_REVIEW, appr.state)
+    self.assertEqual(models.Approval.REVIEW_REQUESTED, appr.state)
     self.assertEqual('user@example.com', appr.set_by)
     self.assertEqual(
         self.feature_1.intent_to_ship_url,

--- a/internals/models.py
+++ b/internals/models.py
@@ -1326,17 +1326,17 @@ class Feature(DictModel):
 class Approval(DictModel):
   """Describes the current state of one approval on a feature."""
 
-  NEEDS_REVIEW = 0
+  # Not used: NEEDS_REVIEW = 0
   NA = 1
-  # REVIEW_REQUESTED = 2  Reserved for FLT
+  REVIEW_REQUESTED = 2
   REVIEW_STARTED = 3
   NEED_INFO = 4
   APPROVED = 5
   NOT_APPROVED = 6
   APPROVAL_VALUES = {
-      NEEDS_REVIEW: 'needs_review',
+      # Not used: NEEDS_REVIEW: 'needs_review',
       NA: 'na',
-      # REVIEW_REQUESTED: 'review_requested',
+      REVIEW_REQUESTED: 'review_requested',
       REVIEW_STARTED: 'review_started',
       NEED_INFO: 'need_info',
       APPROVED: 'approved',

--- a/internals/models_test.py
+++ b/internals/models_test.py
@@ -367,7 +367,7 @@ class ApprovalTest(testing_config.CustomTestCase):
   def test_is_valid_state(self):
     """We know what approval states are valid."""
     self.assertTrue(
-        models.Approval.is_valid_state(models.Approval.NEEDS_REVIEW))
+        models.Approval.is_valid_state(models.Approval.REVIEW_REQUESTED))
     self.assertFalse(models.Approval.is_valid_state(None))
     self.assertFalse(models.Approval.is_valid_state('not an int'))
     self.assertFalse(models.Approval.is_valid_state(999))
@@ -375,7 +375,8 @@ class ApprovalTest(testing_config.CustomTestCase):
   def test_set_approval(self):
     """We can set an Approval entity."""
     models.Approval.set_approval(
-        self.feature_1_id, 2, 0, 'owner@example.com')
+        self.feature_1_id, 2, models.Approval.REVIEW_REQUESTED,
+        'owner@example.com')
     self.assertEqual(
         2,
         len(models.Approval.query().fetch(None)))

--- a/internals/search.py
+++ b/internals/search.py
@@ -22,7 +22,7 @@ from internals import notifier
 
 
 PENDING_STATES = [
-    models.Approval.NEEDS_REVIEW, models.Approval.REVIEW_STARTED,
+    models.Approval.REVIEW_REQUESTED, models.Approval.REVIEW_STARTED,
     models.Approval.NEED_INFO]
 
 def process_pending_approval_me_query():

--- a/static/elements/chromedash-approvals-dialog.js
+++ b/static/elements/chromedash-approvals-dialog.js
@@ -4,14 +4,15 @@ import './chromedash-dialog';
 import SHARED_STYLES from '../css/shared.css';
 
 const STATE_NAMES = [
-  [0, 'Needs review'],
+  // Not used: [0, 'Needs review'],
   [1, 'N/a or Ack'],
+  [2, 'Review requested'],
   [3, 'Review started'],
   [4, 'Need info'],
   [5, 'Approved'],
   [6, 'Not approved'],
 ];
-const ACTIVE_STATES = [0, 3, 4];
+const PENDING_STATES = [2, 3, 4];
 
 const APPROVAL_DEFS = [
   {name: 'Intent to Prototype',
@@ -147,7 +148,7 @@ class ChromedashApprovalsDialog extends LitElement {
       (res) => {
         this.approvals = res.approvals;
         const numPending = this.approvals.filter((av) =>
-          ACTIVE_STATES.includes(av.state)).length;
+          PENDING_STATES.includes(av.state)).length;
         this.subsetPending = (numPending > 0 &&
                               numPending < APPROVAL_DEFS.length);
         this.showAllIntents = numPending == 0;
@@ -177,7 +178,9 @@ class ChromedashApprovalsDialog extends LitElement {
         return item[1];
       }
     }
-    throw new Error(`Unexpected approval state ${state}`);
+    // This should not normally be seen by users, but it will help us
+    // cope with data migration.
+    return `State ${state}`;
   }
 
   renderApprovalValue(approvalValue) {
@@ -231,7 +234,7 @@ class ChromedashApprovalsDialog extends LitElement {
     const approvalValues = this.approvals.filter((a) =>
       a.field_id == approvalDef.id);
     const isActive = approvalValues.some((av) =>
-      ACTIVE_STATES.includes(av.state));
+      PENDING_STATES.includes(av.state));
 
     if (!isActive && !this.showAllIntents) return nothing;
 

--- a/static/elements/chromedash-approvals-dialog.js
+++ b/static/elements/chromedash-approvals-dialog.js
@@ -171,6 +171,15 @@ class ChromedashApprovalsDialog extends LitElement {
     return dateStr.split('.')[0]; // Ignore microseconds.
   }
 
+  findStateName(state) {
+    for (let item of STATE_NAMES) {
+      if (item[0] == state) {
+        return item[1];
+      }
+    }
+    throw new Error(`Unexpected approval state ${state}`);
+  }
+
   renderApprovalValue(approvalValue) {
     const selectedValue = (
       this.changedApprovalsByField.get(approvalValue.field_id) ||
@@ -197,7 +206,7 @@ class ChromedashApprovalsDialog extends LitElement {
                  >${valName[1]}</option>`
                 )}
             </select>` : html`
-            ${STATE_NAMES[approvalValue.state][1]}
+           ${this.findStateName(approvalValue.state)}
             `}
         </span>
       </div>


### PR DESCRIPTION
The existing code used a state integer as an index into a list of [id, name] pairs.  However, that was wrong because the whole point of having that list was that the ids did not line up with the indexes.

In this PR:
* Add a lookup function findStateName() to get the correct state name for read-only display.

I didn't notice this sooner because it only shows up when testing with two different users.  Each user sees the other user's approval values as read-only.