### PR TITLE
Show "Edit" links for active stage and in missing prereqs dialog

### DIFF
--- a/static/elements/chromedash-process-overview.js
+++ b/static/elements/chromedash-process-overview.js
@@ -99,6 +99,8 @@ export class ChromedashProcessOverview extends LitElement {
         margin-left: var(--content-padding-half);
       }
 
+      .active .edit-progress-item,
+      .missing-prereqs .edit-progress-item,
       .pending:hover .edit-progress-item,
       .done:hover .edit-progress-item {
         visibility: visible;


### PR DESCRIPTION
As per discussion in WebStatus meeting, the "Edit" links should be visible even when not hovering in the "missing prereqs" dialog and in the active stage.
