### PR TITLE
Enabled spinner for roadmap section

### DIFF
--- a/static/sass/roadmap.scss
+++ b/static/sass/roadmap.scss
@@ -8,10 +8,6 @@ body[data-path*='roadmap'] {
     display: none;
   }
 
-  #spinner {
-    display: none;
-  }
-
 }
 
 #drawer-column {


### PR DESCRIPTION
Enabled spinner for roadmap section. 

I removed spinner style(from body[data-path*='roadmap']) from the roadmap.scss. Since it is defined here as none, the spinner was not showing up in the roadmap section and as a result 
```
document.body.classList.remove('loading');
```
from [roadmap-page.js#L27](https://github.com/GoogleChrome/chromium-dashboard/blob/4ab0c110beba826891f7bcc351783c63382d50fa/static/js-src/roadmap-page.js#L27) is useless. Because spinner display is none, instead it should be flex which is defined in [main.scss#L14](https://github.com/GoogleChrome/chromium-dashboard/blob/4ab0c110beba826891f7bcc351783c63382d50fa/static/sass/main.scss#L14)


Before:
![Screenshot (18)](https://user-images.githubusercontent.com/62694340/163861107-1edabd33-240b-40cb-aaa1-abea2ba22d4a.png)

After
![Screenshot (19)](https://user-images.githubusercontent.com/62694340/163861144-5080bdde-bf48-4b44-b384-c9ad0222c992.png)


And for centering the spinner  #1841 



