### PR TITLE
Fix bolding in various places

### DIFF
--- a/static/sass/shared-css.js
+++ b/static/sass/shared-css.js
@@ -10,7 +10,7 @@ export const SHARED_STYLES = [
   * {
     box-sizing: border-box;
     list-style: none;
-    font: inherit;
+     /* font: inherit; */
     text-decoration: inherit;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   }

--- a/static/sass/shared.scss
+++ b/static/sass/shared.scss
@@ -5,7 +5,7 @@
 * {
   box-sizing: border-box;
   list-style: none;
-  font: inherit;
+  // font: inherit;
   text-decoration: inherit;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -41,7 +41,7 @@ limitations under the License.
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300&amp;display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300,400,500&amp;display=swap" rel="stylesheet">
 
   {% block meta %}{% endblock %}
 

--- a/templates/guide/new.html
+++ b/templates/guide/new.html
@@ -34,7 +34,7 @@
       </tr>
       {{ overview_form }}
       <tr>
-        <th>Feature type:</th>
+        <th><b>Feature type:</b></th>
         <td class="choices" style="padding-top:0">
           <div>
             <label for="id_feature_type_0">

--- a/templates/guide/stage.html
+++ b/templates/guide/stage.html
@@ -32,7 +32,7 @@
       {{ feature_form }}
 
       <tr>
-        <th>Process stage:</th>
+        <th><b>Process stage:</b></th>
         <td>
           {% if already_on_this_stage %}
             This feature is already in stage <b>{{ stage_name }}</b>.


### PR DESCRIPTION
Bold headers on Process Overview and Form Field editors got lost due to default font: inherit, and missing bold fonts.