### PR TITLE
Add field for anticipated spec changes before i2s.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -1367,6 +1367,7 @@ class Feature(DictModel):
   experiment_extension_reason = ndb.StringProperty()
   ongoing_constraints = ndb.StringProperty()
   origin_trial_feedback_url = ndb.StringProperty()
+  anticipated_spec_changes = ndb.StringProperty()
 
   finch_url = ndb.StringProperty()
 
@@ -1423,6 +1424,7 @@ QUERIABLE_FIELDS = {
 
     'standards.maturity': Feature.standard_maturity,
     'standards.spec': Feature.spec_link,
+    'standards.anticipated_spec_changes': Feature.anticipated_spec_changes,
     'api_spec': Feature.api_spec,
     'spec_mentors': Feature.spec_mentors,
     'security_review_status': Feature.security_review_status,

--- a/internals/processes.py
+++ b/internals/processes.py
@@ -498,7 +498,8 @@ INTENT_EMAIL_SECTIONS = {
     models.INTENT_EXTEND_TRIAL: [
         'i2p_thread', 'experiment', 'extension_reason'],
     models.INTENT_SHIP: [
-        'need_api_owners_lgtms', 'i2p_thread', 'tracking_bug', 'sample_links'],
+        'need_api_owners_lgtms', 'i2p_thread', 'tracking_bug', 'sample_links',
+        'anticipated_spec_changes'],
     models.INTENT_REMOVED: [],
     models.INTENT_SHIPPED: [],
     models.INTENT_PARKED: [],

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -342,6 +342,10 @@ class FeatureEditStage(basehandlers.FlaskHandler):
       feature.origin_trial_feedback_url = self.parse_link(
           'origin_trial_feedback_url')
 
+    if self.touched('anticipated_spec_changes'):
+      feature.anticipated_spec_changes = self.form.get(
+          'anticipated_spec_changes')
+
     if self.touched('finch_url'):
       feature.finch_url = self.parse_link('finch_url')
 

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -386,7 +386,7 @@ ALL_FIELDS = {
          'when designing this feature.')),
 
     'webview_risks': forms.CharField(
-        label='WebView Application Risks', required=False,
+        label='WebView application risks', required=False,
         widget=forms.Textarea(attrs={'cols': 50, 'maxlength': 1480}),
         help_text=
         ('Does this intent deprecate or change behavior of existing APIs, '
@@ -499,6 +499,16 @@ ALL_FIELDS = {
         help_text=
         ('If your feature was available as an origin trial, link to a summary '
          'of usage and developer feedback. If not, leave this empty.')),
+
+    'anticipated_spec_changes': forms.CharField(
+        required=False, label='Anticipated spec changes',
+        widget=forms.Textarea(
+            attrs={'rows': 4, 'cols': 50, 'maxlength': 500,
+                   'placeholder': 'https://\nhttps://'}),
+        help_text=
+        ('Please list known spec issues whose resolution may introduce '
+         'web compat risk (e.g., change to naming or structure of '
+         'the API).')),
 
     'finch_url': forms.URLField(
         required=False, label='Finch experiment',
@@ -847,7 +857,7 @@ ImplStatus_OriginTrial = define_form_class_using_shared_fields(
 Most_PrepareToShip = define_form_class_using_shared_fields(
     'Most_PrepareToShip',
     ('tag_review', 'tag_review_status', 'non_oss_deps',
-     'webview_risks', 'origin_trial_feedback_url',
+     'webview_risks', 'anticipated_spec_changes', 'origin_trial_feedback_url',
      'launch_bug_url', 'intent_to_ship_url', 'i2s_lgtms', 'comments'))
 
 
@@ -1003,7 +1013,7 @@ Flat_PrepareToShip = define_form_class_using_shared_fields(
     'Flat_PrepareToShip',
     (# Standardization
      'tag_review', 'tag_review_status',
-     'webview_risks',
+     'webview_risks', 'anticipated_spec_changes',
      'intent_to_ship_url', 'i2s_lgtms',
      # Implementation
      'measurement',
@@ -1110,7 +1120,7 @@ DISPLAY_FIELDS_IN_STAGES = {
         'experiment_timeline',  # Deprecated
         ),
     models.INTENT_SHIP: make_display_specs(
-        'finch_url',
+        'finch_url', 'anticipated_spec_changes',
         'shipped_milestone', 'shipped_android_milestone',
         'shipped_ios_milestone', 'shipped_webview_milestone',
         'intent_to_ship_url', 'i2s_lgtms'),

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -136,7 +136,7 @@
       <p class="preformatted">{{feature.security_risks|urlize}}</p>
     {% endif %}
 
-    <br><br><h4>WebView Application Risks</h4>
+    <br><br><h4>WebView application risks</h4>
     <p style="font-style: italic">
       Does this intent deprecate or change behavior of existing APIs,
       such that it has potentially high risk for Android WebView-based
@@ -234,6 +234,16 @@
 <br><br><h4>Estimated milestones</h4>
 {% include "../estimated-milestones-table.html" %}
 
+
+{% if 'anticipated_spec_changes' in sections_to_show or feature.anticipated_spec_changes %}
+  <br><br><h4>Anticipated spec changes</h4>
+  <p style="font-style: italic">
+    Please list known spec issues whose resolution may introduce
+    web compat risk (e.g., change to naming or structure of
+    the API).</p>
+
+  {{feature.anticipated_spec_changes|urlize}}
+{% endif %}
 
 <br><br><h4>Link to entry on the {{APP_TITLE}}</h4>
 <a href="{{default_url}}">{{default_url}}</a>


### PR DESCRIPTION
This should resolve issue #1817.   There's a lot of FYI context in that issue, but the actual requested change is to add a field to the database which then shows up in the intent-to-ship emails.

Changes in this PR:
* models.py: Add the anticipated_spec_changes field and define a query term for it
* guideforms.py: Define the django form field for anticipated_spec_changes and locate it on the "prepare to ship" form, flat form, and on the feature detail page.
* processes.py: indicate that anticipanted_spec_changes should be shown on the intent-to-ship email, but not necessarily on other emails.
* intent_to_implement.html: This template is used for all intent emails.  Add a conditional to show anticipated_spec_changes if it has a defined value or if the user is preparing an intent-to-ship email.

Also in this PR: Correct the display name of another field to use sentence-case capitalization.