### PR TITLE
Centered loading spinner

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -25,11 +25,8 @@ body {
   justify-content: center;
   position: fixed;
   height: 60%; // Centered, half that.
-  max-width: var(--max-content-width);
+  // max-width: var(--max-content-width);
   width: 100%;
-  left: 0px;
-  right: 0px;
-  margin: auto;
 }
 
 #site-banner {

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -27,6 +27,9 @@ body {
   height: 60%; // Centered, half that.
   max-width: var(--max-content-width);
   width: 100%;
+  left: 0px;
+  right: 0px;
+  margin: auto;
 }
 
 #site-banner {


### PR DESCRIPTION
Centered spinner horizontally on the page

I was able to center the spinner by two ways
1. By removing max-width (defined as 760px in [_vars.scss](https://github.com/GoogleChrome/chromium-dashboard/blob/9d5e7be6e0681974bbc9c3335f64884fdbfebdec/static/sass/_vars.scss#L37)) from the spinner, see [commented max-width](https://github.com/GoogleChrome/chromium-dashboard/pull/1841/commits/63d68156462804ed9e7759ff125d9d3b4a4f87fb) commit
2. By setting left, right to 0 and margin as auto, see [centered spinner](https://github.com/GoogleChrome/chromium-dashboard/pull/1841/commits/a1559f7abfbdd2b87b2455b23dba412841aee9d3) commit. 

This PR is for a new feature and not related to any issue.