### PR TITLE
Add anti-framing header to all responses.

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -144,6 +144,7 @@ class APIHandler(BaseHandler):
         'Strict-Transport-Security':
             'max-age=63072000; includeSubDomains; preload',
         'X-UA-Compatible': 'IE=Edge,chrome=1',
+        'X-Frame-Options': 'DENY',
         }
     return headers
 
@@ -267,6 +268,7 @@ class FlaskHandler(BaseHandler):
         'Strict-Transport-Security':
             'max-age=63072000; includeSubDomains; preload',
         'X-UA-Compatible': 'IE=Edge,chrome=1',
+        'X-Frame-Options': 'DENY',
         }
     headers.update(self.get_cache_headers())
     return headers

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -312,6 +312,7 @@ class APIHandlerTests(testing_config.CustomTestCase):
         {'Strict-Transport-Security':
              'max-age=63072000; includeSubDomains; preload',
          'X-UA-Compatible': 'IE=Edge,chrome=1',
+         'X-Frame-Options': 'DENY',
          },
         actual)
 
@@ -449,6 +450,7 @@ class FlaskHandlerTests(testing_config.CustomTestCase):
         {'Strict-Transport-Security':
              'max-age=63072000; includeSubDomains; preload',
          'X-UA-Compatible': 'IE=Edge,chrome=1',
+         'X-Frame-Options': 'DENY',
          },
         actual)
 


### PR DESCRIPTION
Add anti-framing header as per recommendations about clickjacking defense.