### PR TITLE
Fix secure cookie header

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -490,11 +490,12 @@ def FlaskApplication(import_name, routes, pattern_base='', debug=False):
   # Flask apps also have a debug setting that can be used to auto-reload
   # template source code, but we use django for that.
 
-  # Set cookie headers in Flask; see https://flask.palletsprojects.com/en/2.0.x/config/
+  # Set cookie headers in Flask; see
+  # https://flask.palletsprojects.com/en/2.0.x/config/
   # for more details.
-  app.config["SESSION_COOKIE_SECUR"] = True
-  app.config["SESSION_COOKIE_HTTPONLY"] = True
-  app.config["SESSION_COOKIE_SAMESITE"] = 'Lax'
-
+  if not settings.DEV_MODE:
+    app.config["SESSION_COOKIE_SECURE"] = True
+    app.config["SESSION_COOKIE_HTTPONLY"] = True
+    app.config["SESSION_COOKIE_SAMESITE"] = 'Lax'
 
   return app


### PR DESCRIPTION
This is a follow-up to #1808 to correct a typo.  Also, only set these cookie details when not running locally because localhost is not using SSL.