### PR TITLE
Add non_oss_deps field to guide and intent email template.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -1310,6 +1310,7 @@ class Feature(DictModel):
   doc_links = ndb.StringProperty(repeated=True)
   measurement = ndb.StringProperty()
   sample_links = ndb.StringProperty(repeated=True)
+  non_oss_deps = ndb.StringProperty()
 
   experiment_goals = ndb.StringProperty()
   experiment_timeline = ndb.StringProperty()

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -1,6 +1,3 @@
-
-
-
 # -*- coding: utf-8 -*-
 # Copyright 2020 Google Inc.
 #
@@ -514,6 +511,8 @@ class FeatureEditStage(basehandlers.FlaskHandler):
       feature.other_views_notes = self.form.get('other_views_notes')
     if self.touched('prefixed'):
       feature.prefixed = self.form.get('prefixed') == 'on'
+    if self.touched('non_oss_deps'):
+      feature.non_oss_deps = self.form.get('non_oss_deps')
 
     if self.touched('tag_review'):
       feature.tag_review = self.form.get('tag_review')

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -1,6 +1,3 @@
-
-
-
 # -*- coding: utf-8 -*-
 # Copyright 2020 Google Inc.
 #
@@ -547,6 +544,17 @@ ALL_FIELDS = {
                    'placeholder': 'https://\nhttps://'}),
         help_text='Links to samples (one URL per line).'),
 
+    'non_oss_deps': forms.CharField(
+        label='Non-OSS dependencies', required=False,
+        widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
+        help_text=
+        ('Does the feature depend on any code or APIs outside the Chromium '
+         'open source repository and its open-source dependencies to '
+         'function? (e.g. server-side APIs, operating system APIs '
+         'tailored to this feature or closed-source code bundles) '
+         'Yes or no. If yes, explain why this is necessary.'
+         )),
+
     'bug_url': forms.URLField(
         required=False, label='Tracking bug URL',
         widget=forms.URLInput(attrs={'placeholder': 'https://'}),
@@ -760,7 +768,7 @@ NewFeature_EvalReadinessToShip = define_form_class_using_shared_fields(
      'ff_views', 'ff_views_link', 'ff_views_notes',
      'web_dev_views', 'web_dev_views_link', 'web_dev_views_notes',
      'other_views_notes',
-     'prefixed', 'comments'))
+     'prefixed', 'non_oss_deps', 'comments'))
 
 
 ImplStatus_AllMilestones = define_form_class_using_shared_fields(
@@ -795,7 +803,7 @@ ImplStatus_OriginTrial = define_form_class_using_shared_fields(
 
 Most_PrepareToShip = define_form_class_using_shared_fields(
     'Most_PrepareToShip',
-    ('tag_review', 'tag_review_status',
+    ('tag_review', 'tag_review_status', 'non_oss_deps',
      'origin_trial_feedback_url',
      'launch_bug_url', 'intent_to_ship_url', 'i2s_lgtms', 'comments'))
 
@@ -951,7 +959,8 @@ Flat_PrepareToShip = define_form_class_using_shared_fields(
      'tag_review', 'tag_review_status',
      'intent_to_ship_url', 'i2s_lgtms',
      # Implementation
-     'measurement'))
+     'measurement',
+     'non_oss_deps'))
 
 
 Flat_Ship = define_form_class_using_shared_fields(
@@ -1038,7 +1047,8 @@ DISPLAY_FIELDS_IN_STAGES = {
     models.INTENT_IMPLEMENT_SHIP: make_display_specs(
         'launch_bug_url',
         'tag_review', 'tag_review_status',
-        'measurement', 'prefixed'),
+        'measurement', 'prefixed', 'non_oss_deps',
+        ),
     models.INTENT_EXTEND_TRIAL: make_display_specs(
         'experiment_goals', 'experiment_risks',
         'experiment_extension_reason', 'ongoing_constraints',

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -203,6 +203,16 @@
   {{feature.measurement|urlize}}
 {% endif %}
 
+{% if feature.non_oss_deps %}
+  <br><br><h4>Non-OSS dependencies</h4>
+  <div>Does the feature depend on any code or APIs outside the Chromium
+  open source repository and its open-source dependencies to
+  function?</div>
+
+  {{feature.non_oss_deps|urlize}}
+{% endif %}
+
+
 {% if 'sample_links' in sections_to_show %}
    {% if feature.resources and feature.resources.samples %}
      <br><br><h4>Sample links</h4>


### PR DESCRIPTION
This should resolve issue #1659.

In this PR:
* Add a new field `non_oss_deps` in models.py.
* Add it in guideforms.py  so that is shows up in the prepare-to-ship stage.
* Add it to guide.py so that it is saved when the form is submitted.
* Add it to intent_to_implement.html so that it is included in the intent email template.
