### PR TITLE
Add navigational context for feature detail page back arrow.

### DIFF
--- a/pages/featuredetail.py
+++ b/pages/featuredetail.py
@@ -41,6 +41,10 @@ class FeatureDetailHandler(basehandlers.FlaskHandler):
     feature_process = processes.ALL_PROCESSES.get(
         f.feature_type, processes.BLINK_LAUNCH_PROCESS)
     field_defs = guideforms.DISPLAY_FIELDS_IN_STAGES
+    context_link = '/features/%d' % feature_id
+    if self.request.args.get('context') == 'myfeatures':
+      context_link = '/myfeatures'
+
     template_data = {
         'process_json': json.dumps(processes.process_to_dict(feature_process)),
         'field_defs_json': json.dumps(field_defs),
@@ -49,5 +53,6 @@ class FeatureDetailHandler(basehandlers.FlaskHandler):
         'feature_json': json.dumps(f.format_for_template()),
         'updated_display': f.updated.strftime("%Y-%m-%d"),
         'new_crbug_url': f.new_crbug_url(),
+        'context_link': context_link,
     }
     return template_data

--- a/static/elements/chromedash-feature-table.js
+++ b/static/elements/chromedash-feature-table.js
@@ -268,7 +268,7 @@ class ChromedashFeatureTable extends LitElement {
       <tr>
         <td class="name_col">
           ${this.renderQuickActions(feature)}
-          <a href="/feature/${feature.id}">${feature.name}</a>
+          <a href="/feature/${feature.id}?context=myfeatures">${feature.name}</a>
           ${this.renderHighlights(feature)}
         </td>
         <td class="icon_col">

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -69,7 +69,7 @@
   </div>
 
   <h2 id="breadcrumbs">
-    <a href="/features/{{ feature_id }}">
+    <a href="{{ context_link }}">
       <iron-icon icon="chromestatus:arrow-back"></iron-icon>
       Feature: {{ feature.name }}
     </a>


### PR DESCRIPTION
This addresses a request from last week's demo to API Owners.  When they click through a feature name link on the myfeatures pages, they see the feature detail page.  The request was to make the back arrow icon on the feature detail page navigate back to the myfeatures page in that case, rather than always going to the all features page.

In this PR:
* Add `?context=myfeatures` to the links generated on the myfeatures page
* Calculate the context link for the back arrow in feature.py (without blindly trusting any query string parameter)
* Use that context link for the back arrow icon href in the feature.html template.