### PR TITLE
Enable CORS  for data/*

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -61,7 +61,6 @@ PATH_PARAMS_ANCHOR_PATTERN = r'([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?'
 URL_RE = re.compile(r'\b%s%s%s\b' % (
     SCHEME_PATTERN, DOMAIN_PATTERN, PATH_PARAMS_ANCHOR_PATTERN))
 ALLOWED_SCHEMES = [None, 'http', 'https']
-CORS_ALLOW_LIST = ['*']
 
 
 class BaseHandler(flask.views.MethodView):
@@ -518,7 +517,7 @@ def FlaskApplication(import_name, routes, pattern_base='', debug=False):
   # template source code, but we use django for that.
 
   # Set the CORS HEADERS.
-  CORS(app, resources={r"/data/*": {"origins": CORS_ALLOW_LIST}})
+  CORS(app, resources={r'/data/*': {'origins': '*'}})
 
   # Set cookie headers in Flask; see
   # https://flask.palletsprojects.com/en/2.0.x/config/

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -41,6 +41,7 @@ import django
 
 from google.auth.transport import requests
 from flask import session
+from flask_cors import CORS
 import sys
 
 # Initialize django so that it'll function when run as a standalone script.
@@ -60,6 +61,7 @@ PATH_PARAMS_ANCHOR_PATTERN = r'([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?'
 URL_RE = re.compile(r'\b%s%s%s\b' % (
     SCHEME_PATTERN, DOMAIN_PATTERN, PATH_PARAMS_ANCHOR_PATTERN))
 ALLOWED_SCHEMES = [None, 'http', 'https']
+CORS_ALLOW_LIST = ['*']
 
 
 class BaseHandler(flask.views.MethodView):
@@ -514,6 +516,9 @@ def FlaskApplication(import_name, routes, pattern_base='', debug=False):
   app.config["TRAP_BAD_REQUEST_ERRORS"] = settings.DEV_MODE
   # Flask apps also have a debug setting that can be used to auto-reload
   # template source code, but we use django for that.
+
+  # Set the CORS HEADERS.
+  CORS(app, resources={r"/data/*": {"origins": CORS_ALLOW_LIST}})
 
   # Set cookie headers in Flask; see
   # https://flask.palletsprojects.com/en/2.0.x/config/

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -19,7 +19,6 @@ from unittest import mock
 import flask
 import flask.views
 import werkzeug.exceptions  # Flask HTTP stuff.
-from flask_cors import CORS
 
 # from google.appengine.api import users
 from framework import users
@@ -452,19 +451,6 @@ class FlaskHandlerTests(testing_config.CustomTestCase):
              'max-age=63072000; includeSubDomains; preload',
          'X-UA-Compatible': 'IE=Edge,chrome=1',
          'X-Frame-Options': 'DENY',
-         },
-        actual)
-
-  def test_get_CORS_headers(self):
-    """Test CORS headers for intended APIs."""
-    CORS(test_app, resources={r'/fakepath/*': {'origins': '*'}})
-    with test_app.test_request_context('/fakepath/path'):
-      actual = self.handler.get_headers()
-    self.assertEqual(
-        {'Strict-Transport-Security':
-             'max-age=63072000; includeSubDomains; preload',
-         'Access-Control-Allow-Origin': '*',
-         'X-UA-Compatible': 'IE=Edge,chrome=1',
          },
         actual)
 

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -19,6 +19,7 @@ from unittest import mock
 import flask
 import flask.views
 import werkzeug.exceptions  # Flask HTTP stuff.
+from flask_cors import CORS
 
 # from google.appengine.api import users
 from framework import users
@@ -456,7 +457,8 @@ class FlaskHandlerTests(testing_config.CustomTestCase):
 
   def test_get_CORS_headers(self):
     """Test CORS headers for intended APIs."""
-    with test_app.test_request_context('/data/path'):
+    CORS(test_app, resources={r'/fakepath/*': {'origins': '*'}})
+    with test_app.test_request_context('/fakepath/path'):
       actual = self.handler.get_headers()
     self.assertEqual(
         {'Strict-Transport-Security':

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -454,6 +454,18 @@ class FlaskHandlerTests(testing_config.CustomTestCase):
          },
         actual)
 
+  def test_get_CORS_headers(self):
+    """Test CORS headers for intended APIs."""
+    with test_app.test_request_context('/data/path'):
+      actual = self.handler.get_headers()
+    self.assertEqual(
+        {'Strict-Transport-Security':
+             'max-age=63072000; includeSubDomains; preload',
+         'Access-Control-Allow-Origin': '*',
+         'X-UA-Compatible': 'IE=Edge,chrome=1',
+         },
+        actual)
+
   def test_get_template_data__missing(self):
     """Every subsclass should overide get_template_data()."""
     self.handler = basehandlers.FlaskHandler()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ requests==2.27.1
 # TODO(jrobbins): Update to a 2.x version of flask, which may require source
 # code changes.
 Flask==1.1.2
+flask-cors==3.0.10
 funcsigs==1.0.2
 Jinja2==2.11.3
 MarkupSafe==1.1.1


### PR DESCRIPTION
Fix #1912. Enable CORS for `/data/*` through the flask-cors library