### PR TITLE
Eliminate unneeded env_vars.yaml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,6 @@ You will need to activate the venv in every shell that you use.
 
 If you encounter any error during the installation process, the section **Notes** (later in this README.md) may help.
 
-##### Add env_vars.yaml
-
-Create a file named `env_vars.yaml` in the root directory and fill it with:
-
-```yaml
-env_variables:
-  DJANGO_SETTINGS_MODULE: 'settings'
-  DJANGO_SECRET: 'this-is-a-secret'
-```
-
 ### Developing
 
 To start the main server and the notifier backend, run:

--- a/app.yaml
+++ b/app.yaml
@@ -29,13 +29,12 @@ handlers:
   script: auto
   secure: always
 
-includes:
-- env_vars.yaml
-
 app_engine_apis: true
 
 env_variables:
   GAE_USE_SOCKETS_HTTPLIB : ''
+  DJANGO_SETTINGS_MODULE: 'settings'
+  DJANGO_SECRET: 'this-is-a-secret'
 
 inbound_services:
 - mail

--- a/notifier.yaml
+++ b/notifier.yaml
@@ -12,5 +12,6 @@ handlers:
 
 app_engine_apis: true
 
-includes:
-- env_vars.yaml
+env_variables:
+  DJANGO_SETTINGS_MODULE: 'settings'
+  DJANGO_SECRET: 'this-is-a-secret'


### PR DESCRIPTION
I believe the rationale for creating a separate file for the environment variables was so that the django session secret could be kept out of version control.  However, we never used the django session secret.   We do use the Flask session secret, but that is stored in datastore rather than in any source file.

Eliminating this file and putting the contents of it directly into the other yaml files simplifies our source code organization and removes one step needed to set up a new developer workspace.