### PR TITLE
Cope with missing select values.

### DIFF
--- a/pages/guide.py
+++ b/pages/guide.py
@@ -197,6 +197,10 @@ class FeatureEditStage(basehandlers.FlaskHandler):
 
   TEMPLATE_PATH = 'guide/stage.html'
 
+  def find_fields_of_class(self, fieldClass):
+    return [field_name for field_name in guideforms.ALL_FIELDS
+            if isinstance(guideforms.ALL_FIELDS[field_name], fieldClass)]
+
   def touched(self, param_name):
     """Return True if the user edited the specified field."""
     # TODO(jrobbins): for now we just consider everything on the current form
@@ -206,9 +210,7 @@ class FeatureEditStage(basehandlers.FlaskHandler):
 
     # For now, checkboxes are always considered "touched", if they are
     # present on the form.
-    # TODO(jrobbins): Simplify this after next deployment.
-    checkboxes = ('unlisted', 'all_platforms', 'wpt', 'prefixed', 'api_spec',
-                  'requires_embedder_support')
+    checkboxes = self.find_fields_of_class(forms.BooleanField)
     if param_name in checkboxes:
       form_fields_str = self.form.get('form_fields')
       if form_fields_str:
@@ -217,6 +219,14 @@ class FeatureEditStage(basehandlers.FlaskHandler):
         return param_name in form_fields
       else:
         return True
+
+    # For now, selects are considered "touched", if they are
+    # present on the form and are not empty strings.
+    selects = self.find_fields_of_class(forms.ChoiceField)
+    if param_name in selects:
+      return self.form.get(param_name)
+
+    # See TODO at top of this method.
     return param_name in self.form
 
   def get_blink_component_from_bug(self, blink_components, bug_url):


### PR DESCRIPTION
This should resolve the errors that we started seeing when running locally today.

In this PR:
* Continue our short-term strategy of processing all values contained in POST data, and also any boolean fields that belong on the current form (as specified in the 'form_fields' hidden field).
* Compute the list of known checkbox fields by using ALL_FIELDS rather than a hard-coded list of strings.
* Add a new case for known select fields that also uses ALL_FIELDS.  Don't consider the empty string to be a 'touched' value fo selects.
* Add unit tests.