### PR TITLE
Avoid scrolling to top when opening approvals dialog.

### DIFF
--- a/static/elements/chromedash-feature-table.js
+++ b/static/elements/chromedash-feature-table.js
@@ -188,7 +188,7 @@ class ChromedashFeatureTable extends LitElement {
 
   renderApprovalsIcon(feature) {
     return html`
-      <a href="#" class="tooltip"
+      <a class="tooltip"
         @click="${() => this.openApprovalsDialog(feature.id)}"
         title="Review approvals">
         <iron-icon icon="chromestatus:approval"></iron-icon>

--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -210,7 +210,7 @@ class ChromedashFeature extends LitElement {
         <h2><a href="/feature/${this.feature.id}">${this.feature.name}</a>
           ${this.canApprove ? html`
             <span class="tooltip" title="Review approvals">
-              <a href="#" id="approvals-icon" data-tooltip
+              <a id="approvals-icon" data-tooltip
                  @click="${() => this.openApprovalsDialog(this.feature.id)}">
                 <iron-icon icon="chromestatus:approval"></iron-icon>
               </a>


### PR DESCRIPTION
Having the `href="#"` cause the page to always scroll to the top.  It is not noticeable if there is a short list of features because the page fits in the window anyway.  But, when working through a long list of features, it is very annoying to have each dialog box scroll to the top so that the user needs to scroll down again before continuing to the next feature in the list.

Removing the `href="#"` seems to resolve the problem.  These links were not real links anyway, they have an @click handler.