### PR TITLE
Update edit feature link in email announcement.

### DIFF
--- a/templates/new-feature-email.html
+++ b/templates/new-feature-email.html
@@ -25,8 +25,8 @@
     <a href="https://github.com/GoogleChrome/samples#contributing-samples"
        >contributing</a>).
   </li>
-  <li>Don't forget add your demo link to the
-    <a href="https://chromestatus.com/admin/features/edit/{{id}}"
-       >chromestatus feature entry</a>.
+  <li>Add demo links and other details to the
+    <a href="https://chromestatus.com/guide/edit/{{id}}"
+       >ChromeStatus feature entry</a>.
   </li>
 </ul>


### PR DESCRIPTION
This fixes a link that appears in the email notification for a new feature.
The old URL /admin/features/edit was phased out more than a year ago.
I also broadened this call-to-action phrase and fixed the grammar.