### PR TITLE
Add approvals indexes for sorting by set_on.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -24,6 +24,14 @@ indexes:
   - name: "name"
 - kind: "Approval"
   properties:
+  - name: "set_by"
+  - name: "set_on"
+- kind: "Approval"
+  properties:
+  - name: "field_id"
+  - name: "set_on"
+- kind: "Approval"
+  properties:
   - name: "state"
   - name: "set_on"
 - kind: "Approval"


### PR DESCRIPTION
We used to do some sorting in python, but now we use order(set_on) on the datastore query to sort everything by date.  

So, a couple of queries that previously only required an index on a single field (which is automatically provided without needing to list it in index.yaml) now need to have a two-field index that includes set_on plus whatever single-field is used in the condition.