### PR TITLE
hack_components: Add "Blink>BatteryStatus" component.

### DIFF
--- a/hack_components.py
+++ b/hack_components.py
@@ -7,6 +7,7 @@ HACK_BLINK_COMPONENTS = [
   "Blink>AudioOutputDevices",
   "Blink>BackgroundFetch",
   "Blink>BackgroundSync",
+  "Blink>BatteryStatus",
   "Blink>Bindings",
   "Blink>Bluetooth",
   "Blink>CSS",


### PR DESCRIPTION
This was added to Monorail a few months ago in https://crbug.com/1253272
