### PR TITLE
Detect LGTM emails and record them

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -18,6 +18,8 @@ import logging
 
 import settings
 from framework import basehandlers
+from framework import permissions
+from framework import users
 from internals import approval_defs
 from internals import models
 
@@ -65,6 +67,10 @@ CHROMESTATUS_LINK_GENERATED_RE = re.compile(
 CHROMESTATUS_LINK_ALTERNATE_RE = re.compile(
     r'entry on the feature dashboard:?\s+'
     r'https://www.chromestatus.com/feature/(\d+)', re.I)
+NOT_LGTM_RE = re.compile(
+    r'\b(not|almost|need|want|missing) (a |an )?LGTM\b',
+    re.I)
+LGTM_RE = re.compile(r'\b(LGTM|LGTM1|LGTM2|LGTM3)\b', re.I)
 
 
 def detect_feature_id(body):
@@ -90,12 +96,6 @@ def detect_thread_url(body):
   return None
 
 
-LGTM_RE = re.compile(
-    r'To view this discussion on the web visit\s+'
-    r'(https://groups.google.com/a/chromium.org/d/msgid/blink-dev/'
-    r'\S+)[.]')
-
-
 def detect_lgtm(body):
   """Return true if LGTM is on first non-blank line."""
   lines = body.split('\n')
@@ -106,13 +106,20 @@ def detect_lgtm(body):
       first_nonblank_line = line.strip()
       break
 
+  if (first_nonblank_line.startswith('>') or
+      NOT_LGTM_RE.search(first_nonblank_line)):
+    return False
+
   match = LGTM_RE.search(first_nonblank_line)
   return match
 
 
-def is_lgtm_allowed(feature, approval_field, from_addr):
+def is_lgtm_allowed(from_addr, feature, approval_field):
   """Return true if the user is allowed to approve this feature."""
-  return False
+  user = users.User(email=from_addr)
+  approvers = approval_defs.get_approvers(field_id)
+  allowed = permissions.can_approve_feature(user, feature, approvers)
+  return allowed
 
 
 def detect_new_thread(feature_id, approval_field):
@@ -160,53 +167,57 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     if message:
       logging.info(message)
       return {'message': message}
+    if not feature:
+      logging.info('Could not retrieve feature')
+      return {'message': 'Feature not found'}
 
     self.set_intent_thread_url(feature, approval_field, thread_url)
     self.create_approvals(feature, approval_field, from_addr, body)
     return {'message': 'Done'}
 
   def load_detected_feature(self, feature_id, thread_url, approval_field):
-    """Find the feature being referenced by this email message."""
+    """Find the feature being referenced by this email message.
+
+    Returns a pair with the feature and an error message, either of
+    which can be None.
+    """
     # If the message had a link to a chromestatus entry, use its ID.
     if feature_id:
       return models.Feature.get_by_id(feature_id), None
 
-    # If there is a discussion link, and we previously stored that link
-    # for a feature, then that is the feature being updated.
-    if thread_url:
-      matching_features = []
-      if approval_field == approval_defs.PrototypeApproval:
-        query = models.Feature.query(
-            models.Feature.intent_to_implement_url == thread_url)
-        matching_features = query.fetch()
-      # TODO(jrobbins): Ready-for-trial threads
-      elif approval_field == approval_defs.ExperimentApproval:
-        query = models.Feature.query(
-            models.Feature.intent_to_experiment_url == thread_url)
-        matching_features = query.fetch()
-      elif approval_field == approval_defs.ExtendExperimentApproval:
-        query = models.Feature.query(
-            models.Feature.intent_to_extend_experiment_url == thread_url)
-        matching_features = query.fetch()
-      elif approval_field == approval_defs.ShipApproval:
-        query = models.Feature.query(
-            models.Feature.intent_to_ship_url == thread_url)
-        matching_features = query.fetch()
-      else:
-        return None, 'Unsupported approval field'
-
-      if len(matching_features) == 0:
-        return None, 'No feature entry references this discussion thread'
-      if len(matching_features) > 1:
-        ids = [f.key.integer_id() for f in matching_features]
-        return None, 'Ambiguous feature entries %r' % ids
-
-    # We could not find the feature.  Try to give a helpful error message.
-    if not feature_id:
+    # If there is also no thread_url, then give up.
+    if not thread_url:
       return None, 'No feature ID or discussion link'
 
-    if not feature:
-      return None, 'Feature not found'
+    # Find the feature by querying for the previously saved discussion link.
+    matching_features = []
+    if approval_field == approval_defs.PrototypeApproval:
+      query = models.Feature.query(
+          models.Feature.intent_to_implement_url == thread_url)
+      matching_features = query.fetch()
+    # TODO(jrobbins): Ready-for-trial threads
+    elif approval_field == approval_defs.ExperimentApproval:
+      query = models.Feature.query(
+          models.Feature.intent_to_experiment_url == thread_url)
+      matching_features = query.fetch()
+    elif approval_field == approval_defs.ExtendExperimentApproval:
+      query = models.Feature.query(
+          models.Feature.intent_to_extend_experiment_url == thread_url)
+      matching_features = query.fetch()
+    elif approval_field == approval_defs.ShipApproval:
+      query = models.Feature.query(
+          models.Feature.intent_to_ship_url == thread_url)
+      matching_features = query.fetch()
+    else:
+      return None, 'Unsupported approval field'
+
+    if len(matching_features) == 0:
+      return None, 'No feature entry references this discussion thread'
+    if len(matching_features) > 1:
+      ids = [f.key.integer_id() for f in matching_features]
+      return None, 'Ambiguous feature entries %r' % ids
+
+    return matching_features[0], None
 
   def set_intent_thread_url(self, feature, approval_field, thread_url):
     """If the feature has no previous thread URL for this intent, set it."""
@@ -243,12 +254,35 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     # set an approval value, and clear the original REVIEW_REQUESTED if
     # the approval rule (1 or 3 LTGMs) is satisfied.
     if (detect_lgtm(body) and
-        is_lgtm_allowed(feature, approval_field, from_addr)):
-      logging.info('found LGTM @@@')
+        is_lgtm_allowed(from_addr, feature, approval_field)):
+      logging.info('found LGTM')
+      models.Approval.set_approval(
+          feature_id, approval_field.field_id,
+          models.Approval.APPROVED, from_addr)
+      self.record_lgtm(feature, approval_field, from_addr)
 
     # Case 2: Create a review request for any discussion that does not already
     # have any approval values stored.
     elif detect_new_thread(feature_id, approval_field):
+      logging.info('found new thread')
       models.Approval.set_approval(
           feature_id, approval_field.field_id,
           models.Approval.REVIEW_REQUESTED, from_addr)
+
+  def record_lgtm(self, feature, approval_field, from_addr):
+    """Add from_addr to the old way or recording LGTMs."""
+
+    # Note: Intent to prototype has no old field
+    # TODO(jrobbins): Ready-for-trial threads
+
+    if (approval_field == approval_defs.ExperimentApproval and
+        from_addr not in feature.i2e_lgtms):
+      feature.i2e_lgtms += [from_addr]
+      feature.put()
+
+    # Note: Intent to extend experiment has no old field
+
+    if (approval_field == approval_defs.ShipApproval and
+        from_addr not in feature.i2s_lgtms):
+      feature.i2s_lgtms += [from_addr]
+      feature.put()

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -117,7 +117,7 @@ def detect_lgtm(body):
 def is_lgtm_allowed(from_addr, feature, approval_field):
   """Return true if the user is allowed to approve this feature."""
   user = users.User(email=from_addr)
-  approvers = approval_defs.get_approvers(field_id)
+  approvers = approval_defs.get_approvers(approval_field.field_id)
   allowed = permissions.can_approve_feature(user, feature, approvers)
   return allowed
 
@@ -271,16 +271,13 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
 
   def record_lgtm(self, feature, approval_field, from_addr):
     """Add from_addr to the old way or recording LGTMs."""
-
-    # Note: Intent to prototype has no old field
-    # TODO(jrobbins): Ready-for-trial threads
+    # Note: Intent-to-prototype and Intent-to-extend are not checked
+    # here because there are no old fields for them.
 
     if (approval_field == approval_defs.ExperimentApproval and
         from_addr not in feature.i2e_lgtms):
       feature.i2e_lgtms += [from_addr]
       feature.put()
-
-    # Note: Intent to extend experiment has no old field
 
     if (approval_field == approval_defs.ShipApproval and
         from_addr not in feature.i2s_lgtms):

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -15,6 +15,7 @@
 import testing_config  # Must be imported first
 
 import flask
+import mock
 import werkzeug
 
 from internals import models
@@ -103,6 +104,80 @@ class FunctionTest(testing_config.CustomTestCase):
          '-oNTb%2BZjiJk%2B6RNb9%2Bv05w%40mail.gmail.com'),
         detect_intent.detect_thread_url(footer))
 
+    def test_detect_lgtm__good(self):
+      """We can find an LGTM in the email body text."""
+      self.assertTrue(detect_intent.detect_lgtm('LGTM'))
+      self.assertTrue(detect_intent.detect_lgtm('Lgtm'))
+      self.assertTrue(detect_intent.detect_lgtm('lgtm'))
+      self.assertTrue(detect_intent.detect_lgtm('LGTM1'))
+      self.assertTrue(detect_intent.detect_lgtm('LGTM2'))
+      self.assertTrue(detect_intent.detect_lgtm('LGTM3'))
+
+      self.assertTrue(detect_intent.detect_lgtm('LGTM with nits'))
+      self.assertTrue(detect_intent.detect_lgtm('This LGTM!'))
+      self.assertTrue(detect_intent.detect_lgtm('Sounds good! LGTM2'))
+      self.assertTrue(detect_intent.detect_lgtm('LGTM to extend M94-M97'))
+
+      self.assertTrue(detect_intent.detect_lgtm('''
+
+        LGTM
+
+        Thanks for all your work.
+      '''))
+
+    def test_detect_lgtm__bad(self):
+      """We don't mistakenly count a message as an LGTM ."""
+      self.assertFalse(detect_intent.detect_lgtm("> LGTM from other approver"))
+
+      self.assertFalse(detect_intent.detect_lgtm('LG'))
+      self.assertFalse(detect_intent.detect_lgtm('Looks good to me'))
+
+      self.assertFalse(detect_intent.detect_lgtm('Almost LGTM'))
+      self.assertFalse(detect_intent.detect_lgtm('This is not an LGTM'))
+      self.assertFalse(detect_intent.detect_lgtm('Not LGTM yet'))
+      self.assertFalse(detect_intent.detect_lgtm('You still need LGTM'))
+      self.assertFalse(detect_intent.detect_lgtm("You're missing LGTM"))
+      self.assertFalse(detect_intent.detect_lgtm("You're missing a LGTM"))
+      self.assertFalse(detect_intent.detect_lgtm("You're missing an LGTM"))
+
+      self.assertFalse(detect_intent.detect_lgtm('''
+        Any discussion whatsoever that might even include the word
+        LGTM on any line other than the first line.
+        '''))
+
+    @mock.patch('internals.approval_defs.get_approvers')
+    def test_is_lgtm_allowed__approver(self, mock_get_approvers):
+      """A user who is in the list of approvers can LGTM."""
+      mock_get_approvers.return_value = ['owner@example.com']
+      self.assertTrue(detect_intent.is_lgtm_allowed(
+          'owner@example.com', f, approval_defs.ShipApproval))
+
+    @mock.patch('framework.permissions.can_admin_site')
+    @mock.patch('internals.approval_defs.get_approvers')
+    def test_is_lgtm_allowed__admin(
+        self, mock_get_approvers, mock_can_admin_site):
+      """A site admin can LGTM."""
+      mock_get_approvers.return_value = ['owner@example.com']
+      mock_can_admin_site.return_value = True
+      self.assertTrue(detect_intent.is_lgtm_allowed(
+          'admin@example.com', f, approval_defs.ShipApproval))
+
+    @mock.patch('internals.approval_defs.get_approvers')
+    def test_is_lgtm_allowed__other(self, mock_get_approvers):
+      """An average user cannot LGTM."""
+      mock_get_approvers.return_value = ['owner@example.com']
+      self.assertFalse(detect_intent.is_lgtm_allowed(
+          'other@example.com', f, approval_defs.ShipApproval))
+
+    @mock.patch('internals.models.Approval.get_approvals')
+    def test_detect_new_thread(self, mock_get_approvals):
+      """A thread is new if there are no previsou approval values."""
+      mock_get_approvals.return_value = []
+      self.assertTrue(detect_intent.detect_new_thread('id', 'field'))
+
+      mock_get_approvals.return_value = ['fake approval value']
+      self.assertTrue(detect_intent.detect_new_thread('id', 'field'))
+
 
 class IntentEmailHandlerTest(testing_config.CustomTestCase):
 
@@ -116,6 +191,8 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
 
     self.request_path = '/tasks/detect-intent'
 
+    self.thread_url = (
+        'https://groups.google.com/a/chromium.org/d/msgid/blink-dev/fake')
     self.entry_link = (
         '\n*Link to entry on the Chrome Platform Status*\n'
         'https://www.chromestatus.com/feature/%d\n' % self.feature_id)
@@ -123,12 +200,17 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
         '\n--\n'
         'instructions...\n'
         '---\n'
-        'To view this discussion on the web visit '
-        'https://groups.google.com/a/chromium.org/d/msgid/blink-dev/fake.')
-    self.json_data = {
+        'To view this discussion on the web visit ' +
+        self.thread_url + '.')
+    self.review_json_data = {
         'from_addr': 'user@example.com',
         'subject': 'Intent to Ship: Featurename',
         'body': 'Please review. ' + self.entry_link + self.footer,
+        }
+    self.lgtm_json_data = {
+        'from_addr': 'user@example.com',
+        'subject': 'Intent to Ship: Featurename',
+        'body': 'LGTM. ' + self.footer,
         }
     self.handler = detect_intent.IntentEmailHandler()
 
@@ -137,10 +219,10 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
     for appr in models.Approval.query().fetch(None):
       appr.key.delete()
 
-  def test_process_post_data__normal(self):
-    """When everything is perfect, we record the intent thread."""
+  def test_process_post_data__new_thread(self):
+    """When we detect a new thread, we record it as the intent thread."""
     with test_app.test_request_context(
-        self.request_path, json=self.json_data):
+        self.request_path, json=self.review_json_data):
       actual = self.handler.process_post_data()
 
     self.assertEqual(actual, {'message': 'Done'})
@@ -152,6 +234,27 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
     self.assertEqual(approval_defs.ShipApproval.field_id, appr.field_id)
     self.assertEqual(models.Approval.REVIEW_REQUESTED, appr.state)
     self.assertEqual('user@example.com', appr.set_by)
-    self.assertEqual(
-        self.feature_1.intent_to_ship_url,
-        'https://groups.google.com/a/chromium.org/d/msgid/blink-dev/fake')
+    self.assertEqual(self.feature_1.intent_to_ship_url, self.thread_url)
+
+  @mock.patch('internals.detect_intent.is_lgtm_allowed')
+  def test_process_post_data__lgtm(self, mock_is_lgtm_allowed):
+    """If we get an LGTM, we store the approval value and update the feature."""
+    mock_is_lgtm_allowed.return_value = True
+    self.feature_1.intent_to_ship_url = self.thread_url
+    self.feature_1.put()
+
+    with test_app.test_request_context(
+        self.request_path, json=self.lgtm_json_data):
+      actual = self.handler.process_post_data()
+
+    self.assertEqual(actual, {'message': 'Done'})
+
+    created_approvals = list(models.Approval.query().fetch(None))
+    self.assertEqual(1, len(created_approvals))
+    appr = created_approvals[0]
+    self.assertEqual(self.feature_id, appr.feature_id)
+    self.assertEqual(approval_defs.ShipApproval.field_id, appr.field_id)
+    self.assertEqual(models.Approval.APPROVED, appr.state)
+    self.assertEqual('user@example.com', appr.set_by)
+    self.assertEqual(self.feature_1.intent_to_ship_url, self.thread_url)
+    self.assertEqual(self.feature_1.i2s_lgtms, ['user@example.com'])


### PR DESCRIPTION
This implements another part of the blink intent approvals process.

In this PR:
* Define RegExes and functions to detect a LGTM in an email from the blink-intents mailing list.
* Refactor the previous code that loaded the Feature entry into a new method that can find a feature by using the feature link or a discussion link.
* Add permission checking logic to validate that the email From user is allowed to LGTM intents
* Add an APPROVED approval value, and record the user's email address in the old style list of approver email addresses
