### PR TITLE
Fix icons not visible in some views

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -420,7 +420,7 @@ footer {
 
   #subheader {
     div {
-      &:not(.search):not(.actionlinks) {
+      &:not(.search):not(.actionlinks):not(.tooltips) {
         display: none;
       }
 

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -21,7 +21,7 @@
 
 {% block subheader %}
 <div id="subheader" style="display:block">
-  <div style="float:right">
+  <div class="tooltips" style="float:right">
   {% if user %}
     <span class="tooltip" title="Receive an email notification when there are updates">
       <a href="#" data-tooltip id="star-when-signed-in">


### PR DESCRIPTION
This is to fix #1802 where the action icons disappear in small views.

In this PR:
- feature.html: Added a new css class `tooltips` for the div that wraps the action icons.
- main.scss: Excluded `tooltips` class from `display:none` in small view.

Before:
<img src="https://user-images.githubusercontent.com/11501902/162546412-f17a0466-0200-4e0e-90ff-41fcfc8808b5.png" width="400">

After:
<img src="https://user-images.githubusercontent.com/11501902/162546419-ebd68793-f84a-40a0-9d5f-bb3154aa3734.png" width="400">

