### PR TITLE
Be explicit about using python3.9.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Chrome Platform Status
 1. Before you begin, make sure that you have a java JRE (version 8 or greater) installed. JRE is required to use the DataStore Emulator.
 1. Install global CLIs in the home directory
     1. [Google App Engine SDK for Python](https://cloud.google.com/appengine/docs/standard/python3/setting-up-environment). Make sure to select Python 3.
-    1. pip, node, npm, and gunicorn.
+    1. node and npm.
     1. Gulp `npm install --global gulp-cli`
 1. We recommend using an older node version, e.g. node 10
     1. Use `node -v` to check the default node version
@@ -21,14 +21,10 @@ Chrome Platform Status
 3. `cd` into the Chromestatus repo and install npm dependencies `npm ci`
 4. Create a virtual environment.
     1. `sudo apt install python3.9-venv`
-    1. `python3 -m venv cs-env`
+    1. `python3.9 -m venv cs-env`
 6. Install other dependencies
     1. `npm run deps`
     1. `npm run dev-deps`
-
-You will need to activate the venv in every shell that you use.
-1. `source cs-env/bin/activate`
-
 
 If you encounter any error during the installation process, the section **Notes** (later in this README.md) may help.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=6.0.0"
   },
   "scripts": {
-    "deps": "source cs-env/bin/activate; pip install -r requirements.txt --upgrade",
+    "deps": "source cs-env/bin/activate; pip install -r requirements.txt --upgrade; pip install -r requirements.dev.txt --upgrade",
     "dev-deps": "echo 'dev-deps is no longer needed'",
     "do-tests": "source cs-env/bin/activate; curl -X POST 'http://localhost:15606/reset' && python3 -m unittest discover -p '*_test.py'  -b",
     "start-emulator-persist": "gcloud beta emulators datastore start --host-port=:15606 --consistency=1.0",
@@ -16,7 +16,7 @@
     "test": "(npm run start-emulator > /dev/null 2>&1 &); sleep 6; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-tests; status=$?; npm run stop-emulator; exit $status",
     "webtest": "web-test-runner \"static/**/*_test.js\" --node-resolve --playwright --browsers chromium firefox",
     "do-coverage": "coverage3 erase && coverage3 run -m unittest discover -p '*_test.py' -b && coverage3 html",
-    "coverage": "(npm run start-emulator > /dev/null 2>&1 &); sleep 3; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-coverage;  npm run stop-emulator",
+    "coverage": "source cs-env/bin/activate; (npm run start-emulator > /dev/null 2>&1 &); sleep 3; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-coverage;  npm run stop-emulator",
     "view-coverage": "pushd htmlcov/; python3 -m http.server 8080; popd",
     "lint": "gulp lint-fix && lit-analyzer \"static/elements/chromedash-!(featurelist)*.js\"",
     "pylint": "pylint --output-format=parseable *py api/*py customtags/*py framework/*py internals/*py pages/*py",
@@ -26,7 +26,7 @@
     "staging": "npm run build && ./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'` cr-status-staging && ./scripts/deploy_site.sh rc cr-status-staging",
     "start-app": "npm run build && ./scripts/start_server.sh",
     "start": "source cs-env/bin/activate; (npm run start-emulator-persist > /dev/null 2>&1 &); sleep 6; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run start-app; status=$?; npm run stop-emulator; exit $status",
-    "stop": "killall 'gunicorn: master'"
+    "stop": "killall cs-env/bin/python3.9"
   },
   "repository": {
     "type": "git",

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,7 @@
-# This must be installed on your local venv or system, not in lib.
-# Via the command:
-# python -m pip install --no-deps -r requirements.dev.txt
+# This file is also processed when you run `npm run deps` on your workstation,
+# but these libraries will not be install when running on GAE.  These packages
+# are not needed on GAE because they are only for local development, or GAE
+# provides its own copy.
 
-grpcio==1.31.0
 coverage==5.5
+gunicorn==20.1.0


### PR DESCRIPTION
I was running locally, and then suddenly I started getting a bunch of import errors.  I think that the problem is that my system's default version of python upgraded to 3.10, but our app depends on using python 3.9.  The problem is not the python interpreter itself, it is the fact that 'python3.9' is part of the library paths under cs-env.   We want to keep using 3.9 because that is the version that runs on the GAE servers, so this PR puts more things under cs-env where we control the versions rather than relying on globally installed packages.

In this PR:
* Change README.md to:
    * not install pip or gunicorn globally.  Instead they will exist under cs-env.
    * use python3.9 to create cs-env rather than using the default version of python3.
    * not mention activating cs-env in each shell window because the scripts in package.json do that automatically.
* Change package.json scripts to:
    * install both requirements.txt and requirements.dev.txt for developers
    * generate test coverage using the coverage command in cs-env
    * when stopping the server, specify the path to python3.9 under cs-env because we do not run the globally installed gunicorn any longer
* Change requirements.dev.txt to:
    * add gunicorn (with a pinned version) 
    * remove grpcio because that version was needed for python2
    * update the comment

