### PR TITLE
Add a field for next_review_date.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -1178,7 +1178,10 @@ class Feature(DictModel):
         new_val = convert_enum_int_to_string(prop_name, new_val)
         old_val = convert_enum_int_to_string(prop_name, old_val)
         changed_props.append({
-            'prop_name': prop_name, 'old_val': old_val, 'new_val': new_val})
+            'prop_name': prop_name,
+            'old_val': str(old_val),
+            'new_val': str(new_val),
+        })
 
     params = {
       'changes': changed_props,
@@ -1233,6 +1236,7 @@ class Feature(DictModel):
   # Currently, only one is needed.
   i2e_lgtms = ndb.StringProperty(repeated=True)
   i2s_lgtms = ndb.StringProperty(repeated=True)
+  next_review_date = ndb.DateProperty()
 
   # Chromium details.
   bug_url = ndb.StringProperty()

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -1,6 +1,3 @@
-
-
-
 # -*- coding: utf-8 -*-
 # Copyright 2020 Google Inc.
 #
@@ -353,6 +350,11 @@ class FeatureEditStage(basehandlers.FlaskHandler):
 
     if self.touched('i2s_lgtms'):
       feature.i2s_lgtms = self.split_emails('i2s_lgtms')
+
+    if self.touched('next_review_date'):
+      date_str = self.form.get('next_review_date')
+      date_val = datetime.date.fromisoformat(date_str)
+      feature.next_review_date = date_val
 
     # Cast incoming milestones to ints.
     # TODO(jrobbins): Consider supporting milestones that are not ints.

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -1,6 +1,3 @@
-
-
-
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -18,6 +15,7 @@
 import testing_config  # Must be imported before the module under test.
 import urllib.request, urllib.parse, urllib.error
 
+import datetime
 import flask
 import werkzeug
 
@@ -287,6 +285,7 @@ class FeatureEditStageTest(testing_config.CustomTestCase):
             'name': 'Revised feature name',
             'summary': 'Revised feature summary',
             'shipped_milestone': '84',
+            'next_review_date': '2021-11-24',
         }):
       actual_response = self.handler.process_post_data(
           self.feature_1.key.integer_id(), self.stage)
@@ -299,4 +298,6 @@ class FeatureEditStageTest(testing_config.CustomTestCase):
     self.assertEqual(2, revised_feature.category)
     self.assertEqual('Revised feature name', revised_feature.name)
     self.assertEqual('Revised feature summary', revised_feature.summary)
+    self.assertEqual(datetime.date.fromisoformat('2021-11-24'),
+                     revised_feature.next_review_date)
     self.assertEqual(84, revised_feature.shipped_milestone)

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -497,6 +497,15 @@ ALL_FIELDS = {
         help_text=('Full email addresses of API owners who LGTM\'d '
                    'the Request for Deprecation Trial email thread.')),
 
+    'next_review_date': forms.DateField(
+        required=False, label='Next review date',
+        # Django DateField and DateInput default to plain text,
+        # so tell it use type="date".
+        widget=forms.DateInput(attrs={'type': 'date'}),
+        help_text=('If you have gotten review feedback and need time '
+                   'to respond before this feature is reviewed again, '
+                   'fill in the date that you will be ready.')),
+
     'debuggability': forms.CharField(
         label='Debuggability', required=True,
         widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
@@ -726,7 +735,7 @@ ImplStatus_Incubate = define_form_class_using_shared_fields(
 NewFeature_Prototype = define_form_class_using_shared_fields(
     'NewFeature_Prototype',
     ('spec_link', 'standard_maturity', 'api_spec', 'spec_mentors',
-     'intent_to_implement_url', 'comments'))
+     'intent_to_implement_url', 'next_review_date', 'comments'))
   # TODO(jrobbins): advise user to request a tag review
 
 
@@ -782,7 +791,7 @@ NewFeature_OriginTrial = define_form_class_using_shared_fields(
      'experiment_extension_reason', 'ongoing_constraints',
      'origin_trial_feedback_url', 'intent_to_experiment_url',
      'intent_to_extend_experiment_url',
-     'i2e_lgtms', 'comments'))
+     'i2e_lgtms', 'next_review_date', 'comments'))
 
 
 ImplStatus_OriginTrial = define_form_class_using_shared_fields(
@@ -797,7 +806,8 @@ Most_PrepareToShip = define_form_class_using_shared_fields(
     'Most_PrepareToShip',
     ('tag_review', 'tag_review_status',
      'origin_trial_feedback_url',
-     'launch_bug_url', 'intent_to_ship_url', 'i2s_lgtms', 'comments'))
+     'launch_bug_url', 'intent_to_ship_url', 'i2s_lgtms',
+     'next_review_date', 'comments'))
 
 
 Any_Ship = define_form_class_using_shared_fields(
@@ -809,7 +819,7 @@ Existing_Prototype = define_form_class_using_shared_fields(
     'Existing_Prototype',
     ('owner', 'blink_components', 'motivation', 'explainer_links',
      'spec_link', 'standard_maturity', 'api_spec', 'bug_url', 'launch_bug_url',
-     'intent_to_implement_url', 'comments'))
+     'intent_to_implement_url', 'next_review_date', 'comments'))
 
 
 Existing_OriginTrial = define_form_class_using_shared_fields(
@@ -817,7 +827,7 @@ Existing_OriginTrial = define_form_class_using_shared_fields(
     ('experiment_goals', 'experiment_risks',
      'experiment_extension_reason', 'ongoing_constraints',
      'intent_to_experiment_url', 'intent_to_extend_experiment_url',
-     'i2e_lgtms', 'origin_trial_feedback_url', 'comments'))
+     'i2e_lgtms', 'next_review_date', 'origin_trial_feedback_url', 'comments'))
 
 
 PSA_Implement = define_form_class_using_shared_fields(
@@ -830,7 +840,7 @@ PSA_PrepareToShip = define_form_class_using_shared_fields(
     'PSA_PrepareToShip',
     ('tag_review',
      'intent_to_implement_url', 'origin_trial_feedback_url',
-     'launch_bug_url', 'intent_to_ship_url', 'comments'))
+     'launch_bug_url', 'intent_to_ship_url', 'next_review_date', 'comments'))
 
 
 Deprecation_Implement = define_form_class_using_shared_fields(
@@ -843,7 +853,7 @@ Deprecation_PrepareToShip = define_form_class_using_shared_fields(
     'Deprecation_PrepareToShip',
     ('impl_status_chrome', 'tag_review',
      'intent_to_implement_url', 'origin_trial_feedback_url',
-     'launch_bug_url', 'comments'))
+     'next_review_date', 'launch_bug_url', 'comments'))
 
 
 # Note: Even though this is similar to another form, it is likely to change.
@@ -857,14 +867,14 @@ Deprecation_DeprecationTrial = define_form_class_using_shared_fields(
      'intent_to_experiment_url=r4dt_url',
      'intent_to_extend_experiment_url',
      'i2e_lgtms=r4dt_lgtms',  # form field name matches underlying DB field.
-     'origin_trial_feedback_url', 'comments'))
+     'next_review_date', 'origin_trial_feedback_url', 'comments'))
 
 
 # Note: Even though this is similar to another form, it is likely to change.
 Deprecation_PrepareToShip = define_form_class_using_shared_fields(
     'Deprecation_PrepareToShip',
     ('impl_status_chrome',
-     'intent_to_ship_url', 'i2s_lgtms',
+     'intent_to_ship_url', 'i2s_lgtms', 'next_review_date',
      'launch_bug_url', 'comments'))
 
 
@@ -884,6 +894,7 @@ Flat_Metadata = define_form_class_using_shared_fields(
      'impl_status_chrome',
      'blink_components',
      'bug_url', 'launch_bug_url',
+     'next_review_date',
      'comments'))
 
 
@@ -1012,7 +1023,7 @@ DISPLAY_IN_FEATURE_HIGHLIGHTS = [
 
 DISPLAY_FIELDS_IN_STAGES = {
     'Metadata': make_display_specs(
-        'category', 'feature_type', 'intent_stage',
+        'category', 'feature_type', 'intent_stage', 'next_review_date',
         ),
     models.INTENT_INCUBATE: make_display_specs(
         'initial_public_proposal_url', 'explainer_links',


### PR DESCRIPTION
This addresses some of the feedback I got from the demo to API Owners about 15 days ago.

In this PR:
* Add a new field date next_review_action to the Feature entity type.
* Define a django form field for it and configure it to use `<input type="date">`.
* Add the new form field to each of the forms in which it might be relevant, and display it once on the issue detail page.
* Add a case to the guide UX form POST handler logic to store this date field
* Make the preparation for the diff email pass the date as a string because that is needed before it gets used in a JSON string