### PR TITLE
Add field for webview_risks.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -1287,6 +1287,7 @@ class Feature(DictModel):
   ergonomics_risks = ndb.StringProperty()
   activation_risks = ndb.StringProperty()
   security_risks = ndb.StringProperty()
+  webview_risks = ndb.StringProperty()
   debuggability = ndb.StringProperty()
   all_platforms = ndb.BooleanProperty()
   all_platforms_descr = ndb.StringProperty()

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -518,6 +518,8 @@ class FeatureEditStage(basehandlers.FlaskHandler):
       feature.tag_review = self.form.get('tag_review')
     if self.touched('tag_review_status'):
       feature.tag_review_status = self.parse_int('tag_review_status')
+    if self.touched('webview_risks'):
+      feature.webview_risks = self.form.get('webview_risks')
 
     if self.touched('standardization'):
       feature.standardization = int(self.form.get('standardization'))

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -393,7 +393,7 @@ ALL_FIELDS = {
          'such that it has potentially high risk for Android WebView-based '
          'applications? (See <a href="'
          'https://new.chromium.org/developers/webview-changes/'
-         '" target="_blank">here</a> for more a definition of "potentially high '
+         '" target="_blank">here</a> for a definition of "potentially high '
          'risk", information on why changes to this platform carry higher '
          'risk, and general rules of thumb for which changes have higher or '
          'lower risk) If so:'

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -385,6 +385,29 @@ ALL_FIELDS = {
         ('List any security considerations that were taken into account '
          'when deigning this feature.')),
 
+    'webview_risks': forms.CharField(
+        label='WebView Application Risks', required=False,
+        widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
+        help_text=
+        ('Does this intent deprecate or change behavior of existing APIs, '
+         'such that it has potentially high risk for Android WebView-based '
+         'applications? (See <a href="'
+         'https://new.chromium.org/developers/webview-changes/'
+         '" target="_blank">here</a> for more a definition of "potentially high '
+         'risk", information on why changes to this platform carry higher '
+         'risk, and general rules of thumb for which changes have higher or '
+         'lower risk) If so:'
+         '<ul>'
+         '<li>Please use a base::Feature killswitch (<a href="'
+         'https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/common/features.h'
+         '" target="_blank">examples here</a>) that can '
+         'be flipped off in case of compat issues</li>'
+         '<li>Consider reaching out to android-webview-dev@chromium.org for '
+         'advice</li>'
+         '<li>If you are not sure, just put "not sure" as the answer here and '
+         'the API owners can help during the review of your intent-to-ship</li>'
+         '</ul>')),
+
     'experiment_goals': forms.CharField(
         label='Experiment Goals', required=False,
         widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
@@ -811,7 +834,7 @@ ImplStatus_OriginTrial = define_form_class_using_shared_fields(
 Most_PrepareToShip = define_form_class_using_shared_fields(
     'Most_PrepareToShip',
     ('tag_review', 'tag_review_status', 'non_oss_deps',
-     'origin_trial_feedback_url',
+     'webview_risks', 'origin_trial_feedback_url',
      'launch_bug_url', 'intent_to_ship_url', 'i2s_lgtms', 'comments'))
 
 
@@ -857,6 +880,7 @@ Deprecation_Implement = define_form_class_using_shared_fields(
 Deprecation_PrepareToShip = define_form_class_using_shared_fields(
     'Deprecation_PrepareToShip',
     ('impl_status_chrome', 'tag_review',
+     'webview_risks',
      'intent_to_implement_url', 'origin_trial_feedback_url',
      'launch_bug_url', 'comments'))
 
@@ -964,6 +988,7 @@ Flat_PrepareToShip = define_form_class_using_shared_fields(
     'Flat_PrepareToShip',
     (# Standardization
      'tag_review', 'tag_review_status',
+     'webview_risks',
      'intent_to_ship_url', 'i2s_lgtms',
      # Implementation
      'measurement',
@@ -1054,6 +1079,7 @@ DISPLAY_FIELDS_IN_STAGES = {
     models.INTENT_IMPLEMENT_SHIP: make_display_specs(
         'launch_bug_url',
         'tag_review', 'tag_review_status',
+        'webview_risks',
         'measurement', 'prefixed', 'non_oss_deps',
         ),
     models.INTENT_EXTEND_TRIAL: make_display_specs(

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -383,7 +383,7 @@ ALL_FIELDS = {
         widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
         help_text=
         ('List any security considerations that were taken into account '
-         'when deigning this feature.')),
+         'when designing this feature.')),
 
     'webview_risks': forms.CharField(
         label='WebView Application Risks', required=False,

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -136,6 +136,13 @@
       <p class="preformatted">{{feature.security_risks|urlize}}</p>
     {% endif %}
 
+    <br><br><h4>WebView Application Risks</h4>
+    <p style="font-style: italic">
+      Does this intent deprecate or change behavior of existing APIs,
+      such that it has potentially high risk for Android WebView-based
+      applications?</p>
+    <p class="preformatted">{{feature.webview_risks|urlize}}</p>
+
   </div> <!-- end risks -->
 
 {% if 'experiment' in sections_to_show %}
@@ -205,9 +212,10 @@
 
 {% if feature.non_oss_deps %}
   <br><br><h4>Non-OSS dependencies</h4>
-  <div>Does the feature depend on any code or APIs outside the Chromium
-  open source repository and its open-source dependencies to
-  function?</div>
+  <p style="font-style: italic">
+    Does the feature depend on any code or APIs outside the Chromium
+    open source repository and its open-source dependencies to
+    function?</p>
 
   {{feature.non_oss_deps|urlize}}
 {% endif %}


### PR DESCRIPTION
This should resolve issue #1775.

In this PR:
* Add a feature field `webview_risks` that holds a string for "yes", "no", "not sure", or an explanation.
* Define a HTML form field for it and add that form field to the "prepare to ship" stage, the flat forms, and the display on the issue detail page.
* Add that field to the intent email generation template with one sentence of explanation

