### PR TITLE
Redirect to feature detail page when feature ID is in URL.

### DIFF
--- a/pages/featuredetail.py
+++ b/pages/featuredetail.py
@@ -41,7 +41,7 @@ class FeatureDetailHandler(basehandlers.FlaskHandler):
     feature_process = processes.ALL_PROCESSES.get(
         f.feature_type, processes.BLINK_LAUNCH_PROCESS)
     field_defs = guideforms.DISPLAY_FIELDS_IN_STAGES
-    context_link = '/features/%d' % feature_id
+    context_link = '/features'
     if self.request.args.get('context') == 'myfeatures':
       context_link = '/myfeatures'
 

--- a/pages/featuredetail_test.py
+++ b/pages/featuredetail_test.py
@@ -123,7 +123,7 @@ class FeatureDetailTemplateTest(TestWithFeature):
         self.template_data, self.full_template_path)
 
     self.assertIn('href="fake crbug link"', template_text)
-    self.assertIn('href="/features/%d' % self.feature_id , template_text)
+    self.assertIn('href="/features"', template_text)
     self.assertIn('href="fake sample link one"', template_text)
     self.assertIn('href="fake sample link two"', template_text)
     self.assertIn('href="fake doc link one"', template_text)

--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -207,7 +207,7 @@ class ChromedashFeature extends LitElement {
   render() {
     return html`
       <hgroup @click="${this._togglePanelExpansion}">
-        <h2>${this.feature.name}
+        <h2><a href="/feature/${this.feature.id}">${this.feature.name}</a>
           ${this.canApprove ? html`
             <span class="tooltip" title="Review approvals">
               <a href="#" id="approvals-icon" data-tooltip

--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -158,15 +158,6 @@ class ChromedashFeaturelist extends LitElement {
     const feature = e.detail.feature;
     const open = e.detail.open;
     this._setOpenFeatures(feature.id, open);
-
-    if (history && history.replaceState) {
-      if (open) {
-        history.pushState({id: feature.id}, feature.name, '/features/' + feature.id);
-      } else {
-        const hash = this.searchEl.value ? '#' + this.searchEl.value : '';
-        history.replaceState({id: null}, feature.name, '/features' + hash);
-      }
-    }
   }
 
   _onStarToggled(e) {
@@ -356,23 +347,10 @@ class ChromedashFeaturelist extends LitElement {
     }
   }
 
-  /** Scroll to the item in the URL. Otherwise the first 'In development' item */
-  _scrollToInitialPosition() {
-    const lastSlash = location.pathname.lastIndexOf('/');
-    let id;
-    if (lastSlash > 0) {
-      id = parseInt(location.pathname.substring(lastSlash + 1));
-      this.scrollToId(id);
-    }
-  }
-
   _initialize() {
     this._featuresUnveilMetric.end().log().sendToAnalytics('features', 'unveil');
     this._fireEvent('app-ready');
     this._hasInitialized = true;
-    setTimeout(() => {
-      this._scrollToInitialPosition();
-    }, 300);
   }
 
   _computeMilestoneHidden(feature, features, filtered) {

--- a/static/js-src/features-page.js
+++ b/static/js-src/features-page.js
@@ -1,3 +1,13 @@
+/** If the user followed a link with an ID, redirect there. */
+const lastSlash = window.location.pathname.lastIndexOf('/');
+if (lastSlash > 0) {
+  const id = parseInt(window.location.pathname.substring(lastSlash + 1));
+  if (id) {
+    window.location.replace(`/feature/${id}`);
+  }
+}
+
+
 const featureListEl = document.querySelector('chromedash-featurelist');
 const chromeMetadataEl = document.querySelector('chromedash-metadata');
 const searchEl = document.querySelector('.search input');

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -71,6 +71,8 @@
   <h2 id="breadcrumbs">
     <a href="{{ context_link }}">
       <iron-icon icon="chromestatus:arrow-back"></iron-icon>
+    </a>
+    <a href="/feature/{{ feature.id }}">
       Feature: {{ feature.name }}
     </a>
         {% if feature.browsers.chrome.status.text == "No longer pursuing" %} (No longer pursuing){% endif %}


### PR DESCRIPTION
This should resolve issue #1055.

This was suggested by Johnny at last week's meeting.

We plan to replace the existing feature cards with a more compact feature list and have users drill into the feature detail page for most details.  This change is a step toward that plan by making old `/features/NNNN` URLs redirect to the feature detail page.   And, we stop putting the feature ID NNNN into the URL.

