### PR TITLE
Add indexes for queries done when closing a review.

### DIFF
--- a/api/approvals_api.py
+++ b/api/approvals_api.py
@@ -54,7 +54,8 @@ class ApprovalsAPI(basehandlers.APIHandler):
     models.Approval.set_approval(
         feature_id, field_id, new_state, user.email())
 
-    all_approval_values = models.Approval.get_approvals(feature_id, field_id)
+    all_approval_values = models.Approval.get_approvals(
+        feature_id=feature_id, field_id=field_id)
     if approval_defs.is_resolved(all_approval_values, field_id):
       models.Approval.clear_request(feature_id, field_id)
 

--- a/index.yaml
+++ b/index.yaml
@@ -24,6 +24,23 @@ indexes:
   - name: "name"
 - kind: "Approval"
   properties:
+  - name: "feature_id"
+  - name: "field_id"
+  - name: "set_by"
+  - name: "set_on"
+- kind: "Approval"
+  properties:
+  - name: "feature_id"
+  - name: "field_id"
+  - name: "set_on"
+- kind: "Approval"
+  properties:
+  - name: "feature_id"
+  - name: "field_id"
+  - name: "state"
+  - name: "set_on"
+- kind: "Approval"
+  properties:
   - name: "set_by"
   - name: "set_on"
 - kind: "Approval"


### PR DESCRIPTION
There were some features listed in the pending reviews box on the my features page even after they had three approvals.  There is logic to remove the "review requested" approval value once all needed approvals are set, which works locally and on staging, but it does not seem to work on prod.

Prior to this PR, we were missing the datastore indexes needed for the queries that are used to detect which features have satisfied the approval rules, and to find the "review requested" approval value for each such feature that need to be deleted.

I am thinking that the as-is might work on staging because our staging instance uses "Firestore in datastore mode" whereas our prod instance is just plain datastore.  This is not something that we configured, it is just a side-effect of when the project was created, I think.  However, both datastore and Firestore docs say that composite indexes must be set up ahead of time.  So, I am not sure why staging and prod are behaving differently, but this PR seems like an improvement regardless.

In this PR:
* Add the needed indexes
* Make one of the calls to get_approvals() more explicit.
