### PR TITLE
Make non-django form header fields match django-generated ones.

### DIFF
--- a/templates/guide/new.html
+++ b/templates/guide/new.html
@@ -34,7 +34,7 @@
       </tr>
       {{ overview_form }}
       <tr>
-        <th><b>Feature type:</b></th>
+        <th><label>Feature type:</label></th>
         <td class="choices" style="padding-top:0">
           <div>
             <label for="id_feature_type_0">

--- a/templates/guide/stage.html
+++ b/templates/guide/stage.html
@@ -32,7 +32,7 @@
       {{ feature_form }}
 
       <tr>
-        <th><b>Process stage:</b></th>
+        <th><label>Process stage:</label></th>
         <td>
           {% if already_on_this_stage %}
             This feature is already in stage <b>{{ stage_name }}</b>.


### PR DESCRIPTION
I think the django-generated ones used to be bold, so the ones I added in django templates had `<b>` to match, but somewhere along the line the django-generated ones stopped being bold.