### PR TITLE
Pass in entire feature for `openApprovalDialog`

### DIFF
--- a/static/elements/chromedash-feature-page.js
+++ b/static/elements/chromedash-feature-page.js
@@ -156,7 +156,7 @@ export class ChromedashFeaturePage extends LitElement {
 
   handleApprovalClick(e) {
     e.preventDefault();
-    openApprovalsDialog(this.user.email, this.featureId);
+    openApprovalsDialog(this.user.email, this.feature);
   }
 
   renderSkeletonSection() {

--- a/static/elements/chromedash-feature-table.js
+++ b/static/elements/chromedash-feature-table.js
@@ -179,27 +179,27 @@ class ChromedashFeatureTable extends LitElement {
     return false; // Causes features to render instead.
   }
 
-  openApprovalsDialog(featureId) {
+  openApprovalsDialog(feature) {
     // handled in chromedash-myfeatures-page.js
     this._fireEvent('open-approvals-event', {
-      featureId: featureId,
+      feature: feature,
     });
   }
 
-  doLGTM(featureId) {
+  doLGTM(feature) {
     // TODO(jrobbins): Make it pre-select Approved and add comment.
-    this.openApprovalsDialog(featureId);
+    this.openApprovalsDialog(feature);
   }
 
-  doSnooze(featureId) {
+  doSnooze(feature) {
     // TODO(jrobbins): Make it pre-set a new next-review-date value.
-    this.openApprovalsDialog(featureId);
+    this.openApprovalsDialog(feature);
   }
 
   renderApprovalsIcon(feature) {
     return html`
       <a class="tooltip"
-        @click="${() => this.openApprovalsDialog(feature.id)}"
+        @click="${() => this.openApprovalsDialog(feature)}"
         title="Review approvals">
         <iron-icon icon="chromestatus:approval"></iron-icon>
       </a>
@@ -252,13 +252,13 @@ class ChromedashFeatureTable extends LitElement {
       // TODO(jrobbins): Show these buttons when they work.
       // let lgtmButton = html`
       //  <button data-feature-id="${feature.id}"
-      //          @click="${() => this.doLGTM(feature.id)}">
+      //          @click="${() => this.doLGTM(feature)}">
       //    Add LGTM
       //  </button>
       // `;
       // let snoozeButton = html`
       //  <button data-feature-id="${feature.id}"
-      //          @click="${() => this.doSnooze(feature.id)}">
+      //          @click="${() => this.doSnooze(feature)}">
       //    Snooze
       //  </button>
       // `;

--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -197,10 +197,10 @@ class ChromedashFeature extends LitElement {
       });
   }
 
-  openApprovalsDialog(featureId) {
+  openApprovalsDialog(feature) {
     // handled in chromedash-myfeatures-page.js
     this._fireEvent('open-approvals-event', {
-      featureId: featureId,
+      feature: feature,
     });
   }
 
@@ -211,7 +211,7 @@ class ChromedashFeature extends LitElement {
           ${this.canApprove ? html`
             <span class="tooltip" title="Review approvals">
               <a id="approvals-icon" data-tooltip
-                 @click="${() => this.openApprovalsDialog(this.feature.id)}">
+                 @click="${() => this.openApprovalsDialog(this.feature)}">
                 <iron-icon icon="chromestatus:approval"></iron-icon>
               </a>
             </span>

--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -175,8 +175,7 @@ class ChromedashFeaturelist extends LitElement {
   }
 
   _onOpenApprovals(e) {
-    const featureId = e.detail.featureId;
-    openApprovalsDialog(this.signedInUser, featureId);
+    openApprovalsDialog(this.signedInUser, e.detail.feature);
   }
 
   _filterProperty(propPath, regExp, feature) {

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -78,7 +78,7 @@ customElements.define('chromedash-form-field', ChromedashFormField);
 
 // Map of specifications for all form fields.
 // Actually, this includes only fields for which we have migrated the help_text from the guideforms.py specifications.
-// TODO: 
+// TODO:
 //   * Finish migrating remaining fields.
 //   * Migrate other properties.
 //   * Move to its own file.

--- a/static/elements/chromedash-myfeatures-page.js
+++ b/static/elements/chromedash-myfeatures-page.js
@@ -69,8 +69,7 @@ export class ChromedashMyFeaturesPage extends LitElement {
   }
 
   handleOpenApprovals(e) {
-    const featureId = e.detail.featureId;
-    openApprovalsDialog(this.user.email, featureId);
+    openApprovalsDialog(this.user.email, e.detail.feature);
   }
 
   renderBox(title, query, columns, opened=true) {

--- a/static/elements/chromedash-new-feature-list.js
+++ b/static/elements/chromedash-new-feature-list.js
@@ -48,8 +48,7 @@ class ChromedashNewFeatureList extends LitElement {
   }
 
   handleOpenApprovals(e) {
-    const featureId = e.detail.featureId;
-    openApprovalsDialog(this.signedInUser, featureId);
+    openApprovalsDialog(this.signedInUser, e.detail.feature);
   }
 
   renderBox(query) {


### PR DESCRIPTION
Follow-up PR for #1991. In this PR, `openApprovalDialog` takes in a feature object instead of a featureId. This eliminates an additional feature fetching when opening the dialog.