### PR TITLE
Added href to chromedash-x-meter

### DIFF
--- a/static/elements/chromedash-x-meter.js
+++ b/static/elements/chromedash-x-meter.js
@@ -38,19 +38,29 @@ class ChromedashXMeter extends LitElement {
         padding: 3px 0;
         text-indent: 5px;
       }
-    `];
-  }
+      
+      a {
+        text-decoration: none;
+        color: var(--barchart-color);
+      }
 
-  showTimeline() {
-    window.location.href = this.href;
+      a:hover {
+        text-decoration: none;
+        color: var(--barchart-color);
+        cursor: pointer;
+      }
+
+    `];
   }
 
   render() {
     return html`
-      <div @click="${this.showTimeline}" style="width: ${(this.value / this.max * 100)}%">
-        <span>${this.value <= 0.000001 ? '<=0.000001%' : this.value + '%'}
-        </span>
-      </div>
+      <a href = "${this.href}">
+        <div style="width: ${(this.value / this.max * 100)}%">
+          <span>${this.value <= 0.000001 ? '<=0.000001%' : this.value + '%'}
+          </span>
+        </div>
+      </a>
     `;
   }
 }

--- a/static/elements/chromedash-x-meter.js
+++ b/static/elements/chromedash-x-meter.js
@@ -55,7 +55,7 @@ class ChromedashXMeter extends LitElement {
 
   render() {
     return html`
-      <a href = "${this.href}">
+      <a href="${this.href}">
         <div style="width: ${(this.value / this.max * 100)}%">
           <span>${this.value <= 0.000001 ? '<=0.000001%' : this.value + '%'}
           </span>


### PR DESCRIPTION
Fixes #1543 chromedash-x-meter doesn't produce valid links

Wrapped chromedash-x-meter html inside `<a>` tag and added text-decoration: none on hover.
I also removed showTimeline function, because the href will be able to redirect on click 

Before 
![Screenshot (22)](https://user-images.githubusercontent.com/62694340/164415027-3e8dcb3d-114d-4c57-8fa8-5f9e7e941345.png)

After
![Screenshot (23)](https://user-images.githubusercontent.com/62694340/164415080-68e69cb3-a31c-4baf-be80-156bf9e115db.png)
 
