### PR TITLE
Don't offer stars to signed out users.

### DIFF
--- a/static/elements/chromedash-feature-table.js
+++ b/static/elements/chromedash-feature-table.js
@@ -207,19 +207,6 @@ class ChromedashFeatureTable extends LitElement {
     `;
   }
 
-  renderSignedOutStarIcon() {
-    return html`
-      <span class="tooltip"
-        title="Sign in to get email notifications for updates">
-        <a href="#"  @click="${window.promptSignIn}" data-tooltip>
-          <iron-icon icon="chromestatus:star-border"
-            class="pushicon">
-          </iron-icon>
-        </a>
-      </span>
-    `;
-  }
-
   renderIcons(feature) {
     if (this.signedIn) {
       return html`
@@ -228,9 +215,7 @@ class ChromedashFeatureTable extends LitElement {
         ${this.renderStarIcon(feature)}
       `;
     } else {
-      return html`
-        ${this.renderSignedOutStarIcon()}
-      `;
+      return nothing;
     }
   }
 

--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -273,15 +273,7 @@ class ChromedashFeature extends LitElement {
                              class="pushicon"></iron-icon>
                 </a>
               </span>
-             ` : html`
-                <span class="tooltip"
-                    title="Sign in to get email notifications for updates">
-                <a href="#" @click="${window.promptSignIn}" data-tooltip>
-                  <iron-icon icon="chromestatus:star-border"
-                             class="pushicon"></iron-icon>
-                </a>
-              </span>
-             `}
+             ` : nothing}
             <span class="tooltip" title="File a bug against this feature">
               <a href="${ifDefined(this._newBugUrl)}" data-tooltip>
                 <iron-icon icon="chromestatus:bug-report"></iron-icon>

--- a/static/elements/chromedash-roadmap-milestone-card.js
+++ b/static/elements/chromedash-roadmap-milestone-card.js
@@ -178,16 +178,7 @@ class ChromedashRoadmapMilestoneCard extends LitElement {
             @click="${this.toggleStar}">
           </iron-icon>
         </span>
-        ` : html`
-        <span class="tooltip"
-          title="Sign in to get email notifications for updates">
-          <a href="#"  @click="${window.promptSignIn}" data-tooltip>
-            <iron-icon icon="chromestatus:star-border"
-              class="pushicon">
-            </iron-icon>
-          </a>
-        </span>
-        `}
+        ` : nothing}
       </span>
     </li>
 

--- a/static/js-src/feature-page.js
+++ b/static/js-src/feature-page.js
@@ -90,14 +90,6 @@ window.csClient.getStars().then((subscribedFeatures) => {
   }
 });
 
-const starWhenSignedOutEl = document.querySelector('#star-when-signed-out');
-if (starWhenSignedOutEl) {
-  starWhenSignedOutEl.addEventListener('click', function(event) {
-    event.preventDefault();
-    window.promptSignIn(event);
-  });
-}
-
 const starWhenSignedInEl = document.querySelector('#star-when-signed-in');
 if (starWhenSignedInEl) {
   starWhenSignedInEl.addEventListener('click', function(event) {

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -83,15 +83,8 @@ limitations under the License.
         });
     }
 
-    function promptSignIn(e) {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-
-
     // This happens when an anon visitor tries to view a page that
-    // requires being signed in.  We cannot promptSignIn(), because
-    // lacking a user-initiated event, the popup will be blocked.
+    // requires being signed in.
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.get("loginStatus") == 'False') {
       alert('Please log in.');

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -18,20 +18,13 @@
 {% block rss %}
   <link rel="alternate" type="application/rss+xml" href="https://chromestatus.com/features.xml" title="All features" />
 {% endblock %}
- 
+
 {% block subheader %}
 <div id="subheader" style="display:block">
   <div style="float:right">
   {% if user %}
     <span class="tooltip" title="Receive an email notification when there are updates">
       <a href="#" data-tooltip id="star-when-signed-in">
-        <iron-icon icon="chromestatus:star-border"
-                    class="pushicon"></iron-icon>
-      </a>
-    </span>
-  {% else %}
-    <span class="tooltip" title="Sign in to get email notifications for updates">
-      <a href="#" id="star-when-signed-out" data-tooltip>
         <iron-icon icon="chromestatus:star-border"
                     class="pushicon"></iron-icon>
       </a>


### PR DESCRIPTION
This is a follow-up from the discussion on #1729.

We used to offer a star icon even when the user is signed out.  Clicking it would prompt the user to sign in.

Now with Sign In With Google, we don't have a good way to prompt the user to sign in if they have previously clicked the "X" icon on the Sign In With Google popup menu.  So, it is not clear how we would offer this functionality.   Luckily, the fact that Sign In With Google shows a menu that overlaps content when the page loads, it seems likely that more users will sign in on their initial page view.