### PR TITLE
Detect ampersand in intent email subjects.

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -46,6 +46,9 @@ def detect_field(subject):
       subject.startswith('intent to prototype and ship') or
       subject.startswith('intent to implement and ship') or
       subject.startswith('intent to deprecate and remove') or
+      subject.startswith('intent to prototype & ship') or
+      subject.startswith('intent to implement & ship') or
+      subject.startswith('intent to deprecate & remove') or
       subject.startswith('intent to remove')):
     return approval_defs.ShipApproval
 


### PR DESCRIPTION
The intent emails are supposed to have specific subject lines, such as "Intent to ship" or "Intent to implement and ship".  We accept some alternative forms of these subject lines.  Last week we had one that was "Intent to prototype & ship".

In this PR:
+ Allow feature owners to use an ampersand symbol instead of the word "and" in intent subject lines.