### PR TITLE
Handle quoted search values.

### DIFF
--- a/internals/search.py
+++ b/internals/search.py
@@ -121,11 +121,21 @@ def process_queriable_field(field_name, operator, val_str):
   return promise
 
 
+# A full-text query term consisting of a single word or quoted string.
+# The single word case cannot contain an operator.
+# We do not support any kind of escaped quotes in quoted strings.
 TEXT_PATTERN = r'[^":=><! ]+|"[^S]+"'
+# The JSON field name of a feature field.
 FIELD_NAME_PATTERN = r'[-.a-z_0-9]+'
+# Comparison operators.
 OPERATORS_PATTERN = r':|=|<=|<|>=|>|!='
+# A value that a feature field can be compared against.  It can be
+# a single word or a quoted string.
 VALUE_PATTERN = r'[^" ]+|"[^"]+"'
 
+# Overall, a query term can be either a structured term or a full-text term.
+# Structured terms look like: FIELD OPERATOR VALUE.
+# Full-text terms look like: SINGLE_WORD, or like: "QUOTED STRING".
 TERM_RE = re.compile(
     '(?P<field>%s)(?P<op>%s)(?P<val>%s)\s+|(?P<textterm>%s)\s+' % (
         FIELD_NAME_PATTERN, OPERATORS_PATTERN, VALUE_PATTERN,

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -205,6 +205,14 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     self.assertEqual(1, len(actual))
     self.assertEqual(actual[0]['name'], 'feature 2')
 
+    actual = search.process_query('category="2"')
+    self.assertEqual(1, len(actual))
+    self.assertEqual(actual[0]['name'], 'feature 2')
+
+    actual = search.process_query('name="feature 2"')
+    self.assertEqual(1, len(actual))
+    self.assertEqual(actual[0]['name'], 'feature 2')
+
     actual = search.process_query('browsers.webdev.view=1')
     self.assertEqual(2, len(actual))
     self.assertCountEqual(


### PR DESCRIPTION
Instead of just breaking the user query into terms by splitting on spaces, we now look for all substrings that match one of these two patterns:
* Full-text search term: A single word or a quoted string
* A structured search term: A field name, operator, and then a single word or quoted string value.

