### PR TITLE
Set up the new feature list page initially as a feature table.

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ from internals import notifier
 from pages import blink_handler
 from pages import featuredetail
 from pages import featurelist
+from pages import newfeaturelist
 from pages import guide
 from pages import intentpreview
 from pages import metrics
@@ -127,6 +128,7 @@ page_routes = [
     ('/', basehandlers.Redirector,
      {'location': '/features'}),
 
+    ('/newfeatures', newfeaturelist.NewFeatureListHandler),
     ('/features', featurelist.FeatureListHandler),
     ('/features/<int:feature_id>', featurelist.FeatureListHandler),
     ('/features.xml', featurelist.FeatureListXMLHandler),

--- a/pages/newfeaturelist.py
+++ b/pages/newfeaturelist.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+
+import settings
+from framework import basehandlers
+from framework import permissions
+from internals import models
+from framework import ramcache
+
+
+class NewFeatureListHandler(basehandlers.FlaskHandler):
+
+  TEMPLATE_PATH = 'new-feature-list.html'
+
+  def get_template_data(self):
+    template_data = {}
+    return template_data

--- a/static/components.js
+++ b/static/components.js
@@ -23,6 +23,7 @@ import './elements/chromedash-feature';
 import './elements/chromedash-feature-detail';
 import './elements/chromedash-feature-table';
 import './elements/chromedash-featurelist';
+import './elements/chromedash-new-feature-list';
 import './elements/chromedash-gantt';
 import './elements/chromedash-legend';
 import './elements/chromedash-metadata';

--- a/static/elements/chromedash-new-feature-list.js
+++ b/static/elements/chromedash-new-feature-list.js
@@ -1,0 +1,86 @@
+import {LitElement, css, html} from 'lit';
+import './chromedash-approvals-dialog';
+import './chromedash-feature-table';
+import SHARED_STYLES from '../css/shared.css';
+
+
+class ChromedashNewFeatureList extends LitElement {
+  static get properties() {
+    return {
+      signedInUser: {type: String},
+      canEdit: {type: Boolean},
+      canApprove: {type: Boolean},
+      loginUrl: {type: String},
+      starredFeatures: {type: Object}, // will contain a set of starred features
+    };
+  }
+
+  constructor() {
+    super();
+    this.signedInUser = ''; // email address
+    this.starredFeatures = new Set();
+    this.canEdit = false;
+    this.canApprove = false;
+  }
+
+  static get styles() {
+    return [
+      SHARED_STYLES,
+      css`
+      `];
+  }
+
+  // Handles the Star-Toggle event fired by any one of the child components
+  handleStarToggle(e) {
+    const newStarredFeatures = new Set(this.starredFeatures);
+    window.csClient.setStar(e.detail.featureId, e.detail.doStar)
+      .then(() => {
+        if (e.detail.doStar) {
+          newStarredFeatures.add(e.detail.featureId);
+        } else {
+          newStarredFeatures.delete(e.detail.featureId);
+        }
+        this.starredFeatures = newStarredFeatures;
+      })
+      .catch(() => {
+        alert('Unable to star the Feature. Please Try Again.');
+      });
+  }
+
+  handleOpenApprovals(e) {
+    const featureId = e.detail.featureId;
+    const dialog = this.shadowRoot.querySelector('chromedash-approvals-dialog');
+    dialog.openWithFeature(featureId);
+  }
+
+  renderBox(query) {
+    return html`
+        <chromedash-feature-table
+          query="${query}"
+          showQuery="true"
+          ?signedIn=${Boolean(this.signedInUser)}
+          ?canEdit=${this.canEdit}
+          ?canApprove=${this.canApprove}
+          .starredFeatures=${this.starredFeatures}
+          @star-toggle-event=${this.handleStarToggle}
+          @open-approvals-event=${this.handleOpenApprovals}
+          rows=100 columns="normal">
+        </chromedash-feature-table>
+    `;
+  }
+
+  renderFeatureList() {
+    return this.renderBox('');
+  }
+
+  render() {
+    return html`
+      ${this.renderFeatureList()}
+      <chromedash-approvals-dialog
+        .signedInUser=${this.signedInUser}
+      ></chromedash-approvals-dialog>
+    `;
+  }
+}
+
+customElements.define('chromedash-new-feature-list', ChromedashNewFeatureList);

--- a/static/js-src/new-feature-list-page.js
+++ b/static/js-src/new-feature-list-page.js
@@ -1,0 +1,7 @@
+const newFeaturesEl = document.querySelector('chromedash-new-feature-list');
+
+window.csClient.getStars().then((starredFeatureIds) => {
+  newFeaturesEl.starredFeatures = new Set(starredFeatureIds);
+});
+
+document.body.classList.remove('loading');

--- a/templates/new-feature-list.html
+++ b/templates/new-feature-list.html
@@ -1,0 +1,32 @@
+{% extends "_base.html" %}
+{% load inline_file %}
+
+{% block css %}
+{% endblock %}
+
+{% block subheader %}
+  <div class="feature-count">
+    <h2>Features</h2>
+  </div>
+{% endblock %}
+
+
+{% block content %}
+<chromedash-new-feature-list
+  {% if user %} signedinuser="{{user.email}}" {% endif %}
+  {% if user.can_edit %} canedit {% endif %}
+  {% if user.can_approve %} canapprove {% endif %}
+  >
+</chromedash-new-feature-list>
+{% endblock %}
+
+
+{% block js %}
+<script nonce="{{nonce}}">
+    (function() {
+      'use strict';
+
+      {% inline_file "/static/js/new-feature-list-page.min.js" %}
+    })();
+</script>
+{% endblock %}


### PR DESCRIPTION
This is the starting point for the new feature list page.   The new search widgets are not added yet, those will come in a separate PR.

In this PR:
* main.py: Register a new page for server-side routing at url `/newfeatures`.
* pages/newfeatures.py: A basic handler for the new page that provides no page data.
* templates/new-feature-list-page.html: a simple template that just contains one Lit element.
* static/componoents.js: Add the new page-level custom element to the list of files to compile.
* static/elements/chromedash-new-feature-list.js:  New page-level element that just contains a plain old feature table so far.
* static/js-src/new-feature-list-page.js: remove the spinner and fetch the list of features that the user has starred.  Someday this will be in a top-level SPA element, but for now it is the same small bits of JS for most pages.
