### PR TITLE
Use long Expires with GAE version as buster.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -8,6 +8,10 @@ automatic_scaling:
   min_idle_instances: 1
   max_pending_latency: 0.2s
 
+# Use a long HTTP cache expiration time for css and JS, but also
+# include the GAE version number as a query string parameter so that on
+# each deployment, users get new static files to match the new app version.
+default_expiration: "10d"
 
 handlers:
 # Static handlers ---------------------------------------------------------------

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -296,6 +296,8 @@ class FlaskHandler(BaseHandler):
   def get_common_data(self, path=None):
     """Return template data used on all pages, e.g., sign-in info."""
     current_path = path or flask.request.full_path
+    # Used to make browser load new JS and CSS for each GAE version.
+    app_version = os.environ.get('GAE_VERSION', 'Undeployed')
     common_data = {
       'prod': settings.PROD,
       'APP_TITLE': settings.APP_TITLE,
@@ -304,6 +306,7 @@ class FlaskHandler(BaseHandler):
       'TEMPLATE_CACHE_TIME': settings.TEMPLATE_CACHE_TIME,
       'banner_message': settings.BANNER_MESSAGE,
       'banner_time': utils.get_banner_time(settings.BANNER_TIME),
+      'app_version': app_version,
     }
 
     user = self.get_current_user()

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -492,6 +492,7 @@ class FlaskHandlerTests(testing_config.CustomTestCase):
 
     self.assertIn('prod', actual)
     self.assertIsNone(actual['user'])
+    self.assertEqual(actual['app_version'], 'Undeployed')
 
   def test_get_common_data__signed_in(self):
     """When user is signed in, offer sign out link."""

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -24,7 +24,7 @@ limitations under the License.
 
   <meta name="theme-color" content="#366597">
 
-  <link rel="stylesheet" href="/static/css/base.css" />
+  <link rel="stylesheet" href="/static/css/base.css?v={{app_version}}" />
 
   <link rel="icon" sizes="192x192" href="/static/img/crstatus_192.png">
 
@@ -105,7 +105,7 @@ limitations under the License.
   </script>
 
   <script type="module" nonce="{{nonce}}" defer
-          src="/static/dist/components.js"></script>
+          src="/static/dist/components.js?v={{app_version}}"></script>
   {% block preload %}{% endblock %}
 
   {% block rss %}{% endblock%}

--- a/templates/admin/users/new.html
+++ b/templates/admin/users/new.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 
 {% block css %}
-  <link rel="stylesheet" href="/static/css/forms.css">
+  <link rel="stylesheet" href="/static/css/forms.css?v={{app_version}}">
 {% endblock %}
 
 {% block subheader %}

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -10,8 +10,8 @@
 {% endblock %}
 
 {% block css %}
-    <link rel="stylesheet" href="/static/css/forms.css">
-    <link rel="stylesheet" href="/static/css/guide.css">
+    <link rel="stylesheet" href="/static/css/forms.css?v={{app_version}}">
+    <link rel="stylesheet" href="/static/css/guide.css?v={{app_version}}">
 {% endblock %}
 
 {% block rss %}
@@ -78,7 +78,7 @@
 
 {% block content %}
   <!-- TODO(kevinshen56714): get feature_id from SPA router -->
-  <chromedash-feature-page 
+  <chromedash-feature-page
       featureId='{{ feature_id }}'>
   </chromedash-feature-page>
 

--- a/templates/guide/edit.html
+++ b/templates/guide/edit.html
@@ -1,8 +1,8 @@
 {% extends "_base.html" %}
 {% block page_title %}{{ feature.name }} - {% endblock %}
 {% block css %}
-<link rel="stylesheet" href="/static/css/forms.css">
-<link rel="stylesheet" href="/static/css/guide.css">
+<link rel="stylesheet" href="/static/css/forms.css?v={{app_version}}">
+<link rel="stylesheet" href="/static/css/guide.css?v={{app_version}}">
 {% endblock %}
 
 {% block subheader %}
@@ -44,6 +44,6 @@
 {% endblock %}
 
 {% block js %}
-<script src="/static/js/admin/process_overview_form.min.js"
+<script src="/static/js/admin/process_overview_form.min.js?v={{app_version}}"
         nonce="{{nonce}}"></script>
 {% endblock %}

--- a/templates/guide/editall.html
+++ b/templates/guide/editall.html
@@ -2,8 +2,8 @@
 {% block page_title %}{{ feature.name }} - {% endblock %}
 
 {% block css %}
-<link rel="stylesheet" href="/static/css/forms.css">
-<link rel="stylesheet" href="/static/css/guide.css">
+<link rel="stylesheet" href="/static/css/forms.css?v={{app_version}}">
+<link rel="stylesheet" href="/static/css/guide.css?v={{app_version}}">
 {% endblock %}
 
 {% block subheader %}

--- a/templates/guide/new.html
+++ b/templates/guide/new.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 
 {% block css %}
-<link rel="stylesheet" href="/static/css/forms.css">
+<link rel="stylesheet" href="/static/css/forms.css?v={{app_version}}">
 
 <!--
  The following style is a workaround to better support radio buttons
@@ -9,7 +9,7 @@
  We do depend on sl-focus-ring being defined.
 -->
 <style>
-table label input[type=radio]:focus { 
+table label input[type=radio]:focus {
   box-shadow: var(--sl-focus-ring);
 }
 </style>
@@ -101,6 +101,6 @@ table label input[type=radio]:focus {
 {% endblock %}
 
 {% block js %}
-<script src="/static/js/admin/process_overview_form.min.js"
+<script src="/static/js/admin/process_overview_form.min.js?v={{app_version}}"
         nonce="{{nonce}}"></script>
 {% endblock %}

--- a/templates/guide/stage.html
+++ b/templates/guide/stage.html
@@ -2,8 +2,8 @@
 {% block page_title %}{{ feature.name }} - {% endblock %}
 
 {% block css %}
-<link rel="stylesheet" href="/static/css/forms.css">
-<link rel="stylesheet" href="/static/css/guide.css">
+<link rel="stylesheet" href="/static/css/forms.css?v={{app_version}}">
+<link rel="stylesheet" href="/static/css/guide.css?v={{app_version}}">
 {% endblock %}
 
 {% block subheader %}
@@ -103,6 +103,6 @@
 {% endblock %}
 
 {% block js %}
-<script src="/static/js/admin/feature_form.min.js"
+<script src="/static/js/admin/feature_form.min.js?v={{app_version}}"
         nonce="{{nonce}}"></script>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 
 {% block css %}
-  <link rel="stylesheet" href="/static/css/forms.css">
+  <link rel="stylesheet" href="/static/css/forms.css?v={{app_version}}">
   <style>
     th, td { padding: 4px; }
     input[type="submit"] { margin: 20px; }


### PR DESCRIPTION
When I deployed a new version of the site today it caused a brief outage.  I quickly rolled back and worked around the problem to successfully finish the deployment.  This is a better fix.

The problem was that we had no setting in `app.yaml` for `default_expiration`.  It defaults to 10 hours, so we were sending all images, css, and JS responses with headers telling the browser that it could be cached for 10 hours.  When a new version of the site makes changes to HTML content or some JS content that gets inlined into the HTML pages, that can cause exceptions in JS code that was deployed the week prior but is still being used by some users for up to 10 hours.  In my case, I saw it as a JS error on the feature list page that occurred before `chromedash-feature.js` was parsed, so the page looked pretty blank.  I might do a force-reload, but users who didn't know that I did a deployment would just see an unusable page.

One solution could have been to make a shorter expiration window, e.g., 10 minutes, but that would still potentially cause a brief outage every time we do a deployment.  And, it would slow down frequent users because our growing body of JS code would need to be fetched and parsed while those users are in the middle of using the site.

So, the solution I went with is this (similar to the way Monorail did it):
* Set a fairly long expiration window: 10 days
* Make each `<script src=...>` tag and stylesheet reference include a query parameter in the URL that acts as a "cache buster" to cause an HTTP cache miss when that parameter changes.  Our server code does not see this parameter or do anything with it because the JS is a static file.
* Use the GAE version number as that cache buster value because it changes exactly when we deploy a new version of the app.  FYI, we use the git hash of the latest commit as the GAE version.
* We don't do this for images because we don't have very many of them and they very rarely change.  If we ever need to change an image, we should give it a new filename.