### PR TITLE
Treat N/A as approved.

### DIFF
--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -123,7 +123,7 @@ def is_approved(approval_values, field_id):
   """Return true if we have all needed APPROVED values and no NOT_APPROVED."""
   count = 0
   for av in approval_values:
-    if av.state == models.Approval.APPROVED:
+    if av.state in (models.Approval.APPROVED, models.Approval.NA):
       count += 1
     elif av.state == models.Approval.NOT_APPROVED:
       return False

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -123,6 +123,11 @@ class IsApprovedTest(unittest.TestCase):
         state=models.Approval.REVIEW_REQUESTED,
         set_on=datetime.datetime.now(),
         set_by='one@example.com')
+    self.appr_na = models.Approval(
+        feature_id=feature_1_id, field_id=1,
+        state=models.Approval.NA,
+        set_on=datetime.datetime.now(),
+        set_by='one@example.com')
     self.appr_no = models.Approval(
         feature_id=feature_1_id, field_id=1,
         state=models.Approval.NOT_APPROVED,
@@ -144,16 +149,19 @@ class IsApprovedTest(unittest.TestCase):
     self.assertFalse(approval_defs.is_approved([self.appr_nr], 1))
     self.assertFalse(approval_defs.is_approved([self.appr_no], 1))
     self.assertTrue(approval_defs.is_approved([self.appr_yes], 1))
+    self.assertTrue(approval_defs.is_approved([self.appr_na], 1))
     self.assertFalse(approval_defs.is_approved([self.appr_nr, self.appr_no], 1))
     self.assertFalse(approval_defs.is_approved(
         [self.appr_nr, self.appr_no, self.appr_yes], 1))
     self.assertTrue(approval_defs.is_approved([self.appr_nr, self.appr_yes], 1))
+    self.assertTrue(approval_defs.is_approved([self.appr_nr, self.appr_na], 1))
 
     # Field requires 3 LGTMs
     self.assertFalse(approval_defs.is_approved([], 2))
     self.assertFalse(approval_defs.is_approved([self.appr_nr], 2))
     self.assertFalse(approval_defs.is_approved([self.appr_no], 2))
     self.assertFalse(approval_defs.is_approved([self.appr_yes], 2))
+    self.assertFalse(approval_defs.is_approved([self.appr_na], 2))
     self.assertFalse(approval_defs.is_approved([self.appr_nr, self.appr_no], 2))
     self.assertFalse(approval_defs.is_approved(
         [self.appr_nr, self.appr_no, self.appr_yes], 2))
@@ -161,8 +169,14 @@ class IsApprovedTest(unittest.TestCase):
 
     self.assertTrue(approval_defs.is_approved(
         [self.appr_yes, self.appr_yes, self.appr_yes], 2))
+    self.assertTrue(approval_defs.is_approved(
+        [self.appr_yes, self.appr_yes, self.appr_na], 2))
+    self.assertTrue(approval_defs.is_approved(
+        [self.appr_na, self.appr_na, self.appr_na], 2))
     self.assertFalse(approval_defs.is_approved(
         [self.appr_yes, self.appr_yes, self.appr_yes, self.appr_no], 2))
+    self.assertFalse(approval_defs.is_approved(
+        [self.appr_na, self.appr_yes, self.appr_yes, self.appr_no], 2))
 
   @mock.patch('internals.approval_defs.APPROVAL_FIELDS_BY_ID',
               MOCK_APPROVALS_BY_ID)


### PR DESCRIPTION
This change came out of observing the API Owners use the tool this week.  The intent-to-prototype email threads do not require approval, they are just FYIs to the feature owners.  During their weekly meeting they typically mark these intents as "N/A". 

The problem was that the intent was still in the "Features pending my review" box.

In this PR:
+ Change the condition used when counting LGTMs to match either APPROVED or NA.