### PR TITLE
Make chromestatus link detection more robust.

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -63,10 +63,10 @@ def detect_field(subject):
 
 CHROMESTATUS_LINK_GENERATED_RE = re.compile(
     r'entry on the Chrome Platform Status:?\s+'
-    r'https://www.chromestatus.com/feature/(\d+)', re.I)
+    r'https?://(www.)?chromestatus.com/feature/(?P<id>\d+)', re.I)
 CHROMESTATUS_LINK_ALTERNATE_RE = re.compile(
     r'entry on the feature dashboard:?\s+'
-    r'https://www.chromestatus.com/feature/(\d+)', re.I)
+    r'https?://(www.)?chromestatus.com/feature/(?P<id>\d+)', re.I)
 NOT_LGTM_RE = re.compile(
     r'\b(not|almost|need|want|missing) (a |an )?LGTM\b',
     re.I)
@@ -78,7 +78,7 @@ def detect_feature_id(body):
   match = (CHROMESTATUS_LINK_GENERATED_RE.search(body) or
            CHROMESTATUS_LINK_ALTERNATE_RE.search(body))
   if match:
-    return int(match.group(1))
+    return int(match.group('id'))
   return None
 
 

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -87,12 +87,34 @@ class FunctionTest(testing_config.CustomTestCase):
         5144822362931200,
         detect_intent.detect_feature_id(body))
 
+  def test_detect_feature_id__generated_no_www(self):
+    """We can parse the feature ID from a link in the generated body."""
+    body = (
+        'blah blah blah\n'
+        'Link to entry on the Chrome Platform Status\n'
+        'http://chromestatus.com/feature/5144822362931200\n'
+        'blah blah blah')
+    self.assertEqual(
+        5144822362931200,
+        detect_intent.detect_feature_id(body))
+
   def test_detect_feature_id__alternative(self):
     """We can parse the feature ID from another common link."""
     body = (
         'blah blah blah\n'
         'Entry on the feature dashboard\n'
         'https://www.chromestatus.com/feature/5144822362931200\n'
+        'blah blah blah')
+    self.assertEqual(
+        5144822362931200,
+        detect_intent.detect_feature_id(body))
+
+  def test_detect_feature_id__alternative_no_www(self):
+    """We can parse the feature ID from another common link."""
+    body = (
+        'blah blah blah\n'
+        'Entry on the feature dashboard\n'
+        'http://chromestatus.com/feature/5144822362931200\n'
         'blah blah blah')
     self.assertEqual(
         5144822362931200,


### PR DESCRIPTION
The logs show that we are getting some inbound emails for intent threads, but failing to detect the link to the chromestatus entry in the body of those emails.  It looks like the users have not used our intent generation page and instead have copied and pasted from a previous discussion thread or doc and then pasted in details.  The URL that a user would copy from the browser URL bar does not have the "www." in the domain name, so these users don't have that in their intent emails.

In this PR:
* Make the "www." optional
* Refer to the ID regex match group by name rather than by index so that we can add new groups in the future without being off by one.