### PR TITLE
Add chromedash-form-table and -form-field and use for all feature field forms

### DIFF
--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -832,12 +832,17 @@ class ChromedashForm(forms.Form):
 
     def as_table(self):
         "Return this form rendered as HTML <tr>s -- excluding the <table></table>."
-        header = '<tr%(html_class_attr)s><th colspan="2"><b>%(label)s</b></th></tr>'
-        html = header + '<tr%(html_class_attr)s><td>%(errors)s%(field)s</td><td>%(help_text)s</td></tr>'
+        # header = '<tr%(html_class_attr)s><th colspan="2"><b>%(label)s</b></th></tr>'
+        # html = header + '<tr%(html_class_attr)s><td>%(errors)s%(field)s</td><td>%(help_text)s</td></tr>'
+        label = '<span slot="label">%(label)s</span>'
+        field = '<span slot="field">%(field)s</span>'
+        error = '<span slot="error">%(errors)s</span>'
+        help =  '<span slot="help">%(help_text)s</span>'
+        html = '<chromedash-form-field %(html_class_attr)s>' + label + field + error + help + '%(label)s' + '</chromedash-form-field>'
         return self._html_output(
             normal_row=html,
-            error_row='<tr><td colspan="2">%s</td></tr>',
-            row_ender='</td></tr>',
+            error_row='<chromedash-form-field error_text="%s"></chromedash-form-field>',
+            row_ender='</chromedash-form-field>',
             help_text_html='<span class="helptext">%s</span>',
             errors_on_separate_row=False,
         )

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -832,8 +832,6 @@ class ChromedashForm(forms.Form):
 
     def as_table(self):
         "Return this form rendered as HTML <tr>s -- excluding the <table></table>."
-        # header = '<tr%(html_class_attr)s><th colspan="2"><b>%(label)s</b></th></tr>'
-        # html = header + '<tr%(html_class_attr)s><td>%(errors)s%(field)s</td><td>%(help_text)s</td></tr>'
         label = '<span slot="label">%(label)s</span>'
         field = '<span slot="field">%(field)s</span>'
         error = '<span slot="error">%(errors)s</span>'

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -841,7 +841,7 @@ class ChromedashForm(forms.Form):
         html = '<chromedash-form-field %(html_class_attr)s>' + label + field + error + help + '%(label)s' + '</chromedash-form-field>'
         return self._html_output(
             normal_row=html,
-            error_row='<chromedash-form-field error_text="%s"></chromedash-form-field>',
+            error_row='<chromedash-form-field><span slot="error">%s</span></chromedash-form-field>',
             row_ender='</chromedash-form-field>',
             help_text_html='<span class="helptext">%s</span>',
             errors_on_separate_row=False,

--- a/static/components.js
+++ b/static/components.js
@@ -34,6 +34,8 @@ import './elements/chromedash-feature-filter';
 import './elements/chromedash-feature-page';
 import './elements/chromedash-feature-table';
 import './elements/chromedash-featurelist';
+import './elements/chromedash-form-field';
+import './elements/chromedash-form-table';
 import './elements/chromedash-new-feature-list';
 import './elements/chromedash-gantt';
 import './elements/chromedash-legend';

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -1,0 +1,84 @@
+import {LitElement, css, html} from 'lit';
+import {ifDefined} from 'lit/directives/if-defined.js';
+// import {live} from 'lit/directives/live.js';
+import {SHARED_STYLES} from '../sass/shared-css.js';
+
+export class ChromedashFormField extends LitElement {
+  static get properties() {
+    return {
+      id: {type: String},
+      name: {type: String},
+      label: {type: String},
+      class: {type: String},
+      error_text: {type: String},
+      field_text: {type: String},
+    };
+  }
+
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      css`
+        :host {
+          display: table-row-group;
+        }
+
+        /* :host,
+        tr {
+          width: 100%;
+        } */
+
+        tr[hidden] th,
+        tr[hidden] td {
+          padding: 0;
+        }
+
+        th {
+          padding: 12px 10px 5px 0;
+          vertical-align: top;
+        }
+
+        td {
+          padding: 6px 10px;
+          vertical-align: top;
+        }
+
+        td:first-of-type {
+          width: 60%;
+        }
+
+        .helptext {
+          display: block;
+          font-size: small;
+          max-width: 40em;
+          margin-top: 2px;
+        }
+
+      `,
+    ];
+  }
+
+  render() {
+    return html`
+      <tr class="${ifDefined(this.class)}">
+        <th colspan="2">
+          <b>
+          ${this.label}
+          <slot name="label"></slot>
+          </b>
+        </th>
+      </tr>
+      <tr class="${ifDefined(this.class)}">
+        <td>
+          <slot name="field"></slot>
+          <slot name="error"></slot>
+        </td>
+        <td>
+          <slot name="help" class="helptext"></slot>
+        </td>
+      </tr>`;
+  }
+}
+
+customElements.define('chromedash-form-field', ChromedashFormField);
+

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -1,10 +1,8 @@
 import {LitElement, css, html} from 'lit';
-import {SHARED_STYLES} from '../sass/shared-css.js';
 
 export class ChromedashFormField extends LitElement {
   static get styles() {
     return [
-      ...SHARED_STYLES,
       css`
         :host {
           display: table-row-group;
@@ -15,14 +13,17 @@ export class ChromedashFormField extends LitElement {
           padding: 0;
         }
 
+        th, td {
+          text-align: left;
+          vertical-align: top;
+        }
+
         th {
           padding: 12px 10px 5px 0;
-          vertical-align: top;
         }
 
         td {
           padding: 6px 10px;
-          vertical-align: top;
         }
 
         td:first-of-type {
@@ -48,7 +49,7 @@ export class ChromedashFormField extends LitElement {
       <tr>
         <th colspan="2">
           <b>
-          <slot name="label"></slot>
+          <slot name="label">the label goes here</slot>
           </b>
         </th>
       </tr>

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -54,6 +54,9 @@ export class ChromedashFormField extends LitElement {
           margin-top: 2px;
         }
 
+        .errorlist {
+          color: red;
+        }
       `,
     ];
   }
@@ -70,8 +73,8 @@ export class ChromedashFormField extends LitElement {
       </tr>
       <tr class="${ifDefined(this.class)}">
         <td>
+          <slot name="error" class="errorlist"></slot>
           <slot name="field"></slot>
-          <slot name="error"></slot>
         </td>
         <td>
           <slot name="help" class="helptext"></slot>

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -1,20 +1,7 @@
 import {LitElement, css, html} from 'lit';
-import {ifDefined} from 'lit/directives/if-defined.js';
-// import {live} from 'lit/directives/live.js';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
 export class ChromedashFormField extends LitElement {
-  static get properties() {
-    return {
-      id: {type: String},
-      name: {type: String},
-      label: {type: String},
-      class: {type: String},
-      error_text: {type: String},
-      field_text: {type: String},
-    };
-  }
-
   static get styles() {
     return [
       ...SHARED_STYLES,
@@ -22,11 +9,6 @@ export class ChromedashFormField extends LitElement {
         :host {
           display: table-row-group;
         }
-
-        /* :host,
-        tr {
-          width: 100%;
-        } */
 
         tr[hidden] th,
         tr[hidden] td {
@@ -63,15 +45,14 @@ export class ChromedashFormField extends LitElement {
 
   render() {
     return html`
-      <tr class="${ifDefined(this.class)}">
+      <tr>
         <th colspan="2">
           <b>
-          ${this.label}
           <slot name="label"></slot>
           </b>
         </th>
       </tr>
-      <tr class="${ifDefined(this.class)}">
+      <tr>
         <td>
           <slot name="error" class="errorlist"></slot>
           <slot name="field"></slot>

--- a/static/elements/chromedash-form-field_test.js
+++ b/static/elements/chromedash-form-field_test.js
@@ -1,0 +1,38 @@
+import {html} from 'lit';
+import {assert, fixture} from '@open-wc/testing';
+import {ChromedashFormField} from './chromedash-form-field';
+
+describe('chromedash-form-field', () => {
+
+  it('renders with no data', async () => {
+    const component = await fixture(
+      html`<chromedash-form-field></chromedash-form-field>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashFormField);
+    const fieldRow = component.shadowRoot.querySelector('tr');
+    assert.exists(fieldRow);
+  });
+
+  it('renders with slots for label, field, error, help', async () => {
+    const component = await fixture(
+      html`
+      <chromedash-form-field>
+        <span slot="label">Label</span>
+        <span slot="field">Field</span>
+        <span slot="error">Error</span>
+        <span slot="help">Help</span>
+      </chromedash-form-field>`);
+    assert.exists(component);
+
+    const firstRow = component.shadowRoot.querySelector('tr');
+    assert.exists(firstRow);
+    assert.exists(firstRow.querySelector('slot[name="label"'));
+
+    const secondRow = component.shadowRoot.querySelector('tr:nth-child(2)');
+    assert.exists(secondRow);
+    assert.exists(secondRow.querySelector('slot[name="error"'));
+    assert.exists(secondRow.querySelector('slot[name="field"'));
+    assert.exists(secondRow.querySelector('slot[name="help"'));
+  });
+
+});

--- a/static/elements/chromedash-form-field_test.js
+++ b/static/elements/chromedash-form-field_test.js
@@ -1,9 +1,9 @@
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashFormField} from './chromedash-form-field';
+import {slotAssignedElements} from './utils';
 
 describe('chromedash-form-field', () => {
-
   it('renders with no data', async () => {
     const component = await fixture(
       html`<chromedash-form-field></chromedash-form-field>`);
@@ -23,16 +23,22 @@ describe('chromedash-form-field', () => {
         <span slot="help">Help</span>
       </chromedash-form-field>`);
     assert.exists(component);
+    await component.updateComplete;
 
-    const firstRow = component.shadowRoot.querySelector('tr');
-    assert.exists(firstRow);
-    assert.exists(firstRow.querySelector('slot[name="label"'));
+    const labelElements = slotAssignedElements(component, 'label');
+    assert.exists(labelElements);
+    assert.include(labelElements[0].innerHTML, 'Label');
 
-    const secondRow = component.shadowRoot.querySelector('tr:nth-child(2)');
-    assert.exists(secondRow);
-    assert.exists(secondRow.querySelector('slot[name="error"'));
-    assert.exists(secondRow.querySelector('slot[name="field"'));
-    assert.exists(secondRow.querySelector('slot[name="help"'));
+    const fieldElements = slotAssignedElements(component, 'field');
+    assert.exists(fieldElements);
+    assert.include(fieldElements[0].innerHTML, 'Field');
+
+    const errorElements = slotAssignedElements(component, 'error');
+    assert.exists(errorElements);
+    assert.include(errorElements[0].innerHTML, 'Error');
+
+    const helpElements = slotAssignedElements(component, 'help');
+    assert.exists(helpElements);
+    assert.include(helpElements[0].innerHTML, 'Help');
   });
-
 });

--- a/static/elements/chromedash-form-table.js
+++ b/static/elements/chromedash-form-table.js
@@ -1,0 +1,32 @@
+import {LitElement, css, html} from 'lit';
+// import {ifDefined} from 'lit/directives/if-defined.js';
+// import {live} from 'lit/directives/live.js';
+import {SHARED_STYLES} from '../sass/shared-css.js';
+
+export class ChromedashFormTable extends LitElement {
+  static get properties() {
+    return {
+      class: {type: String},
+    };
+  }
+
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      css`
+      :host {
+        display: table;
+        max-width: 80em;
+      }
+
+  `];
+  }
+
+  render() {
+    return html`
+<table><tbody><slot></slot></tbody></table>
+`;
+  }
+}
+
+customElements.define('chromedash-form-table', ChromedashFormTable);

--- a/static/elements/chromedash-form-table.js
+++ b/static/elements/chromedash-form-table.js
@@ -1,7 +1,4 @@
 import {LitElement, css, html} from 'lit';
-// import {ifDefined} from 'lit/directives/if-defined.js';
-// import {live} from 'lit/directives/live.js';
-import {SHARED_STYLES} from '../sass/shared-css.js';
 
 export class ChromedashFormTable extends LitElement {
   static get properties() {
@@ -12,7 +9,6 @@ export class ChromedashFormTable extends LitElement {
 
   static get styles() {
     return [
-      ...SHARED_STYLES,
       css`
       :host {
         display: table;
@@ -24,7 +20,7 @@ export class ChromedashFormTable extends LitElement {
 
   render() {
     return html`
-      <slot style="display:contents"></slot>
+      <slot>fallback content</slot>
     `;
   }
 }

--- a/static/elements/chromedash-form-table.js
+++ b/static/elements/chromedash-form-table.js
@@ -24,8 +24,8 @@ export class ChromedashFormTable extends LitElement {
 
   render() {
     return html`
-<table><tbody><slot></slot></tbody></table>
-`;
+      <slot style="display:contents"></slot>
+    `;
   }
 }
 

--- a/static/elements/chromedash-form-table_test.js
+++ b/static/elements/chromedash-form-table_test.js
@@ -1,0 +1,33 @@
+import {html} from 'lit';
+import {assert, fixture} from '@open-wc/testing';
+import {ChromedashFormTable} from './chromedash-form-table';
+
+describe('chromedash-form-table', () => {
+  it('renders with no data', async () => {
+    const component = await fixture(
+      html`<chromedash-form-table></chromedash-form-table>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashFormTable);
+    const formContents = component.shadowRoot.querySelector('*');
+    assert.exists(formContents);
+  });
+
+  it('renders with array of slots for rows', async () => {
+    const component = await fixture(
+      html`
+      <chromedash-form-table>
+      <span>Row 1</span>
+      <span>Row 2</span>
+      </chromedash-form-table>`);
+    assert.exists(component);
+
+    // console.log('component.innerHTML', component.innerHTML);
+    // console.log('component.shadowRoot.innerHTML', component.shadowRoot.innerHTML);
+
+    // const firstRow = component.shadowRoot.querySelector('span');
+    // assert.exists(firstRow);
+
+    // const secondRow = component.shadowRoot.querySelector('span:nth-child(2)');
+    // assert.exists(secondRow);
+  });
+});

--- a/static/elements/chromedash-form-table_test.js
+++ b/static/elements/chromedash-form-table_test.js
@@ -1,6 +1,7 @@
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashFormTable} from './chromedash-form-table';
+import {slotAssignedElements} from './utils';
 
 describe('chromedash-form-table', () => {
   it('renders with no data', async () => {
@@ -20,14 +21,16 @@ describe('chromedash-form-table', () => {
       <span>Row 2</span>
       </chromedash-form-table>`);
     assert.exists(component);
+    await component.updateComplete;
 
-    // console.log('component.innerHTML', component.innerHTML);
-    // console.log('component.shadowRoot.innerHTML', component.shadowRoot.innerHTML);
+    const children = slotAssignedElements(component, '');
 
-    // const firstRow = component.shadowRoot.querySelector('span');
-    // assert.exists(firstRow);
+    const firstRow = children[0];
+    assert.exists(firstRow);
+    assert.include(firstRow.innerHTML, 'Row 1');
 
-    // const secondRow = component.shadowRoot.querySelector('span:nth-child(2)');
-    // assert.exists(secondRow);
+    const secondRow = children[1];
+    assert.exists(secondRow);
+    assert.include(secondRow.innerHTML, 'Row 2');
   });
 });

--- a/static/elements/utils.js
+++ b/static/elements/utils.js
@@ -14,3 +14,14 @@ export function autolink(s) {
     {stripPrefix: false, sanitizeHtml: true});
   return html`${unsafeHTML(markup)}`;
 }
+
+/**
+ * Returns the rendered elements of the named slot of component.
+ * @param {Element} component
+ * @param {string} slotName
+ * @return {Element}
+ */
+ export function slotAssignedElements(component, slotName) {
+  const slotSelector = slotName ? `slot[name=${slotName}]` : 'slot';
+  return component.shadowRoot.querySelector(slotSelector).assignedElements({flatten: true});
+}

--- a/static/elements/utils.js
+++ b/static/elements/utils.js
@@ -4,8 +4,6 @@ import {html} from 'lit';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import Autolinker from 'autolinker';
 
-let toastEl; let approvalDialogEl;
-
 /* Convert user-entered text into safe HTML with clickable links
  * where appropriate.  Returns a lit-html TemplateResult.
  */

--- a/static/elements/utils.js
+++ b/static/elements/utils.js
@@ -4,6 +4,8 @@ import {html} from 'lit';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import Autolinker from 'autolinker';
 
+let toastEl; let approvalDialogEl;
+
 /* Convert user-entered text into safe HTML with clickable links
  * where appropriate.  Returns a lit-html TemplateResult.
  */
@@ -13,6 +15,16 @@ export function autolink(s) {
     s,
     {stripPrefix: false, sanitizeHtml: true});
   return html`${unsafeHTML(markup)}`;
+}
+
+export function showToastMessage(msg) {
+  if (!toastEl) toastEl = document.querySelector('chromedash-toast');
+  toastEl.showMessage(msg);
+}
+
+export function openApprovalsDialog(featureId) {
+  if (!approvalDialogEl) approvalDialogEl = document.querySelector('chromedash-approvals-dialog');
+  approvalDialogEl.openWithFeature(featureId);
 }
 
 /**

--- a/static/sass/forms.scss
+++ b/static/sass/forms.scss
@@ -21,16 +21,6 @@ table {
     width: 60% 
   }
 
-  .choices label {
-    font-weight: bold;
-  }
-  .choices div {
-    margin-top: 1em;
-  }
-  .choices p {
-    margin: .5em 1.5em 1em;
-  }
-
   .helptext {
     display: block;
     font-size: small;
@@ -62,10 +52,6 @@ table {
   input:not([type="submit"]):not([type="search"]) {
     outline: 1px dotted var(--error-border-color);
     background-color: #FFEDF5;
-  }
-
-  .errorlist {
-    color: red;
   }
 }
 

--- a/templates/guide/editall.html
+++ b/templates/guide/editall.html
@@ -23,23 +23,22 @@
   {% for section_name, flat_form in flat_forms %}
     <h3>{{ section_name }}</h3>
     <section class="flat_form">
-      <table>
+      <chromedash-form-table>
         {{ flat_form }}
-      </table>
+      </chromedash-form-table>
     </section>
   {% endfor %}
 
   <section class="final_buttons">
-    <table>
-      <tr>
-        <th></th>
-        <td>
-          <input class="button" type="submit" value="Submit">
-          <button id="cancel-button" data-id="{{ feature_id }}"
-                  type="reset">Cancel</button>
-        </td>
-      </tr>
-    </table>
+    <chromedash-form-table>
+      <chromedash-form-field>
+        <span slot="field">
+            <input class="button" type="submit" value="Submit">
+            <button id="cancel-button" data-id="{{ feature_id }}"
+                    type="reset">Cancel</button>
+        </span>
+      </chromedash-form-field>
+    </chromedash-form-table>
   </section>
 </form>
 

--- a/templates/guide/metadata.html
+++ b/templates/guide/metadata.html
@@ -112,16 +112,16 @@
         <input type="hidden" name="form_fields"
                value="{{ overview_form.fields.keys | join:',' }}" >
 
-        <table>
+        <chromedash-form-table>
           {{ overview_form }}
 
-          <tr>
-            <th colspan="2">
+          <chromedash-form-field>
+            <span slot="field">
               <input class="button" type="submit" value="Submit">
               <button id="close-metadata" type="reset">Cancel</button>
-            </th>
-          </tr>
-        </table>
+            </span>
+          </chromedash-form-field>
+        </chromedash-form-table>
       </form>
     </div>
   {% endif %}

--- a/templates/guide/new.html
+++ b/templates/guide/new.html
@@ -12,6 +12,16 @@
 table label input[type=radio]:focus {
   box-shadow: var(--sl-focus-ring);
 }
+
+.choices label {
+  font-weight: bold;
+}
+.choices div {
+  margin-top: 1em;
+}
+.choices p {
+  margin: .5em 1.5em 1em;
+}
 </style>
 {% endblock %}
 
@@ -33,25 +43,23 @@ table label input[type=radio]:focus {
 <section id="stage_form">
   <form name="overview_form" method="POST" action="{{ current_path }}">
     <input type="hidden" name="token" value="{{xsrf_token}}">
-    <table style="max-width: 80em">
-      <tr>
-        <th></th>
-        <td>
+    <chromedash-form-table>
+
+      <chromedash-form-field>
+        <span slot="help">
           Please see the
           <a href="https://www.chromium.org/blink/launching-features"
              target="_blank" rel="noopener">Launching features</a>
           page for process instructions.
-        </td>
-      </tr>
+        </span>
+      </chromedash-form-field>
 
       {{ overview_form }}
 
-      <tr>
-        <th colspan="2"><b>Feature type:</b></th>
-      </tr>
+      <chromedash-form-field>
+        <span slot="label">Feature type:</span>
+        <span slot="field" class="choices">
 
-      <tr>
-        <td colspan="2" class="choices" style="padding-top:0">
             <label for="id_feature_type_0">
               <input id="id_feature_type_0" name="feature_type" type="radio"
                      value="0" required>
@@ -61,11 +69,7 @@ table label input[type=radio]:focus {
             <p>When building new features, we follow a
               process that emphasizes engagement with the WICG and other
               stakeholders early.</p>
-        </td>
-      </tr>
 
-      <tr>
-        <td colspan="2" class="choices">
             <label for="id_feature_type_1">
               <input id="id_feature_type_1" name="feature_type" type="radio"
                      value="1" required>
@@ -74,25 +78,17 @@ table label input[type=radio]:focus {
 
             <p>If there is already an agreed specification, work may
               quickly start on implementation and origin trials.</p>
-        </td>
-      </tr>
 
-      <tr>
-        <td colspan="2" class="choices">
             <label for="id_feature_type_2">
               <input id="id_feature_type_2" name="feature_type" type="radio"
                      value="2" required>
-              Web developer facing change to existing code
+              Web developer-facing change to existing code
             </label>
 
             <p>Sometimes a change to a shipped feature requires an additional
               feature entry.  This type of feature entry can be referenced
               from a PSA immediately.</p>
-        </td>
-      </tr>
 
-      <tr>
-        <td colspan="2" class="choices">
             <label for="id_feature_type_3">
               <input id="id_feature_type_3" name="feature_type" type="radio"
                      value="3" required>
@@ -100,16 +96,18 @@ table label input[type=radio]:focus {
             </label>
 
             <p>Deprecate and remove an old feature.</p>
-        </td>
-      </tr>
 
-      <tr>
-        <th colspan="2">
+        </span>
+      </chromedash-form-field>
+
+      <chromedash-form-field>
+        <span slot="field"> 
           {% comment %} <sl-button type="submit" class="primary" variant="primary" size="small">Submit</sl-button> {% endcomment %}
           <input type="submit" class="primary" value="Submit">
-        </th>
-      </tr>
-    </table>
+        </span>
+      </chromedash-form-field>
+
+    </chromedash-form-table>
   </form>
 </section>
 

--- a/templates/guide/stage.html
+++ b/templates/guide/stage.html
@@ -28,78 +28,71 @@
                  {% endif %}" >
 
   <section class="stage_form">
-    <table>
+    <chromedash-form-table>
       {{ feature_form }}
 
-      <tr>
-        <th colspan="2"><b>Process stage:</b></th>
-      </tr>
-      <tr>
+      <chromedash-form-field>
+        <span slot="label">Process stage:</span>
+        <span slot="field">
           {% if already_on_this_stage %}
-          <td colspan="2">
-            This feature is already in stage <b>{{ stage_name }}</b>.
-          </td>
           {% else %}
-          <td>
-            <input type="checkbox" name="set_stage"
-                   id="set_stage">
+            <input type="checkbox" name="set_stage" id="set_stage">
             <label for="set_stage">
               Set to: <b>{{ stage_name }}</b>
             </label>
-          </td>
-          <td>
-              <span class="helptext">
-                Check this box to move this feature to this
-                stage in the process. Leave it unchecked if you are adding
-                draft information or revising a previous stage.
-              </span>
-          </td> 
           {% endif %}
-      </tr>
-    </table>
+        </span>
+        <span slot="help">
+          {% if already_on_this_stage %}
+            This feature is already in stage <b>{{ stage_name }}</b>.
+          {% else %}
+            Check this box to move this feature to this
+            stage in the process. Leave it unchecked if you are adding
+            draft information or revising a previous stage.
+          {% endif %}
+        </span>
+      </chromedash-form-field>
+
+    </chromedash-form-table>
   </section>
 
 
   {% if impl_status_name or impl_status_form %}
     <h3>Implementation in Chromium</h3>
     <section class="stage_form">
-      <table>
+      <chromedash-form-table>
         {% if impl_status_name %}
-          <tr>
-            <th colspan="2">Implementation status:</th>
-          </tr>
-          <tr>
-              {% if already_on_this_impl_status %}
-              <td colspan="2">
+        <chromedash-form-field>
+          <span slot="label">Implementation status:</span>
+
+          {% if already_on_this_impl_status %}
+            <span slot="help">
                 This feature already has implementation status:
                 <b>{{ impl_status_name }}</b>.
               </td>
-              {% else %}
-              <td>
-                <input type="hidden" name="impl_status_offered"
-                       value="{{impl_status_offered}}">
-                <input type="checkbox" name="set_impl_status"
-                       id="set_impl_status">
-                <!-- TODO(jrobbins): When checked, make some milestone fields required. -->
-                <label for="set_impl_status">
-                  Set implementation status to: <b>{{ impl_status_name }}</b>
-                </label>
-              </td>
-              <td>
-                <br>
-                <span class="helptext">
-                  Check this box to update the implementation
-                  status of this feature in Chromium.
-                </span>
-              </td>
-              {% endif %}
-
-          </tr>
+            </span>
+          {% else %}
+            <span slot="field">
+              <input type="hidden" name="impl_status_offered"
+                      value="{{impl_status_offered}}">
+              <input type="checkbox" name="set_impl_status"
+                      id="set_impl_status">
+              <!-- TODO(jrobbins): When checked, make some milestone fields required. -->
+              <label for="set_impl_status">
+                Set implementation status to: <b>{{ impl_status_name }}</b>
+              </label>
+            </span>
+            <span slot="help">
+                Check this box to update the implementation
+                status of this feature in Chromium.
+            </span>
+          {% endif %}
+        </chromedash-form-field>
         {% endif %}
 
         {{ impl_status_form }}
 
-      </table>
+      </chromedash-form-table>
     </section>
   {% endif %}
 


### PR DESCRIPTION
This PR replaces all feature form tables with chromedash-form-table and all rows with chromedash-form-field.  

Since tables and trs depend on each other, initial dom parsing will remove all content of tables that is not trs, so it is important to replace all the tables that contain any chromedash-form-field, and thus all trs also must be replaced by chromedash-form-field.  This applies to guide/{new.html, metadata.html, stage.html, editall.html}.

The resulting layout is the same as before, except for a few cases where we were explicitly using colspan="2" in manually generated table rows.  e.g. the new.html radio button group for feature type.

![image](https://user-images.githubusercontent.com/570125/176035536-9aa05366-a6e9-4d36-b508-be333e796f1f.png)
