### PR TITLE
Add stamp icons to feature list and feature detail pages.

### DIFF
--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -19,6 +19,7 @@ class ChromedashFeature extends LitElement {
     return {
       feature: {type: Object},
       canEdit: {type: Boolean},
+      canApprove: {type: Boolean},
       signedin: {type: Boolean},
       open: {type: Boolean, reflect: true}, // Attribute used in the parent for styling
       starred: {type: Boolean},
@@ -197,10 +198,25 @@ class ChromedashFeature extends LitElement {
       });
   }
 
+  openApprovalsDialog(featureId) {
+    // handled in chromedash-myfeatures.js
+    this._fireEvent('open-approvals-event', {
+      featureId: featureId,
+    });
+  }
+
   render() {
     return html`
       <hgroup @click="${this._togglePanelExpansion}">
         <h2>${this.feature.name}
+          ${this.canApprove ? html`
+            <span class="tooltip" title="Review approvals">
+              <a href="#" id="approvals-icon" data-tooltip
+                 @click="${() => this.openApprovalsDialog(this.feature.id)}">
+                <iron-icon icon="chromestatus:approval"></iron-icon>
+              </a>
+            </span>
+            `: nothing}
           ${this.canEdit ? html`
             <span class="tooltip" title="Edit this feature">
               <a href="/guide/edit/${this.feature.id}" data-tooltip>

--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -11,7 +11,8 @@ class ChromedashFeaturelist extends LitElement {
   static get properties() {
     return {
       canEdit: {type: Boolean},
-      signedin: {type: Boolean},
+      canApprove: {type: Boolean},
+      signedInUser: {type: String},
       features: {attribute: false}, // Directly edited and accessed in template/features.html
       metadataEl: {attribute: false}, // The metadata component element. Directly edited in template/features.html
       searchEl: {attribute: false}, // The search input element. Directly edited in template/features.html
@@ -28,7 +29,8 @@ class ChromedashFeaturelist extends LitElement {
     this.metadataEl = document.querySelector('chromedash-metadata');
     this.searchEl = document.querySelector('.search input');
     this.canEdit = false;
-    this.signedin = false;
+    this.canApprove = false;
+    this.signedInUser = '';
     this._hasInitialized = false; // Used to check initialization code.
     this._hasScrolledByUser = false; // Used to set the app header state.
     /* When scrollTo(), we also expand the feature. This is the id of the feature. */
@@ -45,6 +47,7 @@ class ChromedashFeaturelist extends LitElement {
      * to be bound to `this`. */
     this._onFeatureToggledBound = this._onFeatureToggled.bind(this);
     this._onStarToggledBound = this._onStarToggled.bind(this);
+    this._onOpenApprovalsBound = this._onOpenApprovals.bind(this);
 
     this._loadData();
   }
@@ -177,6 +180,12 @@ class ChromedashFeaturelist extends LitElement {
       newStarredFeatures.delete(feature.id);
     }
     this.starredFeatures = newStarredFeatures;
+  }
+
+  _onOpenApprovals(e) {
+    const featureId = e.detail.featureId;
+    const dialog = this.shadowRoot.querySelector('chromedash-approvals-dialog');
+    dialog.openWithFeature(featureId);
   }
 
   _filterProperty(propPath, regExp, feature) {
@@ -403,9 +412,11 @@ class ChromedashFeaturelist extends LitElement {
                  ?starred="${item.starred}"
                  @feature-toggled="${this._onFeatureToggledBound}"
                  @star-toggled="${this._onStarToggledBound}"
+                 @open-approvals-event="${this._onOpenApprovalsBound}"
                  .feature="${item.feature}"
-                 ?canedit="${this.canEdit}"
-                 ?signedin="${this.signedin}"
+                 ?canEdit="${this.canEdit}"
+                 ?canApprove="${this.canApprove}"
+                 ?signedIn="${this.signedInUser != ''}"
           ></chromedash-feature>
           </div>
         `)}
@@ -413,6 +424,10 @@ class ChromedashFeaturelist extends LitElement {
       ${numOverLimit > 0 ?
         html`<p>To see ${numOverLimit} earlier features, please enter a more specific query.</p>` :
         ''}
+
+      <chromedash-approvals-dialog
+        .signedInUser=${this.signedInUser}
+      ></chromedash-approvals-dialog>
     `;
   }
 }

--- a/static/js-src/feature-page.js
+++ b/static/js-src/feature-page.js
@@ -1,6 +1,7 @@
 (function(exports) {
 const toastEl = document.querySelector('chromedash-toast');
 const copyLinkEl = document.querySelector('#copy-link');
+const approvalsIconEl = document.querySelector('#approvals-icon');
 
 // Event handler. Used in feature.html template.
 const subscribeToFeature = (featureId) => {
@@ -36,11 +37,15 @@ const shareFeature = () => {
 };
 
 function copyURLToClipboard() {
-  event.preventDefault();
   const url = copyLinkEl.href;
   navigator.clipboard.writeText(url).then(() => {
     toastEl.showMessage('Link copied');
   });
+}
+
+function openApprovalsDialog() {
+  const dialog = document.querySelector('chromedash-approvals-dialog');
+  dialog.openWithFeature(Number(FEATURE_ID));
 }
 
 // Remove loading spinner at page load.
@@ -63,6 +68,12 @@ if (shareFeatureEl) {
 if (copyLinkEl) {
   copyLinkEl.addEventListener('click', function() {
     copyURLToClipboard();
+  });
+}
+
+if (approvalsIconEl) {
+  approvalsIconEl.addEventListener('click', function() {
+    openApprovalsDialog();
   });
 }
 

--- a/static/js-src/feature-page.js
+++ b/static/js-src/feature-page.js
@@ -60,19 +60,22 @@ if (navigator.share) {
 
 const shareFeatureEl = document.querySelector('#share-feature');
 if (shareFeatureEl) {
-  shareFeatureEl.addEventListener('click', function() {
+  shareFeatureEl.addEventListener('click', function(event) {
+    event.preventDefault();
     shareFeature();
   });
 }
 
 if (copyLinkEl) {
-  copyLinkEl.addEventListener('click', function() {
+  copyLinkEl.addEventListener('click', function(event) {
+    event.preventDefault();
     copyURLToClipboard();
   });
 }
 
 if (approvalsIconEl) {
-  approvalsIconEl.addEventListener('click', function() {
+  approvalsIconEl.addEventListener('click', function(event) {
+    event.preventDefault();
     openApprovalsDialog();
   });
 }
@@ -89,14 +92,16 @@ window.csClient.getStars().then((subscribedFeatures) => {
 
 const starWhenSignedOutEl = document.querySelector('#star-when-signed-out');
 if (starWhenSignedOutEl) {
-  starWhenSignedOutEl.addEventListener('click', function(e) {
-    window.promptSignIn(e);
+  starWhenSignedOutEl.addEventListener('click', function(event) {
+    event.preventDefault();
+    window.promptSignIn(event);
   });
 }
 
 const starWhenSignedInEl = document.querySelector('#star-when-signed-in');
 if (starWhenSignedInEl) {
-  starWhenSignedInEl.addEventListener('click', function() {
+  starWhenSignedInEl.addEventListener('click', function(event) {
+    event.preventDefault();
     subscribeToFeature(Number(FEATURE_ID));
   });
 }

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -52,6 +52,13 @@
       <iron-icon icon="chromestatus:link"></iron-icon>
     </a>
   </span>
+  {% if user.can_approve %}
+    <span class="tooltip" title="Review approvals">
+      <a href="#" id="approvals-icon" data-tooltip>
+        <iron-icon icon="chromestatus:approval"></iron-icon>
+      </a>
+    </span>
+  {% endif %}
   {% if user.can_edit %}
     <span class="tooltip" title="Edit this feature">
       <a href="/guide/edit/{{ feature.id }}" class="editfeature" data-tooltip>
@@ -237,6 +244,12 @@
       dismissedcues='{{ user.dismissed_cues|default:"[]" }}'>
     </chromedash-feature-detail>
   </chromedash-accordion>
+
+  {% if user and user.can_approve %}
+    <chromedash-approvals-dialog
+      signedInUser="{{user.email}}"
+      ></chromedash-approvals-dialog>
+  {% endif %}
 
 {% endblock %}
 

--- a/templates/features.html
+++ b/templates/features.html
@@ -50,8 +50,9 @@
 
 {% block content %}
   <chromedash-featurelist
-    {% if user %}signedin{% endif %}
-    {% if user.can_edit %}canedit{% endif %}
+    {% if user %} signedInUser="{{user.email}}" {% endif %}
+    {% if user.can_edit %}canEdit{% endif %}
+    {% if user.can_approve %}canApprove{% endif %}
     ></chromedash-featurelist>
 {% endblock %}
 


### PR DESCRIPTION
This adds the feature approval icon to more places where it might be useful.  It is only shown to users who have permission to approve intents.

In this PR:
* Add the approval stamp icon to the feature detail page next to the edit icon.  And, add event handlers to make it actually open the dialog.
* Add the approval stamp icon to the feature cards on the feature list page.  And, event handlers.  And, pass some permission info down so that the cards know when to show the icon.