### PR TITLE
#1655 fix-CSS ISSUE : larger Property names not breaking up and sliding into Percentage column. 

### DIFF
--- a/static/elements/chromedash-metrics.js
+++ b/static/elements/chromedash-metrics.js
@@ -58,6 +58,7 @@ class ChromedashMetrics extends LitElement {
       li > :first-child {
         flex: 1;
         margin-right: 10px;
+        word-break: break-all;
       }
 
       li > :nth-child(2) {


### PR DESCRIPTION
CSS ISSUE : larger Property names not breaking up and sliding into Percentage column. GoogleChrome#1655 fix

Large property names should wrap to 2nd line.
The word-break property specifies how words should break when reaching the end of a line.
added { word-break: break-all; } to all inside


PFA screenshot for the same.
![image](https://user-images.githubusercontent.com/4961480/147322862-f3e01649-94a8-4947-bab5-d46bcd1ee099.png)
Expected behavior
Large property names should wrap to 2nd line.
The word-break property specifies how words should break when reaching the end of a line.
image
Solution : Need to apply below CSS to property names.
{
word-break: break-all;
}
Before Fix :
![image](https://user-images.githubusercontent.com/4961480/147322862-f3e01649-94a8-4947-bab5-d46bcd1ee099.png)
After Fix :
![image](https://user-images.githubusercontent.com/4961480/147322882-bb2ffe8a-5fa0-4fda-9ce7-e29d9ab33fbd.png)
