### PR TITLE
Implement search result paginaton in the server-side internals.

### DIFF
--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -182,38 +182,38 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     mock_star_me.return_value = [self.feature_1.key.integer_id()]
     mock_pend_me.return_value = [self.feature_2.key.integer_id()]
 
-    actual_pending = search.process_query('pending-approval-by:me')
+    actual_pending, tc = search.process_query('pending-approval-by:me')
     self.assertEqual(actual_pending[0]['name'], 'feature 2')
 
-    actual_star_me = search.process_query('starred-by:me')
+    actual_star_me, tc = search.process_query('starred-by:me')
     self.assertEqual(actual_star_me[0]['name'], 'feature 1')
 
-    actual_own_me = search.process_query('owner:me')
+    actual_own_me, tc = search.process_query('owner:me')
     self.assertEqual(actual_own_me[0]['name'], 'feature 2')
 
-    actual_recent = search.process_query('is:recently-reviewed')
+    actual_recent, tc = search.process_query('is:recently-reviewed')
     self.assertEqual(actual_recent[0]['name'],'feature 1')
 
   def test_process_query__single_field(self):
     """We can can run single-field queries."""
 
-    actual = search.process_query('category=1')
+    actual, tc = search.process_query('category=1')
     self.assertEqual(1, len(actual))
     self.assertEqual(actual[0]['name'], 'feature 1')
 
-    actual = search.process_query('category=2')
+    actual, tc = search.process_query('category=2')
     self.assertEqual(1, len(actual))
     self.assertEqual(actual[0]['name'], 'feature 2')
 
-    actual = search.process_query('category="2"')
+    actual, tc = search.process_query('category="2"')
     self.assertEqual(1, len(actual))
     self.assertEqual(actual[0]['name'], 'feature 2')
 
-    actual = search.process_query('name="feature 2"')
+    actual, tc = search.process_query('name="feature 2"')
     self.assertEqual(1, len(actual))
     self.assertEqual(actual[0]['name'], 'feature 2')
 
-    actual = search.process_query('browsers.webdev.view=1')
+    actual, tc = search.process_query('browsers.webdev.view=1')
     self.assertEqual(2, len(actual))
     self.assertCountEqual(
         [f['name'] for f in actual],
@@ -225,5 +225,5 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     """Query terms that are not predefined or field-op-value, give warnings."""
     self.assertEqual(
         search.process_query('anything else'),
-        [])
+        ([], 0))
     self.assertEqual(2, len(mock_warn.mock_calls))

--- a/static/elements/chromedash-feature-table.js
+++ b/static/elements/chromedash-feature-table.js
@@ -9,6 +9,7 @@ class ChromedashFeatureTable extends LitElement {
       query: {type: String},
       showQuery: {type: Boolean},
       features: {type: Array},
+      total_count: {type: Number},
       loading: {type: Boolean},
       rows: {type: Number},
       columns: {type: String},
@@ -44,8 +45,9 @@ class ChromedashFeatureTable extends LitElement {
   }
 
   fetchFeatures() {
-    window.csClient.searchFeatures(this.query).then((features) => {
-      this.features = features;
+    window.csClient.searchFeatures(this.query).then((resp) => {
+      this.features = resp.features;
+      this.total_count = resp.total_count;
       this.loading = false;
       if (this.columns == 'approvals') {
         this.loadApprovalData();

--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -241,7 +241,8 @@ class ChromeStatusClient {
   }
 
   getFeaturesInMilestone(milestone) {
-    return this.doGet(`/features?milestone=${milestone}`);
+    return this.doGet(`/features?milestone=${milestone}`).then(
+      (resp) => resp['features_by_type']);
   }
 
   searchFeatures(userQuery) {


### PR DESCRIPTION
One main reason why our old "All features" page is slow is because it lacks the concept of search result pagination.  Everything is requested in one big request, which was so slow that we needed to implement a cap of 500 and it is still slow.

For the new feature list page, I intend to implement search result pagination that shows 100 items per page and offers the user previous and next page buttons along with a total count of results.

In this PR:
* In features_api.py:
    * Always return both results and a total_count
    * Remove the special case for when there is no q= query string parameter and instead treat that as an empty query
* In search.py:
    * Redo post-processing for deleted and unlisted features as additional query conditions.  This is needed because filtering after pagination would cause under-filled pagination pages.
    * Add support for sorting on a single field using only the feature IDs.  Done before loading feature entities.
    * Trim results to the requested pagination page and fetch only the feature entities that appear on that page.
* In the JS code:
    * Store the total_count on the new feature page.  This is not displayed yet but useful for testing.
    * Update cs-client to ignore for now the new total_count in the milestone response.
 