### PR TITLE
Fix two problems with post-to-thread.

### DIFF
--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -37,22 +37,22 @@ ApprovalFieldDef = collections.namedtuple(
     'name, description, field_id, rule, approvers')
 
 PrototypeApproval = ApprovalFieldDef(
-    'Intent to prototype',
+    'Intent to Prototype',
     'One API Owner must approve your intent',
     1, ONE_LGTM, API_OWNERS_URL)
 
 ExperimentApproval = ApprovalFieldDef(
-    'Intent to experiment',
+    'Intent to Experiment',
     'One API Owner must approve your intent',
     2, ONE_LGTM, API_OWNERS_URL)
 
 ExtendExperimentApproval = ApprovalFieldDef(
-    'Intent to extend experiment',
+    'Intent to Extend Experiment',
     'One API Owner must approve your intent',
     3, ONE_LGTM, API_OWNERS_URL)
 
 ShipApproval = ApprovalFieldDef(
-    'Intent to ship',
+    'Intent to Ship',
     'Three API Owners must approve your intent',
     4, THREE_LGTM, API_OWNERS_URL)
 

--- a/py2/sendemail.py
+++ b/py2/sendemail.py
@@ -79,10 +79,14 @@ def handle_outbound_mail_task():
       sender=sender, to=to, subject=subject, html=email_html)
   message.check_initialized()
 
+  if references:
+    message.headers = {'References': references}
+
   logging.info('Will send the following email:\n')
   logging.info('Sender: %s', message.sender)
   logging.info('To: %s', message.to)
   logging.info('Subject: %s', message.subject)
+  logging.info('References: %s', references or '(not included)')
   logging.info('Body:\n%s', message.html[:settings.MAX_LOG_LINE])
   if settings.SEND_EMAIL:
     message.send()

--- a/py2/sendemail_py2test.py
+++ b/py2/sendemail_py2test.py
@@ -35,6 +35,7 @@ class OutboundEmailHandlerTest(unittest.TestCase):
     self.html = '<b>body</b>'
     self.sender = ('Chromestatus <admin@%s.appspotmail.com>' %
                    settings.APP_ID)
+    self.refs = 'fake-message-id-of-previous-message'
 
   @mock.patch('settings.SEND_EMAIL', True)
   @mock.patch('settings.SEND_ALL_EMAIL_TO', None)
@@ -45,6 +46,7 @@ class OutboundEmailHandlerTest(unittest.TestCase):
         'to': self.to,
         'subject': self.subject,
         'html': self.html,
+        'references': self.refs,
         }
     with sendemail.app.test_request_context(self.request_path, json=params):
       actual_response = sendemail.handle_outbound_mail_task()
@@ -56,6 +58,7 @@ class OutboundEmailHandlerTest(unittest.TestCase):
     mock_message.check_initialized.assert_called_once_with()
     mock_message.send.assert_called_once_with()
     self.assertEqual({'message': 'Done'}, actual_response)
+    self.assertEqual(self.refs, mock_message.headers['References'])
 
   @mock.patch('settings.SEND_EMAIL', True)
   @mock.patch('google.appengine.api.mail.EmailMessage')

--- a/templates/review-comment-email.html
+++ b/templates/review-comment-email.html
@@ -1,1 +1,1 @@
-<pre>{{comment_content}}</pre>
+<div style="white-space: pre-wrap">{{comment_content}}</div>


### PR DESCRIPTION
When the API Owners tried posting a comment to a review discussion thread, they found that the message was sent to the mailing list but that it did not get threaded into the discussion, and the message looked bad because it used a monospace font.

In this PR:
* Actually set the References: header.  It was previously passed into the py2 outbound email task but then ignored.
* Change the capitalization of the review field name, e.g., "Intent to Ship", to match the capitalization that we use when generating the intent email preview.  This makes the two email messages have the exact same Subject line.
* Change the formatting of the email from `<pre>` to a div with `white-space:pre-wrap`.  That should preserve the line breaks and whitespace that the user entered without using a monospaced font.