### PR TITLE
Specify current value of sl-select widgets.

### DIFF
--- a/templates/django/forms/widgets/select.html
+++ b/templates/django/forms/widgets/select.html
@@ -1,6 +1,7 @@
-<sl-select 
+<sl-select
     name="{{ widget.name }}"
     size="small"
+    value="{{ widget.value|first }}"
     {% include "django/forms/widgets/attrs.html" %}>
   {% for group_name, group_choices, group_index in widget.optgroups %}
     {% if group_name %}
@@ -14,4 +15,3 @@
     {% endif %}
   {% endfor %}
 </sl-select>
-  


### PR DESCRIPTION
This sets the current value of a sl-select widget.

The value of widget.value seems to be an array of strings for some reason, so I am using the django `|first` filter to get the first string.  This seems to also work with the field has no value.