### PR TITLE
Store intent thread subject lines and use them.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -1270,10 +1270,14 @@ class Feature(DictModel):
 
   # Tracability to intent discussion threads
   intent_to_implement_url = ndb.StringProperty()
+  intent_to_implement_subject_line = ndb.StringProperty()
   intent_to_ship_url = ndb.StringProperty()
+  intent_to_ship_subject_line = ndb.StringProperty()
   ready_for_trial_url = ndb.StringProperty()
   intent_to_experiment_url = ndb.StringProperty()
+  intent_to_experiment_subject_line = ndb.StringProperty()
   intent_to_extend_experiment_url = ndb.StringProperty()
+  intent_to_extend_experiment_subject_line = ndb.StringProperty()
   # Currently, only one is needed.
   i2e_lgtms = ndb.StringProperty(repeated=True)
   i2s_lgtms = ndb.StringProperty(repeated=True)

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -274,6 +274,38 @@ BLINK_DEV_ARCHIVE_URL_PREFIX = (
 TEST_ARCHIVE_URL_PREFIX = (
     'https://groups.google.com/d/msgid/jrobbins-test/')
 
+
+def get_existing_thread_subject(feature, approval_field):
+  """If we have the subject line of the Google Groups thread, use it."""
+  # This improves message threading in gmail.
+
+  if approval_field == approval_defs.PrototypeApproval:
+    return feature.intent_to_implement_subject_line
+  # TODO(jrobbins): Ready-for-trial threads
+  elif approval_field == approval_defs.ExperimentApproval:
+    return feature.intent_to_experiment_subject_line
+  elif approval_field == approval_defs.ExtendExperimentApproval:
+    return feature.intent_to_extend_experiment_subject_line
+  elif approval_field == approval_defs.ShipApproval:
+    return feature.intent_to_ship_subject_line
+  else:
+    raise ValueError('Unexpected approval type')
+
+
+def generate_thread_subject(feature, approval_field):
+  """Use the expected subject based on the feature type and approval type."""
+  intent_phrase = approval_field.name
+  if feature.feature_type == models.FEATURE_TYPE_DEPRECATION_ID:
+    if approval_field == approval_defs.PrototypeApproval:
+      intent_phrase = 'Intent to Deprecate and Remove'
+    if approval_field == approval_defs.ExperimentApproval:
+      intent_phrase = 'Request for Deprecation Trial'
+    if approval_field == approval_defs.ExtendExperimentApproval:
+      intent_phrase = 'Intent to Extend Deprecation Trial'
+
+  return '%s: %s' % (intent_phrase, feature.name)
+
+
 def get_thread_id(feature, approval_field):
   """If we have the URL of the Google Groups thread, we can get its ID."""
   if approval_field == approval_defs.PrototypeApproval:
@@ -308,7 +340,9 @@ def post_comment_to_mailing_list(
   to_addr = settings.REVIEW_COMMENT_MAILING_LIST
   from_user = author_addr.split('@')[0]
   approval_field = approval_defs.APPROVAL_FIELDS_BY_ID[approval_field_id]
-  subject = 'Re: %s: %s' % (approval_field.name, feature.name)
+  subject = (get_existing_thread_subject(feature, approval_field) or
+             generate_thread_subject(feature, approval_field))
+  subject = 'Re: ' + subject
   thread_id = get_thread_id(feature, approval_field)
   references = None
   if thread_id:

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -342,7 +342,8 @@ def post_comment_to_mailing_list(
   approval_field = approval_defs.APPROVAL_FIELDS_BY_ID[approval_field_id]
   subject = (get_existing_thread_subject(feature, approval_field) or
              generate_thread_subject(feature, approval_field))
-  subject = 'Re: ' + subject
+  if not subject.startswith('Re: '):
+    subject = 'Re: ' + subject
   thread_id = get_thread_id(feature, approval_field)
   references = None
   if thread_id:

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -389,6 +389,69 @@ class FunctionsTest(testing_config.CustomTestCase):
         notifier.get_thread_id(
             self.feature_1, approval_defs.ShipApproval))
 
+  def test_get_existing_thread_subject__none(self):
+    """If a feature does not store an existing thread subject, use None."""
+    self.assertIsNone(notifier.get_existing_thread_subject(
+        self.feature_1, approval_defs.PrototypeApproval))
+
+  def test_get_existing_thread_subject__found(self):
+    """If a feature does not store an existing thread subject, use it."""
+    self.feature_1.intent_to_ship_subject_line = (
+        'Intent to really ship: feature one')
+    actual = notifier.get_existing_thread_subject(
+        self.feature_1, approval_defs.ShipApproval)
+    self.assertEqual('Intent to really ship: feature one', actual)
+
+  def test_get_existing_thread_subject__unknown(self):
+    """Raise ValueError if called with an unknown approval field."""
+    PivotApproval = approval_defs.ApprovalFieldDef(
+        'Intent to Pivot',
+        'One API Owner must approve your intent',
+        99, approval_defs.ONE_LGTM, [])
+    with self.assertRaises(ValueError):
+      notifier.get_existing_thread_subject(
+          self.feature_1, PivotApproval)
+
+  def test_generate_thread_subject__normal(self):
+    """Most intents just use the name of the intent."""
+    self.assertEqual(
+        'Intent to Prototype: feature one',
+        notifier.generate_thread_subject(
+            self.feature_1, approval_defs.PrototypeApproval))
+    self.assertEqual(
+        'Intent to Experiment: feature one',
+        notifier.generate_thread_subject(
+            self.feature_1, approval_defs.ExperimentApproval))
+    self.assertEqual(
+        'Intent to Extend Experiment: feature one',
+        notifier.generate_thread_subject(
+            self.feature_1, approval_defs.ExtendExperimentApproval))
+    self.assertEqual(
+        'Intent to Ship: feature one',
+        notifier.generate_thread_subject(
+            self.feature_1, approval_defs.ShipApproval))
+
+  def test_generate_thread_subject__deprecation(self):
+    """Deprecation intents use different subjects for most intents."""
+    self.feature_1.feature_type = models.FEATURE_TYPE_DEPRECATION_ID
+    self.assertEqual(
+        'Intent to Deprecate and Remove: feature one',
+        notifier.generate_thread_subject(
+            self.feature_1, approval_defs.PrototypeApproval))
+    self.assertEqual(
+        'Request for Deprecation Trial: feature one',
+        notifier.generate_thread_subject(
+            self.feature_1, approval_defs.ExperimentApproval))
+    self.assertEqual(
+        'Intent to Extend Deprecation Trial: feature one',
+        notifier.generate_thread_subject(
+            self.feature_1, approval_defs.ExtendExperimentApproval))
+    self.assertEqual(
+        'Intent to Ship: feature one',
+        notifier.generate_thread_subject(
+            self.feature_1, approval_defs.ShipApproval))
+
+
   def test_get_thread_id__trailing_junk(self):
     """We can select the correct approval thread field of a feature."""
     self.feature_1.intent_to_implement_url += '?param=val#anchor'


### PR DESCRIPTION
This should resolve issue #1764.

Since users ultimately send intent email messages themselves, they sometimes use variations on the subject line.  When the app posts a comment to the intent thread, it has been using a thread ID in the email headers and generating an expected subject line.  Google Groups seems to just check the email header.  Gmail seems to only group emails into a conversation if both the email header and the subject line to match.

In this PR:
* Add a DB field to store the actual subject line that we detect when we detect an intent thread.
* When posting a reply, use that stored subject line if present.
* When not stored, handle some additional cases of expected subject lines for deprecations.
* Also, improve detection of the subject line for extending a deprecation trial.

