### PR TITLE
Implement a new approval config datastore entity type and API

### DIFF
--- a/api/approvals_api.py
+++ b/api/approvals_api.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
+import datetime
 import logging
 
 from framework import basehandlers
@@ -58,6 +56,47 @@ class ApprovalsAPI(basehandlers.APIHandler):
     all_approval_values = models.Approval.get_approvals(feature_id, field_id)
     if approval_defs.is_resolved(all_approval_values, field_id):
       models.Approval.clear_request(feature_id, field_id)
+
+    # Callers don't use the JSON response for this API call.
+    return {'message': 'Done'}
+
+
+class ApprovalConfigsAPI(basehandlers.APIHandler):
+  """Get and set the approval configs for a feature."""
+
+  def do_get(self, feature_id):
+    """Return a list of all approval configs on the given feature."""
+    # Note: We assume that anyone may view approval configs.
+    configs = models.ApprovalConfig.get_configs(feature_id)
+    dicts = [ac.format_for_template(add_id=False) for ac in configs]
+    data = {
+        'configs': dicts,
+        }
+    return data
+
+  def do_post(self, feature_id):
+    """Set an approval config for the specified feature."""
+    field_id = self.get_int_param('fieldId')
+    owners_str = self.get_param('owners', required=False)
+    next_action_str = self.get_param('next_action', required=False)
+    additional_review = self.get_param('additional_review', required=False)
+    user = self.get_current_user(required=True)
+
+    # A user can set the config iff they could approve.
+    approvers = approval_defs.get_approvers(field_id)
+    if not permissions.can_approve_feature(user, feature, approvers):
+      self.abort(403, msg='User is not an approver')
+
+    owners = None
+    if owners_str:
+      owners = self.split_emails('owners')
+
+    next_action = Nnoe
+    if next_action_str:
+      next_action = datetime.date.fromisoformat(next_action_str)
+
+    models.ApprovalConfig.set_config(
+        feature_id, field_id, owners, next_action, additional_review)
 
     # Callers don't use the JSON response for this API call.
     return {'message': 'Done'}

--- a/api/approvals_api.py
+++ b/api/approvals_api.py
@@ -94,7 +94,10 @@ class ApprovalConfigsAPI(basehandlers.APIHandler):
 
     next_action = None
     if next_action_str:
-      next_action = datetime.date.fromisoformat(next_action_str)
+      try:
+        next_action = datetime.date.fromisoformat(next_action_str)
+      except ValueError:
+        self.abort(400, msg='Invalid date formate or value')
 
     models.ApprovalConfig.set_config(
         feature_id, field_id, owners, next_action, additional_review)

--- a/api/approvals_api.py
+++ b/api/approvals_api.py
@@ -80,6 +80,7 @@ class ApprovalConfigsAPI(basehandlers.APIHandler):
     owners_str = self.get_param('owners', required=False)
     next_action_str = self.get_param('next_action', required=False)
     additional_review = self.get_param('additional_review', required=False)
+    feature = self.get_specified_feature(feature_id=feature_id)
     user = self.get_current_user(required=True)
 
     # A user can set the config iff they could approve.
@@ -91,7 +92,7 @@ class ApprovalConfigsAPI(basehandlers.APIHandler):
     if owners_str:
       owners = self.split_emails('owners')
 
-    next_action = Nnoe
+    next_action = None
     if next_action_str:
       next_action = datetime.date.fromisoformat(next_action_str)
 

--- a/api/approvals_api_test.py
+++ b/api/approvals_api_test.py
@@ -208,3 +208,140 @@ class ApprovalsAPITest(testing_config.CustomTestCase):
     self.assertEqual(appr.field_id, 1)
     self.assertEqual(appr.set_by, 'owner1@example.com')
     self.assertEqual(appr.state, models.Approval.NEED_INFO)
+
+
+class ApprovalConfigsAPITest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.feature_1 = models.Feature(
+        name='feature one', summary='sum', category=1, visibility=1,
+        standardization=1, web_dev_views=1, impl_status_chrome=1)
+    self.feature_1.put()
+    self.feature_1_id = self.feature_1.key.integer_id()
+    self.config_1 = models.ApprovalConfig(
+        feature_id=self.feature_1_id, field_id=1,
+        owners=['one_a@example.com', 'one_b@example.com'])
+    self.config_1.put()
+
+    self.feature_2 = models.Feature(
+        name='feature two', summary='sum', category=1, visibility=1,
+        standardization=1, web_dev_views=1, impl_status_chrome=1)
+    self.feature_2.put()
+    self.feature_2_id = self.feature_2.key.integer_id()
+    self.config_2 = models.ApprovalConfig(
+        feature_id=self.feature_2_id, field_id=2,
+        owners=['two_a@example.com', 'two_b@example.com'])
+    self.config_2.put()
+
+    self.feature_3 = models.Feature(
+        name='feature three', summary='sum', category=1, visibility=1,
+        standardization=1, web_dev_views=1, impl_status_chrome=1)
+    self.feature_3.put()
+    self.feature_3_id = self.feature_3.key.integer_id()
+    # Feature 3 has no configs
+
+    self.handler = approvals_api.ApprovalConfigsAPI()
+    self.request_path = '/api/v0/features/%d/configs' % self.feature_1_id
+
+  def tearDown(self):
+    self.feature_1.key.delete()
+    self.feature_2.key.delete()
+    self.feature_3.key.delete()
+    for config in models.ApprovalConfig.query():
+      config.key.delete()
+
+  def test_do_get__found(self):
+    """Anon or any user can get some configs."""
+    testing_config.sign_in('other@example.com', 123567890)
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_get(self.feature_1_id)
+    self.assertEqual(
+        {'configs': [{
+            'feature_id': self.feature_1_id,
+            'field_id': 1,
+            'owners': ['one_a@example.com', 'one_b@example.com'],
+            'additional_review': False,
+            'next_action': None,
+            }]},
+        actual)
+
+    testing_config.sign_out()
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_get(self.feature_2_id)
+    self.assertEqual(
+        {'configs': [{
+            'feature_id': self.feature_2_id,
+            'field_id': 2,
+            'owners': ['two_a@example.com', 'two_b@example.com'],
+            'additional_review': False,
+            'next_action': None,
+            }]},
+        actual)
+
+  def test_do_get__no_configs(self):
+    """If there are no configs, we return an empty list."""
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_get(self.feature_3_id)
+
+    self.assertEqual(
+        {'configs': []},
+        actual)
+
+  @mock.patch('internals.approval_defs.get_approvers')
+  def test_do_post__add_a_config(self, mock_get_approvers):
+    """If there are already existing configs, we can add new one."""
+    mock_get_approvers.return_value = ['owner1@example.com']
+    testing_config.sign_in('owner1@example.com', 123567890)
+
+    params = {'fieldId': 3,
+              'next_action': '2021-11-30'}
+    with test_app.test_request_context(self.request_path, json=params):
+      actual = self.handler.do_post(self.feature_1_id)
+
+    self.assertEqual({'message': 'Done'}, actual)
+    revised_configs = models.ApprovalConfig.query(
+        models.ApprovalConfig.feature_id == self.feature_1_id).fetch(None)
+    self.assertEqual(2, len(revised_configs))
+
+  @mock.patch('internals.approval_defs.get_approvers')
+  def test_do_post__update(self, mock_get_approvers):
+    """We can update an existing config."""
+    mock_get_approvers.return_value = ['owner1@example.com']
+    testing_config.sign_in('owner1@example.com', 123567890)
+
+    params = {'fieldId': 1,
+              'next_action': '2021-11-30'}
+    with test_app.test_request_context(self.request_path, json=params):
+      actual = self.handler.do_post(self.feature_1_id)
+
+    self.assertEqual({'message': 'Done'}, actual)
+    revised_config = models.ApprovalConfig.query(
+        models.ApprovalConfig.feature_id == self.feature_1_id).fetch(None)[0]
+    self.assertEqual(self.feature_1_id, revised_config.feature_id)
+    self.assertEqual(1, revised_config.field_id)
+    self.assertEqual(datetime.date.fromisoformat('2021-11-30'),
+                     revised_config.next_action)
+    self.assertEqual(['one_a@example.com', 'one_b@example.com'],
+                     revised_config.owners)
+    self.assertEqual(False, revised_config.additional_review)
+
+  @mock.patch('internals.approval_defs.get_approvers')
+  def test_do_post__no_configs(self, mock_get_approvers):
+    """If there are no existing configs, we create one."""
+    mock_get_approvers.return_value = ['owner1@example.com']
+    testing_config.sign_in('owner1@example.com', 123567890)
+
+    params = {'fieldId': 3,
+              'next_action': '2021-11-30'}
+    with test_app.test_request_context(self.request_path, json=params):
+      actual = self.handler.do_post(self.feature_3_id)
+
+    self.assertEqual({'message': 'Done'}, actual)
+    new_config = models.ApprovalConfig.query(
+        models.ApprovalConfig.feature_id == self.feature_3_id).fetch(None)[0]
+    self.assertEqual(self.feature_3_id, new_config.feature_id)
+    self.assertEqual(3, new_config.field_id)
+    self.assertEqual(datetime.date.fromisoformat('2021-11-30'),
+                     new_config.next_action)
+    self.assertEqual([], new_config.owners)
+    self.assertEqual(False, new_config.additional_review)

--- a/api/approvals_api_test.py
+++ b/api/approvals_api_test.py
@@ -345,3 +345,19 @@ class ApprovalConfigsAPITest(testing_config.CustomTestCase):
                      new_config.next_action)
     self.assertEqual([], new_config.owners)
     self.assertEqual(False, new_config.additional_review)
+
+  @mock.patch('internals.approval_defs.get_approvers')
+  def test_do_post__bad_date(self, mock_get_approvers):
+    """We reject bad date formats and values."""
+    mock_get_approvers.return_value = ['owner1@example.com']
+    testing_config.sign_in('owner1@example.com', 123567890)
+
+    params = {'next_action': '11/30/21'}
+    with test_app.test_request_context(self.request_path, json=params):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post(self.feature_3_id)
+
+    params = {'next_action': '2021-11-35'}
+    with test_app.test_request_context(self.request_path, json=params):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post(self.feature_3_id)

--- a/internals/models.py
+++ b/internals/models.py
@@ -1407,6 +1407,41 @@ class Approval(DictModel):
       rr.key.delete()
 
 
+class ApprovalConfig(DictModel):
+  """Allows customization of an approval field for one feature."""
+
+  feature_id = ndb.IntegerProperty(required=True)
+  field_id = ndb.IntegerProperty(required=True)
+  owners = ndb.StringProperty(repeated=True)
+  next_action = ndb.DateProperty()
+  additional_review = ndb.BooleanProperty(default=False)
+
+  @classmethod
+  def get_configs(cls, feature_id):
+    """Return approval configs for all approval fields."""
+    query = ApprovalConfig.query(ApprovalConfig.feature_id == feature_id)
+    configs = list(query.fetch(None))
+    return configs
+
+  @classmethod
+  def set_config(
+      cls, feature_id, field_id, owners=None, next_action=None,
+      additional_review=None):
+    """Add or update an approval config object."""
+    config = ApprovalConfig(feature_id=feature_id, field_id=field_id)
+    for existing in cls.get_approval_configs(feature_id):
+      if existing.field_id == field_id:
+        config = existing
+
+    if owners is not None:
+      config.owners = owners
+    if next_action is not None:
+      config.next_action = next_action
+    if additional_review is not None:
+      config.additional_review = additional_review
+    config.put()
+
+
 class Comment(DictModel):
   """A review comment on a feature."""
   feature_id = ndb.IntegerProperty(required=True)

--- a/internals/models.py
+++ b/internals/models.py
@@ -1416,7 +1416,7 @@ class ApprovalConfig(DictModel):
   def get_configs(cls, feature_id):
     """Return approval configs for all approval fields."""
     query = ApprovalConfig.query(ApprovalConfig.feature_id == feature_id)
-    configs = list(query.fetch(None))
+    configs = query.fetch(None)
     return configs
 
   @classmethod
@@ -1425,7 +1425,7 @@ class ApprovalConfig(DictModel):
       additional_review=None):
     """Add or update an approval config object."""
     config = ApprovalConfig(feature_id=feature_id, field_id=field_id)
-    for existing in cls.get_approval_configs(feature_id):
+    for existing in cls.get_configs(feature_id):
       if existing.field_id == field_id:
         config = existing
 

--- a/main.py
+++ b/main.py
@@ -88,6 +88,8 @@ api_routes = [
      approvals_api.ApprovalsAPI),
     (API_BASE + '/features/<int:feature_id>/approvals/<int:field_id>',
      approvals_api.ApprovalsAPI),
+    (API_BASE + '/features/<int:feature_id>/configs',
+     approvals_api.ApprovalConfigsAPI),
     (API_BASE + '/features/<int:feature_id>/approvals/comments',
      comments_api.CommentsAPI),
     (API_BASE + '/features/<int:feature_id>/approvals/<int:field_id>/comments',

--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -183,7 +183,7 @@ class ChromeStatusClient {
     // TODO: catch((error) => { display message }
   }
 
-  // Approvals and review comments
+  // Approvals, configs, and review comments
 
   getApprovals(featureId) {
     return this.doGet(`/features/${featureId}/approvals`);
@@ -194,6 +194,19 @@ class ChromeStatusClient {
         `/features/${featureId}/approvals`,
         {fieldId: Number(fieldId),
           state: Number(state)});
+  }
+
+  getApprovalConfigs(featureId) {
+    return this.doGet(`/features/${featureId}/configs`);
+  }
+
+  setApprovalConfig(featureId, fieldId, owners, nextAction, additionalReview) {
+    return this.doPost(
+        `/features/${featureId}/configs`,
+        {fieldId: Number(fieldId),
+          owners,
+          nextAction,
+          additionalReview});
   }
 
   getComments(featureId, fieldId) {


### PR DESCRIPTION
This replaces my previous attempt at representing the next-action date for reviews (#1617).

In this PR:
* Define new datastore entity for ApprovalConfig which will be stored per-feature and per-approval-field.
* Implement get and set methods in models.py.
* Implement a new API class for ApprovalConfigs with the ability to get and set.
* Unit tests 
* cs-client.js methods to call the new API.

Nothing uses this new API yet, but I will work on the UI and JS for these features in my next PR.