### PR TITLE
Fix UI behavior afte saving user prefs.

### DIFF
--- a/pages/users.py
+++ b/pages/users.py
@@ -56,10 +56,13 @@ class SettingsHandler(basehandlers.FlaskHandler):
     user_pref = models.UserPref.get_signed_in_user_pref()
     if not user_pref:
       return flask.redirect(settings.LOGIN_PAGE_URL)
+    referer = self.request.headers.get('Referer', '')
+    recently_saved = referer.endswith('/settings')
 
     template_data = {
         'user_pref': user_pref,
         'user_pref_form': models.UserPrefForm(user_pref.to_dict()),
+        'recently_saved': recently_saved,
     }
     return template_data
 
@@ -73,4 +76,4 @@ class SettingsHandler(basehandlers.FlaskHandler):
                  user_pref.email, new_notify)
     user_pref.notify_as_starrer = bool(new_notify)
     user_pref.put()
-    return flask.redirect('/admin/users/new')
+    return flask.redirect('/settings')

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -29,5 +29,11 @@
 {% block js %}
 <script nonce="{{nonce}}">
   document.body.classList.remove('loading');
+
+  {% if recently_saved %}
+    const toastEl = document.querySelector('chromedash-toast');
+    setTimeout(() => {toastEl.showMessage('Settings saved')}, 500);
+  {% endif %}
+
 </script>
 {% endblock %}


### PR DESCRIPTION
There was a bug where the user submitted their settings form and then they were redirected to the admin screen to add a new users.  For most users that admin page was a 403 forbidden.

In this PR:
+ Fix the redirect to keep the user on the settings page after form submission.
+ Add a django page data variable to indicate that the page should show a "settings saved" toast if the user submits the form.
+ Add a little bit of JS on the page to actually show that message in the existing chromium-toast element.