### PR TITLE
Get JS unit tests passing, switch to assert, add tests.

### DIFF
--- a/static/elements/chromedash-process-overview_test.js
+++ b/static/elements/chromedash-process-overview_test.js
@@ -1,23 +1,60 @@
 import {html} from 'lit';
-import {expect, fixture} from '@open-wc/testing';
+import {assert, fixture} from '@open-wc/testing';
 import {ChromedashProcessOverview} from './chromedash-process-overview';
 
 describe('chromedash-proces-overview', () => {
-  it('renders element with no data, untyped fixture', async () => {
-    const container = await fixture(
-        html`<chromedash-process-overview></chromedash-process-overview>`);
-    expect(container).to.exist;
-    expect(typeof container).to.equal('object');
-    container.shadowRoot.querySelector<HTMLElement>('div');
+
+  let process, feature;
+
+  beforeEach(() => {
+    process = {
+      stages: [
+        {name: 'stage one',
+         description: 'a description',
+         progress_items: [],
+         outgoing_stage: 1,
+         actions: [],
+        }]
+    };
+    feature = {
+      id: 123456,
+      intent_stage_int: 1,
+    };
   });
 
-  it('renders element with no data, typed fixture', async () => {
-    const container = await fixture< ChromedashProcessOverview >(
-          html`<chromedash-process-overview></chromedash-process-overview>`);
-    expect(container).to.exist;
-    // I don't really expect the container to be boolean, but it is in this case.
-    expect(typeof container).to.equal('boolean');
-    // I really want to start testing the container as a DOM node of some kind:
-    // container.shadowRoot.querySelector<HTMLElement>('div');
+  it('renders with no data', async () => {
+    const component = await fixture(
+        html`<chromedash-process-overview></chromedash-process-overview>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashProcessOverview);
+    const stageHeader = component.shadowRoot.querySelector('th');
+    assert.exists(stageHeader);
   });
+
+  it('highlights the active stage', async () => {
+    const component = await fixture(
+        html`<chromedash-process-overview
+              .process=${process}
+              .feature=${feature}
+             ></chromedash-process-overview>`);
+    assert.exists(component);
+
+    const activeRow = component.shadowRoot.querySelector('tr.active');
+    assert.exists(activeRow);
+    assert.include(activeRow.innerHTML, 'stage one');
+  });
+
+  it('does not highlight when there is no active stage', async () => {
+    feature.intent_stage_int = 4;
+    const component = await fixture(
+        html`<chromedash-process-overview
+              .process=${process}
+              .feature=${feature}
+             ></chromedash-process-overview>`);
+    assert.exists(component);
+
+    const activeRow = component.shadowRoot.querySelector('tr.active');
+    assert.isNull(activeRow);
+  });
+
 });


### PR DESCRIPTION
In this PR:
* Remove typescript-like syntax that was a comparison in JS.
* Replace expect with assert
* Add a couple more tests and use beforeEach() to set up shared values that can be tweaked in certain tests