### PR TITLE
Set * {margin:0; padding:0;} for non-sass shared css.

### DIFF
--- a/static/sass/shared-css.js
+++ b/static/sass/shared-css.js
@@ -1,13 +1,15 @@
 import { css } from "lit";
 import {VARS} from "./_vars-css.js";
 
-export const SHARED_STYLES = [ 
+export const SHARED_STYLES = [
   VARS,
   css`
 
   * {
     box-sizing: border-box;
     list-style: none;
+    margin: 0;
+    padding: 0;
     font: inherit;
     text-decoration: inherit;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);


### PR DESCRIPTION
This is a follow-up to #1816 which replaced shared SASS files with shared lit-css files.

I found a lot more margin around some heading using the same approach.  This impacted the feature list page and roadmap page by making headers too spread out.

My theory is that SASS was adding some CSS properties automatically.  Since we are no longer using SASS for our components, we need to specify them explicitly.