### PR TITLE
Add `do_get` for `processes_api`, `fielddefs_api`, and `cues_api`

### DIFF
--- a/api/cues_api.py
+++ b/api/cues_api.py
@@ -46,4 +46,9 @@ class CuesAPI(basehandlers.APIHandler):
   def do_get(self):
     """Return a list of the dismissed cue cards"""
     user_pref = models.UserPref.get_signed_in_user_pref()
-    return user_pref.dismissed_cues
+
+    dismissed_cues = []
+    if user_pref:
+      return user_pref.dismissed_cues
+
+    return dismissed_cues

--- a/api/cues_api.py
+++ b/api/cues_api.py
@@ -49,6 +49,6 @@ class CuesAPI(basehandlers.APIHandler):
 
     dismissed_cues = []
     if user_pref:
-      return user_pref.dismissed_cues
+      dismissed_cues = user_pref.dismissed_cues
 
     return dismissed_cues

--- a/api/cues_api.py
+++ b/api/cues_api.py
@@ -42,3 +42,8 @@ class CuesAPI(basehandlers.APIHandler):
     models.UserPref.dismiss_cue(cue)
     # Callers don't use the JSON response for this API call.
     return {'message': 'Done'}
+
+  def do_get(self):
+    """Return a list of the dismissed cue cards"""
+    user_pref = models.UserPref.get_signed_in_user_pref()
+    return user_pref.dismissed_cues

--- a/api/cues_api_test.py
+++ b/api/cues_api_test.py
@@ -84,3 +84,4 @@ class CuesAPITest(testing_config.CustomTestCase):
     with test_app.test_request_context(self.request_path):
       actual_response = self.handler.do_get()
     self.assertEqual(['progress-checkmarks'], actual_response)
+    

--- a/api/fielddefs_api.py
+++ b/api/fielddefs_api.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from framework import basehandlers
+from pages import guideforms
+
+
+class FieldDefsAPI(basehandlers.APIHandler):
+  """Field definitions are needed to identify the list of fields by process phase"""
+
+  def do_get(self):
+    """Return the displayed fields in stages"""
+    field_defs = guideforms.DISPLAY_FIELDS_IN_STAGES
+
+    return field_defs
+

--- a/api/fielddefs_api_test.py
+++ b/api/fielddefs_api_test.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config  # Must be imported before the module under test.
+
+import flask
+
+from api import fielddefs_api
+from pages import guideforms
+
+test_app = flask.Flask(__name__)
+
+
+class FieldDefsAPITest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.handler = fielddefs_api.FieldDefsAPI()
+    self.request_path = '/api/v0/fielddefs'
+
+  def test_get__anon(self):
+    """We can get field definitions as an anonymous."""
+    testing_config.sign_out()
+    with test_app.test_request_context(self.request_path):
+      actual_response = self.handler.do_get()
+    self.assertEqual(guideforms.DISPLAY_FIELDS_IN_STAGES, actual_response)
+
+  def test_get__signed_in(self):
+    """We can get field definitions as a signed-in user."""
+    testing_config.sign_in('one@example.com', 123567890)
+    with test_app.test_request_context(self.request_path):
+      actual_response = self.handler.do_get()
+    self.assertEqual(guideforms.DISPLAY_FIELDS_IN_STAGES, actual_response)

--- a/api/processes_api.py
+++ b/api/processes_api.py
@@ -25,6 +25,9 @@ class ProcessesAPI(basehandlers.APIHandler):
   def do_get(self, feature_id):
     """Return the process of the feature."""
     f = models.Feature.get_by_id(feature_id)
+    if f is None:
+      self.abort(404, msg=f'Feature {feature_id} not found')
+
     feature_process = processes.ALL_PROCESSES.get(
       f.feature_type, processes.BLINK_LAUNCH_PROCESS)
 

--- a/api/processes_api.py
+++ b/api/processes_api.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from framework import basehandlers
+from internals import models
+from internals import processes
+
+
+class ProcessesAPI(basehandlers.APIHandler):
+  """Processes contain details about the feature status"""
+
+  def do_get(self, feature_id):
+    """Return the process of the feature."""
+    f = models.Feature.get_by_id(feature_id)
+    feature_process = processes.ALL_PROCESSES.get(
+      f.feature_type, processes.BLINK_LAUNCH_PROCESS)
+
+    return processes.process_to_dict(feature_process)

--- a/api/processes_api_test.py
+++ b/api/processes_api_test.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config  # Must be imported before the module under test.
+
+import flask
+
+from api import processes_api
+from framework import ramcache
+from internals import models
+from internals import processes
+
+test_app = flask.Flask(__name__)
+
+
+class ProcessesAPITest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.feature_1 = models.Feature(
+        name='feature one', summary='sum', category=1, visibility=1,
+        standardization=1, web_dev_views=1, impl_status_chrome=1)
+    self.feature_1.put()
+    self.feature_id = self.feature_1.key.integer_id()
+    
+    self.handler = processes_api.ProcessesAPI()
+    self.request_path = f'/api/v0/processes/{self.feature_id}'
+
+  def tearDown(self):
+    self.feature_1.key.delete()
+    ramcache.flush_all()
+    ramcache.check_for_distributed_invalidation()
+
+  def test_get__default_feature_type(self):
+    """We can get process for features with the default feature type (New feature incubation)."""
+    with test_app.test_request_context(self.request_path):
+      actual_response = self.handler.do_get(self.feature_id)
+    expected_response = processes.process_to_dict(processes.BLINK_LAUNCH_PROCESS)
+    self.assertEqual(expected_response, actual_response)
+
+  def test_get__feature_type_0(self):
+    """We can get process for features with feature type 0 (New feature incubation)."""
+    self.feature_1.feature_type = 0
+    with test_app.test_request_context(self.request_path):
+      actual_response = self.handler.do_get(self.feature_id)
+    expected_response = processes.process_to_dict(processes.BLINK_LAUNCH_PROCESS)
+    self.assertEqual(expected_response, actual_response)
+
+  def test_get__feature_type_1(self):
+    """We can get process for features with feature type 1 (Existing feature implementation)."""
+    self.feature_1.feature_type = 1
+    with test_app.test_request_context(self.request_path):
+      actual_response = self.handler.do_get(self.feature_id)
+    expected_response = processes.process_to_dict(processes.BLINK_FAST_TRACK_PROCESS)
+    self.assertEqual(expected_response, actual_response)
+
+  def test_get__feature_type_2(self):
+    """We can get process for features with feature type 2 (Web developer facing change to existing code)."""
+    self.feature_1.feature_type = 2
+    with test_app.test_request_context(self.request_path):
+      actual_response = self.handler.do_get(self.feature_id)
+    expected_response = processes.process_to_dict(processes.PSA_ONLY_PROCESS)
+    self.assertEqual(expected_response, actual_response)
+
+  def test_get__feature_type_3(self):
+    """We can get process for features with feature type 3 (Feature deprecation)."""
+    self.feature_1.feature_type = 3
+    with test_app.test_request_context(self.request_path):
+      actual_response = self.handler.do_get(self.feature_id)
+    expected_response = processes.process_to_dict(processes.DEPRECATION_PROCESS)
+    self.assertEqual(expected_response, actual_response)

--- a/api/processes_api_test.py
+++ b/api/processes_api_test.py
@@ -35,7 +35,7 @@ class ProcessesAPITest(testing_config.CustomTestCase):
     self.feature_id = self.feature_1.key.integer_id()
     
     self.handler = processes_api.ProcessesAPI()
-    self.request_path = f'/api/v0/processes/{self.feature_id}'
+    self.request_path = f'/api/v0/features/{self.feature_id}/process'
 
   def tearDown(self):
     self.feature_1.key.delete()

--- a/main.py
+++ b/main.py
@@ -96,10 +96,9 @@ api_routes = [
      comments_api.CommentsAPI),
     (API_BASE + '/features/<int:feature_id>/approvals/<int:field_id>/comments',
      comments_api.CommentsAPI),
+    (API_BASE + '/features/<int:feature_id>/process', processes_api.ProcessesAPI),
 
     (API_BASE + '/fielddefs', fielddefs_api.FieldDefsAPI),
-
-    (API_BASE + '/processes/<int:feature_id>', processes_api.ProcessesAPI),
 
     (API_BASE + '/login', login_api.LoginAPI),
     (API_BASE + '/logout', logout_api.LogoutAPI),

--- a/main.py
+++ b/main.py
@@ -22,9 +22,11 @@ from api import channels_api
 from api import comments_api
 from api import cues_api
 from api import features_api
+from api import fielddefs_api
 from api import login_api
 from api import logout_api
 from api import metricsdata
+from api import processes_api
 from api import stars_api
 from api import token_refresh_api
 from framework import basehandlers
@@ -94,6 +96,10 @@ api_routes = [
      comments_api.CommentsAPI),
     (API_BASE + '/features/<int:feature_id>/approvals/<int:field_id>/comments',
      comments_api.CommentsAPI),
+
+    (API_BASE + '/fielddefs', fielddefs_api.FieldDefsAPI),
+
+    (API_BASE + '/processes/<int:feature_id>', processes_api.ProcessesAPI),
 
     (API_BASE + '/login', login_api.LoginAPI),
     (API_BASE + '/logout', logout_api.LogoutAPI),

--- a/static/elements/chromedash-feature-detail.js
+++ b/static/elements/chromedash-feature-detail.js
@@ -11,18 +11,18 @@ class ChromedashFeatureDetail extends LitElement {
   static get properties() {
     return {
       feature: {type: Object},
-      process: {type: Array},
+      process: {type: Object},
       fieldDefs: {type: Object},
-      dismissedCues: {type: Object},
+      dismissedCues: {type: Array},
     };
   }
 
   constructor() {
     super();
     this.feature = {};
-    this.process = [];
-    this.fieldDefs = [];
-    this.dismissedCues = {};
+    this.process = {};
+    this.fieldDefs = {};
+    this.dismissedCues = [];
   }
 
   static get styles() {
@@ -233,11 +233,11 @@ class ChromedashFeatureDetail extends LitElement {
 
   render() {
     return html`
-       ${this.renderStage('Metadata')}
-       ${this.process.stages.map(stage => html`
-            ${this.renderStage(stage)}
-       `)}
-       ${this.renderStage('Misc')}
+      ${this.renderStage('Metadata')}
+      ${this.process.stages.map(stage => html`
+          ${this.renderStage(stage)}
+      `)}
+      ${this.renderStage('Misc')}
     `;
   }
 }

--- a/static/elements/chromedash-feature-page.js
+++ b/static/elements/chromedash-feature-page.js
@@ -79,28 +79,21 @@ export class ChromedashFeaturePage extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.fetchFeature();
+    this.fetchFeatureData();
   }
 
-  fetchFeature() {
+  fetchFeatureData() {
     this.loading = true;
-    const p1 = window.csClient.getFeature(this.featureId).then(
-      (feature) => {
-        this.feature = feature;
-      });
-    const p2 = window.csClient.getProcess(this.featureId).then(
-      (process) => {
-        this.process = process;
-      });
-    const p3 = window.csClient.getFieldDefs().then(
-      (fieldDefs) => {
-        this.fieldDefs = fieldDefs;
-      });
-    const p4 = window.csClient.getDismissedCues().then(
-      (dismissedCues) => {
-        this.dismissedCues = dismissedCues;
-      });
-    Promise.all([p1, p2, p3, p4]).then(() => {
+    Promise.all([
+      window.csClient.getFeature(this.featureId),
+      window.csClient.getProcess(this.featureId),
+      window.csClient.getFieldDefs(),
+      window.csClient.getDismissedCues(),
+    ]).then(([feature, process, fieldDefs, dismissedCues]) => {
+      this.feature = feature;
+      this.process = process;
+      this.fieldDefs = fieldDefs;
+      this.dismissedCues = dismissedCues;
       this.loading = false;
     }).catch(() => {
       const toastEl = document.querySelector('chromedash-toast');

--- a/static/elements/chromedash-feature-page.js
+++ b/static/elements/chromedash-feature-page.js
@@ -86,7 +86,7 @@ export class ChromedashFeaturePage extends LitElement {
     this.loading = true;
     Promise.all([
       window.csClient.getFeature(this.featureId),
-      window.csClient.getProcess(this.featureId),
+      window.csClient.getFeatureProcess(this.featureId),
       window.csClient.getFieldDefs(),
       window.csClient.getDismissedCues(),
     ]).then(([feature, process, fieldDefs, dismissedCues]) => {

--- a/static/elements/chromedash-feature-page_test.js
+++ b/static/elements/chromedash-feature-page_test.js
@@ -17,7 +17,7 @@ describe('chromedash-feature-page', () => {
 
   /* window.csClient and <chromedash-toast> are initialized at _base.html
    * which are not available here, so we initialize them before each test.
-   * We also stub out the API calls here so that it returns test data. */
+   * We also stub out the API calls here so that they return test data. */
   beforeEach(async () => {
     await fixture(html`<chromedash-toast></chromedash-toast>`);
     window.csClient = new ChromeStatusClient('fake_token', 1);

--- a/static/elements/chromedash-feature-page_test.js
+++ b/static/elements/chromedash-feature-page_test.js
@@ -22,17 +22,17 @@ describe('chromedash-feature-page', () => {
     await fixture(html`<chromedash-toast></chromedash-toast>`);
     window.csClient = new ChromeStatusClient('fake_token', 1);
     sinon.stub(window.csClient, 'getFeature');
-    sinon.stub(window.csClient, 'getProcess');
+    sinon.stub(window.csClient, 'getFeatureProcess');
     sinon.stub(window.csClient, 'getFieldDefs');
     sinon.stub(window.csClient, 'getDismissedCues');
-    window.csClient.getProcess.returns(processPromise);
+    window.csClient.getFeatureProcess.returns(processPromise);
     window.csClient.getFieldDefs.returns(fieldDefsPromise);
     window.csClient.getDismissedCues.returns(dismissedCuesPromise);
   });
 
   afterEach(() => {
     window.csClient.getFeature.restore();
-    window.csClient.getProcess.restore();
+    window.csClient.getFeatureProcess.restore();
     window.csClient.getFieldDefs.restore();
     window.csClient.getDismissedCues.restore();
   });

--- a/static/elements/chromedash-feature-page_test.js
+++ b/static/elements/chromedash-feature-page_test.js
@@ -6,17 +6,35 @@ import '../js-src/cs-client';
 import sinon from 'sinon';
 
 describe('chromedash-feature-page', () => {
+  const processPromise = Promise.resolve({
+    name: 'fake process',
+    stages: [{name: 'fake stage name', outgoing_stage: 1}],
+  });
+  const fieldDefsPromise = Promise.resolve({
+    1: ['fake field one', 'fake field two', 'fake field three'],
+  });
+  const dismissedCuesPromise = Promise.resolve(['progress-checkmarks']);
+
   /* window.csClient and <chromedash-toast> are initialized at _base.html
    * which are not available here, so we initialize them before each test.
-   * We also stub out the getFeature API call here so that it returns test data. */
+   * We also stub out the API calls here so that it returns test data. */
   beforeEach(async () => {
     await fixture(html`<chromedash-toast></chromedash-toast>`);
     window.csClient = new ChromeStatusClient('fake_token', 1);
     sinon.stub(window.csClient, 'getFeature');
+    sinon.stub(window.csClient, 'getProcess');
+    sinon.stub(window.csClient, 'getFieldDefs');
+    sinon.stub(window.csClient, 'getDismissedCues');
+    window.csClient.getProcess.returns(processPromise);
+    window.csClient.getFieldDefs.returns(fieldDefsPromise);
+    window.csClient.getDismissedCues.returns(dismissedCuesPromise);
   });
 
   afterEach(() => {
     window.csClient.getFeature.restore();
+    window.csClient.getProcess.restore();
+    window.csClient.getFieldDefs.restore();
+    window.csClient.getDismissedCues.restore();
   });
 
   it('renders with no data', async () => {
@@ -30,7 +48,7 @@ describe('chromedash-feature-page', () => {
 
     // invalid feature requests would trigger the toast to show message
     const toastEl = document.querySelector('chromedash-toast');
-    const toastMsgSpan = toastEl.shadowRoot.querySelector('span');
+    const toastMsgSpan = toastEl.shadowRoot.querySelector('span#msg');
     assert.include(toastMsgSpan.innerHTML,
       'Some errors occurred. Please refresh the page or try again later.');
   });

--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -243,14 +243,14 @@ class ChromeStatusClient {
     return this.doGet(`/features?q=${userQuery}`);
   }
 
+  // Processes API
+  getFeatureProcess(featureId) {
+    return this.doGet(`/features/${featureId}/process`);
+  }
+
   // Fielddefs API
   getFieldDefs() {
     return this.doGet(`/fielddefs`);
-  }
-
-  // Processes API
-  getProcess(featureId) {
-    return this.doGet(`/processes/${featureId}`);
   }
 
   // Channels API

--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -145,6 +145,10 @@ class ChromeStatusClient {
 
   // Cues API
 
+  getDismissedCues() {
+    return this.doGet(`/currentuser/cues`);
+  }
+
   dismissCue(cue) {
     return this.doPost('/currentuser/cues', {cue: cue})
       .then((res) => res);
@@ -237,6 +241,16 @@ class ChromeStatusClient {
 
   searchFeatures(userQuery) {
     return this.doGet(`/features?q=${userQuery}`);
+  }
+
+  // Fielddefs API
+  getFieldDefs() {
+    return this.doGet(`/fielddefs`);
+  }
+
+  // Processes API
+  getProcess(featureId) {
+    return this.doGet(`/processes/${featureId}`);
   }
 
   // Channels API

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -78,20 +78,9 @@
 
 {% block content %}
   <!-- TODO(kevinshen56714): get feature_id from SPA router -->
-  <chromedash-feature-page 
+  <chromedash-feature-page
       featureId='{{ feature_id }}'>
   </chromedash-feature-page>
-
-  <sl-details
-    id="details"
-    summary="Additional fields by process phase">
-    <chromedash-feature-detail
-      feature='{{ feature_json }}'
-      process='{{ process_json }}'
-      fielddefs='{{ field_defs_json }}'
-      dismissedcues='{{ user.dismissed_cues|default:"[]" }}'>
-    </chromedash-feature-detail>
-  </sl-details>
 
   {% if user and user.can_approve %}
     <chromedash-approvals-dialog


### PR DESCRIPTION
The main goal of this PR is to move the `<sl-detail>` in feature.html into the `chromedash-feature-page` component.

To achieve that,
1. `processes_api.py` and `processes_api_test.py` are added with a do_get method
2. `fielddefs_api.py` and `fielddefs_api_test.py` are added with a do_get method
3. do_get method method is also added to the `cues_api.py` (`cues_api_test.py` is also updated)
4. corresponding `getProcess`, `getFieldDefs`, and `getDismissedCues` functions are added to the csClient and called from the `chromedash-feature-page` component