### PR TITLE
Fix checkboxes and disabled input autocomplete.

### DIFF
--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -69,6 +69,13 @@ class MultiUrlField(forms.Field):
 class ChromedashTextInput(forms.widgets.Input):
     template_name = 'django/forms/widgets/text.html'
 
+    def __init__(self, attrs=None):
+        default_attrs = {'autocomplete': 'off'}
+        if attrs:
+            default_attrs.update(attrs)
+        super().__init__(default_attrs)
+
+
 class ChromedashTextarea(forms.widgets.Textarea):
     template_name = 'django/forms/widgets/chromedash-textarea.html'
 

--- a/static/components.js
+++ b/static/components.js
@@ -8,6 +8,7 @@ import '@polymer/iron-iconset-svg';
 // Shoelace components
 // css is imported via _base.html in base.css, built by gulpfile.babel.js.
 import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/checkbox/checkbox.js';
 import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 import '@shoelace-style/shoelace/dist/components/details/details.js';
 import '@shoelace-style/shoelace/dist/components/input/input.js';

--- a/templates/django/forms/widgets/checkbox.html
+++ b/templates/django/forms/widgets/checkbox.html
@@ -1,0 +1,8 @@
+<sl-checkbox
+    name="{{ widget.name }}"
+    {% if widget.value != None %} 
+    value="{{ widget.value|stringformat:'s' }}"
+    {% endif %}
+    size="small"
+    {% include "django/forms/widgets/attrs.html" %}>
+</sl-checkbox>

--- a/templates/django/forms/widgets/input.html
+++ b/templates/django/forms/widgets/input.html
@@ -4,6 +4,5 @@
     value="{{ widget.value|stringformat:'s' }}"
     {% endif %}
     size="small"
-    {% include "django/forms/widgets/attrs.html" %}
-    autocomplete="off">
+    {% include "django/forms/widgets/attrs.html" %}>
 </sl-input>

--- a/templates/django/forms/widgets/input.html
+++ b/templates/django/forms/widgets/input.html
@@ -1,8 +1,9 @@
-<sl-input type="{{ widget.type }}" 
+<sl-input type="{{ widget.type }}"
     name="{{ widget.name }}"
-    {% if widget.value != None %} 
+    {% if widget.value != None %}
     value="{{ widget.value|stringformat:'s' }}"
     {% endif %}
     size="small"
-    {% include "django/forms/widgets/attrs.html" %}>
+    {% include "django/forms/widgets/attrs.html" %}
+    autocomplete="off">
 </sl-input>


### PR DESCRIPTION
In this PR:
* Disable autocomplete on our django form use of `<sl-input>` fields because choosing an autocomplete value causes the input text to turn to an unreadable light blue color in Chrome.   The underlying bug *might* be related to https://bugs.chromium.org/p/chromium/issues/detail?id=649162
* Add a template for checkboxes that uses `<sl-checkbox>` because implicitly using `<sl-input type=checkbox>` is not how shoelace works.