### PR TITLE
Make the footer sticky on every page

### DIFF
--- a/static/sass/features/features.scss
+++ b/static/sass/features/features.scss
@@ -38,7 +38,6 @@ chromedash-legend {
 
 chromedash-featurelist {
   max-width: $max-content-width;
-  margin-bottom: 54px + $content-padding * 2; // bottom bar + some.
 }
 
 #subheader {

--- a/static/sass/features/features.scss
+++ b/static/sass/features/features.scss
@@ -52,16 +52,6 @@ chromedash-featurelist {
   }
 }
 
-@media only screen and (min-width: 701px) {
-
-  footer {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-  }
-}
-
 @media only screen and (max-width: 700px) {
   #subheader {
     width: initial;

--- a/static/sass/features/launch.scss
+++ b/static/sass/features/launch.scss
@@ -4,7 +4,6 @@
   flex-direction: column;
   counter-reset: h3;
   height: auto;
-  margin-bottom: 86px;
 
   section {
     max-width: 600px;

--- a/static/sass/forms.scss
+++ b/static/sass/forms.scss
@@ -78,8 +78,6 @@ li {
 }
 
 form[name="feature_form"] {
-  margin-bottom: 54px + $content-padding * 2; // bottom bar + some.
-
   h3 {
     margin: $content-padding / 2 0;
   }
@@ -90,10 +88,6 @@ form[name="feature_form"] {
 
 form[name="feature_form"] .stage_form {
   margin-bottom: 2em;
-}
-
-.stage_form, .final_buttons {
-  margin-bottom: 6em;
 }
 
 form section.flat_form + h3, .final_buttons {

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -328,18 +328,25 @@ footer {
   color: var(--warning-color);
 }
 
-@media only screen and (min-width: 701px) {
-  .main-toolbar {
-    .toolbar-content {
-      width: 100%;
-    }
-  }
-  
+// Enable sticky footer when the screen is wide and long enough
+@media only screen and (min-width: 601px) and (min-height: 601px) {
   footer {
     position: fixed;
     bottom: 0;
     left: 0;
     width: 100%;
+  }
+
+  #content-column {
+    margin-bottom: 54px + $content-padding * 2; // bottom bar + some.
+  }
+}
+
+@media only screen and (min-width: 701px) {
+  .main-toolbar {
+    .toolbar-content {
+      width: 100%;
+    }
   }
   
   // Overrides styles set by app-header-layout so there's no visual

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -334,6 +334,14 @@ footer {
       width: 100%;
     }
   }
+  
+  footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+  }
+  
   // Overrides styles set by app-header-layout so there's no visual
   // layout FOUC/jump as the drawer panel upgrades.
   app-header {

--- a/static/sass/metrics.scss
+++ b/static/sass/metrics.scss
@@ -31,16 +31,6 @@
   }
 }
 
-@media only screen and (min-width: 701px) {
-
-  footer {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-  }
-}
-
 @media only screen and (max-width: 700px) {
   #subheader {
     margin: $content-padding 0;

--- a/templates/guide/edit.html
+++ b/templates/guide/edit.html
@@ -34,7 +34,7 @@
   </chromedash-process-overview>
 </section>
 
-<section style="margin: 1em 0 8em 0">
+<section style="margin: 1em 0 1em 0">
   Please see the
  <a href="https://www.chromium.org/blink/launching-features"
     target="_blank" rel="noopener">Launching features</a>


### PR DESCRIPTION
In this PR, the footer css that was originally in the `metrics.scss` and `features.scss` is moved to `main.scss`, meaning the sticky footer is applied to all pages.

Basically, I found that the footer is currently only sticky on the metrics and features pages. However, I think it generally looks better on all the other pages as well if the footer always sticks at the bottom of the page.

For example,

## On the My Features page
#### Without sticky footer:
![Screen Shot 2022-06-27 at 8 15 00 PM](https://user-images.githubusercontent.com/11501902/176061279-2d035325-8993-4424-9ab0-5280e9d097eb.png)
#### With sticky footer:
![Screen Shot 2022-06-27 at 8 16 00 PM](https://user-images.githubusercontent.com/11501902/176061308-b00d86c6-935c-4b6c-b3ec-478be57b0ff5.png)

## On the Roadmap page during loading
#### Without sticky footer:
![Screen Shot 2022-06-27 at 8 19 50 PM](https://user-images.githubusercontent.com/11501902/176061493-d00a3df6-9e7c-4ed8-b7b7-18a55fb498c5.png)

#### With sticky footer:
![Screen Shot 2022-06-27 at 8 18 18 PM](https://user-images.githubusercontent.com/11501902/176061510-ca3b8539-3dfe-4a7c-94c2-39b8647b1df0.png)

