### PR TITLE
Fix incorrect caching logic that caused transient duplicates on myfeatures.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -839,8 +839,8 @@ class Feature(DictModel):
     futures = []
 
     for feature_id in feature_ids:
-      KEY = '%s|%s' % (Feature.DEFAULT_CACHE_KEY, feature_id)
-      feature = ramcache.get(KEY)
+      lookup_key = '%s|%s' % (Feature.DEFAULT_CACHE_KEY, feature_id)
+      feature = ramcache.get(lookup_key)
       if feature is None or update_cache:
         futures.append(Feature.get_by_id_async(feature_id))
       else:
@@ -853,7 +853,9 @@ class Feature(DictModel):
         feature['updated_display'] = (
             unformatted_feature.updated.strftime("%Y-%m-%d"))
         feature['new_crbug_url'] = unformatted_feature.new_crbug_url()
-        ramcache.set(KEY, feature)
+        store_key = '%s|%s' % (Feature.DEFAULT_CACHE_KEY,
+                               unformatted_feature.key.integer_id())
+        ramcache.set(store_key, feature)
         result_dict[unformatted_feature.key.integer_id()] = feature
 
     result_list = [

--- a/internals/models_test.py
+++ b/internals/models_test.py
@@ -168,13 +168,23 @@ class FeatureTest(testing_config.CustomTestCase):
     self.assertEqual([], actual)
 
   def test_get_by_ids__cache_miss(self):
-    """We can load features from datastore."""
+    """We can load features from datastore, and cache them for later."""
     ramcache.global_cache.clear()
 
-    actual = models.Feature.get_by_ids([self.feature_1.key.integer_id()])
+    actual = models.Feature.get_by_ids([
+        self.feature_1.key.integer_id(),
+        self.feature_2.key.integer_id()])
 
-    self.assertEqual(1, len(actual))
+    self.assertEqual(2, len(actual))
     self.assertEqual('feature a', actual[0]['name'])
+    self.assertEqual('feature b', actual[1]['name'])
+
+    lookup_key_1 = '%s|%s' % (models.Feature.DEFAULT_CACHE_KEY,
+                              self.feature_1.key.integer_id())
+    lookup_key_2 = '%s|%s' % (models.Feature.DEFAULT_CACHE_KEY,
+                              self.feature_2.key.integer_id())
+    self.assertEqual('feature a', ramcache.get(lookup_key_1)['name'])
+    self.assertEqual('feature b', ramcache.get(lookup_key_2)['name'])
 
   def test_get_by_ids__cache_hit(self):
     """We can load features from ramcache."""


### PR DESCRIPTION
This resolves issue #1647.

Basically, `Feature.get_by_ids()` was caching features using the wrong cache key.  But, the problem only shows up when there are concurrent requests.  See the issue comments for a full explanation.

In this PR:
* Fix the call to `memcache.set()` to use the correct cache key for the feature being cached.
* Rename both of the variables involved so that a similar error would be more obvious in the future.
* Add a unit test.