### PR TITLE
Extract URLs from text fields before rendering

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -413,11 +413,11 @@ class FlaskHandler(BaseHandler):
   def parse_link(self, param_name):
     link = flask.request.form.get(param_name) or None
     if link:
-      if not link.startswith('http'):
-        link = str('http://' + link)
-      else:
-        link = str(link)
-    return link
+      # see https://www.regextester.com/93901 for url regex
+      url_pattern = (r'\b([\w_-]+(?:(?:\.[\w_-]+)+))'
+                     r'([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?\b')
+      match_obj = re.search(url_pattern, str(link))
+    return 'http://' + match_obj.group() if match_obj else None
 
   def parse_int(self, param_name):
     param = flask.request.form.get(param_name) or None

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -417,9 +417,12 @@ class FlaskHandler(BaseHandler):
       url_pattern = (r'\b(http:\/\/|https:\/\/)?([\w_-]+(?:(?:\.[\w_-]+)+))'
                      r'([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?\b')
       match_obj = re.search(url_pattern, str(link))
-      link = match_obj.group() or None
-      if not link.startswith(('http://', 'https://')):
-        link = 'http://' + link
+      if match_obj:
+        link = match_obj.group()
+        if not link.startswith(('http://', 'https://')):
+          link = 'http://' + link
+      else:
+        link = None
     return link
 
   def parse_int(self, param_name):

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -414,10 +414,13 @@ class FlaskHandler(BaseHandler):
     link = flask.request.form.get(param_name) or None
     if link:
       # see https://www.regextester.com/93901 for url regex
-      url_pattern = (r'\b([\w_-]+(?:(?:\.[\w_-]+)+))'
+      url_pattern = (r'\b(http:\/\/|https:\/\/)?([\w_-]+(?:(?:\.[\w_-]+)+))'
                      r'([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?\b')
       match_obj = re.search(url_pattern, str(link))
-    return 'http://' + match_obj.group() if match_obj else None
+      link = match_obj.group() or None
+      if not link.startswith(('http://', 'https://')):
+        link = 'http://' + link
+    return link
 
   def parse_int(self, param_name):
     param = flask.request.form.get(param_name) or None


### PR DESCRIPTION
This is to fix #1484. Currently, the form fields that require URLs allow incomplete urls or other text that breaks links (even though all URL fields are validated on entry).

In this PR, I enhanced the ```parse_link``` function in ```basehandler.py``` to extract URLs from text fields and render them before concatenating additional text.

As an example, if you enter these urls:
<img src="https://user-images.githubusercontent.com/11501902/164120819-6c79792a-0708-4c9d-8278-db754a7e6eec.png" width="600px" />

Before (broken links)
<img src="https://user-images.githubusercontent.com/11501902/164120835-816e35fd-65b4-4c66-b345-f3c789795359.png" width="600px" />

After (either removed or trimmed)
<img src="https://user-images.githubusercontent.com/11501902/164120848-712cb3e5-bace-41ce-8ec3-020675cfbbc8.png" width="600px" />

