### PR TITLE
Upgrade to instances with more RAM.

### DIFF
--- a/app-py3.yaml
+++ b/app-py3.yaml
@@ -2,7 +2,7 @@
 
 runtime: python39
 service: app-py3
-instance_class: F4
+instance_class: F4_1G
 
 automatic_scaling:
   min_idle_instances: 1


### PR DESCRIPTION
This should resolve issue #1602 by ensuring that our instances have enough RAM to process a complete batch of metrics data from uma-export.

This PR configures or py3 instances to run on F4_1G instances, which have two gigabytes of RAM each.

Our traffic only requires us to run a small number of instances, so the increased cost of using the instance with more RAM should be small.