### PR TITLE
Validate link scheme.

### DIFF
--- a/pages/guide.py
+++ b/pages/guide.py
@@ -311,7 +311,7 @@ class FeatureEditStage(basehandlers.FlaskHandler):
           'initial_public_proposal_url')
 
     if self.touched('explainer_links'):
-      feature.explainer_links = self.split_input('explainer_links')
+      feature.explainer_links = self.parse_links('explainer_links')
 
     if self.touched('bug_url'):
       feature.bug_url = self.parse_link('bug_url')
@@ -430,13 +430,13 @@ class FeatureEditStage(basehandlers.FlaskHandler):
       feature.owner = self.split_emails('owner')
 
     if self.touched('doc_links'):
-      feature.doc_links = self.split_input('doc_links')
+      feature.doc_links = self.parse_links('doc_links')
 
     if self.touched('measurement'):
       feature.measurement = self.form.get('measurement')
 
     if self.touched('sample_links'):
-      feature.sample_links = self.split_input('sample_links')
+      feature.sample_links = self.parse_links('sample_links')
 
     if self.touched('search_tags'):
       feature.search_tags = self.split_input('search_tags', delim=',')

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -1,6 +1,3 @@
-
-
-
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -265,23 +262,6 @@ class FeatureEditStageTest(testing_config.CustomTestCase):
       self.assertTrue(self.handler.touched('name'))
       self.assertFalse(self.handler.touched('summary'))
 
-  def test_split_input(self):
-    """We can parse items from multi-item text fields"""
-    with test_app.test_request_context(
-        'path', data={
-            'empty': '',
-            'colors': 'yellow\nblue',
-            'names': 'alice, bob',
-        }):
-      self.assertEqual([], self.handler.split_input('missing'))
-      self.assertEqual([], self.handler.split_input('empty'))
-      self.assertEqual(
-          ['yellow', 'blue'],
-          self.handler.split_input('colors'))
-      self.assertEqual(
-          ['alice', 'bob'],
-          self.handler.split_input('names', delim=','))
-
   def test_get__anon(self):
     """Anon cannot edit features, gets a redirect to viewing page."""
     testing_config.sign_out()
@@ -391,7 +371,7 @@ class FeatureEditStageTemplateTest(TestWithFeature):
         standardization=1, web_dev_views=models.DEV_NO_SIGNALS,
         impl_status_chrome=1)
     self.feature_1.put()
-    self.stage = models.INTENT_INCUBATE  # Shows first form  
+    self.stage = models.INTENT_INCUBATE  # Shows first form
     testing_config.sign_in('user1@google.com', 1234567890)
 
     with test_app.test_request_context(self.request_path):
@@ -423,7 +403,7 @@ class FeatureEditAllFieldsTemplateTest(TestWithFeature):
         standardization=1, web_dev_views=models.DEV_NO_SIGNALS,
         impl_status_chrome=1)
     self.feature_1.put()
-    self.stage = models.INTENT_INCUBATE  # Shows first form  
+    self.stage = models.INTENT_INCUBATE  # Shows first form
     testing_config.sign_in('user1@google.com', 1234567890)
 
     with test_app.test_request_context(self.request_path):
@@ -441,4 +421,3 @@ class FeatureEditAllFieldsTemplateTest(TestWithFeature):
         self.template_data, self.full_template_path)
     parser = html5lib.HTMLParser(strict=True)
     document = parser.parse(template_text)
-


### PR DESCRIPTION
This should resolve an issue that was reported to us via a review.

In this PR:
* Refactor the link parsing regexes into constants at the top of the file.
* Match any scheme, but then validate against a short list of allowed schemes
* Refactor the link parsing logic into a helper function that can be called from two places
* Define a new method `parse_links()` to actually parse links rather than just split text into lines
* Add unit tests