### PR TITLE
Refresh Google Sign-In session.

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -118,21 +118,44 @@ limitations under the License.
             window.location.reload();
         });
     }
-    
+
+    function refreshSession() {
+        console.log('refreshing google sigin-in session');
+        let cu = auth2.currentUser.get();
+        cu.reloadAuthResponse().then(function(unused_auth_response) {
+            // Calling this sets the flask session cookie.
+            csClient.signIn(auth2.currentUser.get());
+        }).catch(() => {
+            console.error('Refreshing session failed.');
+            let ar = cu.getAuthResponse();
+            let expires_at = ar.expires_at;
+            if (expires_at < Number(new Date())) {
+                signOut();
+                console.log('Explicitly signing out because session expired.');
+            }
+        });
+
+    }
+
     var googleUser = {};
-    var startApp = function() {
+    function startApp() {
         gapi.load('auth2', function(){
           auth2 = gapi.auth2.init({
               client_id: '{{google_sign_in_client_id}}',
               cookiepolicy: 'single_host_origin',
               scope: 'profile email'
           });
-          
           if (document.getElementById('gSignInCustomBtn')) {
             attachSignin(document.getElementById('gSignInCustomBtn'));
+          } else {
+            // Google Sign-In sessions only last 1-hour.  Refresh the
+            // session immediately after each page naviagation
+            // and once every 10 minutes the user sits on a page.
+            refreshSession();
+            window.setInterval(refreshSession, 10 * 60 * 1000);
           }
         });
-    };
+    }
 
     function attachSignin(element) {
       auth2.attachClickHandler(element, {},
@@ -142,7 +165,7 @@ limitations under the License.
               console.log(error);
           });
     }
-    
+
     function onLoad() {
       startApp();
     }


### PR DESCRIPTION
This should address issues #1502, issue #1644, and probably some others.

One underlying cause of problems for users is that the Google Sign-In session expires after 1 hour, however there is no UI indication that things are going wrong.  Google Sign-In does have a way to refresh the session to start the 1-hour limit over again, as documented in this reference page, however the reason why we need to use these calls is not spelled out anywhere in the Google Sign-In docs, it is only discussed on Stack Overflow.
https://developers.google.com/identity/sign-in/web/reference#googleusergetid

In this PR: 
* Add a new JS function refreshSession() that calls reloadAuthResponse() to get a new Google Sign-In session token that has a new expiration date 1 hour in the future.  And, call our login API to encode that into a flask session cookie and set that cookie so that the next form submission will work.
* Call the new function immediately after each page load and repeat it again every 10 minutes that the user sits on a page.  The reason to use setInterval() is so that it will be called if the user reactivates an idle tab, and to keep retrying if they have intermittent connectivity.
* Tell the user about any failed API call so that they will know to try again.