### PR TITLE
Try on-demand `chromedash-approval-dialog` creation

### DIFF
--- a/static/elements/chromedash-feature-page.js
+++ b/static/elements/chromedash-feature-page.js
@@ -1,7 +1,8 @@
 import {LitElement, css, html, nothing} from 'lit';
 import './chromedash-feature-detail';
 import './chromedash-gantt';
-import {autolink, showToastMessage, openApprovalsDialog} from './utils.js';
+import {openApprovalsDialog} from './chromedash-approvals-dialog';
+import {autolink, showToastMessage} from './utils.js';
 
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
@@ -155,28 +156,28 @@ export class ChromedashFeaturePage extends LitElement {
 
   handleApprovalClick(e) {
     e.preventDefault();
-    openApprovalsDialog(this.featureId);
+    openApprovalsDialog(this.user.email, this.featureId);
   }
 
   renderSkeletonSection() {
     return html`
-          <section>
-            <h3><sl-skeleton effect="sheen"></sl-skeleton></h3>
-            <p>
-              <sl-skeleton effect="sheen"></sl-skeleton>
-              <sl-skeleton effect="sheen"></sl-skeleton>
-            </p>
-          </section>
+      <section>
+        <h3><sl-skeleton effect="sheen"></sl-skeleton></h3>
+        <p>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+        </p>
+      </section>
     `;
   }
 
   renderSkeletons() {
     return html`
-        <div id="feature" style="margin-top: 65px;">
-          ${this.renderSkeletonSection()}
-          ${this.renderSkeletonSection()}
-          ${this.renderSkeletonSection()}
-          ${this.renderSkeletonSection()}
+      <div id="feature" style="margin-top: 65px;">
+        ${this.renderSkeletonSection()}
+        ${this.renderSkeletonSection()}
+        ${this.renderSkeletonSection()}
+        ${this.renderSkeletonSection()}
       </div>
    `;
   }

--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -1,4 +1,5 @@
 import {LitElement, html} from 'lit';
+import {openApprovalsDialog} from './chromedash-approvals-dialog';
 // eslint-disable-next-line no-unused-vars
 import './chromedash-feature';
 import {FEATURELIST_CSS} from '../sass/elements/chromedash-featurelist-css.js';
@@ -175,8 +176,7 @@ class ChromedashFeaturelist extends LitElement {
 
   _onOpenApprovals(e) {
     const featureId = e.detail.featureId;
-    const dialog = this.shadowRoot.querySelector('chromedash-approvals-dialog');
-    dialog.openWithFeature(featureId);
+    openApprovalsDialog(this.signedInUser, featureId);
   }
 
   _filterProperty(propPath, regExp, feature) {
@@ -402,10 +402,6 @@ class ChromedashFeaturelist extends LitElement {
       ${numOverLimit > 0 ?
         html`<p>To see ${numOverLimit} earlier features, please enter a more specific query.</p>` :
         ''}
-
-      <chromedash-approvals-dialog
-        .signedInUser=${this.signedInUser}
-      ></chromedash-approvals-dialog>
     `;
   }
 }

--- a/static/elements/chromedash-myfeatures-page.js
+++ b/static/elements/chromedash-myfeatures-page.js
@@ -1,6 +1,7 @@
 import {LitElement, css, html, nothing} from 'lit';
 import './chromedash-feature-table';
-import {showToastMessage, openApprovalsDialog} from './utils.js';
+import {openApprovalsDialog} from './chromedash-approvals-dialog';
+import {showToastMessage} from './utils.js';
 
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
@@ -69,7 +70,7 @@ export class ChromedashMyFeaturesPage extends LitElement {
 
   handleOpenApprovals(e) {
     const featureId = e.detail.featureId;
-    openApprovalsDialog(featureId);
+    openApprovalsDialog(this.user.email, featureId);
   }
 
   renderBox(title, query, columns, opened=true) {

--- a/static/elements/chromedash-new-feature-list.js
+++ b/static/elements/chromedash-new-feature-list.js
@@ -1,5 +1,5 @@
 import {LitElement, css, html} from 'lit';
-import './chromedash-approvals-dialog';
+import {openApprovalsDialog} from './chromedash-approvals-dialog';
 import './chromedash-feature-table';
 import SHARED_STYLES from '../css/shared.css';
 
@@ -49,8 +49,7 @@ class ChromedashNewFeatureList extends LitElement {
 
   handleOpenApprovals(e) {
     const featureId = e.detail.featureId;
-    const dialog = this.shadowRoot.querySelector('chromedash-approvals-dialog');
-    dialog.openWithFeature(featureId);
+    openApprovalsDialog(this.signedInUser, featureId);
   }
 
   renderBox(query) {
@@ -76,9 +75,6 @@ class ChromedashNewFeatureList extends LitElement {
   render() {
     return html`
       ${this.renderFeatureList()}
-      <chromedash-approvals-dialog
-        .signedInUser=${this.signedInUser}
-      ></chromedash-approvals-dialog>
     `;
   }
 }

--- a/static/elements/utils.js
+++ b/static/elements/utils.js
@@ -4,7 +4,7 @@ import {html} from 'lit';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import Autolinker from 'autolinker';
 
-let toastEl; let approvalDialogEl;
+let toastEl;
 
 /* Convert user-entered text into safe HTML with clickable links
  * where appropriate.  Returns a lit-html TemplateResult.
@@ -20,11 +20,6 @@ export function autolink(s) {
 export function showToastMessage(msg) {
   if (!toastEl) toastEl = document.querySelector('chromedash-toast');
   toastEl.showMessage(msg);
-}
-
-export function openApprovalsDialog(featureId) {
-  if (!approvalDialogEl) approvalDialogEl = document.querySelector('chromedash-approvals-dialog');
-  approvalDialogEl.openWithFeature(featureId);
 }
 
 /**

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -19,11 +19,4 @@
     featureId='{{ feature_id }}'
     contextLink='{{ context_link }}'>
   </chromedash-feature-page>
-  
-  {# TODO(kevinshen56714): move the approvals-dialog to the SPA index page #}
-  {% if user and user.can_approve %}
-    <chromedash-approvals-dialog 
-      signedInUser="{{user.email}}">
-    </chromedash-approvals-dialog>
-  {% endif %}
 {% endblock %}

--- a/templates/myfeatures.html
+++ b/templates/myfeatures.html
@@ -6,11 +6,4 @@
 
 {% block content %}
   <chromedash-myfeatures-page></chromedash-myfeatures-page>
-
-  {# TODO(kevinshen56714): move the approvals-dialog to the SPA index page #}
-  {% if user and user.can_approve %}
-    <chromedash-approvals-dialog      
-      signedInUser="{{user.email}}">
-    </chromedash-approvals-dialog>
-  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Following our [previous discussion](https://github.com/GoogleChrome/chromium-dashboard/pull/1976#pullrequestreview-1024066817), I moved the `openApprovalDialog` util function to the `chromedash-approval-dialog` file. The new function creates the element and appends it to the document body on demand. Once it's created, the function will use the same instance (like a singleton) that it has created. This allows us to not put the element in Django templates or other element's render function at all! If this looks good, I will create another PR for the toast util function as well.

I also slightly modified the Promises in the openWithFeature function because I think the original code does each fetch twice (one at variable definition and one at Promise.all)