### PR TITLE
Convert My Features page into a single component page

### DIFF
--- a/static/components.js
+++ b/static/components.js
@@ -39,7 +39,7 @@ import './elements/chromedash-gantt';
 import './elements/chromedash-legend';
 import './elements/chromedash-metadata';
 import './elements/chromedash-metrics';
-import './elements/chromedash-myfeatures';
+import './elements/chromedash-myfeatures-page';
 import './elements/chromedash-process-overview';
 import './elements/chromedash-textarea';
 import './elements/chromedash-timeline';

--- a/static/elements/chromedash-feature-filter.js
+++ b/static/elements/chromedash-feature-filter.js
@@ -1,5 +1,5 @@
 import {LitElement, css, html, nothing} from 'lit';
-import SHARED_STYLES from '../css/shared.css';
+import {SHARED_STYLES} from '../sass/shared-css.js';
 
 const ENTER_KEY_CODE = 13;
 
@@ -213,7 +213,7 @@ class ChromedashFeatureFilter extends LitElement {
 
   static get styles() {
     return [
-      SHARED_STYLES,
+      ...SHARED_STYLES,
       css`
       iron-icon {
         --iron-icon-height: 18px;

--- a/static/elements/chromedash-feature-page.js
+++ b/static/elements/chromedash-feature-page.js
@@ -99,14 +99,14 @@ export class ChromedashFeaturePage extends LitElement {
       window.csClient.getFieldDefs(),
       window.csClient.getDismissedCues(),
       window.csClient.getStars(),
-    ]).then(([permissionsRes, feature, process, fieldDefs, dismissedCues, subscribedFeatures]) => {
+    ]).then(([permissionsRes, feature, process, fieldDefs, dismissedCues, starredFeatures]) => {
       this.user = permissionsRes.user;
       this.feature = feature;
       this.process = process;
       this.fieldDefs = fieldDefs;
       this.dismissedCues = dismissedCues;
 
-      if (subscribedFeatures.includes(this.featureId)) {
+      if (starredFeatures.includes(this.featureId)) {
         this.starred = true;
       }
       this.loading = false;

--- a/static/elements/chromedash-feature-page.js
+++ b/static/elements/chromedash-feature-page.js
@@ -99,8 +99,8 @@ export class ChromedashFeaturePage extends LitElement {
       window.csClient.getFieldDefs(),
       window.csClient.getDismissedCues(),
       window.csClient.getStars(),
-    ]).then(([permissionsRes, feature, process, fieldDefs, dismissedCues, starredFeatures]) => {
-      this.user = permissionsRes.user;
+    ]).then(([user, feature, process, fieldDefs, dismissedCues, starredFeatures]) => {
+      this.user = user;
       this.feature = feature;
       this.process = process;
       this.fieldDefs = fieldDefs;
@@ -382,7 +382,7 @@ export class ChromedashFeaturePage extends LitElement {
 
       ${this.user && this.user.can_approve ? html`
         <chromedash-approvals-dialog
-          signedInUser="${this.user.email}">
+          .signedInUser="${this.user.email}">
         </chromedash-approvals-dialog>
       `: nothing}
     `;

--- a/static/elements/chromedash-feature-page.js
+++ b/static/elements/chromedash-feature-page.js
@@ -1,5 +1,4 @@
 import {LitElement, css, html, nothing} from 'lit';
-import './chromedash-approvals-dialog';
 import './chromedash-feature-detail';
 import './chromedash-gantt';
 import {autolink, showToastMessage} from './utils.js';
@@ -380,12 +379,6 @@ export class ChromedashFeaturePage extends LitElement {
           .dismissedCues=${this.dismissedCues}>
         </chromedash-feature-detail>
       </sl-details>
-
-      ${this.user && this.user.can_approve ? html`
-        <chromedash-approvals-dialog
-          .signedInUser="${this.user.email}">
-        </chromedash-approvals-dialog>
-      `: nothing}
     `;
   }
 

--- a/static/elements/chromedash-feature-page.js
+++ b/static/elements/chromedash-feature-page.js
@@ -1,5 +1,8 @@
 import {LitElement, css, html, nothing} from 'lit';
-import {autolink} from './utils.js';
+import './chromedash-approvals-dialog';
+import './chromedash-feature-detail';
+import './chromedash-gantt';
+import {autolink, showToastMessage} from './utils.js';
 
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
@@ -65,7 +68,6 @@ export class ChromedashFeaturePage extends LitElement {
       fieldDefs: {type: Object},
       dismissedCues: {type: Array},
       contextLink: {type: String},
-      toastEl: {type: Element},
       starred: {type: Boolean},
       loading: {attribute: false},
     };
@@ -80,7 +82,6 @@ export class ChromedashFeaturePage extends LitElement {
     this.fieldDefs = {};
     this.dismissedCues = [];
     this.contextLink = '';
-    this.toastEl = document.querySelector('chromedash-toast');
     this.starred = false;
     this.loading = true;
   }
@@ -115,7 +116,7 @@ export class ChromedashFeaturePage extends LitElement {
       // Has to include this for now to remove the spinner at _base.html.
       document.body.classList.remove('loading');
     }).catch(() => {
-      this.toastEl.showMessage('Some errors occurred. Please refresh the page or try again later.');
+      showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });
   }
 
@@ -149,7 +150,7 @@ export class ChromedashFeaturePage extends LitElement {
     e.preventDefault();
     const url = e.currentTarget.href;
     navigator.clipboard.writeText(url).then(() => {
-      this.toastEl.showMessage('Link copied');
+      showToastMessage('Link copied');
     });
   }
 

--- a/static/elements/chromedash-feature-page.js
+++ b/static/elements/chromedash-feature-page.js
@@ -1,7 +1,7 @@
 import {LitElement, css, html, nothing} from 'lit';
 import './chromedash-feature-detail';
 import './chromedash-gantt';
-import {autolink, showToastMessage} from './utils.js';
+import {autolink, showToastMessage, openApprovalsDialog} from './utils.js';
 
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
@@ -155,8 +155,7 @@ export class ChromedashFeaturePage extends LitElement {
 
   handleApprovalClick(e) {
     e.preventDefault();
-    const dialog = this.shadowRoot.querySelector('chromedash-approvals-dialog');
-    dialog.openWithFeature(this.featureId);
+    openApprovalsDialog(this.featureId);
   }
 
   renderSubHeader() {

--- a/static/elements/chromedash-feature-page_test.js
+++ b/static/elements/chromedash-feature-page_test.js
@@ -22,6 +22,33 @@ describe('chromedash-feature-page', () => {
   });
   const dismissedCuesPromise = Promise.resolve(['progress-checkmarks']);
   const starsPromise = Promise.resolve([123456]);
+  const channelsPromise = Promise.resolve({
+    'canary_asan': {
+      'version': 81,
+      'earliest_beta': '2020-02-13T00:00:00',
+      'mstone': 'fake milestone number',
+    },
+    'canary': {
+      'version': 81,
+      'earliest_beta': '2020-02-13T00:00:00',
+      'mstone': 'fake milestone number',
+    },
+    'dev': {
+      'version': 81,
+      'earliest_beta': '2020-02-13T00:00:00',
+      'mstone': 'fake milestone number',
+    },
+    'beta': {
+      'version': 80,
+      'earliest_beta': '2020-02-13T00:00:00',
+      'mstone': 'fake milestone number',
+    },
+    'stable': {
+      'version': 79,
+      'earliest_beta': '2020-02-13T00:00:00',
+      'mstone': 'fake milestone number',
+    },
+  });
 
   /* window.csClient and <chromedash-toast> are initialized at _base.html
    * which are not available here, so we initialize them before each test.
@@ -40,6 +67,10 @@ describe('chromedash-feature-page', () => {
     window.csClient.getFieldDefs.returns(fieldDefsPromise);
     window.csClient.getDismissedCues.returns(dismissedCuesPromise);
     window.csClient.getStars.returns(starsPromise);
+
+    // For the child component - chromedash-gantt
+    sinon.stub(window.csClient, 'getChannels');
+    window.csClient.getChannels.returns(Promise.resolve(channelsPromise));
   });
 
   afterEach(() => {
@@ -49,6 +80,7 @@ describe('chromedash-feature-page', () => {
     window.csClient.getFieldDefs.restore();
     window.csClient.getDismissedCues.restore();
     window.csClient.getStars.restore();
+    window.csClient.getChannels.restore();
   });
 
   it('renders with no data', async () => {

--- a/static/elements/chromedash-feature-page_test.js
+++ b/static/elements/chromedash-feature-page_test.js
@@ -7,13 +7,11 @@ import sinon from 'sinon';
 
 describe('chromedash-feature-page', () => {
   const permissionsPromise = Promise.resolve({
-    user: {
-      can_approve: false,
-      can_create_feature: true,
-      can_edit: true,
-      is_admin: false,
-      email: 'example@google.com',
-    },
+    can_approve: false,
+    can_create_feature: true,
+    can_edit: true,
+    is_admin: false,
+    email: 'example@google.com',
   });
   const processPromise = Promise.resolve({
     name: 'fake process',

--- a/static/elements/chromedash-feature-table.js
+++ b/static/elements/chromedash-feature-table.js
@@ -148,7 +148,7 @@ class ChromedashFeatureTable extends LitElement {
     const featureId = Number(iconEl.dataset.featureId);
     const newStarred = !this.starredFeatures.has(featureId);
 
-    // handled in chromedash-myfeatures.js
+    // handled in chromedash-myfeatures-page.js
     this._fireEvent('star-toggle-event', {
       featureId: featureId,
       doStar: newStarred,
@@ -170,7 +170,7 @@ class ChromedashFeatureTable extends LitElement {
   }
 
   openApprovalsDialog(featureId) {
-    // handled in chromedash-myfeatures.js
+    // handled in chromedash-myfeatures-page.js
     this._fireEvent('open-approvals-event', {
       featureId: featureId,
     });

--- a/static/elements/chromedash-feature-table.js
+++ b/static/elements/chromedash-feature-table.js
@@ -73,6 +73,15 @@ class ChromedashFeatureTable extends LitElement {
     }
   }
 
+  // For rerendering of the "Features I starred" section when a feature is starred
+  // only re-fetch if !this.loading to avoid double fetching on first update.
+  updated(changedProperties) {
+    if (this.query == 'starred-by:me' && !this.loading &&
+      changedProperties.has('starredFeatures')) {
+      this.fetchFeatures();
+    }
+  }
+
   handleSearch(event) {
     this.loading = true;
     this.query = event.detail.query;
@@ -140,7 +149,6 @@ class ChromedashFeatureTable extends LitElement {
   }
 
   toggleStar(e) {
-    console.log('toggleStar');
     e.preventDefault();
     e.stopPropagation();
 
@@ -207,17 +215,16 @@ class ChromedashFeatureTable extends LitElement {
 
   renderStarIcon(feature) {
     return html`
-      <span class="tooltip"
+      <a href="#" class="tooltip" data-tooltip @click=${this.toggleStar}
         title="Receive an email notification when there are updates">
         <iron-icon
           icon="${this.starredFeatures.has(Number(feature.id)) ?
           'chromestatus:star' :
           'chromestatus:star-border'}"
           class="pushicon"
-          data-feature-id="${feature.id}"
-          @click="${this.toggleStar}">
+          data-feature-id="${feature.id}">
         </iron-icon>
-      </span>
+      </a>
     `;
   }
 
@@ -381,7 +388,7 @@ class ChromedashFeatureTable extends LitElement {
       ${this.renderSearch()}
        <table>
         ${this.renderMessages() ||
-          this.features.map(this.renderFeature.bind(this))}
+          this.features.map((feature) => this.renderFeature(feature))}
        </table>
      `;
   }

--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -198,7 +198,7 @@ class ChromedashFeature extends LitElement {
   }
 
   openApprovalsDialog(featureId) {
-    // handled in chromedash-myfeatures.js
+    // handled in chromedash-myfeatures-page.js
     this._fireEvent('open-approvals-event', {
       featureId: featureId,
     });

--- a/static/elements/chromedash-myfeatures-page.js
+++ b/static/elements/chromedash-myfeatures-page.js
@@ -1,5 +1,4 @@
 import {LitElement, css, html, nothing} from 'lit';
-import './chromedash-approvals-dialog';
 import './chromedash-feature-table';
 import {showToastMessage} from './utils.js';
 
@@ -120,11 +119,6 @@ export class ChromedashMyFeaturesPage extends LitElement {
       ${this.user && this.user.can_approve ? this.renderPendingAndRecentApprovals() : nothing}
       ${this.renderIOwn()}
       ${this.renderIStarred()}
-      ${this.user && this.user.can_approve ? html`
-        <chromedash-approvals-dialog
-          .signedInUser="${this.user.email}">
-        </chromedash-approvals-dialog>
-      `: nothing}
     `;
   }
 }

--- a/static/elements/chromedash-myfeatures-page.js
+++ b/static/elements/chromedash-myfeatures-page.js
@@ -1,6 +1,6 @@
 import {LitElement, css, html, nothing} from 'lit';
 import './chromedash-feature-table';
-import {showToastMessage} from './utils.js';
+import {showToastMessage, openApprovalsDialog} from './utils.js';
 
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
@@ -69,8 +69,7 @@ export class ChromedashMyFeaturesPage extends LitElement {
 
   handleOpenApprovals(e) {
     const featureId = e.detail.featureId;
-    const dialog = this.shadowRoot.querySelector('chromedash-approvals-dialog');
-    dialog.openWithFeature(featureId);
+    openApprovalsDialog(featureId);
   }
 
   renderBox(title, query, columns, opened=true) {

--- a/static/elements/chromedash-myfeatures-page.js
+++ b/static/elements/chromedash-myfeatures-page.js
@@ -1,4 +1,7 @@
 import {LitElement, css, html, nothing} from 'lit';
+import './chromedash-approvals-dialog';
+import './chromedash-feature-table';
+import {showToastMessage} from './utils.js';
 
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
@@ -18,7 +21,6 @@ export class ChromedashMyFeaturesPage extends LitElement {
     return {
       user: {type: Object},
       starredFeatures: {type: Set}, // will contain a set of starred features
-      toastEl: {type: Element},
     };
   }
 
@@ -26,7 +28,6 @@ export class ChromedashMyFeaturesPage extends LitElement {
     super();
     this.user = {};
     this.starredFeatures = new Set();
-    this.toastEl = document.querySelector('chromedash-toast');
   }
 
   connectedCallback() {
@@ -46,7 +47,7 @@ export class ChromedashMyFeaturesPage extends LitElement {
       // Has to include this for now to remove the spinner at _base.html.
       document.body.classList.remove('loading');
     }).catch(() => {
-      this.toastEl.showMessage('Some errors occurred. Please refresh the page or try again later.');
+      showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });
   }
 
@@ -63,7 +64,7 @@ export class ChromedashMyFeaturesPage extends LitElement {
         this.starredFeatures = newStarredFeatures;
       })
       .catch(() => {
-        this.toastEl.showMessage('Unable to star the Feature. Please Try Again.');
+        showToastMessage('Unable to star the Feature. Please Try Again.');
       });
   }
 

--- a/static/elements/chromedash-myfeatures-page.js
+++ b/static/elements/chromedash-myfeatures-page.js
@@ -4,7 +4,7 @@ import './chromedash-feature-table';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
 
-class ChromedashMyFeatures extends LitElement {
+class ChromedashMyFeaturesPage extends LitElement {
   static get properties() {
     return {
       signedInUser: {type: String},
@@ -106,4 +106,4 @@ class ChromedashMyFeatures extends LitElement {
   }
 }
 
-customElements.define('chromedash-myfeatures', ChromedashMyFeatures);
+customElements.define('chromedash-myfeatures-page', ChromedashMyFeaturesPage);

--- a/static/elements/chromedash-myfeatures-page_test.js
+++ b/static/elements/chromedash-myfeatures-page_test.js
@@ -18,6 +18,10 @@ describe('chromedash-myfeatures-page', () => {
     sinon.stub(window.csClient, 'getStars');
     window.csClient.getStars.returns(Promise.resolve([123456]));
 
+    // For the child component - chromedash-feature-table
+    sinon.stub(window.csClient, 'searchFeatures');
+    window.csClient.searchFeatures.returns(Promise.resolve([]));
+
     recentReview = null;
     pendingReview = null;
     featureIOwn = null;

--- a/static/elements/chromedash-myfeatures-page_test.js
+++ b/static/elements/chromedash-myfeatures-page_test.js
@@ -1,0 +1,113 @@
+import {html} from 'lit';
+import {assert, fixture} from '@open-wc/testing';
+import {ChromedashMyFeaturesPage} from './chromedash-myfeatures-page';
+import './chromedash-toast';
+import '../js-src/cs-client';
+import sinon from 'sinon';
+
+describe('chromedash-myfeatures-page', () => {
+  let recentReview; let pendingReview; let featureIOwn; let featureIStarred;
+
+  /* window.csClient and <chromedash-toast> are initialized at _base.html
+   * which are not available here, so we initialize them before each test.
+   * We also stub out the API calls here so that they return test data. */
+  beforeEach(async () => {
+    await fixture(html`<chromedash-toast></chromedash-toast>`);
+    window.csClient = new ChromeStatusClient('fake_token', 1);
+    sinon.stub(window.csClient, 'getPermissions');
+    sinon.stub(window.csClient, 'getStars');
+    window.csClient.getStars.returns(Promise.resolve([123456]));
+
+    recentReview = null;
+    pendingReview = null;
+    featureIOwn = null;
+    featureIStarred = null;
+  });
+
+  afterEach(() => {
+    window.csClient.getPermissions.restore();
+    window.csClient.getStars.restore();
+  });
+
+  it('user has no approval permission', async () => {
+    window.csClient.getPermissions.returns(Promise.resolve({
+      can_approve: false,
+      can_create_feature: true,
+      can_edit: true,
+      is_admin: false,
+      email: 'example@gmail.com',
+    }));
+    const component = await fixture(
+      html`<chromedash-myfeatures-page></chromedash-myfeatures-page>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashMyFeaturesPage);
+
+    const subheaderDiv = component.shadowRoot.querySelector('div#subheader');
+    assert.exists(subheaderDiv);
+    assert.include(subheaderDiv.innerHTML, 'My features');
+
+    const slDetails = component.shadowRoot.querySelectorAll('sl-details');
+    slDetails.forEach((item) => {
+      const itemHTML = item.outerHTML;
+      if (itemHTML.includes('summary="Features I own"')) featureIOwn = item;
+      if (itemHTML.includes('summary="Features I starred"')) featureIStarred = item;
+      if (itemHTML.includes('summary="Features pending my approval"')) pendingReview = item;
+      if (itemHTML.includes('summary="Recently reviewed features"')) recentReview = item;
+    });
+
+    // No review-related sl-details
+    assert.notExists(pendingReview);
+    assert.notExists(recentReview);
+
+    // Features I own sl-details exists and has a correct query
+    assert.exists(featureIOwn);
+    assert.include(featureIOwn.innerHTML, 'query="owner:me"');
+
+    // Features I starred sl-details exists and has a correct query
+    assert.exists(featureIStarred);
+    assert.include(featureIStarred.innerHTML, 'query="starred-by:me"');
+  });
+
+  it('user has approval permission', async () => {
+    window.csClient.getPermissions.returns(Promise.resolve({
+      can_approve: true,
+      can_create_feature: true,
+      can_edit: true,
+      is_admin: false,
+      email: 'example@gmail.com',
+    }));
+    const component = await fixture(
+      html`<chromedash-myfeatures-page></chromedash-myfeatures-page>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashMyFeaturesPage);
+
+    const subheaderDiv = component.shadowRoot.querySelector('div#subheader');
+    assert.exists(subheaderDiv);
+    assert.include(subheaderDiv.innerHTML, 'My features');
+
+    const slDetails = component.shadowRoot.querySelectorAll('sl-details');
+    slDetails.forEach((item) => {
+      const itemHTML = item.outerHTML;
+      if (itemHTML.includes('summary="Features I own"')) featureIOwn = item;
+      if (itemHTML.includes('summary="Features I starred"')) featureIStarred = item;
+      if (itemHTML.includes('summary="Features pending my approval"')) pendingReview = item;
+      if (itemHTML.includes('summary="Recently reviewed features"')) recentReview = item;
+    });
+
+    // "Recently reviewed features" exists and has a correct query
+    assert.exists(pendingReview);
+    assert.include(pendingReview.innerHTML, 'query="pending-approval-by:me"');
+
+    // "Features pending my approval" exists and has a correct query
+    assert.exists(recentReview);
+    assert.include(recentReview.innerHTML, 'query="is:recently-reviewed"');
+
+    // "Features I own" sl-details exists and has a correct query
+    assert.exists(featureIOwn);
+    assert.include(featureIOwn.innerHTML, 'query="owner:me"');
+
+    // "Features I starred" sl-details exists and has a correct query
+    assert.exists(featureIStarred);
+    assert.include(featureIStarred.innerHTML, 'query="starred-by:me"');
+  });
+});

--- a/static/elements/utils.js
+++ b/static/elements/utils.js
@@ -4,7 +4,7 @@ import {html} from 'lit';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import Autolinker from 'autolinker';
 
-const toastEl = document.querySelector('chromedash-toast');
+let toastEl;
 
 /* Convert user-entered text into safe HTML with clickable links
  * where appropriate.  Returns a lit-html TemplateResult.
@@ -18,5 +18,6 @@ export function autolink(s) {
 }
 
 export function showToastMessage(msg) {
+  if (!toastEl) toastEl = document.querySelector('chromedash-toast');
   toastEl.showMessage(msg);
 }

--- a/static/elements/utils.js
+++ b/static/elements/utils.js
@@ -4,7 +4,7 @@ import {html} from 'lit';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import Autolinker from 'autolinker';
 
-let toastEl;
+let toastEl; let approvalDialogEl;
 
 /* Convert user-entered text into safe HTML with clickable links
  * where appropriate.  Returns a lit-html TemplateResult.
@@ -20,4 +20,9 @@ export function autolink(s) {
 export function showToastMessage(msg) {
   if (!toastEl) toastEl = document.querySelector('chromedash-toast');
   toastEl.showMessage(msg);
+}
+
+export function openApprovalsDialog(featureId) {
+  if (!approvalDialogEl) approvalDialogEl = document.querySelector('chromedash-approvals-dialog');
+  approvalDialogEl.openWithFeature(featureId);
 }

--- a/static/elements/utils.js
+++ b/static/elements/utils.js
@@ -4,6 +4,8 @@ import {html} from 'lit';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import Autolinker from 'autolinker';
 
+const toastEl = document.querySelector('chromedash-toast');
+
 /* Convert user-entered text into safe HTML with clickable links
  * where appropriate.  Returns a lit-html TemplateResult.
  */
@@ -13,4 +15,8 @@ export function autolink(s) {
     s,
     {stripPrefix: false, sanitizeHtml: true});
   return html`${unsafeHTML(markup)}`;
+}
+
+export function showToastMessage(msg) {
+  toastEl.showMessage(msg);
 }

--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -157,7 +157,8 @@ class ChromeStatusClient {
 
   // Permissions API
   getPermissions() {
-    return this.doGet('/currentuser/permissions');
+    return this.doGet('/currentuser/permissions')
+      .then((res) => res.user);
   }
 
   // Star API

--- a/static/js-src/myfeatures-page.js
+++ b/static/js-src/myfeatures-page.js
@@ -1,7 +1,0 @@
-const myFeaturesEl = document.querySelector('chromedash-myfeatures-page');
-
-window.csClient.getStars().then((starredFeatureIds) => {
-  myFeaturesEl.starredFeatures = new Set(starredFeatureIds);
-});
-
-document.body.classList.remove('loading');

--- a/static/js-src/myfeatures-page.js
+++ b/static/js-src/myfeatures-page.js
@@ -1,4 +1,4 @@
-const myFeaturesEl = document.querySelector('chromedash-myfeatures');
+const myFeaturesEl = document.querySelector('chromedash-myfeatures-page');
 
 window.csClient.getStars().then((starredFeatureIds) => {
   myFeaturesEl.starredFeatures = new Set(starredFeatureIds);

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -16,7 +16,14 @@
 {% block content %}
   {# TODO(kevinshen56714): get feature_id and context_link from SPA router #}
   <chromedash-feature-page
-      featureId='{{ feature_id }}'
-      contextLink='{{ context_link }}'>
+    featureId='{{ feature_id }}'
+    contextLink='{{ context_link }}'>
   </chromedash-feature-page>
+  
+  {# TODO(kevinshen56714): move the approvals-dialog to the SPA index page #}
+  {% if user and user.can_approve %}
+    <chromedash-approvals-dialog 
+      signedInUser="{{user.email}}">
+    </chromedash-approvals-dialog>
+  {% endif %}
 {% endblock %}

--- a/templates/myfeatures.html
+++ b/templates/myfeatures.html
@@ -12,12 +12,12 @@
 
 {% block content %}
 
-<chromedash-myfeatures
+<chromedash-myfeatures-page
   {% if user %} signedinuser="{{user.email}}" {% endif %}
   {% if user.can_edit %} canedit {% endif %}
   {% if user.can_approve %} canapprove {% endif %}
   >
-</chromedash-myfeatures>
+</chromedash-myfeatures-page>
 
 {% endblock %}
 

--- a/templates/myfeatures.html
+++ b/templates/myfeatures.html
@@ -5,5 +5,12 @@
 {% endblock %}
 
 {% block content %}
-<chromedash-myfeatures-page></chromedash-myfeatures-page>
+  <chromedash-myfeatures-page></chromedash-myfeatures-page>
+
+  {# TODO(kevinshen56714): move the approvals-dialog to the SPA index page #}
+  {% if user and user.can_approve %}
+    <chromedash-approvals-dialog      
+      signedInUser="{{user.email}}">
+    </chromedash-approvals-dialog>
+  {% endif %}
 {% endblock %}

--- a/templates/myfeatures.html
+++ b/templates/myfeatures.html
@@ -4,29 +4,6 @@
 {% block css %}
 {% endblock %}
 
-{% block subheader %}
-<div id="subheader">
-  <h2>My features</h2>
-</div>
-{% endblock %}
-
 {% block content %}
-
-<chromedash-myfeatures-page
-  {% if user %} signedinuser="{{user.email}}" {% endif %}
-  {% if user.can_edit %} canedit {% endif %}
-  {% if user.can_approve %} canapprove {% endif %}
-  >
-</chromedash-myfeatures-page>
-
-{% endblock %}
-
-{% block js %}
-<script nonce="{{nonce}}">
-    (function() {
-      'use strict';
-
-      {% inline_file "/static/js/myfeatures-page.min.js" %}
-    })();
-</script>
+<chromedash-myfeatures-page></chromedash-myfeatures-page>
 {% endblock %}


### PR DESCRIPTION
This PR turns the `myfeatures.html` into a single Lit element page. Specifically,

1. The original `chromedash-myfeatures.js` is renamed to `chromedash-myfeatures-page.js` with data fetched from APIs instead of from Django template data.
2. `chromedash-myfeatures-page-test.js` is added to test the rendering of my features page.
3. `static/js-src/myfeatures-page.js` is safely removed.
4. The content of myfeatures.html is now a single Lit element!
5. `chromedash-feature-table.js` is refined with the following changes:
    5.1. Added `<a>` tag for star icons so that hovering over them would change the cursor.
    5.2. Added a `updated()` method so that the "Features I starred" section would be rerendered every time a feature is unstarred or starred for a more dynamic UI. See the videos below:

## Before
https://user-images.githubusercontent.com/11501902/176015140-7079a196-3e12-4686-baa2-8cb17a98747f.mov

## After
https://user-images.githubusercontent.com/11501902/176015170-2d4f8720-9a02-4ee7-aacb-aa77f85fe324.mov


