### PR TITLE
In py3 code, replace the separate mock lib with unittest.mock.

### DIFF
--- a/api/accounts_api_test.py
+++ b/api/accounts_api_test.py
@@ -13,13 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import testing_config  # Must be imported before the module under test.
 
 import flask
-import mock
+from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 
 from api import accounts_api

--- a/api/approvals_api_test.py
+++ b/api/approvals_api_test.py
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import datetime
 import testing_config  # Must be imported before the module under test.
 
 import flask
-import mock
+from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 
 from api import approvals_api

--- a/api/channels_api_test.py
+++ b/api/channels_api_test.py
@@ -14,7 +14,7 @@
 
 import testing_config  # Must be imported first
 import json
-import mock
+from unittest import mock
 import unittest
 
 from api import channels_api

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -13,14 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import datetime
 import testing_config  # Must be imported before the module under test.
 
 import flask
-import mock
+from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 
 from api import comments_api

--- a/api/cues_api_test.py
+++ b/api/cues_api_test.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import testing_config  # Must be imported before the module under test.
 
 import flask
-import mock
+from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 
 from api import cues_api

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import testing_config  # Must be imported before the module under test.
 
 import flask
-import mock
+from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 
 from api import features_api

--- a/api/metricsdata_test.py
+++ b/api/metricsdata_test.py
@@ -1,6 +1,3 @@
-
-
-
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -18,7 +15,7 @@
 import testing_config  # Must be imported first
 
 import datetime
-import mock
+from unittest import mock
 import flask
 
 # from google.appengine.api import users

--- a/api/stars_api_test.py
+++ b/api/stars_api_test.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import testing_config  # Must be imported before the module under test.
 
 import flask
-import mock
+from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 
 from api import stars_api

--- a/api/token_refresh_api_test.py
+++ b/api/token_refresh_api_test.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import testing_config  # Must be imported before the module under test.
 
 import flask
-import mock
+from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 
 from api import token_refresh_api

--- a/framework/cloud_tasks_helpers_test.py
+++ b/framework/cloud_tasks_helpers_test.py
@@ -1,6 +1,3 @@
-
-
-
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -15,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 import unittest
 import testing_config  # Must be imported before the module under test.
 

--- a/framework/csp_test.py
+++ b/framework/csp_test.py
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import unittest
 import testing_config  # Must be imported before the module under test.
 
 import flask
-import mock
+from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 
 from framework import csp

--- a/framework/permissions_test.py
+++ b/framework/permissions_test.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import testing_config  # Must be imported before the module under test.
 
-import mock
+from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 
 # from google.appengine.api import users

--- a/framework/ramcache_test.py
+++ b/framework/ramcache_test.py
@@ -1,6 +1,3 @@
-
-
-
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -16,7 +13,7 @@
 # limitations under the License.
 
 import datetime
-import mock
+from unittest import mock
 import testing_config  # Must be imported before the module under test.
 
 from framework import ramcache

--- a/framework/secrets_test.py
+++ b/framework/secrets_test.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import testing_config  # Must be imported before the module under test.
 
-import mock
+from unittest import mock
 
 from framework import secrets
 

--- a/framework/utils_test.py
+++ b/framework/utils_test.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import unittest
 import testing_config  # Must be imported before the module under test.
 
-import mock
+from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 
 from framework import utils

--- a/framework/xsrf_test.py
+++ b/framework/xsrf_test.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import testing_config  # Must be imported before the module under test.
 
-import mock
+from unittest import mock
 
 from framework import xsrf
 

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -19,7 +19,7 @@ import testing_config  # Must be imported before the module under test.
 import unittest
 import urllib.request, urllib.parse, urllib.error
 
-import mock
+from unittest import mock
 import flask
 import werkzeug
 

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -15,7 +15,7 @@
 import testing_config  # Must be imported first
 
 import flask
-import mock
+from unittest import mock
 import werkzeug
 
 from internals import models

--- a/internals/fetchmetrics_test.py
+++ b/internals/fetchmetrics_test.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import base64
 import datetime
 import json
 import testing_config  # Must be imported before the module under test.
 import urllib.request, urllib.parse, urllib.error
 
-import mock
+from unittest import mock
 import flask
 import werkzeug
 

--- a/internals/models_test.py
+++ b/internals/models_test.py
@@ -15,9 +15,8 @@
 import testing_config  # Must be imported before the module under test.
 
 import datetime
-import mock
+from unittest import mock
 from framework import ramcache
-# from google.appengine.api import users
 from framework import users
 
 from internals import models

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -17,7 +17,7 @@ import json
 import testing_config  # Must be imported before the module under test.
 
 import flask
-import mock
+from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 from google.cloud import ndb
 

--- a/internals/processes_test.py
+++ b/internals/processes_test.py
@@ -1,6 +1,3 @@
-
-
-
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -18,7 +15,7 @@
 import collections
 import testing_config  # Must be imported before the module under test.
 
-import mock
+from unittest import mock
 
 from internals import approval_defs
 from internals import models

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -15,7 +15,7 @@
 import testing_config  # Must be imported before the module under test.
 
 import datetime
-import mock
+from unittest import mock
 
 from internals import models
 from internals import notifier

--- a/pages/guideforms_test.py
+++ b/pages/guideforms_test.py
@@ -1,6 +1,3 @@
-
-
-
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -18,7 +15,7 @@
 import testing_config  # Must be imported first
 import unittest
 
-import mock
+from unittest import mock
 
 from pages import guideforms
 from internals import models

--- a/pages/intentpreview_test.py
+++ b/pages/intentpreview_test.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import testing_config  # Must be imported before the module under test.
 
-import mock
+from unittest import mock
 import flask
 import werkzeug
 

--- a/pages/myfeatures_test.py
+++ b/pages/myfeatures_test.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import testing_config  # Must be imported first
 
 import flask
-import mock
+from unittest import mock
 import werkzeug
 
 import settings

--- a/pages/schedule_test.py
+++ b/pages/schedule_test.py
@@ -1,6 +1,3 @@
-
-
-
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -16,7 +13,7 @@
 # limitations under the License.
 
 import testing_config  # Must be imported first
-import mock
+from unittest import mock
 import unittest
 
 from pages import schedule

--- a/pages/users_test.py
+++ b/pages/users_test.py
@@ -1,6 +1,3 @@
-
-
-
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -16,7 +13,7 @@
 # limitations under the License.
 
 import testing_config  # Must be imported first
-import mock
+from unittest import mock
 import unittest
 
 import flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,10 +11,6 @@ google-cloud-logging
 google-auth==1.24.0
 requests
 
-# TODO(jrobbins): Remove this after we upgrade all py3 unit tests to use:
-# import unittest.mock.
-mock==3.0.5
-
 # TODO(jrobbins): Update to a 2.x version of flask, which may require source
 # code changes.
 Flask==1.1.2


### PR DESCRIPTION
Instead of using the separate mock library that we use for py2, use the unitest.mock standard library that is part of py3.

For some reason, mocking flask.request does not work, so I needed to use `with test_app.test_request_context(...)` instead.