### PR TITLE
Define namedtuples for progress items and actions.

### DIFF
--- a/internals/processes.py
+++ b/internals/processes.py
@@ -1,6 +1,3 @@
-
-
-
 # -*- coding: utf-8 -*-
 # Copyright 2020 Google Inc.
 #
@@ -36,13 +33,23 @@ ProcessStage = collections.namedtuple(
     'name, description, progress_items, actions, approvals, '
     'incoming_stage, outgoing_stage')
 
+ProgressItem = collections.namedtuple(
+    'ProgressItem',
+    'name, field')
+
+Action = collections.namedtuple(
+    'Action',
+    'name, url, prerequisites')
+
 
 def process_to_dict(process):
   """Return nested dicts for the nested namedtuples of a process."""
   # These lines are sort of like a deep version of _asdict().
   stages = [stage._asdict() for stage in process.stages]
   for stage in stages:
-    stage['approvals'] = [a._asdict() for a in stage['approvals']]
+    stage['progress_items'] = [pi._asdict() for pi in stage['progress_items']]
+    stage['actions'] = [act._asdict() for act in stage['actions']]
+    stage['approvals'] = [appr._asdict() for appr in stage['approvals']]
 
   process_dict = {
       'name': process.name,
@@ -66,14 +73,90 @@ LAUNCH_BUG_TEMPLATE_URL = '/admin/features/launch/{feature_id}?launch=1'
 # TODO(jrobbins): Creation of the launch bug has been a TODO for 5 years.
 
 
+PI_INITIAL_PUBLIC_PROPOSAL = ProgressItem(
+    'Initial public proposal', 'initial_public_proposal_url')
+PI_MOTIVATION = ProgressItem('Motivation', 'motivation')
+PI_EXPLAINER = ProgressItem('Explainer', 'explainer_links')
+
+PI_SPEC_LINK = ProgressItem('Spec link', 'spec_link')
+PI_SPEC_MENTOR = ProgressItem('Spec mentor', 'spec_mentors')
+PI_DRAFT_API_SPEC = ProgressItem('Draft API spec', None)
+PI_I2P_EMAIL = ProgressItem(
+    'Intent to Prototype email', 'intent_to_implement_url')
+
+PI_SAMPLES = ProgressItem('Samples', 'sample_links')
+PI_DRAFT_API_OVERVIEW = ProgressItem('Draft API overview (may be on MDN)', None)
+PI_REQUEST_SIGNALS = ProgressItem('Request signals', 'safari_views')
+PI_SEC_REVIEW = ProgressItem('Security review issues addressed', None)
+PI_PRI_REVIEW = ProgressItem('Privacy review issues addressed', None)
+# TODO(jrobbins): needs detector.
+PI_EXTERNAL_REVIEWS = ProgressItem('External reviews', None)
+PI_R4DT_EMAIL = ProgressItem('Ready for Trial email', 'ready_for_trial_url')
+
+PI_TAG_REQUESTED = ProgressItem('TAG review requested', 'tag_review')
+PI_VENDOR_SIGNALS = ProgressItem('Vendor signals', 'safari_views')
+PI_WEB_DEV_SIGNALS = ProgressItem('Web developer signals', 'web_dev_views')
+PI_DOC_LINKS = ProgressItem('Doc links', 'doc_links')
+# TODO(jrobbins): needs detector.
+PI_DOC_SIGNOFF = ProgressItem('Documentation signoff', None)
+PI_EST_TARGET_MILESTONE = ProgressItem(
+    'Estimated target milestone', 'shipped_milestone')
+
+# TODO(jrobbins): needs detector.
+PI_OT_REQUEST = ProgressItem('OT request', None)
+# TODO(jrobbins): needs detector.
+PI_OT_AVAILABLE = ProgressItem('OT available', None)
+# TODO(jrobbins): needs detector.
+PI_OT_RESULTS = ProgressItem('OT results', None)
+PI_I2E_EMAIL = ProgressItem(
+    'Intent to Experiment email', 'intent_to_experiment_url')
+PI_I2E_LGTMS = ProgressItem('One LGTM on Intent to Experiment', 'i2e_lgtms')
+
+PI_MIGRATE_INCUBATION = ProgressItem('Request to migrate incubation', None)
+PI_TAG_ADDRESSED = ProgressItem(
+    'TAG review issues addressed', 'tag_review_status')
+PI_UPDATE_VENDOR_SIGNALS = ProgressItem(
+    'Updated vendor signals', 'safari_views')
+PI_UPDATE_TARGET_MILESTONE = ProgressItem(
+    'Updated target milestone', 'shipped_milestone')
+PI_I2S_EMAIL = ProgressItem('Intent to Ship email', 'intent_to_ship_url')
+PI_I2S_LGTMS = ProgressItem('Three LGTMs on Intent to Ship', 'i2s_lgtms')
+
+# TODO(jrobbins): needs detector.
+PI_FINAL_VENDOR_SIGNALS = ProgressItem('Finalized vendor signals', 'safari_views')
+# TODO(jrobbins): needs detector.
+PI_FINAL_TARGET_MILESTONE = ProgressItem(
+    'Finalized target milestone', 'shipped_milestone')
+
+PI_CODE = ProgressItem('Code in Chromium', None)
+
+PI_PSA_EMAIL = ProgressItem('Web facing PSA email', None)
+
+# TODO(jrobbins): needs detector.
+PI_DT_REQUEST = ProgressItem('DT request', None)
+# TODO(jrobbins): needs detector.
+PI_DT_AVAILABLE = ProgressItem('DT available', None)
+# TODO(jrobbins): needs detector.
+PI_REMOVAL_OF_DT = ProgressItem('Removal of DT', None)
+PI_DT_EMAIL = ProgressItem(
+    'Request for Deprecation Trial email', 'intent_to_experiment_url')
+PI_DT_LGTMS = ProgressItem(
+    'One LGTM on Request for Deprecation Trial', 'i2e_lgtms')
+
+# TODO(jrobbins): needs detector.
+PI_EXISTING_FEATURE = ProgressItem('Link to existing feature', None)
+
+PI_CODE_REMOVED = ProgressItem('Code removed', None)
+
+
 BLINK_PROCESS_STAGES = [
   ProcessStage(
       'Start incubating',
       'Create an initial WebStatus feature entry and kick off standards '
       'incubation (WICG) to share ideas.',
-      ['Initial public proposal',
-       'Motivation',
-       'Explainer',
+      [PI_INITIAL_PUBLIC_PROPOSAL,
+       PI_MOTIVATION,
+       PI_EXPLAINER,
       ],
       [],
       [],
@@ -83,12 +166,13 @@ BLINK_PROCESS_STAGES = [
       'Start prototyping',
       'Share an explainer doc and API. '
       'Start prototyping code in a public repo.',
-      ['Spec link',
-       'Spec mentor',
-       'Draft API spec',
-       'Intent to Prototype email',
+      [PI_SPEC_LINK,
+       PI_SPEC_MENTOR,
+       PI_DRAFT_API_SPEC,
+       PI_I2P_EMAIL,
       ],
-      [('Draft Intent to Prototype email', INTENT_EMAIL_URL)],
+      [Action('Draft Intent to Prototype email', INTENT_EMAIL_URL,
+              [PI_SPEC_LINK])],
       [approval_defs.PrototypeApproval],
       models.INTENT_INCUBATE, models.INTENT_IMPLEMENT),
 
@@ -97,27 +181,27 @@ BLINK_PROCESS_STAGES = [
       'Publicize availablity for developers to try. '
       'Provide sample code. '
       'Request feedback from browser vendors.',
-      ['Samples',
-       'Draft API overview',
-       'Request signals',
-       'Security review issues addressed',
-       'Privacy review issues addressed',
-       'External reviews',  # TODO(jrobbins): needs detector.
-       'Ready for Trial email',
+      [PI_SAMPLES,
+       PI_DRAFT_API_OVERVIEW,
+       PI_REQUEST_SIGNALS,
+       PI_SEC_REVIEW,
+       PI_PRI_REVIEW,
+       PI_EXTERNAL_REVIEWS,
+       PI_R4DT_EMAIL,
       ],
-      [('Draft Ready for Trial email', INTENT_EMAIL_URL)],
+      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL, [])],
       [],
       models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
   ProcessStage(
       'Evaluate readiness to ship',
       'Work through a TAG review and gather vendor signals.',
-      ['TAG review requested',
-       'Vendor signals',
-       'Web developer signals',
-       'Doc links',
-       'Documentation signoff',  # TODO(jrobbins): needs detector.
-       'Estimated target milestone',
+      [PI_TAG_REQUESTED,
+       PI_VENDOR_SIGNALS,
+       PI_WEB_DEV_SIGNALS,
+       PI_DOC_LINKS,
+       PI_DOC_SIGNOFF,
+       PI_EST_TARGET_MILESTONE,
       ],
       [],
       [],
@@ -127,13 +211,13 @@ BLINK_PROCESS_STAGES = [
       'Origin Trial',
       '(Optional) Set up and run an origin trial. '
       'Act on feedback from partners and web developers.',
-      ['OT request',  # TODO(jrobbins): needs detector.
-       'OT available',  # TODO(jrobbins): needs detector.
-       'OT results',  # TODO(jrobbins): needs detector.
-       'Intent to Experiment email',
-       'One LGTM on Intent to Experiment',
+      [PI_OT_REQUEST,
+       PI_OT_AVAILABLE,
+       PI_OT_RESULTS,
+       PI_I2E_EMAIL,
+       PI_I2E_LGTMS,
       ],
-      [('Draft Intent to Experiment email', INTENT_EMAIL_URL)],
+      [Action('Draft Intent to Experiment email', INTENT_EMAIL_URL, [])],
       [approval_defs.ExperimentApproval],
       models.INTENT_IMPLEMENT_SHIP, models.INTENT_EXTEND_TRIAL),
 
@@ -141,14 +225,14 @@ BLINK_PROCESS_STAGES = [
       'Prepare to ship',
       'Lock in shipping milestone. Finalize docs and announcements. '
       'Further standardization.',
-      ['Request to migrate incubation',
-       'TAG review issues addressed',
-       'Updated vendor signals',
-       'Updated target milestone',
-       'Intent to Ship email',
-       'Three LGTMs on Intent to Ship',
+      [PI_MIGRATE_INCUBATION,
+       PI_TAG_ADDRESSED,
+       PI_UPDATE_VENDOR_SIGNALS,
+       PI_UPDATE_TARGET_MILESTONE,
+       PI_I2S_EMAIL,
+       PI_I2S_LGTMS,
       ],
-      [('Draft Intent to Ship email', INTENT_EMAIL_URL)],
+      [Action('Draft Intent to Ship email', INTENT_EMAIL_URL, [])],
       [approval_defs.ShipApproval],
       models.INTENT_IMPLEMENT_SHIP, models.INTENT_SHIP),
 
@@ -156,8 +240,8 @@ BLINK_PROCESS_STAGES = [
       'Ship',
       'Update milestones and other information when the feature '
       'actually ships.',
-      ['Finalized vendor signals',  # TODO(jrobbins): needs detector.
-       'Finalized target milestone',  # TODO(jrobbins): needs detector.
+      [PI_FINAL_VENDOR_SIGNALS,
+       PI_FINAL_TARGET_MILESTONE,
       ],
       [],
       [],
@@ -177,11 +261,10 @@ BLINK_FAST_TRACK_STAGES = [
       'Start prototyping',
       'Write up use cases and scenarios, start coding as a '
       'runtime enabled feature.',
-      ['Spec link',
-       'API spec',
-       'Code in Chromium',
+      [PI_SPEC_LINK,
+       PI_CODE,
        ],
-      [('Draft Intent to Prototype email', INTENT_EMAIL_URL)],
+      [Action('Draft Intent to Prototype email', INTENT_EMAIL_URL, [])],
       [approval_defs.PrototypeApproval],
       models.INTENT_NONE, models.INTENT_IMPLEMENT),
 
@@ -190,13 +273,13 @@ BLINK_FAST_TRACK_STAGES = [
       'Publicize availablity for developers to try. '
       'Provide sample code. '
       'Act on feedback from partners and web developers.',
-      ['Samples',
-       'Draft API overview (may be on MDN)',
-       'Ready for Trial email',
-       'Vendor signals',
-       'Estimated target milestone',
+      [PI_SAMPLES,
+       PI_DRAFT_API_OVERVIEW,
+       PI_R4DT_EMAIL,
+       PI_VENDOR_SIGNALS,
+       PI_EST_TARGET_MILESTONE,
       ],
-      [('Draft Ready for Trial email', INTENT_EMAIL_URL)],
+      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL, [])],
       [],
       models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
@@ -204,13 +287,13 @@ BLINK_FAST_TRACK_STAGES = [
       'Origin Trial',
       '(Optional) Set up and run an origin trial. '
       'Act on feedback from partners and web developers.',
-      ['OT request',  # TODO(jrobbins): needs detector.
-       'OT available',  # TODO(jrobbins): needs detector.
-       'OT results',  # TODO(jrobbins): needs detector.
-       'Intent to Experiment email',
-       'One LGTM on Intent to Experiment',
+      [PI_OT_REQUEST,
+       PI_OT_AVAILABLE,
+       PI_OT_RESULTS,
+       PI_I2E_EMAIL,
+       PI_I2E_LGTMS,
       ],
-      [('Draft Intent to Experiment email', INTENT_EMAIL_URL)],
+      [Action('Draft Intent to Experiment email', INTENT_EMAIL_URL, [])],
       [approval_defs.ExperimentApproval],
       models.INTENT_EXPERIMENT, models.INTENT_EXTEND_TRIAL),
 
@@ -218,12 +301,12 @@ BLINK_FAST_TRACK_STAGES = [
       'Prepare to ship',
       'Lock in shipping milestone. Finalize docs and announcements. '
       'Further standardization.',
-      ['Documentation signoff',  # TODO(jrobbins): needs detector.
-       'Updated target milestone',  # TODO(jrobbins): needs detector.
-       'Intent to Ship email',
-       'Three LGTMs on Intent to Ship',
+      [PI_DOC_SIGNOFF,
+       PI_UPDATE_TARGET_MILESTONE,
+       PI_I2S_EMAIL,
+       PI_I2S_LGTMS,
       ],
-      [('Draft Intent to Ship email', INTENT_EMAIL_URL)],
+      [Action('Draft Intent to Ship email', INTENT_EMAIL_URL, [])],
       [approval_defs.ShipApproval],
       models.INTENT_EXPERIMENT, models.INTENT_SHIP),
 
@@ -231,8 +314,8 @@ BLINK_FAST_TRACK_STAGES = [
       'Ship',
       'Update milestones and other information when the feature '
       'actually ships.',
-      ['Finalized vendor signals',  # TODO(jrobbins): needs detector.
-       'Finalized target milestone',  # TODO(jrobbins): needs detector.
+      [PI_FINAL_VENDOR_SIGNALS,
+       PI_FINAL_TARGET_MILESTONE,
       ],
       [],
       [],
@@ -251,8 +334,8 @@ PSA_ONLY_STAGES = [
   ProcessStage(
       'Implement',
       'Check code into Chromium under a flag.',
-      ['Spec links',
-       'Code in Chromium',
+      [PI_SPEC_LINK,
+       PI_CODE,
       ],
       [],
       [],
@@ -262,22 +345,22 @@ PSA_ONLY_STAGES = [
       'Dev trials and iterate on implementation',
       '(Optional) Publicize availablity for developers to try. '
       'Act on feedback from partners and web developers.',
-      ['Ready for Trial email',
-       'Vendor signals',
-       'Estimated target milestone',
+      [PI_R4DT_EMAIL,
+       PI_VENDOR_SIGNALS,
+       PI_EST_TARGET_MILESTONE,
       ],
-      [('Draft Ready for Trial email', INTENT_EMAIL_URL)],
+      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL, [])],
       [],
       models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
   ProcessStage(
       'Prepare to ship',
       'Lock in shipping milestone.',
-      ['Web facing PSA email',
-       'Updated target milestone',
-       'Intent to Ship email',
+      [PI_PSA_EMAIL,
+       PI_UPDATE_TARGET_MILESTONE,
+       PI_I2S_EMAIL,
       ],
-      [('Draft Intent to Ship email', INTENT_EMAIL_URL)],
+      [Action('Draft Intent to Ship email', INTENT_EMAIL_URL, [])],
       [approval_defs.ShipApproval],
       models.INTENT_EXPERIMENT, models.INTENT_SHIP),
 
@@ -285,8 +368,8 @@ PSA_ONLY_STAGES = [
       'Ship',
       'Update milestones and other information when the feature '
       'actually ships.',
-      ['Finalized vendor signals',  # TODO(jrobbins): needs detector.
-       'Finalized target milestone',  # TODO(jrobbins): needs detector.
+      [PI_FINAL_VENDOR_SIGNALS,
+       PI_FINAL_TARGET_MILESTONE,
       ],
       [],
       [],
@@ -306,11 +389,12 @@ DEPRECATION_STAGES = [
       'Create an initial WebStatus feature entry to deprecate '
       'an existing feature, including motivation and impact. '
       'Then, move existing Chromium code under a flag.',
-      ['Link to existing feature',  # TODO(jrobbins): needs detector.
-       'Motivation',
-       'Code in Chromium',
+      [PI_EXISTING_FEATURE,
+       PI_MOTIVATION,
+       PI_CODE,
       ],
-      [('Draft Intent to Deprecate and Remove email', INTENT_EMAIL_URL)],
+      [Action('Draft Intent to Deprecate and Remove email', INTENT_EMAIL_URL,
+              [])],
       [approval_defs.PrototypeApproval],
       models.INTENT_NONE, models.INTENT_IMPLEMENT),
 
@@ -318,24 +402,25 @@ DEPRECATION_STAGES = [
   ProcessStage(
       'Dev trial of deprecation',
       'Publicize deprecation and address risks. ',
-      ['Ready for Trial email',
-       'Vendor signals',
-       'Estimated target milestone',
+      [PI_R4DT_EMAIL,
+       PI_VENDOR_SIGNALS,
+       PI_EST_TARGET_MILESTONE,
       ],
-      [('Draft Ready for Trial email', INTENT_EMAIL_URL)],
+      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL, [])],
       [],
       models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
   ProcessStage(
       'Prepare for Deprecation Trial',
       '(Optional) Set up and run a deprecation trial. ',
-      ['DT request',  # TODO(jrobbins): needs detector.
-       'DT available',  # TODO(jrobbins): needs detector.
-       'Removal of DT',  # TODO(jrobbins): needs detector.
-       'Request for Deprecation Trial email',
-       'One LGTM on Request for Deprecation Trial',
+      [PI_DT_REQUEST,
+       PI_DT_AVAILABLE,
+       PI_REMOVAL_OF_DT,
+       PI_DT_EMAIL,
+       PI_DT_LGTMS,
       ],
-      [('Draft Request for Deprecation Trial email', INTENT_EMAIL_URL)],
+      [Action('Draft Request for Deprecation Trial email', INTENT_EMAIL_URL,
+              [])],
       # TODO(jrobbins): Intent to extend deprecation.
       [approval_defs.ExperimentApproval],
       models.INTENT_EXPERIMENT, models.INTENT_EXTEND_TRIAL),
@@ -344,20 +429,22 @@ DEPRECATION_STAGES = [
       'Prepare to ship',
       'Lock in shipping milestone. '
       'Finalize docs and announcements before disabling feature by default.',
-      ['Updated target milestone',  # TODO(jrobbins): needs detector.
-       'Intent to Ship email',
-       'Three LGTMs on Intent to Ship',
+      [PI_UPDATE_TARGET_MILESTONE,
+       PI_I2S_EMAIL,
+       PI_I2S_LGTMS,
       ],
-      [('Draft Intent to Ship email', INTENT_EMAIL_URL)],
+      [Action('Draft Intent to Ship email', INTENT_EMAIL_URL, [])],
       [approval_defs.ShipApproval],
       models.INTENT_EXPERIMENT, models.INTENT_SHIP),
 
   ProcessStage(
       'Remove code',
       'Once the feature is no longer available, remove the code.',
-      ['Code removed',
+      [PI_CODE_REMOVED,
       ],
-      [('Generate an Intent to Extend Deprecation Trial', INTENT_EMAIL_URL)],
+      [Action('Generate an Intent to Extend Deprecation Trial',
+              INTENT_EMAIL_URL, []),
+       ],
       [],
       models.INTENT_SHIP, models.INTENT_REMOVED),
   ]

--- a/internals/processes.py
+++ b/internals/processes.py
@@ -115,9 +115,9 @@ PI_I2E_LGTMS = ProgressItem('One LGTM on Intent to Experiment', 'i2e_lgtms')
 PI_MIGRATE_INCUBATION = ProgressItem('Request to migrate incubation', None)
 PI_TAG_ADDRESSED = ProgressItem(
     'TAG review issues addressed', 'tag_review_status')
-PI_UPDATE_VENDOR_SIGNALS = ProgressItem(
+PI_UPDATED_VENDOR_SIGNALS = ProgressItem(
     'Updated vendor signals', 'safari_views')
-PI_UPDATE_TARGET_MILESTONE = ProgressItem(
+PI_UPDATED_TARGET_MILESTONE = ProgressItem(
     'Updated target milestone', 'shipped_milestone')
 PI_I2S_EMAIL = ProgressItem('Intent to Ship email', 'intent_to_ship_url')
 PI_I2S_LGTMS = ProgressItem('Three LGTMs on Intent to Ship', 'i2s_lgtms')
@@ -128,7 +128,7 @@ PI_FINAL_VENDOR_SIGNALS = ProgressItem('Finalized vendor signals', 'safari_views
 PI_FINAL_TARGET_MILESTONE = ProgressItem(
     'Finalized target milestone', 'shipped_milestone')
 
-PI_CODE = ProgressItem('Code in Chromium', None)
+PI_CODE_IN_CHROMIUM = ProgressItem('Code in Chromium', None)
 
 PI_PSA_EMAIL = ProgressItem('Web facing PSA email', None)
 
@@ -172,7 +172,8 @@ BLINK_PROCESS_STAGES = [
        PI_I2P_EMAIL,
       ],
       [Action('Draft Intent to Prototype email', INTENT_EMAIL_URL,
-              [PI_SPEC_LINK])],
+              [PI_INITIAL_PUBLIC_PROPOSAL.name, PI_MOTIVATION.name,
+               PI_EXPLAINER.name, PI_SPEC_LINK.name])],
       [approval_defs.PrototypeApproval],
       models.INTENT_INCUBATE, models.INTENT_IMPLEMENT),
 
@@ -189,7 +190,9 @@ BLINK_PROCESS_STAGES = [
        PI_EXTERNAL_REVIEWS,
        PI_R4DT_EMAIL,
       ],
-      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL, [])],
+      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL,
+              [PI_INITIAL_PUBLIC_PROPOSAL.name, PI_MOTIVATION.name,
+               PI_EXPLAINER.name, PI_SPEC_LINK.name])],
       [],
       models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
@@ -217,7 +220,10 @@ BLINK_PROCESS_STAGES = [
        PI_I2E_EMAIL,
        PI_I2E_LGTMS,
       ],
-      [Action('Draft Intent to Experiment email', INTENT_EMAIL_URL, [])],
+      [Action('Draft Intent to Experiment email', INTENT_EMAIL_URL,
+              [PI_INITIAL_PUBLIC_PROPOSAL.name, PI_MOTIVATION.name,
+               PI_EXPLAINER.name, PI_SPEC_LINK.name,
+               PI_EST_TARGET_MILESTONE.name])],
       [approval_defs.ExperimentApproval],
       models.INTENT_IMPLEMENT_SHIP, models.INTENT_EXTEND_TRIAL),
 
@@ -227,12 +233,16 @@ BLINK_PROCESS_STAGES = [
       'Further standardization.',
       [PI_MIGRATE_INCUBATION,
        PI_TAG_ADDRESSED,
-       PI_UPDATE_VENDOR_SIGNALS,
-       PI_UPDATE_TARGET_MILESTONE,
+       PI_UPDATED_VENDOR_SIGNALS,
+       PI_UPDATED_TARGET_MILESTONE,
        PI_I2S_EMAIL,
        PI_I2S_LGTMS,
       ],
-      [Action('Draft Intent to Ship email', INTENT_EMAIL_URL, [])],
+      [Action('Draft Intent to Ship email', INTENT_EMAIL_URL,
+              [PI_INITIAL_PUBLIC_PROPOSAL.name, PI_MOTIVATION.name,
+               PI_EXPLAINER.name, PI_SPEC_LINK.name,
+               PI_TAG_ADDRESSED.name, PI_UPDATED_VENDOR_SIGNALS.name,
+               PI_UPDATED_TARGET_MILESTONE.name])],
       [approval_defs.ShipApproval],
       models.INTENT_IMPLEMENT_SHIP, models.INTENT_SHIP),
 
@@ -262,9 +272,10 @@ BLINK_FAST_TRACK_STAGES = [
       'Write up use cases and scenarios, start coding as a '
       'runtime enabled feature.',
       [PI_SPEC_LINK,
-       PI_CODE,
+       PI_CODE_IN_CHROMIUM,
        ],
-      [Action('Draft Intent to Prototype email', INTENT_EMAIL_URL, [])],
+      [Action('Draft Intent to Prototype email', INTENT_EMAIL_URL,
+              [PI_SPEC_LINK.name])],
       [approval_defs.PrototypeApproval],
       models.INTENT_NONE, models.INTENT_IMPLEMENT),
 
@@ -279,7 +290,8 @@ BLINK_FAST_TRACK_STAGES = [
        PI_VENDOR_SIGNALS,
        PI_EST_TARGET_MILESTONE,
       ],
-      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL, [])],
+      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL,
+              [PI_SPEC_LINK.name, PI_EST_TARGET_MILESTONE.name])],
       [],
       models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
@@ -293,7 +305,8 @@ BLINK_FAST_TRACK_STAGES = [
        PI_I2E_EMAIL,
        PI_I2E_LGTMS,
       ],
-      [Action('Draft Intent to Experiment email', INTENT_EMAIL_URL, [])],
+      [Action('Draft Intent to Experiment email', INTENT_EMAIL_URL,
+              [PI_SPEC_LINK.name, PI_EST_TARGET_MILESTONE.name])],
       [approval_defs.ExperimentApproval],
       models.INTENT_EXPERIMENT, models.INTENT_EXTEND_TRIAL),
 
@@ -302,11 +315,12 @@ BLINK_FAST_TRACK_STAGES = [
       'Lock in shipping milestone. Finalize docs and announcements. '
       'Further standardization.',
       [PI_DOC_SIGNOFF,
-       PI_UPDATE_TARGET_MILESTONE,
+       PI_UPDATED_TARGET_MILESTONE,
        PI_I2S_EMAIL,
        PI_I2S_LGTMS,
       ],
-      [Action('Draft Intent to Ship email', INTENT_EMAIL_URL, [])],
+      [Action('Draft Intent to Ship email', INTENT_EMAIL_URL,
+              [PI_SPEC_LINK.name, PI_UPDATED_TARGET_MILESTONE.name])],
       [approval_defs.ShipApproval],
       models.INTENT_EXPERIMENT, models.INTENT_SHIP),
 
@@ -335,7 +349,7 @@ PSA_ONLY_STAGES = [
       'Implement',
       'Check code into Chromium under a flag.',
       [PI_SPEC_LINK,
-       PI_CODE,
+       PI_CODE_IN_CHROMIUM,
       ],
       [],
       [],
@@ -349,7 +363,8 @@ PSA_ONLY_STAGES = [
        PI_VENDOR_SIGNALS,
        PI_EST_TARGET_MILESTONE,
       ],
-      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL, [])],
+      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL,
+              [PI_SPEC_LINK.name, PI_EST_TARGET_MILESTONE.name])],
       [],
       models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
@@ -357,10 +372,11 @@ PSA_ONLY_STAGES = [
       'Prepare to ship',
       'Lock in shipping milestone.',
       [PI_PSA_EMAIL,
-       PI_UPDATE_TARGET_MILESTONE,
+       PI_UPDATED_TARGET_MILESTONE,
        PI_I2S_EMAIL,
       ],
-      [Action('Draft Intent to Ship email', INTENT_EMAIL_URL, [])],
+      [Action('Draft Intent to Ship email', INTENT_EMAIL_URL,
+              [PI_SPEC_LINK.name, PI_UPDATED_TARGET_MILESTONE.name])],
       [approval_defs.ShipApproval],
       models.INTENT_EXPERIMENT, models.INTENT_SHIP),
 
@@ -375,6 +391,7 @@ PSA_ONLY_STAGES = [
       [],
       models.INTENT_SHIP, models.INTENT_SHIPPED),
   ]
+
 
 PSA_ONLY_PROCESS = Process(
     'Web developer facing change to existing code',
@@ -391,10 +408,9 @@ DEPRECATION_STAGES = [
       'Then, move existing Chromium code under a flag.',
       [PI_EXISTING_FEATURE,
        PI_MOTIVATION,
-       PI_CODE,
       ],
       [Action('Draft Intent to Deprecate and Remove email', INTENT_EMAIL_URL,
-              [])],
+              [PI_MOTIVATION.name])],
       [approval_defs.PrototypeApproval],
       models.INTENT_NONE, models.INTENT_IMPLEMENT),
 
@@ -406,7 +422,9 @@ DEPRECATION_STAGES = [
        PI_VENDOR_SIGNALS,
        PI_EST_TARGET_MILESTONE,
       ],
-      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL, [])],
+      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL,
+              [PI_MOTIVATION.name, PI_VENDOR_SIGNALS.name,
+               PI_EST_TARGET_MILESTONE.name])],
       [],
       models.INTENT_IMPLEMENT, models.INTENT_EXPERIMENT),
 
@@ -420,7 +438,8 @@ DEPRECATION_STAGES = [
        PI_DT_LGTMS,
       ],
       [Action('Draft Request for Deprecation Trial email', INTENT_EMAIL_URL,
-              [])],
+              [PI_MOTIVATION.name, PI_VENDOR_SIGNALS.name,
+               PI_EST_TARGET_MILESTONE.name])],
       # TODO(jrobbins): Intent to extend deprecation.
       [approval_defs.ExperimentApproval],
       models.INTENT_EXPERIMENT, models.INTENT_EXTEND_TRIAL),
@@ -429,11 +448,13 @@ DEPRECATION_STAGES = [
       'Prepare to ship',
       'Lock in shipping milestone. '
       'Finalize docs and announcements before disabling feature by default.',
-      [PI_UPDATE_TARGET_MILESTONE,
+      [PI_UPDATED_TARGET_MILESTONE,
        PI_I2S_EMAIL,
        PI_I2S_LGTMS,
       ],
-      [Action('Draft Intent to Ship email', INTENT_EMAIL_URL, [])],
+      [Action('Draft Intent to Ship email', INTENT_EMAIL_URL,
+              [PI_MOTIVATION.name, PI_VENDOR_SIGNALS.name,
+               PI_UPDATED_TARGET_MILESTONE.name])],
       [approval_defs.ShipApproval],
       models.INTENT_EXPERIMENT, models.INTENT_SHIP),
 
@@ -443,7 +464,9 @@ DEPRECATION_STAGES = [
       [PI_CODE_REMOVED,
       ],
       [Action('Generate an Intent to Extend Deprecation Trial',
-              INTENT_EMAIL_URL, []),
+              INTENT_EMAIL_URL,
+              [PI_MOTIVATION.name, PI_VENDOR_SIGNALS.name,
+               PI_UPDATED_TARGET_MILESTONE.name]),
        ],
       [],
       models.INTENT_SHIP, models.INTENT_REMOVED),
@@ -562,9 +585,24 @@ PROGRESS_DETECTORS = {
     lambda f: bool(
         f.ff_views != models.NO_PUBLIC_SIGNALS or
         f.safari_views != models.NO_PUBLIC_SIGNALS or
-        f.ie_views != models.NO_PUBLIC_SIGNALS),  # Deprecated
+        f.ie_views != models.NO_PUBLIC_SIGNALS),  # IE Deprecated
+
+    'Updated vendor signals':
+    lambda f: bool(
+        f.ff_views != models.NO_PUBLIC_SIGNALS or
+        f.safari_views != models.NO_PUBLIC_SIGNALS or
+        f.ie_views != models.NO_PUBLIC_SIGNALS),  # IE Deprecated
+
+    'Final vendor signals':
+    lambda f: bool(
+        f.ff_views != models.NO_PUBLIC_SIGNALS or
+        f.safari_views != models.NO_PUBLIC_SIGNALS or
+        f.ie_views != models.NO_PUBLIC_SIGNALS),  # IE Deprecated
 
     'Estimated target milestone':
+    lambda f: bool(f.shipped_milestone),
+
+    'Final target milestone':
     lambda f: bool(f.shipped_milestone),
 
     'Code in Chromium':

--- a/internals/processes_test.py
+++ b/internals/processes_test.py
@@ -39,6 +39,7 @@ PI_COLD_DOUGH = processes.ProgressItem('Cold dough', 'dough')
 PI_LOAF = processes.ProgressItem('A loaf', None)
 PI_DIRTY_PAN = processes.ProgressItem('A dirty pan', None)
 
+
 class HelperFunctionsTest(testing_config.CustomTestCase):
 
   def test_process_to_dict(self):
@@ -102,6 +103,37 @@ class HelperFunctionsTest(testing_config.CustomTestCase):
     self.assertFalse(processes.review_is_done(models.REVIEW_ISSUES_OPEN))
     self.assertTrue(processes.review_is_done(models.REVIEW_ISSUES_ADDRESSED))
     self.assertTrue(processes.review_is_done(models.REVIEW_NA))
+
+
+class ProcessesWellFormedTest(testing_config.CustomTestCase):
+  """Verify that our processes have no undefined references."""
+
+  def verify_references_to_prerequisites(self, process):
+    progress_items_so_far = {}
+    for stage in process.stages:
+      progress_items_so_far.update({
+          pi.name: pi
+          for pi in stage.progress_items})
+      for action in stage.actions:
+        for prereq_name in action.prerequisites:
+          self.assertIn(prereq_name, progress_items_so_far)
+          self.assertTrue(progress_items_so_far[prereq_name].field)
+
+  def test_BLINK_LAUNCH_PROCESS(self):
+    """Prerequisites in BLINK_LAUNCH_PROCESS are defined and actionable."""
+    self.verify_references_to_prerequisites(processes.BLINK_LAUNCH_PROCESS)
+
+  def test_BLINK_FAST_TRACK_PROCESS(self):
+    """Prerequisites in BLINK_FAST_TRACK_PROCESS are defined and actionable."""
+    self.verify_references_to_prerequisites(processes.BLINK_FAST_TRACK_PROCESS)
+
+  def test_PSA_ONLY_PROCESS(self):
+    """Prerequisites in PSA_ONLY_PROCESS are defined and actionable."""
+    self.verify_references_to_prerequisites(processes.PSA_ONLY_PROCESS)
+
+  def test_DEPRECATION_PROCESS(self):
+    """Prerequisites in DEPRECATION_PROCESS are defined and actionable."""
+    self.verify_references_to_prerequisites(processes.DEPRECATION_PROCESS)
 
 
 class ProgressDetectorsTest(testing_config.CustomTestCase):

--- a/internals/processes_test.py
+++ b/internals/processes_test.py
@@ -35,6 +35,10 @@ BAKE_APPROVAL_DEF_DICT = collections.OrderedDict([
     ('approvers', ['chef@example.com']),
     ])
 
+PI_COLD_DOUGH = processes.ProgressItem('Cold dough', 'dough')
+PI_LOAF = processes.ProgressItem('A loaf', None)
+PI_DIRTY_PAN = processes.ProgressItem('A dirty pan', None)
+
 class HelperFunctionsTest(testing_config.CustomTestCase):
 
   def test_process_to_dict(self):
@@ -45,14 +49,15 @@ class HelperFunctionsTest(testing_config.CustomTestCase):
         [processes.ProcessStage(
             'Make dough',
             'Mix it and kneed',
-            ['Cold dough'],
-            [('Share kneeding video', 'https://example.com')],
+            [PI_COLD_DOUGH],
+            [processes.Action(
+                'Share kneeding video', 'https://example.com', [])],
             [],
             0, 1),
          processes.ProcessStage(
              'Bake it',
              'Heat at 375 for 40 minutes',
-             ['A loaf', 'A dirty pan'],
+             [PI_LOAF, PI_DIRTY_PAN],
              [],
              [BakeApproval],
              1, 2),
@@ -64,14 +69,19 @@ class HelperFunctionsTest(testing_config.CustomTestCase):
         'stages': [
             {'name': 'Make dough',
              'description': 'Mix it and kneed',
-             'progress_items': ['Cold dough'],
-             'actions': [('Share kneeding video', 'https://example.com')],
+             'progress_items': [{'name': 'Cold dough', 'field': 'dough'}],
+             'actions': [{
+                 'name': 'Share kneeding video',
+                 'url': 'https://example.com',
+                 'prerequisites': []}],
              'approvals': [],
              'incoming_stage': 0,
              'outgoing_stage': 1},
             {'name': 'Bake it',
              'description': 'Heat at 375 for 40 minutes',
-             'progress_items': ['A loaf', 'A dirty pan'],
+             'progress_items': [
+                 {'name': 'A loaf', 'field': None},
+                 {'name': 'A dirty pan', 'field': None}],
              'actions': [],
              'approvals': [BAKE_APPROVAL_DEF_DICT],
              'incoming_stage': 1,

--- a/templates/guide/edit.html
+++ b/templates/guide/edit.html
@@ -27,7 +27,6 @@
 
 <section style="margin: 1em 0 1em 0; max-width: 67em">
   <chromedash-process-overview
-    title='Blink Process'
     feature='{{ feature_json }}'
     process='{{ process_json }}'
     progress='{{ progress_so_far }}'


### PR DESCRIPTION
In this PR:
* Create named tuples for ProgressItem and Action and change the process definitions to use them.
* For most ProgressItems, specify the field that must be edited to complete that item.
* For each Action, list the prerequisite ProgressItems that must be completed to avoid the interstitial dialog (and therefore which fields must be edited) even if some of those progress items were from previous process stages.
* Update chromedash-process-overview.js to handle the new format of progress items and actions.
* Now that progress item fields are specified, offer the user an "Edit" link when they hover over a progress item.
* Remove title="Blink Process" because it shows up as a tooltip whenever the user hovers anywhere in the process.