### PR TITLE
Bring Django to the latest release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Also see requirements.dev.txt
 
 # Py3 Libraries
-Django==2.2.25
+Django==3.2.11
 funcsigs
 google-python-cloud-debugger
 google-cloud-tasks


### PR DESCRIPTION
Upgrade Django to 3.2.11 by going through release notes. The only relevant bit is 

- django.utils.html.escape() now uses html.escape() to escape HTML. This converts ' to `&#x27` instead of the previous equivalent decimal code `&#39` in [the 3.0 release](https://docs.djangoproject.com/en/3.2/releases/3.0/)