### PR TITLE
Revert "npm: bump rollup from 1.17.0 to 2.70.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "minimist": ">=1.2.6",
         "path-parse": ">=1.0.7",
         "regenerator-runtime": "^0.13.9",
-        "rollup": "^2.70.1",
+        "rollup": "^1.17.0",
         "rollup-plugin-babel": "^4.4.0",
         "rollup-plugin-babel-minify": "^9.1.0",
         "rollup-plugin-lit-css": "^2.0.0",
@@ -1291,6 +1291,12 @@
       "version": "0.1.30",
       "resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
       "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -9379,18 +9385,17 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.70.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-      "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.17.0.tgz",
+      "integrity": "sha512-k/j1m0NIsI4SYgCJR4MWPstGJOWfJyd6gycKoMhyoKPVXxm+L49XtbUwZyFsrSU2YXsOkM4u1ll9CS/ZgJBUpw==",
       "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "@types/node": "^12.6.2",
+        "acorn": "^6.2.0"
+      },
       "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
+        "rollup": "bin/rollup"
       }
     },
     "node_modules/rollup-plugin-babel": {
@@ -9456,18 +9461,16 @@
         "estree-walker": "^0.6.1"
       }
     },
-    "node_modules/rollup/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+    "node_modules/rollup/node_modules/acorn": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "bin": {
+        "acorn": "bin/acorn"
+      },
       "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+        "node": ">=0.4.0"
       }
     },
     "node_modules/run-async": {
@@ -12925,6 +12928,12 @@
       "version": "0.1.30",
       "resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
       "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=",
+      "dev": true
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
     "@types/node": {
@@ -20112,20 +20121,21 @@
       }
     },
     "rollup": {
-      "version": "2.70.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-      "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.17.0.tgz",
+      "integrity": "sha512-k/j1m0NIsI4SYgCJR4MWPstGJOWfJyd6gycKoMhyoKPVXxm+L49XtbUwZyFsrSU2YXsOkM4u1ll9CS/ZgJBUpw==",
       "dev": true,
       "requires": {
-        "fsevents": "~2.3.2"
+        "@types/estree": "0.0.39",
+        "@types/node": "^12.6.2",
+        "acorn": "^6.2.0"
       },
       "dependencies": {
-        "fsevents": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-          "dev": true,
-          "optional": true
+        "acorn": {
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "minimist": ">=1.2.6",
     "path-parse": ">=1.0.7",
     "regenerator-runtime": "^0.13.9",
-    "rollup": "^2.70.1",
+    "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-babel-minify": "^9.1.0",
     "rollup-plugin-lit-css": "^2.0.0",


### PR DESCRIPTION
Reverts GoogleChrome/chromium-dashboard#1791.  It is failing on the main CI 