### PR TITLE
Small fixes to intent email handling.

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -63,10 +63,10 @@ def detect_field(subject):
 
 CHROMESTATUS_LINK_GENERATED_RE = re.compile(
     r'entry on the Chrome Platform Status:?\s+'
-    r'https?://(www.)?chromestatus.com/feature/(?P<id>\d+)', re.I)
+    r'[> ]*https?://(www.)?chromestatus.com/feature/(?P<id>\d+)', re.I)
 CHROMESTATUS_LINK_ALTERNATE_RE = re.compile(
     r'entry on the feature dashboard:?\s+'
-    r'https?://(www.)?chromestatus.com/feature/(?P<id>\d+)', re.I)
+    r'[> ]*https?://(www.)?chromestatus.com/feature/(?P<id>\d+)', re.I)
 NOT_LGTM_RE = re.compile(
     r'\b(not|almost|need|want|missing) (a |an )?LGTM\b',
     re.I)
@@ -86,11 +86,16 @@ THREAD_LINK_RE = re.compile(
     r'To view this discussion on the web visit\s+'
     r'(https://groups.google.com/a/chromium.org/d/msgid/blink-dev/'
     r'\S+)[.]')
+STAGING_THREAD_LINK_RE = re.compile(
+    r'To view this discussion on the web visit\s+'
+    r'(https://groups.google.com/d/msgid/jrobbins-test/'
+    r'\S+)[.]')
 
 
 def detect_thread_url(body):
   """Look for the link to the thread in the blink-dev archive."""
-  match = THREAD_LINK_RE.search(body)
+  match = (THREAD_LINK_RE.search(body) or
+           STAGING_THREAD_LINK_RE.search(body))
   if match:
     return match.group(1)
   return None

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -120,6 +120,19 @@ class FunctionTest(testing_config.CustomTestCase):
         5144822362931200,
         detect_intent.detect_feature_id(body))
 
+  def test_detect_feature_id__quoted(self):
+    """We can parse the feature ID from link in quoted body text."""
+    body = (
+        'I have something more to add\n'
+        '\n'
+        'On Monday, November 29, 2021 at 3:49:24 PM UTC-8 a user wrote:\n'
+        '>>> Entry on the feature dashboard\n'
+        '>>> http://chromestatus.com/feature/5144822362931200\n'
+        '>>> blah blah blah')
+    self.assertEqual(
+        5144822362931200,
+        detect_intent.detect_feature_id(body))
+
   def test_detect_thread_url(self):
     """We can parse the thread archive link from the body footer."""
     footer = (
@@ -133,6 +146,22 @@ class FunctionTest(testing_config.CustomTestCase):
     self.assertEqual(
         ('https://groups.google.com'
          '/a/chromium.org/d/msgid/blink-dev/CAMO6jDPGfXfE5z6hJcWO112zX3We'
+         '-oNTb%2BZjiJk%2B6RNb9%2Bv05w%40mail.gmail.com'),
+        detect_intent.detect_thread_url(footer))
+
+  def test_detect_thread_url__staging(self):
+    """We can parse the staging thread archive link from the body footer."""
+    footer = (
+        'You received this message because you are subscribed to the Google '
+        'Groups "jrobbins-test" group.\n'
+        'To unsubscribe from this group and stop receiving emails from it,'
+        'send an email to jrobbins-test+unsubscribe@googlegroups.com.\n'
+        'To view this discussion on the web visit https://groups.google.com'
+        '/d/msgid/jrobbins-test/CAMO6jDPGfXfE5z6hJcWO112zX3We'
+        '-oNTb%2BZjiJk%2B6RNb9%2Bv05w%40mail.gmail.com.')
+    self.assertEqual(
+        ('https://groups.google.com'
+         '/d/msgid/jrobbins-test/CAMO6jDPGfXfE5z6hJcWO112zX3We'
          '-oNTb%2BZjiJk%2B6RNb9%2Bv05w%40mail.gmail.com'),
         detect_intent.detect_thread_url(footer))
 

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -287,6 +287,9 @@ def get_thread_id(feature, approval_field):
   if not thread_url:
     return None
 
+  thread_url = thread_url.split('#')[0]  # Chop off any anchor
+  thread_url = thread_url.split('?')[0]  # Chop off any query string params
+
   thread_id = None
   if thread_url.startswith(BLINK_DEV_ARCHIVE_URL_PREFIX):
     thread_id = thread_url[len(BLINK_DEV_ARCHIVE_URL_PREFIX):]

--- a/internals/sendemail.py
+++ b/internals/sendemail.py
@@ -156,7 +156,8 @@ def call_py3_task_handler(handler_path, task_dict):
       url=handler_url, payload=request_body, method=urlfetch.POST,
       follow_redirects=False)
 
-  logging.info('request_response is %r', handler_response)
+  logging.info('request_response is %r:\n%r',
+               handler_response.status_code, handler_response.content)
   return handler_response
 
 

--- a/internals/sendemail_py2test.py
+++ b/internals/sendemail_py2test.py
@@ -202,11 +202,13 @@ class FunctionTest(unittest.TestCase):
   @mock.patch('google.appengine.api.urlfetch.fetch')
   def test_call_py3_task_handler(self, mock_fetch):
     """Our py2 code can make a request to our py3 code."""
-    mock_fetch.return_value = 'mock response'
+    mock_response = testing_config_py2.Blank(
+        status_code=200, content='mock content')
+    mock_fetch.return_value = mock_response
 
     actual = sendemail.call_py3_task_handler('/path', {'a': 1})
 
-    self.assertEqual('mock response', actual)
+    self.assertEqual(mock_response, actual)
     mock_fetch.assert_called_once_with(
         url='http://localhost:8080/path', method=urlfetch.POST,
         payload=b'{"a": 1}', follow_redirects=False)


### PR DESCRIPTION
These are a couple of fixes to defects that I found while manually testing this week's release.

In this PR:
* When trying to detect an LGTM, allow finding the link to the chromestatus entry in quoted text.  Quoted text has some combination of spaces and greater-than signs prepended to each line.
* Existing values for the intent discussion thread URLs have been copied and pasted into the Guide UX by users, however depending on how the user copied it, the URL may have some Google Groups-related query string parameters.  We should strip those off when trying to generate a message ID to use to get a reply email to thread into the correct conversation.
* Improve the logging when handing off an inbound email from py2 to py3.
