### PR TITLE
Added case insensitive sort for features list 

### DIFF
--- a/static/elements/chromedash-roadmap.js
+++ b/static/elements/chromedash-roadmap.js
@@ -161,7 +161,7 @@ class ChromedashRoadmap extends LitElement {
       newMilestonesInfo[milestoneNum].version = milestoneNum;
       newMilestonesInfo[milestoneNum].features = milestoneFeatures[milestoneNum];
       Object.keys(newMilestonesInfo[milestoneNum].features).forEach(status => {
-        newMilestonesInfo[milestoneNum].features[status].sort( (a, b) => compareFeatures(a, b));
+        newMilestonesInfo[milestoneNum].features[status].sort(compareFeatures);
       });
     });
 
@@ -206,7 +206,7 @@ class ChromedashRoadmap extends LitElement {
       newMilestonesInfo[milestoneNum].version = milestoneNum;
       newMilestonesInfo[milestoneNum].features = milestoneFeatures[milestoneNum];
       Object.keys(newMilestonesInfo[milestoneNum].features).forEach(status => {
-        newMilestonesInfo[milestoneNum].features[status].sort( (a, b) => compareFeatures(a, b));
+        newMilestonesInfo[milestoneNum].features[status].sort(compareFeatures);
       });
     });
 

--- a/static/elements/chromedash-roadmap.js
+++ b/static/elements/chromedash-roadmap.js
@@ -49,6 +49,7 @@ const DEPRECATED_STATUS = ['Deprecated', 'No longer pursuing'];
 const ORIGIN_TRIAL = ['Origin trial'];
 const BROWSER_INTERVENTION = ['Browser Intervention'];
 const SHOW_DATES = true;
+const compareFeatures = (a, b) => a.name.localeCompare(b.name, 'fr', {ignorePunctuation: true}); // comparator for sorting milestone features
 
 class ChromedashRoadmap extends LitElement {
   static styles = style;
@@ -159,6 +160,9 @@ class ChromedashRoadmap extends LitElement {
     milestoneNumsArray.forEach((milestoneNum) => {
       newMilestonesInfo[milestoneNum].version = milestoneNum;
       newMilestonesInfo[milestoneNum].features = milestoneFeatures[milestoneNum];
+      Object.keys(newMilestonesInfo[milestoneNum].features).forEach(status => {
+        newMilestonesInfo[milestoneNum].features[status].sort( (a, b) => compareFeatures(a, b));
+      });
     });
 
     // update the properties to render the latest milestone cards
@@ -201,6 +205,9 @@ class ChromedashRoadmap extends LitElement {
     milestoneNumsArray.forEach((milestoneNum) => {
       newMilestonesInfo[milestoneNum].version = milestoneNum;
       newMilestonesInfo[milestoneNum].features = milestoneFeatures[milestoneNum];
+      Object.keys(newMilestonesInfo[milestoneNum].features).forEach(status => {
+        newMilestonesInfo[milestoneNum].features[status].sort( (a, b) => compareFeatures(a, b));
+      });
     });
 
     // update the properties to render the newly fetched milestones

--- a/static/js-src/roadmap-page.js
+++ b/static/js-src/roadmap-page.js
@@ -31,7 +31,7 @@ async function init() {
   channelsArray.forEach((channel) => {
     channels[channel].features = features[channel];
     Object.keys(channels[channel].features).forEach(status => {
-      channels[channel].features[status].sort( (a, b) => compareFeatures(a, b));
+      channels[channel].features[status].sort(compareFeatures);
     });
   });
 

--- a/static/js-src/roadmap-page.js
+++ b/static/js-src/roadmap-page.js
@@ -27,8 +27,12 @@ async function init() {
   document.body.classList.remove('loading');
 
   const roadmapEl = document.querySelector('chromedash-roadmap');
+  const compareFeatures = (a, b) => a.name.localeCompare(b.name, 'fr', {ignorePunctuation: true});
   channelsArray.forEach((channel) => {
     channels[channel].features = features[channel];
+    Object.keys(channels[channel].features).forEach(status => {
+      channels[channel].features[status].sort( (a, b) => compareFeatures(a, b));
+    });
   });
 
   roadmapEl.channels = channels;


### PR DESCRIPTION
Fixes Lists on /roadmap view should use case-insensitive sort #1774

Added case insentive sort for features list using custom comparator

`(a, b) => a.name.localeCompare(b.name, 'fr', {ignorePunctuation: true})`

Samples after sorting

![image](https://user-images.githubusercontent.com/62694340/160395096-cd162817-4b47-4259-bf2b-3ae7f1ba6216.png)
![image](https://user-images.githubusercontent.com/62694340/160395139-b4f2b412-2e3a-4dbe-b2fd-7ba092d5ba1b.png)
