### PR TITLE
Detect intents where user linked to feature edit page.

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -76,10 +76,12 @@ def detect_field(subject):
 
 CHROMESTATUS_LINK_GENERATED_RE = re.compile(
     r'entry on the Chrome Platform Status:?\s+'
-    r'[> ]*https?://(www\.)?chromestatus\.com/feature/(?P<id>\d+)', re.I)
+    r'[> ]*https?://(www\.)?chromestatus\.com/'
+    r'(feature|edit)/(?P<id>\d+)', re.I)
 CHROMESTATUS_LINK_ALTERNATE_RE = re.compile(
     r'entry on the feature dashboard.*\s+'
-    r'[> ]*https?://(www\.)?chromestatus\.com/feature/(?P<id>\d+)', re.I)
+    r'[> ]*https?://(www\.)?chromestatus\.com/'
+    r'(feature|edit)/(?P<id>\d+)', re.I)
 NOT_LGTM_RE = re.compile(
     r'\b(not|almost|need|want|missing) (a |an )?LGTM\b',
     re.I)

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -77,11 +77,11 @@ def detect_field(subject):
 CHROMESTATUS_LINK_GENERATED_RE = re.compile(
     r'entry on the Chrome Platform Status:?\s+'
     r'[> ]*https?://(www\.)?chromestatus\.com/'
-    r'(feature|edit)/(?P<id>\d+)', re.I)
+    r'(feature|guide/edit)/(?P<id>\d+)', re.I)
 CHROMESTATUS_LINK_ALTERNATE_RE = re.compile(
     r'entry on the feature dashboard.*\s+'
     r'[> ]*https?://(www\.)?chromestatus\.com/'
-    r'(feature|edit)/(?P<id>\d+)', re.I)
+    r'(feature|guide/edit)/(?P<id>\d+)', re.I)
 NOT_LGTM_RE = re.compile(
     r'\b(not|almost|need|want|missing) (a |an )?LGTM\b',
     re.I)

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -133,7 +133,7 @@ class FunctionTest(testing_config.CustomTestCase):
     body = (
         'blah blah blah\n'
         'Link to entry on the Chrome Platform Status\n'
-        'https://www.chromestatus.com/edit/5144822362931200\n'
+        'https://www.chromestatus.com/guide/edit/5144822362931200\n'
         'blah blah blah')
     self.assertEqual(
         5144822362931200,
@@ -166,7 +166,7 @@ class FunctionTest(testing_config.CustomTestCase):
     body = (
         'blah blah blah\n'
         'Entry on the feature dashboard\n'
-        'https://www.chromestatus.com/edit/5144822362931200\n'
+        'https://www.chromestatus.com/guide/edit/5144822362931200\n'
         'blah blah blah')
     self.assertEqual(
         5144822362931200,

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -128,6 +128,17 @@ class FunctionTest(testing_config.CustomTestCase):
         5144822362931200,
         detect_intent.detect_feature_id(body))
 
+  def test_detect_feature_id__generated_edit(self):
+    """We can parse the feature ID from a link in the generated body."""
+    body = (
+        'blah blah blah\n'
+        'Link to entry on the Chrome Platform Status\n'
+        'https://www.chromestatus.com/edit/5144822362931200\n'
+        'blah blah blah')
+    self.assertEqual(
+        5144822362931200,
+        detect_intent.detect_feature_id(body))
+
   def test_detect_feature_id__generated_no_www(self):
     """We can parse the feature ID from a link in the generated body."""
     body = (
@@ -145,6 +156,17 @@ class FunctionTest(testing_config.CustomTestCase):
         'blah blah blah\n'
         'Entry on the feature dashboard\n'
         'https://www.chromestatus.com/feature/5144822362931200\n'
+        'blah blah blah')
+    self.assertEqual(
+        5144822362931200,
+        detect_intent.detect_feature_id(body))
+
+  def test_detect_feature_id__alternative_edit(self):
+    """We can parse the feature ID from another common link."""
+    body = (
+        'blah blah blah\n'
+        'Entry on the feature dashboard\n'
+        'https://www.chromestatus.com/edit/5144822362931200\n'
         'blah blah blah')
     self.assertEqual(
         5144822362931200,


### PR DESCRIPTION
When a feature owner sends an intent email, they are supposed to link to the feature detail page, e.g.,
`hitps://chromestatus.com/feature/123456789`
However, some at least one user pasted in the URL themselves and they choose to paste in the feature editing page URL, e.g.,
`hitps://chromestatus.com/guide/edit\123456789`

This change allows us to detect either URL.