### PR TITLE
Simply local setup steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,13 @@ Chrome Platform Status
 1. Install global CLIs in the home directory
     1. [Google App Engine SDK for Python](https://cloud.google.com/appengine/docs/standard/python3/setting-up-environment). Make sure to select Python 3.
     1. node and npm.
-    1. Gulp `npm install --global gulp-cli`
+    1. Gulp: `npm install --global gulp-cli`
+    1. Python virtual environment: `sudo apt install python3.9-venv`
 1. We recommend using an older node version, e.g. node 10
     1. Use `node -v` to check the default node version
     2. `nvm use 12` to switch to node 12
-3. `cd` into the Chromestatus repo and install npm dependencies `npm ci`
-4. Create a virtual environment.
-    1. `sudo apt install python3.9-venv`
-    1. `python3.9 -m venv cs-env`
-6. Install other dependencies
-    1. `npm run deps`
-    1. `npm run dev-deps`
+1. `cd chromium-dashboard`
+1. Install JS an python dependencies: `npm run setup`
 
 If you encounter any error during the installation process, the section **Notes** (later in this README.md) may help.
 
@@ -66,8 +62,9 @@ There are some developing information in developer-documentation.md.
 
 - When installing the GAE SDK, make sure to get the version for python 3.
 
-- If you run the server locally, and then you are disconnected from your terminial window, the jobs might remain running which will prevent you from starting the server again.  To work around this, use `ps aux | grep gunicorn` and then use the unix `kill -9` command to terminate those jobs.
+- If you run the server locally, and then you are disconnected from your terminial window, the jobs might remain running which will prevent you from starting the server again.  To work around this, use `npm run stop-emulator; npm stop`.  Or, use `ps aux | grep gunicorn` and/or `ps aux | grep emulator`, then use the unix `kill -9` command to terminate those jobs.
 
+- If you need to test or debug anything to do with dependencies, you can get a clean start by running `npm run clean-setup`.
 
 #### Blink components
 

--- a/package.json
+++ b/package.json
@@ -7,12 +7,21 @@
     "node": ">=6.0.0"
   },
   "scripts": {
+    "setup": "npm ci; python3.9 -m venv cs-env; npm run deps",
+    "clean-setup": "rm -rf node_modules cs-env; npm run setup",
     "deps": "source cs-env/bin/activate; pip install -r requirements.txt --upgrade; pip install -r requirements.dev.txt --upgrade",
     "dev-deps": "echo 'dev-deps is no longer needed'",
+
     "do-tests": "source cs-env/bin/activate; curl -X POST 'http://localhost:15606/reset' && python3 -m unittest discover -p '*_test.py'  -b",
     "start-emulator-persist": "gcloud beta emulators datastore start --host-port=:15606 --consistency=1.0",
     "start-emulator": "gcloud beta emulators datastore start --host-port=:15606 --no-store-on-disk --consistency=1.0",
     "stop-emulator": "curl -X POST 'http://localhost:15606/shutdown'",
+    "build": "gulp",
+    "watch": "gulp watch",
+    "start-app": "npm run build && ./scripts/start_server.sh",
+    "start": "source cs-env/bin/activate; (npm run start-emulator-persist > /dev/null 2>&1 &); sleep 6; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run start-app; status=$?; npm run stop-emulator; exit $status",
+    "stop": "killall cs-env/bin/python3.9",
+
     "test": "(npm run start-emulator > /dev/null 2>&1 &); sleep 6; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-tests; status=$?; npm run stop-emulator; exit $status",
     "webtest": "web-test-runner \"static/**/*_test.js\" --node-resolve --playwright --browsers chromium firefox",
     "do-coverage": "coverage3 erase && coverage3 run -m unittest discover -p '*_test.py' -b && coverage3 html",
@@ -20,13 +29,9 @@
     "view-coverage": "pushd htmlcov/; python3 -m http.server 8080; popd",
     "lint": "gulp lint-fix && lit-analyzer \"static/elements/chromedash-!(featurelist)*.js\"",
     "pylint": "pylint --output-format=parseable *py api/*py customtags/*py framework/*py internals/*py pages/*py",
-    "build": "gulp",
-    "watch": "gulp watch",
-    "deploy": "npm run build && ./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'` && ./scripts/deploy_site.sh rc",
+
     "staging": "npm run build && ./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'` cr-status-staging && ./scripts/deploy_site.sh rc cr-status-staging",
-    "start-app": "npm run build && ./scripts/start_server.sh",
-    "start": "source cs-env/bin/activate; (npm run start-emulator-persist > /dev/null 2>&1 &); sleep 6; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run start-app; status=$?; npm run stop-emulator; exit $status",
-    "stop": "killall cs-env/bin/python3.9"
+    "deploy": "npm run build && ./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'` && ./scripts/deploy_site.sh rc"
   },
   "repository": {
     "type": "git",

--- a/static/elements/utils.js
+++ b/static/elements/utils.js
@@ -33,7 +33,7 @@ export function openApprovalsDialog(featureId) {
  * @param {string} slotName
  * @return {Element}
  */
- export function slotAssignedElements(component, slotName) {
+export function slotAssignedElements(component, slotName) {
   const slotSelector = slotName ? `slot[name=${slotName}]` : 'slot';
   return component.shadowRoot.querySelector(slotSelector).assignedElements({flatten: true});
 }


### PR DESCRIPTION
In this PR:
* Add a new npm script `setup` that does three of the installation steps.
* Organize the npm scripts into four groups: installation, running locally, testing, and deployment.
* Reduce the number of installation steps by leveraging the new `setup` script.
* Update a note about how to stop left-over processes.