### PR TITLE
Add styling for invalid form field values

### DIFF
--- a/static/sass/_vars-css.js
+++ b/static/sass/_vars-css.js
@@ -16,6 +16,7 @@ export const VARS = css`
 
   --bar-shadow-color: rgba(0, 0, 0, .065);
   --bar-border-color: #D4D4D4;
+  --error-border-color: #FF0000;
 
   --chromium-color-dark: #366597;
   --chromium-color-medium: #85b4df;

--- a/static/sass/_vars.scss
+++ b/static/sass/_vars.scss
@@ -12,6 +12,7 @@ $nav-link-color: #444;
 
 $bar-shadow-color: rgba(0, 0, 0, .065);
 $bar-border-color: #D4D4D4;
+$error-border-color: #FF0000;
 
 $chromium-color-dark: #366597;
 $chromium-color-medium: #85b4df;

--- a/static/sass/shared-css.js
+++ b/static/sass/shared-css.js
@@ -59,6 +59,15 @@ export const SHARED_STYLES = [
   textarea {
     border: 1px solid var(--bar-border-color);
   }
+  input:not([type="submit"]):not([type="search"]):invalid:not(:focus) {
+    outline: 1px dotted var(--error-border-color);
+    background-color: #FFEDF5;
+  }
+  input:not([type="submit"]):not([type="search"]):invalid:not(:focus) ~ span::after {
+    color: $error-border-color;
+    content: ' (Currently invalid)';
+  }
+
   input:not([type="submit"])[disabled],
   textarea[disabled],
   button[disabled] {

--- a/static/sass/shared.scss
+++ b/static/sass/shared.scss
@@ -45,6 +45,14 @@ a:hover {
 input:not([type="submit"]), textarea {
   border: 1px solid $bar-border-color;
 }
+input:not([type="submit"]):not([type="search"]):invalid:not(:focus) {
+  outline: 1px dotted $error-border-color;
+  background-color: #FFEDF5;
+}
+input:not([type="submit"]):not([type="search"]):invalid:not(:focus) ~ span::after {
+  color: $error-border-color;
+  content: ' (Currently invalid)';
+}
 input:not([type="submit"])[disabled], textarea[disabled], button[disabled] {
   opacity: 0.5;
 }


### PR DESCRIPTION
In response to #1716, this PR adds styles to highlight invalid form field values.  The form fields already have the appropriate type="email" or type="url" attributes, and also "multiple" is generally true.  Consequently, the values are automatically validated, once entered.  Empty strings are not invalid, unless a form field is required.

The added styles include the ":invalid" pseudo-class.  We also include :not(:focus) so the style change does not show up until you leave the form field, since it is rather distracting to always see errors while still entering a value. 

Finally, we append " (currently invalid)" after the help text.
