### PR TITLE
Avoid a lint warning on datatlist options.

### DIFF
--- a/static/elements/chromedash-timeline.js
+++ b/static/elements/chromedash-timeline.js
@@ -266,7 +266,7 @@ ORDER BY yyyymmdd DESC, client`;
       <input id="datalistinput" type="search" list="features" placeholder="Select or search a property" @change="${this.updateSelectedBucketId}" />
       <datalist id="features">
         ${this.props.map((prop) => html`
-          <option value="${prop[1]}" dataset-debug-bucket-id="${prop[0]}" />
+          <option value="${prop[1]}" dataset-debug-bucket-id="${prop[0]}"></option>
         `)}
       </datalist>
       <label>Show all historical data: <input type="checkbox" ?checked="${this.showAllHistoricalData}" @change="${this.toggleShowAllHistoricalData}"></label>


### PR DESCRIPTION
Running `npm run lint` reports a single warning saying that this `<option>` tag is not closed.  It still gives the warning when ending the tag with `/>` or `>`.  I believe that `<option>` does not need to be closed according to the HTML spec.  So, this is only to avoid that lint warning.  There is no change to the page as it looks or works in a browser.