### PR TITLE
Implement posting review comments to blink-dev mailing list.

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -273,7 +273,7 @@ TEST_ARCHIVE_URL_PREFIX = (
     'https://groups.google.com/d/msgid/jrobbins-test/')
 
 def get_thread_id(feature, approval_field):
-  """If we have the URL of the Google Groups thread, we can get it's ID."""
+  """If we have the URL of the Google Groups thread, we can get its ID."""
   if approval_field == approval_defs.PrototypeApproval:
     thread_url = feature.intent_to_implement_url
   # TODO(jrobbins): Ready-for-trial threads

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -1,6 +1,3 @@
-
-
-
 # -*- coding: utf-8 -*-
 # Copyright 2017 Google Inc.
 #
@@ -27,8 +24,6 @@ import os
 from framework import ramcache
 from google.cloud import ndb
 import requests
-# from google.appengine.api import users
-from framework import users
 
 from django.template.loader import render_to_string
 from django.utils.html import conditional_escape as escape
@@ -36,6 +31,7 @@ from django.utils.html import conditional_escape as escape
 from framework import basehandlers
 from framework import cloud_tasks_helpers
 import settings
+from internals import approval_defs
 from internals import models
 
 
@@ -269,3 +265,70 @@ class FeatureChangeHandler(basehandlers.FlaskHandler):
               one_email_dict['html'][:settings.MAX_LOG_LINE])
 
     return {'message': 'Done'}
+
+
+BLINK_DEV_ARCHIVE_URL_PREFIX = (
+    'https://groups.google.com/a/chromium.org/d/msgid/blink-dev/')
+TEST_ARCHIVE_URL_PREFIX = (
+    'https://groups.google.com/d/msgid/jrobbins-test/')
+
+def get_thread_id(feature, approval_field):
+  """If we have the URL of the Google Groups thread, we can get it's ID."""
+  if approval_field == approval_defs.PrototypeApproval:
+    thread_url = feature.intent_to_implement_url
+  # TODO(jrobbins): Ready-for-trial threads
+  if approval_field == approval_defs.ExperimentApproval:
+    thread_url = feature.intent_to_experiment_url
+  if approval_field == approval_defs.ExtendExperimentApproval:
+    thread_url = feature.intent_to_extend_experiment_url
+  if approval_field == approval_defs.ShipApproval:
+    thread_url = feature.intent_to_ship_url
+
+  if not thread_url:
+    return None
+
+  thread_id = None
+  if thread_url.startswith(BLINK_DEV_ARCHIVE_URL_PREFIX):
+    thread_id = thread_url[len(BLINK_DEV_ARCHIVE_URL_PREFIX):]
+  if thread_url.startswith(TEST_ARCHIVE_URL_PREFIX):
+    thread_id = thread_url[len(TEST_ARCHIVE_URL_PREFIX):]
+
+  return thread_id
+
+
+def post_comment_to_mailing_list(
+    feature, approval_field_id, author_addr, comment_content):
+  """Post a message to the intent thread."""
+  to_addr = settings.REVIEW_COMMENT_MAILING_LIST
+  from_user = author_addr.split('@')[0]
+  approval_field = approval_defs.APPROVAL_FIELDS_BY_ID[approval_field_id]
+  subject = '%s: %s' % (approval_field.name, feature.name)
+  thread_id = get_thread_id(feature, approval_field)
+  references = None
+  if thread_id:
+    references = '<%s>' % thread_id
+  html = render_to_string(
+      'review-comment-email.html', {'comment_content': comment_content})
+
+  one_email_task = {
+      'to': to_addr,
+      'from_user': from_user,
+      'references': references,
+      'subject': subject,
+      'html': html,
+      }
+
+  if settings.SEND_EMAIL:
+    cloud_tasks_helpers.enqueue_task(
+        '/tasks/outbound-email', one_email_task)
+  else:
+    logging.info(
+        'Would send the following email:\n'
+        'To: %s\n'
+        'From: %s\n'
+        'References: %s\n'
+        'Subject: %s\n'
+        'Body:\n%s',
+        one_email_task['to'], one_email_task['from_user'],
+        one_email_task['references'], one_email_task['subject'],
+        one_email_task['html'][:settings.MAX_LOG_LINE])

--- a/internals/sendemail.py
+++ b/internals/sendemail.py
@@ -40,11 +40,11 @@ def require_task_header():
     flask.abort(403, msg='Lacking X-AppEngine-QueueName header')
 
 
-def get_param(request, name):
+def get_param(request, name, required=True):
   """Get the specified JSON parameter."""
   json_body = request.get_json(force=True)
   val = json_body.get(name)
-  if not val:
+  if required and not val:
     flask.abort(400, msg='Missing parameter %r' % name)
   return val
 
@@ -55,19 +55,26 @@ def handle_outbound_mail_task():
   require_task_header()
 
   to = get_param(flask.request, 'to')
+  from_user = get_param(flask.request, 'from_user', required=False)
   subject = get_param(flask.request, 'subject')
   email_html = get_param(flask.request, 'html')
+  references = get_param(flask.request, 'references', required=False)
 
-  if settings.SEND_ALL_EMAIL_TO:
+  if settings.SEND_ALL_EMAIL_TO and to != settings.REVIEW_COMMENT_MAILING_LIST:
     to_user, to_domain = to.split('@')
     to = settings.SEND_ALL_EMAIL_TO % {'user': to_user, 'domain': to_domain}
 
+  sender = 'Chromestatus <admin@%s.appspotmail.com>' % settings.APP_ID
+  if from_user:
+    sender = '%s via Chromestatus <admin+%s@%s.appspotmail.com>' % (
+        from_user, from_user, settings.APP_ID)
+
   message = mail.EmailMessage(
-      sender='Chromestatus <admin@%s.appspotmail.com>' % settings.APP_ID,
-      to=to, subject=subject, html=email_html)
+      sender=sender, to=to, subject=subject, html=email_html)
   message.check_initialized()
 
   logging.info('Will send the following email:\n')
+  logging.info('Sender: %s', message.sender)
   logging.info('To: %s', message.to)
   logging.info('Subject: %s', message.subject)
   logging.info('Body:\n%s', message.html[:settings.MAX_LOG_LINE])

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,7 @@ itsdangerous==1.1.0
 requests==2.25.1
 
 # See also: requirements.dev.txt
+
+# Work-around for failure to deploy
+# https://stackoverflow.com/questions/69936420/google-cloud-platform-app-deploy-failure-due-to-pyparsing
+pyparsing==2.4.7

--- a/settings.py
+++ b/settings.py
@@ -68,6 +68,9 @@ LOGIN_PAGE_URL = '/features?loginStatus=False'
 
 INBOUND_EMAIL_ADDR = 'chromestatus@cr-status-staging.appspotmail.com'
 
+# This is where review comment emails are sent:
+REVIEW_COMMENT_MAILING_LIST = 'jrobbins-test@googlegroups.com'
+
 # Truncate some log lines to stay under limits of Google Cloud Logging.
 MAX_LOG_LINE = 200 * 1000
 
@@ -90,6 +93,7 @@ elif APP_ID == 'cr-status':
       '999517574127-7ueh2a17bv1ave9thlgtap19pt5qjp4g.'
       'apps.googleusercontent.com')
   INBOUND_EMAIL_ADDR = 'chromestatus@cr-status.appspotmail.com'
+  REVIEW_COMMENT_MAILING_LIST = 'blink-dev@chromium.org'
 elif APP_ID == 'cr-status-staging':
   STAGING = True
   SEND_EMAIL = True

--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -204,15 +204,15 @@ class ChromeStatusClient {
     }
   }
 
-  postComment(featureId, fieldId, state, comment) {
+  postComment(featureId, fieldId, state, comment, postToApprovalFieldId) {
     if (fieldId) {
       return this.doPost(
           `/features/${featureId}/approvals/${fieldId}/comments`,
-          {state, comment});
+          {state, comment, postToApprovalFieldId});
     } else {
       return this.doPost(
           `/features/${featureId}/approvals/comments`,
-          {comment});
+          {comment, postToApprovalFieldId});
     }
   }
 

--- a/templates/review-comment-email.html
+++ b/templates/review-comment-email.html
@@ -1,0 +1,1 @@
+<pre>{{comment_content}}</pre>


### PR DESCRIPTION
This implements the ability for a API Owner to make a review comment in the approvals dialog box and opt into having that comment also sent to the discussion thread for that intent on the blink-dev mailing list.

On staging we use a separate test mailing list rather than blink-dev.

In this PR:

 * Change the UI from a checkbox to a `<select>` to allow the user to specify which intent thread the comment is intended for.  Usually each feature should only have one intent discussion thread at a time, but that expectation might not be true given that we have incomplete data for existing features.  Also, we only offer the option when we are sure to be able to parse the thread ID out of the discussion URL.

* Pass the approval field ID from the chromedash-approvals-dialog element via cs-client to the comments API handler.

 * In the comment handler, call a new function in notifier.py.

 * In notifier.py, implement `post_comment_to_mailing_list()` to create a task with all the info needed for the email.  The email body is formatted using a template so that all of our sent emails are HTML rather than plain text, which simplifies sendemail.py.

 * In sendemail.py, add support for an optional parameter for the sender so that posted messages are attributed to the user who posted the comment.  We cannot actually send as that user, so we just use their user name in the "friendly" part of the address.  The sending email address must also be different for each sender to avoid confusing gmail, so we use the "plus" part of the address.

* Add a settings.py value for the email address of the mailing list to post to.
