### PR TITLE
Avoid a JS error for pending approvals without a config.

### DIFF
--- a/static/elements/chromedash-feature-table.js
+++ b/static/elements/chromedash-feature-table.js
@@ -265,8 +265,8 @@ class ChromedashFeatureTable extends LitElement {
   }
 
   getEarliestReviewDate(feature) {
-    const configs = this.configs[feature.id];
-    const allDates = configs.map(c => c.next_action).filter(d => d);
+    const featureConfigs = this.configs[feature.id] || [];
+    const allDates = featureConfigs.map(c => c.next_action).filter(d => d);
     if (allDates.length > 0) {
       allDates.sort();
       return allDates[0];
@@ -275,7 +275,7 @@ class ChromedashFeatureTable extends LitElement {
   }
 
   getActiveOwners(feature) {
-    const featureConfigs = this.configs[feature.id];
+    const featureConfigs = this.configs[feature.id] || [];
     const allOwners = featureConfigs.map(c => c.owners).flat();
     // TODO(jrobbins): Limit to only owners of active intents
     let activeOwners = allOwners;
@@ -335,7 +335,7 @@ class ChromedashFeatureTable extends LitElement {
               Owners: ${owners.join(', ')}
             </div>
             ` : nothing}
-          ${activeApprovals.length > 0 ? html`
+          ${activeApprovals && activeApprovals.length > 0 ? html`
             <div>
               ${this.renderApprovalsSoFar(activeApprovals)}
             </div>


### PR DESCRIPTION
Even though the "My features page" renders fine, it logs some errors to the console.  I think these errors occur in the time between when the features are loaded from the backend and when the feature approval configs are loaded from the backend.  During this window of time, a value that is assumed to be an array could be null.

In this PR:
* Make sure that variables that are expected to hold lists are actually lists, even if they are empty lists.
* Make variable naming more consistent
* Make another condition handle the case where a variable has a null value
* 