### PR TITLE
Autolink feature details and improve wrapping.

### DIFF
--- a/static/elements/chromedash-feature-detail.js
+++ b/static/elements/chromedash-feature-detail.js
@@ -1,7 +1,11 @@
 import {LitElement, css, html, nothing} from 'lit';
 import '@polymer/iron-icon';
 import './chromedash-callout';
+import {autolink} from './utils.js';
 import {SHARED_STYLES} from '../sass/shared-css.js';
+
+const LONG_TEXT = 60;
+
 
 class ChromedashFeatureDetail extends LitElement {
   static get properties() {
@@ -82,6 +86,11 @@ class ChromedashFeatureDetail extends LitElement {
         padding: var(--content-padding-half);
       }
 
+      .longurl {
+        display: block;
+        padding: var(--content-padding-half);
+      }
+
       .active {
         border: var(--spot-card-border);
         box-shadow: var(--spot-card-box-shadow);
@@ -143,16 +152,18 @@ class ChromedashFeatureDetail extends LitElement {
 
   renderText(value) {
     value = String(value);
-    if (value.length > 30 || value.includes('\n')) {
-      return html`<span class="longtext">${value}</span>`;
+    const markup = autolink(value);
+    if (value.length > LONG_TEXT || value.includes('\n')) {
+      return html`<span class="longtext">${markup}</span>`;
     }
-    return html`<span class="text">${value}</span>`;
+    return html`<span class="text">${markup}</span>`;
   }
 
   renderUrl(value) {
     if (value.startsWith('http')) {
       return html`
-        <a href=${value} target="_blank" class="url"
+        <a href=${value} target="_blank"
+           class="url ${value.length > LONG_TEXT ? 'longurl' : ''}"
            >${value}</a>
       `;
     }

--- a/static/elements/utils.js
+++ b/static/elements/utils.js
@@ -10,6 +10,6 @@ import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 export function autolink(s) {
   const markup = urlize(
     s,
-    {target: '_blank', trim: 'www', autoescape: true});
+    {target: '_blank', autoescape: true});
   return html`${unsafeHTML(markup)}`;
 }


### PR DESCRIPTION
Improve the usefulness and appearance of field values display on the feature detail page.

In this PR:
* Display strings up to 60 characters (rather than 30) on the same line as the label, because that is how many can fit.
* For long URLs, use a CSS class that displays the URL as a block element, which causes it to start on its own line.  This eliminates the current awkward wrapping behavior where the URL starts on the line of the label and then wraps back under the label.
* Autolink text values so that URLs are clickable.  But, don't remove the leading `http://` or `www` because our technical users may care about those details.