### PR TITLE
Revert "Reduce unneeded polymer deps."

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,14 @@
     "": {
       "name": "chromestatus-dashboard",
       "dependencies": {
+        "@polymer/app-layout": "^3.1.0",
         "@polymer/iron-collapse": "^3.0.1",
         "@polymer/iron-icon": "^3.0.1",
         "@polymer/iron-iconset-svg": "^3.0.1",
+        "@polymer/paper-item": "^3.0.1",
+        "@polymer/paper-listbox": "^3.0.1",
+        "@polymer/paper-ripple": "^3.0.2",
+        "@polymer/paper-styles": "^3.0.1",
         "lit": "^2",
         "node-fetch": ">=3.1.1",
         "node-sass": ">=4.13.1",
@@ -1112,6 +1117,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@polymer/app-layout": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@polymer/app-layout/-/app-layout-3.1.0.tgz",
+      "integrity": "sha512-+jf5/TtUDj/la9Vi59ooGNjnTN8JTkyIUK8gxAms0N3MmyeqrmcNLlJKDVyE6IIGKz0WfFeGKqKtmtTLHrZIlg==",
+      "dependencies": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-media-query": "^3.0.0-pre.26",
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-scroll-target-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
     "node_modules/@polymer/font-roboto": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@polymer/font-roboto/-/font-roboto-3.0.2.tgz",
@@ -1170,6 +1187,25 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
+    "node_modules/@polymer/iron-media-query": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-media-query/-/iron-media-query-3.0.1.tgz",
+      "integrity": "sha512-czUX1pm1zfmfcZtq5J57XFkcobBv08Y50exp0/3v8Bos5VL/jv2tU0RwiTfDBxUMhjicGbgwEBFQPY2V5DMzyw==",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-menu-behavior": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-menu-behavior/-/iron-menu-behavior-3.0.2.tgz",
+      "integrity": "sha512-8dpASkFNBIkxAJWsFLWIO1M7tKM0+wKs3PqdeF/dDdBciwoaaFgC2K1XCZFZnbe2t9/nJgemXxVugGZAWpYCGg==",
+      "dependencies": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-selector": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
     "node_modules/@polymer/iron-meta": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-meta/-/iron-meta-3.0.1.tgz",
@@ -1183,6 +1219,63 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-resizable-behavior/-/iron-resizable-behavior-3.0.1.tgz",
       "integrity": "sha512-FyHxRxFspVoRaeZSWpT3y0C9awomb4tXXolIJcZ7RvXhMP632V5lez+ch5G5SwK0LpnAPkg35eB0LPMFv+YMMQ==",
       "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-scroll-target-behavior": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-scroll-target-behavior/-/iron-scroll-target-behavior-3.0.1.tgz",
+      "integrity": "sha512-xg1WanG25BIkQE8rhuReqY9zx1K5M7F+YAIYpswEp5eyDIaZ1Y3vUmVeQ3KG+hiSugzI1M752azXN7kvyhOBcQ==",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-selector": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-selector/-/iron-selector-3.0.1.tgz",
+      "integrity": "sha512-sBVk2uas6prW0glUe2xEJJYlvxmYzM40Au9OKbfDK2Qekou/fLKcBRyIYI39kuI8zWRaip8f3CI8qXcUHnKb1A==",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-item": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-item/-/paper-item-3.0.1.tgz",
+      "integrity": "sha512-KTk2N+GsYiI/HuubL3sxebZ6tteQbBOAp4QVLAnbjSPmwl+mJSDWk+omuadesU0bpkCwaWVs3fHuQsmXxy4pkw==",
+      "dependencies": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-listbox": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-listbox/-/paper-listbox-3.0.1.tgz",
+      "integrity": "sha512-vMLWFpYcggAPmEDBmK+96fFefacOG3GLB1EguTn8+ZkqI+328hNfw1MzHjH68rgCIIUtjmm+9qgB1Sy/MN0a/A==",
+      "dependencies": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-menu-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-ripple": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-ripple/-/paper-ripple-3.0.2.tgz",
+      "integrity": "sha512-DnLNvYIMsiayeICroYxx6Q6Hg1cUU8HN2sbutXazlemAlGqdq80qz3TIaVdbpbt/pvjcFGX2HtntMlPstCge8Q==",
+      "dependencies": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-styles": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-styles/-/paper-styles-3.0.1.tgz",
+      "integrity": "sha512-y6hmObLqlCx602TQiSBKHqjwkE7xmDiFkoxdYGaNjtv4xcysOTdVJsDR/R9UHwIaxJ7gHlthMSykir1nv78++g==",
+      "dependencies": {
+        "@polymer/font-roboto": "^3.0.1",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
         "@polymer/polymer": "^3.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -80,9 +80,14 @@
     "trim-newlines": ">=3.0.1"
   },
   "dependencies": {
+    "@polymer/app-layout": "^3.1.0",
     "@polymer/iron-collapse": "^3.0.1",
     "@polymer/iron-icon": "^3.0.1",
     "@polymer/iron-iconset-svg": "^3.0.1",
+    "@polymer/paper-item": "^3.0.1",
+    "@polymer/paper-listbox": "^3.0.1",
+    "@polymer/paper-ripple": "^3.0.2",
+    "@polymer/paper-styles": "^3.0.1",
     "lit": "^2",
     "node-fetch": ">=3.1.1",
     "node-sass": ">=4.13.1",

--- a/static/components.js
+++ b/static/components.js
@@ -1,10 +1,15 @@
 /** This is the entry file for rollup. It bundles all the web components: polymer-paper components and our own components */
 
 // polymer components
+import '@polymer/app-layout';
+import '@polymer/app-layout/app-scroll-effects/effects/waterfall';
 import '@polymer/iron-collapse';
 import '@polymer/iron-icon';
 import '@polymer/iron-iconset-svg';
-
+import '@polymer/paper-item';
+import '@polymer/paper-listbox';
+import '@polymer/paper-ripple';
+import '@polymer/paper-styles/color.js';
 
 // chromedash components
 import './elements/icons';


### PR DESCRIPTION
Reverts GoogleChrome/chromium-dashboard#1757

This caused slight visual changes that were only visible in Chrome.  The underlying problem is that we do still use the `app-layout` element, so having it be undefined caused us to loose the component-specific stylesheet.