### PR TITLE
Try skeletons on feature detail page.

### DIFF
--- a/static/components.js
+++ b/static/components.js
@@ -14,6 +14,7 @@ import '@shoelace-style/shoelace/dist/components/details/details.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/menu-item/menu-item.js';
+import '@shoelace-style/shoelace/dist/components/skeleton/skeleton.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/textarea/textarea.js';
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';

--- a/static/elements/chromedash-feature-page.js
+++ b/static/elements/chromedash-feature-page.js
@@ -35,21 +35,21 @@ export class ChromedashFeaturePage extends LitElement {
           font-weight: 500;
           margin-right: 5px;
         }
-        
+
         #consensus li {
           display: flex;
         }
         #consensus li label {
           width: 125px;
         }
-        
+
         @media only screen and (max-width: 700px) {
           #feature {
             border-radius: 0 !important;
             margin: 7px initial !important;
           }
         }
-        
+
         @media only screen and (min-width: 701px) {
           #feature {
             padding: 30px 40px;
@@ -158,6 +158,29 @@ export class ChromedashFeaturePage extends LitElement {
     openApprovalsDialog(this.featureId);
   }
 
+  renderSkeletonSection() {
+    return html`
+          <section>
+            <h3><sl-skeleton effect="sheen"></sl-skeleton></h3>
+            <p>
+              <sl-skeleton effect="sheen"></sl-skeleton>
+              <sl-skeleton effect="sheen"></sl-skeleton>
+            </p>
+          </section>
+    `;
+  }
+
+  renderSkeletons() {
+    return html`
+        <div id="feature" style="margin-top: 65px;">
+          ${this.renderSkeletonSection()}
+          ${this.renderSkeletonSection()}
+          ${this.renderSkeletonSection()}
+          ${this.renderSkeletonSection()}
+      </div>
+   `;
+  }
+
   renderSubHeader() {
     return html`
       <div id="subheader" style="display:block">
@@ -220,7 +243,7 @@ export class ChromedashFeaturePage extends LitElement {
         edit access.</b></p>
         </section>
       `: nothing}
-   
+
       ${this.feature.summary ? html`
         <section id="summary">
           <p class="preformatted">${autolink(this.feature.summary)}</p>
@@ -295,7 +318,7 @@ export class ChromedashFeaturePage extends LitElement {
           <chromedash-gantt .feature=${this.feature}></chromedash-gantt>
         </p>
       </section>
-  
+
       <section id="consensus">
         <h3>Consensus &amp; Standardization</h3>
         <div style="font-size:smaller;">After a feature ships in Chrome, the values listed here are not guaranteed to be up to date.</div>
@@ -359,7 +382,7 @@ export class ChromedashFeaturePage extends LitElement {
             `)}
         </section>
       `: nothing}
-  
+
       <section id="updated">
         <p><span>Last updated on ${this.feature.updated_display}</span></p>
       </section>
@@ -391,10 +414,7 @@ export class ChromedashFeaturePage extends LitElement {
       <link rel="stylesheet" href="/static/css/forms.css">
       <link rel="stylesheet" href="/static/css/guide.css">
       ${this.loading ?
-        html`
-          <div class="loading">
-            <div id="spinner"><img src="/static/img/ring.svg"></div>
-          </div>` :
+        this.renderSkeletons() :
         html`
           ${this.renderSubHeader()}
           <div id="feature">

--- a/static/sass/shared-css.js
+++ b/static/sass/shared-css.js
@@ -162,4 +162,20 @@ export const SHARED_STYLES = [
   sl-details::part(content) {
     padding: 0;
   }
+
+  sl-skeleton {
+    margin-bottom: 1em;
+    width: 60%;
+  }
+
+  sl-skeleton:nth-of-type(even) {
+    width: 50%;
+  }
+
+  h3 sl-skeleton {
+    width: 30%;
+    height: 1.5em;
+  }
+
+
 `];


### PR DESCRIPTION
This is just an experiment, it's not really needed but I think it might be a small UX improvement.

Right now, when loading the feature detail page, the user sees a blank page with a spinner, then the sl-details grey bar appears for a fraction of a second, then the feature information box is rendered which pushes that sl-details bar down to its final position.  The whole process takes about half a second, so it is not too distracting, but it is noticeable.

In this PR, I try replacing the spinner that is inside this virtual page with shimmering sl-skeleton elements.  The shape of the skeletons is generic and will not match the sections shown for any particular feature.  With this PR, the user initially sees a white box that looks like the eventual feature info box, with some skeleton placeholder content.  Then, the data loads and the actual content is shown a half second later.  There is still a visual pop, but I think that it is a little less noticeable.

Here's what it looks like in that half second:
![image](https://user-images.githubusercontent.com/17365/176573220-2bff4727-6032-48be-a7b2-a903515d174e.png)
