### PR TITLE
In component shared styles, change :root to :host.  Add _reset.

### DIFF
--- a/static/sass/_reset-css.js
+++ b/static/sass/_reset-css.js
@@ -1,0 +1,75 @@
+import {css} from 'lit';
+
+export const RESET = css`
+html, body {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+}
+
+div, span, object, iframe, h1, h2, h3, h4, h5, h6, p,
+pre, a, abbr, acronym, address, code, del, dfn, em, img,
+dl, dt, dd, ol, ul, li, fieldset, form, label, legend, caption, tbody, tfoot, thead, tr {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+}
+
+blockquote, q {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  quotes: "" "";
+}
+blockquote:before, q:before,
+blockquote:after, q:after {
+  content: "";
+}
+
+th, td, caption {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  text-align: left;
+  font-weight: normal;
+  vertical-align: middle;
+}
+
+table {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border-collapse: separate;
+  border-spacing: 0;
+  vertical-align: middle;
+}
+
+a img {
+  border: none;
+}
+`;

--- a/static/sass/_vars-css.js
+++ b/static/sass/_vars-css.js
@@ -1,43 +1,43 @@
 import {css} from 'lit';
 
 export const VARS = css`
-:root {
+:host {
   --default-font-color: #222;
   --page-background: #fafafa;
-  
+
   --light-grey: #eee;
-  
+
   --gray-1: #e6e6e6;
   --gray-2: #a9a9a9;
   --gray-3: #797979;
   --gray-4: #515151;
-  
+
   --nav-link-color: #444;
-  
+
   --bar-shadow-color: rgba(0, 0, 0, .065);
   --bar-border-color: #D4D4D4;
-  
+
   --chromium-color-dark: #366597;
   --chromium-color-medium: #85b4df;
   --chromium-color-light: #bdd6ed;
   --chromium-color-center: #4580c0;
-  
+
   --material-primary-button: #58f;
-  
+
   --card-background: white;
   --card-border: 1px solid #ddd;
   --card-box-shadow: rgba(0, 0, 0, 0.067) 1px 1px 4px;
-  
+
   --md-yellow-100: #FFF9C4;
   --md-yellow-200: #FFF59D;
-  
+
   /* App specific */
   --invalid-color: rgba(255,0,0,0.75);
   --content-padding: 16px;
   --content-padding-negative: -16px;
   --content-padding-huge: 80px;
   --default-border-radius: 3px;
-  
+
   --app-drawer-width: 200px;
   --header-height: 135px;
   --max-content-width: 760px;

--- a/static/sass/shared-css.js
+++ b/static/sass/shared-css.js
@@ -1,15 +1,15 @@
 import { css } from "lit";
 import {VARS} from "./_vars-css.js";
+import {RESET} from "./_reset-css.js";
 
 export const SHARED_STYLES = [
   VARS,
+  RESET,
   css`
 
   * {
     box-sizing: border-box;
     list-style: none;
-    margin: 0;
-    padding: 0;
     font: inherit;
     text-decoration: inherit;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);


### PR DESCRIPTION
This reverts my recent change to add margin:0 and instead converts more of the old SASS to lit-css.

In this PR:
* Remove the margin:0; padding:0; change that I had previously tried.
* Change :root to :host so that CSS variables will be defined for use in later rules.  There is no :root in a shadow DOM.
* Copy the old _reset.scss to a lit-css version in _reset-css.js and include it in shared-css.js.

The result fixes a few visual problems that I noticed:
* Checkboxes had no margin around them because my previous change was applied to widely
* The extra spaced-out headers on the roadmap page now have the correct spacing (even without my margin:0)
* The `<textarea>` tag in the approvals dialog box now has a border, which was missing before