### PR TITLE
Fix summary ellipsis for collapsed chromedash-feature

### DIFF
--- a/static/sass/elements/chromedash-feature.scss
+++ b/static/sass/elements/chromedash-feature.scss
@@ -121,7 +121,7 @@ section {
     color: $gray-3;
     line-height: 20px;
 
-    summary {
+    summary p:not(.preformatted) {
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;


### PR DESCRIPTION
This PR fixes a minor issue with chromedash-feature where summary text does not show an ellipsis on overflow.

Current behavior

<img width="772" alt="Screenshot 2021-11-11 at 15 19 25" src="https://user-images.githubusercontent.com/955980/141323422-20b75e1b-a320-4d46-ba30-3c7b26fa572f.png">

With this PR

<img width="772" alt="Screenshot 2021-11-11 at 15 20 04" src="https://user-images.githubusercontent.com/955980/141323638-ad1ca231-87a4-4ff1-8dc3-331cc5aa87b9.png">

The expanded summary is unaffected.