### PR TITLE
Make i2p threads only record the thread URL, not request a review.

### DIFF
--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -36,9 +36,12 @@ ApprovalFieldDef = collections.namedtuple(
     'ApprovalField',
     'name, description, field_id, rule, approvers')
 
+# Note: This can be requested manually through the UI, but it is not
+# triggered by a blink-dev thread because i2p intents are only FYIs to
+# bilnk-dev and don't actually need approval by the API Owners.
 PrototypeApproval = ApprovalFieldDef(
     'Intent to Prototype',
-    'One API Owner must approve your intent',
+    'Not normally used.  If a review is requested, API Owners can approve.',
     1, ONE_LGTM, API_OWNERS_URL)
 
 ExperimentApproval = ApprovalFieldDef(

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -24,6 +24,12 @@ from internals import approval_defs
 from internals import models
 
 
+FIELDS_REQUIRING_LGTMS = [
+    approval_defs.ShipApproval, approval_defs.ExperimentApproval,
+    approval_defs.ExtendExperimentApproval,
+    ]
+
+
 def detect_field(subject):
   """Look for key words in the subject line that indicate intent type.
 
@@ -270,9 +276,11 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     # have any approval values stored.
     elif detect_new_thread(feature_id, approval_field):
       logging.info('found new thread')
-      models.Approval.set_approval(
-          feature_id, approval_field.field_id,
-          models.Approval.REVIEW_REQUESTED, from_addr)
+      if approval_field in FIELDS_REQUIRING_LGTMS:
+        logging.info('requesting a review')
+        models.Approval.set_approval(
+            feature_id, approval_field.field_id,
+            models.Approval.REVIEW_REQUESTED, from_addr)
 
   def record_lgtm(self, feature, approval_field, from_addr):
     """Add from_addr to the old way or recording LGTMs."""

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -301,6 +301,19 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
     self.assertEqual('user@example.com', appr.set_by)
     self.assertEqual(self.feature_1.intent_to_ship_url, self.thread_url)
 
+  def test_process_post_data__new_thread_just_FYI(self):
+    """When we detect a new thread, it might not require a review."""
+    self.review_json_data['subject'] = 'Intent to Prototype: featurename'
+    with test_app.test_request_context(
+        self.request_path, json=self.review_json_data):
+      actual = self.handler.process_post_data()
+
+    self.assertEqual(actual, {'message': 'Done'})
+
+    created_approvals = list(models.Approval.query().fetch(None))
+    self.assertEqual(0, len(created_approvals))
+    self.assertEqual(self.feature_1.intent_to_implement_url, self.thread_url)
+
   @mock.patch('internals.detect_intent.is_lgtm_allowed')
   def test_process_post_data__lgtm(self, mock_is_lgtm_allowed):
     """If we get an LGTM, we store the approval value and update the feature."""


### PR DESCRIPTION
This should resolve issue #1702.

In this CL:
+ Keep the PrototypeApproval detection, but make it only set the URL of the discussion thread rather than also requesting approval
+ Change the description of PrototypeApproval.  These descriptions are currently not used anywhere in the UI, but they might be in the future.