### PR TITLE
Lay out approval quick-actions and highlights UI elements.

### DIFF
--- a/static/elements/chromedash-feature-table.js
+++ b/static/elements/chromedash-feature-table.js
@@ -55,6 +55,21 @@ class ChromedashFeatureTable extends LitElement {
       }
       td.icon_col {
         white-space: nowrap;
+        vertical-align: top;
+      }
+      .quick_actions {
+        white-space: nowrap;
+        float: right;
+      }
+      .highlights {
+        padding-left: var(--content-padding);
+      }
+      .highlights div {
+        color: var(--unimportant-text-color);
+        padding: var(--content-padding-quarter);
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
       }
       iron-icon {
         --iron-icon-height: 18px;
@@ -63,6 +78,11 @@ class ChromedashFeatureTable extends LitElement {
       }
       iron-icon:hover {
         color: var(--link-hover-color);
+      }
+      button {
+        border: var(--default-border);
+        padding: 0 6px;
+        font-size: var(--button-small-font-size);
       }
     `];
   }
@@ -111,6 +131,16 @@ class ChromedashFeatureTable extends LitElement {
     this._fireEvent('open-approvals-event', {
       featureId: featureId,
     });
+  }
+
+  doLGTM(featureId) {
+    // TODO(jrobbins): Make it pre-select Approved and add comment.
+    this.openApprovalsDialog(featureId);
+  }
+
+  doSnooze(featureId) {
+    // TODO(jrobbins): Make it pre-set a new next-review-date value.
+    this.openApprovalsDialog(featureId);
   }
 
   renderApprovalsIcon(feature) {
@@ -175,11 +205,71 @@ class ChromedashFeatureTable extends LitElement {
     }
   }
 
+  renderQuickActions(feature) {
+    if (this.columns == 'approvals') {
+      // TODO(jrobbins): compute thread link here.
+      let threadLink = html`
+        <a href="#" target="_blank">Thread</a>
+      `;
+      let lgtmButton = html`
+        <button data-feature-id="${feature.id}"
+                @click="${() => this.doLGTM(feature.id)}">
+          Add LGTM
+        </button>
+      `;
+      let snoozeButton = html`
+        <button data-feature-id="${feature.id}"
+                @click="${() => this.doSnooze(feature.id)}">
+          Snooze
+        </button>
+      `;
+      return html`
+        <span class="quick_actions">
+          ${threadLink}
+          ${lgtmButton}
+          ${snoozeButton}
+        </span>
+      `;
+    }
+    return nothing;
+  }
+
+
+  renderHighlights(feature) {
+    if (this.columns == 'approvals') {
+      let nextReviewItem = nothing;
+      let previousLGTMsItem = nothing;
+      let recentCommentItem = nothing;
+
+      if (feature.next_review_date && feature.next_review_date.length > 0) {
+        nextReviewItem = html`
+          <div>
+            Next review date: ${feature.next_review_date}
+          </div>
+        `;
+      }
+
+      // TODO(jrobbins): check currently pendinging approvals and show LGTMs.
+      // TODO(jrobbins): get recent comments and show the last one.
+
+      return html`
+        <div class="highlights">
+          ${nextReviewItem}
+          ${previousLGTMsItem}
+          ${recentCommentItem}
+        </div>
+      `;
+    }
+    return nothing;
+  }
+
   renderFeature(feature) {
     return html`
       <tr>
         <td class="name_col">
+          ${this.renderQuickActions(feature)}
           <a href="/feature/${feature.id}">${feature.name}</a>
+          ${this.renderHighlights(feature)}
         </td>
         <td class="icon_col">
           ${this.renderIcons(feature)}

--- a/static/elements/chromedash-myfeatures.js
+++ b/static/elements/chromedash-myfeatures.js
@@ -82,7 +82,7 @@ class ChromedashMyFeatures extends LitElement {
     const pendingBox = this.renderBox(
       'Features pending my approval', 'pending-approval-by:me', 'approvals');
     const recentBox = this.renderBox(
-      'Recently reviewed features', 'is:recently-reviewed', 'approvals', false);
+      'Recently reviewed features', 'is:recently-reviewed', 'normal', false);
     return [pendingBox, recentBox];
   }
 

--- a/static/sass/shared.scss
+++ b/static/sass/shared.scss
@@ -51,7 +51,7 @@ input:not([type="submit"])[disabled], textarea[disabled], button[disabled] {
 button, input[type="submit"], .button {
   display: inline-block;
   padding: 4px 16px;
-  background: var(--button-background);;
+  background: var(--button-background);
   border: var(--button-border);
   border-radius: var(--button-border-radius);
   color: var(--button-color);

--- a/static/sass/theme.scss
+++ b/static/sass/theme.scss
@@ -73,6 +73,7 @@
   --button-background: inherit;
   --button-color: var(--md-gray-900-alpha);
   --button-font-size: 10pt;
+  --button-small-font-size: 9pt;
   --button-border: 0;
   --button-border-radius: var(--border-radius);
   --primary-button-background: var(--md-blue-700);


### PR DESCRIPTION
This change is progress toward adding some of the functionality that the API Owners requested a couple of weeks ago.

In this PR:
* Lay out a new "quick actions" area each row in the "Features pending my approval" box.  This area has links and buttons to do the most common operations with one click (plus confirmation).  These are only partly implemented so far.
* Lay out a new "highlights" area under each row in the pending box.  This will show some of the most relevant details without needing to open the approvals dialog box.  So far, only the display of `next_review_date` is implemented.
* Changed the "Recently reviewed features" box to not show the "approvals" additional info because those reviews are done and therefore the buttons are not needed.
* Made some minor additions to theme.css.