### PR TITLE
Detect intent links in an older format.

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -77,7 +77,7 @@ CHROMESTATUS_LINK_GENERATED_RE = re.compile(
     r'entry on the Chrome Platform Status:?\s+'
     r'[> ]*https?://(www\.)?chromestatus\.com/feature/(?P<id>\d+)', re.I)
 CHROMESTATUS_LINK_ALTERNATE_RE = re.compile(
-    r'entry on the feature dashboard:?\s+'
+    r'entry on the feature dashboard.*\s+'
     r'[> ]*https?://(www\.)?chromestatus\.com/feature/(?P<id>\d+)', re.I)
 NOT_LGTM_RE = re.compile(
     r'\b(not|almost|need|want|missing) (a |an )?LGTM\b',

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -161,6 +161,17 @@ class FunctionTest(testing_config.CustomTestCase):
         5144822362931200,
         detect_intent.detect_feature_id(body))
 
+  def test_detect_feature_id__alternative_with_link(self):
+    """We can parse the feature ID from another common link."""
+    body = (
+        'blah blah blah\n'
+        'Entry on the feature dashboard: <http://www.chromestatus.com/>\n'
+        'https://chromestatus.com/feature/5144822362931200\n'
+        'blah blah blah')
+    self.assertEqual(
+        5144822362931200,
+        detect_intent.detect_feature_id(body))
+
   def test_detect_feature_id__quoted(self):
     """We can parse the feature ID from link in quoted body text."""
     body = (


### PR DESCRIPTION
This should resolve the second part of #1744.

We already detected the link to chromestatus in an older format like:
`Entry on the feature dashboard`, but if the user linked the word `dashboard` it will appear in the plain text email body like
`Entry on the feature dashboard <http://www.chromestatus.com/>`.  We don't need that trailing content because we are only using this line to identify the feature entry link which is on the next line.  So, we just match them with `.*`.