### PR TITLE
Tighten Flask session cookie headers

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -489,4 +489,11 @@ def FlaskApplication(import_name, routes, pattern_base='', debug=False):
   # Flask apps also have a debug setting that can be used to auto-reload
   # template source code, but we use django for that.
 
+  # Set cookie headers in Flask; see https://flask.palletsprojects.com/en/2.0.x/config/
+  # for more details.
+  app.config["SESSION_COOKIE_SECUR"] = True
+  app.config["SESSION_COOKIE_HTTPONLY"] = True
+  app.config["SESSION_COOKIE_SAMESITE"] = 'Lax'
+
+
   return app


### PR DESCRIPTION
Explicitly set `secure=True`, `httponly=True`, `samesite='Lax'` cookie headers in Flask to address security concerns in the new log-in. 

The default value in Flask for [SESSION_COOKIE_SAMESITE](https://flask.palletsprojects.com/en/2.0.x/config/#SESSION_COOKIE_SAMESITE) is None, which is CSRF-prone from external sites. The bright side is that we did not allow CORS.