### PR TITLE
Update histograms data file branch name.

### DIFF
--- a/internals/fetchmetrics.py
+++ b/internals/fetchmetrics.py
@@ -32,7 +32,7 @@ import settings
 
 UMA_QUERY_SERVER = 'https://uma-export.appspot.com/chromestatus/'
 
-HISTOGRAMS_URL = 'https://chromium.googlesource.com/chromium/src/+/master/' \
+HISTOGRAMS_URL = 'https://chromium.googlesource.com/chromium/src/+/main/' \
     'tools/metrics/histograms/enums.xml?format=TEXT'
 
 # After we have processed all metrics data for a given kind on a given day,


### PR DESCRIPTION
This should resolve issue #1814.

We used the old URL for years to fetch an XML file that has a list of all the UseCounters for CSS or JS features.  However, it started giving stale results several weeks ago.   It turns out that the branch was renamed from master to main, and the newer changes were only on the main branch.  The fix is to update the branch name in the URL to get the latest version of that file.