### PR TITLE
Implement a "Recently reviewed features" box on the myfeatures page

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -9,16 +9,6 @@ indexes:
 
 - kind: "Feature"
   properties:
-  - name: "deleted"
-  - name: "owner"
-  - name: "updated"
-    direction: desc
-- kind: "Comment"
-  properties:
-  - name: "feature_id"
-  - name: "created"
-- kind: "Feature"
-  properties:
   - name: "impl_status_chrome"
   - name: "name"
 - kind: "Feature"
@@ -32,6 +22,29 @@ indexes:
   - name: "shipped_milestone"
     direction: desc
   - name: "name"
+- kind: "Approval"
+  properties:
+  - name: "state"
+  - name: "set_on"
+- kind: "Approval"
+  properties:
+  - name: "state"
+  - name: "set_on"
+    direction: desc
+- kind: "Feature"
+  properties:
+  - name: "deleted"
+  - name: "owner"
+  - name: "updated"
+    direction: desc
+- kind: "Approval"
+  properties:
+  - name: "feature_id"
+  - name: "set_on"
+- kind: "Comment"
+  properties:
+  - name: "feature_id"
+  - name: "created"
 - kind: "Feature"
   properties:
   - name: "impl_status_chrome"

--- a/internals/models.py
+++ b/internals/models.py
@@ -1351,9 +1351,12 @@ class Approval(DictModel):
 
   @classmethod
   def get_approvals(
-      cls, feature_id=None, field_id=None, states=None, set_by=None):
+      cls, feature_id=None, field_id=None, states=None, set_by=None,
+      order=None, limit=None):
     """Return the requested approvals."""
-    query = Approval.query()
+    if order is None:
+      order = Approval.set_on
+    query = Approval.query().order(order)
     if feature_id is not None:
       query = query.filter(Approval.feature_id == feature_id)
     if field_id is not None:
@@ -1362,7 +1365,7 @@ class Approval(DictModel):
       query = query.filter(Approval.state.IN(states))
     if set_by is not None:
       query = query.filter(Approval.set_by == set_by)
-    approvals = query.fetch(None)
+    approvals = query.fetch(limit)
     return approvals
 
   @classmethod

--- a/internals/search.py
+++ b/internals/search.py
@@ -50,7 +50,6 @@ def process_pending_approval_me_query():
 
   approvable_fields_ids = approval_defs.fields_approvable_by(user)
   pending_approvals = models.Approval.get_approvals(states=PENDING_STATES)
-  logging.info('pending_approvals is %r', pending_approvals)
   pending_approvals = [pa for pa in pending_approvals
                        if pa.field_id in approvable_fields_ids]
 
@@ -84,7 +83,6 @@ def process_recent_reviews_query():
   if not user:
     return []
 
-  logging.info('in process_recent_reviews_query')
   recent_approvals = models.Approval.get_approvals(
       states=FINAL_STATES, order=-models.Approval.set_on, limit=10)
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "do-tests": "curl -X POST 'http://localhost:15606/reset' && python3 -m unittest discover -p '*_test.py'  -b",
     "start-emulator": "gcloud beta emulators datastore start --host-port=:15606 --no-store-on-disk --consistency=1.0",
     "stop-emulator": "curl -X POST 'http://localhost:15606/shutdown'",
-    "test": "(npm run start-emulator > /dev/null 2>&1 &); sleep 3; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-tests; status=$?; npm run stop-emulator; exit $status",
+    "test": "(npm run start-emulator > /dev/null 2>&1 &); sleep 6; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-tests; status=$?; npm run stop-emulator; exit $status",
     "test2": "python2 -m unittest discover -p '*_py2test.py'  -b",
     "do-coverage": "coverage3 erase && coverage3 run -m unittest discover -p '*_test.py' -b && coverage3 html",
     "coverage": "(npm run start-emulator > /dev/null 2>&1 &); sleep 3; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-coverage;  npm run stop-emulator",

--- a/static/elements/chromedash-myfeatures.js
+++ b/static/elements/chromedash-myfeatures.js
@@ -58,11 +58,11 @@ class ChromedashMyFeatures extends LitElement {
     dialog.openWithFeature(featureId);
   }
 
-  renderBox(title, query, columns) {
+  renderBox(title, query, columns, opened=true) {
     return html`
       <chromedash-accordion
         title="${title}"
-        opened>
+        ?opened=${opened}>
 
         <chromedash-feature-table
           query="${query}"
@@ -78,9 +78,12 @@ class ChromedashMyFeatures extends LitElement {
     `;
   }
 
-  renderPendingApprovals() {
-    return this.renderBox(
+  renderPendingAndRecentApprovals() {
+    const pendingBox = this.renderBox(
       'Features pending my approval', 'pending-approval-by:me', 'approvals');
+    const recentBox = this.renderBox(
+      'Recently reviewed features', 'is:recently-reviewed', 'approvals', false);
+    return [pendingBox, recentBox];
   }
 
   renderIStarred() {
@@ -95,7 +98,7 @@ class ChromedashMyFeatures extends LitElement {
 
   render() {
     return html`
-      ${this.canApprove ? this.renderPendingApprovals() : nothing}
+      ${this.canApprove ? this.renderPendingAndRecentApprovals() : nothing}
       ${this.renderIOwn()}
       ${this.renderIStarred()}
       <chromedash-approvals-dialog


### PR DESCRIPTION
As mentioned at yesterday's team meeting, I realized that it seems like a problem that once a feature is reviewed it just disappears from the pending approvals box.  People like to see their recent progress in a visible way.

In this PR:
* Add a new "Recently reviewed features" box on the myfeatures page.  The accordion for that box is initially closed.
* Implement a new query to get the 10 most recently reviewed features to populate that box.
* Add new unit tests and improve some existing ones.