### PR TITLE
Include all_platforms in both i2e and i2s.

### DIFF
--- a/internals/processes.py
+++ b/internals/processes.py
@@ -499,7 +499,7 @@ INTENT_EMAIL_SECTIONS = {
         'i2p_thread', 'experiment', 'extension_reason'],
     models.INTENT_SHIP: [
         'need_api_owners_lgtms', 'i2p_thread', 'tracking_bug', 'sample_links',
-        'anticipated_spec_changes'],
+        'anticipated_spec_changes', 'ship'],
     models.INTENT_REMOVED: [],
     models.INTENT_SHIPPED: [],
     models.INTENT_PARKED: [],

--- a/pages/intentpreview_test.py
+++ b/pages/intentpreview_test.py
@@ -79,7 +79,7 @@ class IntentEmailPreviewHandlerTest(testing_config.CustomTestCase):
     self.assertIn('feature', actual_data)
     self.assertEqual('feature one', actual_data['feature']['name'])
 
-  def test_get_page_data(self):
+  def test_get_page_data__implement(self):
     """page_data has correct values."""
     feature_id = self.feature_1.key.integer_id()
     with test_app.test_request_context(self.request_path):
@@ -93,6 +93,20 @@ class IntentEmailPreviewHandlerTest(testing_config.CustomTestCase):
         page_data['sections_to_show'])
     self.assertEqual(
         'Intent to Prototype',
+        page_data['subject_prefix'])
+
+  def test_get_page_data__ship(self):
+    """page_data has correct values."""
+    feature_id = self.feature_1.key.integer_id()
+    with test_app.test_request_context(self.request_path):
+      page_data = self.handler.get_page_data(
+          feature_id, self.feature_1, models.INTENT_SHIP)
+    self.assertEqual(
+        'http://localhost/feature/%d' % feature_id,
+        page_data['default_url'])
+    self.assertIn('ship', page_data['sections_to_show'])
+    self.assertEqual(
+        'Intent to Ship',
         page_data['subject_prefix'])
 
   def test_compute_subject_prefix__incubate_new_feature(self):

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -168,7 +168,7 @@
 <br><br><h4>Debuggability</h4>
 <p class="preformatted">{{feature.debuggability|urlize}}</p>
 
-{% if 'experiment' in sections_to_show %}
+{% if 'experiment' in sections_to_show or 'ship' in sections_to_show %}
   <br><br><h4>Will this feature be supported on all six Blink platforms
       (Windows, Mac, Linux, Chrome OS, Android, and Android WebView)?</h4>
   {% if feature.all_platforms %}Yes{% else %}No{% endif %}


### PR DESCRIPTION
This should resolve issue #1498.

We now include the all_platforms field in the generated intent email for both the i2e and i2s steps (but not i2p).
