### PR TITLE
Add CSS rules for chromedash-select.

### DIFF
--- a/static/sass/forms.scss
+++ b/static/sass/forms.scss
@@ -128,7 +128,8 @@ chromedash-textarea[invalid]::part(textarea)
   background-color: #FFEDF5;
 }
 
-sl-select[size="small"] sl-menu-item::part(base) {
+sl-select[size="small"] sl-menu-item::part(base),
+chromedash-select[size="small"] sl-menu-item::part(base) {
   font-size: 12px;  /* == --sl-font-size-x-small */
   padding: 0px;
 }
@@ -139,13 +140,15 @@ sl-select[size="small"] sl-menu-item::part(base) {
 }
 
 /* menu items for selects should not be displayed at all, until defined */
+chromedash-select sl-menu-item:not(:defined),
 sl-select sl-menu-item:not(:defined) {
-   display: none 
+   display: none
 }
 
 /* Hide extra br following display:block elements */
-chromedash-textarea+br,
-sl-select+br,
-sl-input+br {
+chromedash-textarea + br,
+sl-select + br,
+chromedash-select + br,
+sl-input + br {
   display: none;
 }


### PR DESCRIPTION
You had made some refinements to the CSS for sl-select elements.
When we replaced sl-select with chromedash-select, those tweaks stopped being applied.
This PR adds them back for chrome status-select.