### PR TITLE
Use datalist instead of select for timeline pages

### DIFF
--- a/static/elements/chromedash-timeline.js
+++ b/static/elements/chromedash-timeline.js
@@ -86,7 +86,7 @@ class ChromedashTimeline extends LitElement {
       }
 
       #datalistinput {
-        width: 560px;
+        width: 20em;
       }
     `];
   }
@@ -104,7 +104,7 @@ class ChromedashTimeline extends LitElement {
   }
 
   updateSelectedBucketId(e) {
-    const feature = this.props.find((el) => el[0] === e.currentTarget.value);
+    const feature = this.props.find((el) => el[1] === e.currentTarget.value);
     if (feature) {
       this.selectedBucketId = feature[0];
     }
@@ -266,7 +266,7 @@ ORDER BY yyyymmdd DESC, client`;
       <input id="datalistinput" type="search" list="features" placeholder="Select or search a property" @change="${this.updateSelectedBucketId}" />
       <datalist id="features">
         ${this.props.map((prop) => html`
-          <option value="${prop[1]}" />
+          <option value="${prop[1]}" dataset-debug-bucket-id="${prop[0]}" />
         `)}
       </datalist>
       <label>Show all historical data: <input type="checkbox" ?checked="${this.showAllHistoricalData}" @change="${this.toggleShowAllHistoricalData}"></label>

--- a/static/elements/chromedash-timeline.js
+++ b/static/elements/chromedash-timeline.js
@@ -84,6 +84,10 @@ class ChromedashTimeline extends LitElement {
         background: var(--table-alternate-background);
         display: inline-block;
       }
+
+      #datalistinput {
+        width: 560px;
+      }
     `];
   }
 
@@ -100,7 +104,10 @@ class ChromedashTimeline extends LitElement {
   }
 
   updateSelectedBucketId(e) {
-    this.selectedBucketId = e.currentTarget.value;
+    const feature = this.props.find((el) => el[0] === e.currentTarget.value);
+    if (feature) {
+      this.selectedBucketId = feature[0];
+    }
   }
 
   toggleShowAllHistoricalData() {
@@ -234,6 +241,9 @@ class ChromedashTimeline extends LitElement {
     const feature = this.props.find((el) => el[0] === parseInt(this.selectedBucketId));
     if (feature) {
       let featureName = feature[1];
+      const inputEl = this.shadowRoot.getElementById('datalistinput');
+      inputEl.value = featureName;
+
       if (this.type == 'css') {
         featureName = convertToCamelCaseFeatureName(featureName);
       }
@@ -253,12 +263,12 @@ ORDER BY yyyymmdd DESC, client`;
 
   render() {
     return html`
-      <select .value="${this.selectedBucketId}" @change="${this.updateSelectedBucketId}">
-        <option disabled value="1">Select a property</option>
+      <input id="datalistinput" type="search" list="features" placeholder="Select or search a property" @change="${this.updateSelectedBucketId}" />
+      <datalist id="features">
         ${this.props.map((prop) => html`
-          <option value="${prop[0]}">${prop[1]}</option>
-          `)}
-      </select>
+          <option value="${prop[1]}" />
+        `)}
+      </datalist>
       <label>Show all historical data: <input type="checkbox" ?checked="${this.showAllHistoricalData}" @change="${this.toggleShowAllHistoricalData}"></label>
       <h3 id="usage" class="header_title">Percentage of page loads that use this feature</h3>
       <p class="description">The chart below shows the percentage of page loads (in Chrome) that use

--- a/static/sass/shared-css.js
+++ b/static/sass/shared-css.js
@@ -53,7 +53,7 @@ export const SHARED_STYLES = [
     cursor: pointer;
   }
 
-  input:not([type="submit"]),
+  input:not([type="submit"]):not([type="search"]),
   textarea {
     border: 1px solid var(--bar-border-color);
   }


### PR DESCRIPTION
This is to address #1342 and provide a search friendly dropdown list for the timeline pages.

In this PR:
- chromedash-timeline.js: Changed `<select>` to `<input>` + `<datalist>` and updated the event and API handler logics (so that API requests still use bucket ID number not the displayed property name).
- shared-css.js: Excluded the datalist input from `border: 1px solid var(--bar-border-color);`

Results:
<img width="929" alt="Screen Shot 2022-04-09 at 5 04 03 PM" src="https://user-images.githubusercontent.com/11501902/162592009-2ffff51e-672d-4c9f-8f21-c2534b925b8d.png">
<img width="932" alt="Screen Shot 2022-04-09 at 5 01 39 PM" src="https://user-images.githubusercontent.com/11501902/162592010-124d0a0c-1c79-459f-ac72-fbe9a6ca7d1d.png">

(I manually set the input box width to 560px, which is about the same width of current select element, please let me know if it's fine)
