### PR TITLE
Add settings API and settings page component

### DIFF
--- a/api/settings_api.py
+++ b/api/settings_api.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from framework import basehandlers
+from internals import models
+
+
+class SettingsAPI(basehandlers.APIHandler):
+  """Users can store their settings preferences such as whether to get 
+  notification from the features they starred."""
+
+  def do_post(self):
+    """Set the user settings (currently only the notify_as_starrer)"""
+    user_pref = models.UserPref.get_signed_in_user_pref()
+    if not user_pref:
+      self.abort(403, msg='User must be signed in')
+    new_notify = self.get_bool_param('notify')
+    user_pref.notify_as_starrer = new_notify
+    user_pref.put()
+    # Callers don't use the JSON response for this API call.
+    return {'message': 'Done'}
+
+  def do_get(self):
+    """Return the user settings (currently only the notify_as_starrer)"""
+    user_pref = models.UserPref.get_signed_in_user_pref()
+    if not user_pref:
+      self.abort(404, msg='User preference not found')
+
+    return {'notify_as_starrer': user_pref.notify_as_starrer}

--- a/api/settings_api_test.py
+++ b/api/settings_api_test.py
@@ -1,0 +1,79 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config  # Must be imported before the module under test.
+
+import flask
+import werkzeug.exceptions
+
+from api import settings_api
+from internals import models
+
+test_app = flask.Flask(__name__)
+
+
+class SettingsAPITest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.user_pref_1 = models.UserPref(
+        email='one@example.com',
+        notify_as_starrer=False,
+        dismissed_cues=['progress-checkmarks'])
+    self.user_pref_1.put()
+
+    self.request_path = '/api/v0/currentuser/settings'
+    self.handler = settings_api.SettingsAPI()
+
+  def tearDown(self):
+    self.user_pref_1.key.delete()
+    testing_config.sign_out()
+
+  def test_post__valid(self):
+    """User wants to set a valid setting."""
+    testing_config.sign_in('one@example.com', 123567890)
+
+    with test_app.test_request_context(
+        '/notify', json={"notify": True}):
+      actual_json = self.handler.do_post()
+    self.assertEqual({'message': 'Done'}, actual_json)
+
+    revised_user_pref = models.UserPref.get_signed_in_user_pref()
+    self.assertEqual(True, revised_user_pref.notify_as_starrer)
+
+  def test_post__invalid(self):
+    """User wants to set an invalid setting."""
+    testing_config.sign_in('one@example.com', 123567890)
+
+    with test_app.test_request_context(
+        '/notify', json={"notify": "xyz"}):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post()
+
+    # The invalid string should not be added.
+    revised_user_pref = models.UserPref.get_signed_in_user_pref()
+    self.assertEqual(False, revised_user_pref.notify_as_starrer)
+
+  def test_get__anon(self):
+    """We give 404 if the user preference was not found."""
+    testing_config.sign_out()
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.NotFound):
+        self.handler.do_get()
+
+  def test_get__signed_in(self):
+    """Signed-in user has a notify_as_starrer=False setting."""
+    testing_config.sign_in('one@example.com', 123567890)
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_get()
+    self.assertEqual({'notify_as_starrer': False}, actual)

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ from api import logout_api
 from api import metricsdata
 from api import permissions_api
 from api import processes_api
+from api import settings_api
 from api import stars_api
 from api import token_refresh_api
 from framework import basehandlers
@@ -104,11 +105,11 @@ api_routes = [
     (API_BASE + '/login', login_api.LoginAPI),
     (API_BASE + '/logout', logout_api.LogoutAPI),
     (API_BASE + '/currentuser/permissions', permissions_api.PermissionsAPI),
+    (API_BASE + '/currentuser/settings', settings_api.SettingsAPI),
     (API_BASE + '/currentuser/stars', stars_api.StarsAPI),
     (API_BASE + '/currentuser/cues', cues_api.CuesAPI),
     (API_BASE + '/currentuser/token', token_refresh_api.TokenRefreshAPI),
     # (API_BASE + '/currentuser/autosaves', TODO),
-    # (API_BASE + '/currentuser/settings', TODO),
 
     # Admin operations for user accounts
     (API_BASE + '/accounts', accounts_api.AccountsAPI),

--- a/static/components.js
+++ b/static/components.js
@@ -44,6 +44,7 @@ import './elements/chromedash-metadata';
 import './elements/chromedash-metrics';
 import './elements/chromedash-myfeatures-page';
 import './elements/chromedash-process-overview';
+import './elements/chromedash-settings-page';
 import './elements/chromedash-textarea';
 import './elements/chromedash-timeline';
 import './elements/chromedash-toast';

--- a/static/elements/chromedash-checkbox.js
+++ b/static/elements/chromedash-checkbox.js
@@ -21,10 +21,10 @@ export class ChromedashCheckbox extends LitElement {
     return [
       ...SHARED_STYLES,
       css`
-:host sl-checkbox::part(label) {
-    font-size: var(--sl-input-font-size-small);
-}
-  `];
+        :host sl-checkbox::part(label) {
+            font-size: var(--sl-input-font-size-small);
+        }
+    `];
   }
 
   render() {

--- a/static/elements/chromedash-myfeatures-page.js
+++ b/static/elements/chromedash-myfeatures-page.js
@@ -20,7 +20,7 @@ export class ChromedashMyFeaturesPage extends LitElement {
   static get properties() {
     return {
       user: {type: Object},
-      starredFeatures: {type: Set}, // will contain a set of starred features
+      starredFeatures: {attribute: false}, // will contain a set of starred features
     };
   }
 

--- a/static/elements/chromedash-settings-page.js
+++ b/static/elements/chromedash-settings-page.js
@@ -100,8 +100,7 @@ export class ChromedashSettingsPage extends LitElement {
                 <td>
                   <chromedash-checkbox
                     id="id_notify_as_starrer"
-                    .name="notify_as_starrer"
-                    .size="small"
+                    name="notify_as_starrer"
                     ?checked=${this.notify_as_starrer}
                     @input=${this.handleChange}>
                   </chromedash-checkbox>

--- a/static/elements/chromedash-settings-page.js
+++ b/static/elements/chromedash-settings-page.js
@@ -1,0 +1,124 @@
+import {LitElement, css, html, nothing} from 'lit';
+import {showToastMessage} from './utils';
+
+export class ChromedashSettingsPage extends LitElement {
+  static get styles() {
+    return [
+      css`
+        th,
+        td {
+          padding: 4px;
+        }
+      
+        input[type="submit"] {
+          margin: 20px;
+        }
+
+        input[disabled] {
+          opacity: 0.5;
+          pointer-events: none;
+        }
+
+        #spinner {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          position: fixed;
+          height: 60%;
+          width: 100%;
+        }
+
+        table .helptext {
+          display: block;
+          font-style: italic;
+          font-size: smaller;
+          max-width: 40em;
+          margin-top: 2px;
+        }
+    `];
+  }
+
+  static get properties() {
+    return {
+      notify_as_starrer: {type: Boolean},
+      submitting: {type: Boolean},
+    };
+  }
+
+  constructor() {
+    super();
+    this.notify_as_starrer = false;
+    this.submitting = false;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    window.csClient.getSettings().then((res) => {
+      this.notify_as_starrer = res.notify_as_starrer;
+
+      // TODO(kevinshen56714): Remove this once SPA index page is set up.
+      // Has to include this for now to remove the spinner at _base.html.
+      document.body.classList.remove('loading');
+    }).catch(() => {
+      showToastMessage('Some errors occurred. Please refresh the page or try again later.');
+    });
+  }
+
+  handleSubmit(e) {
+    e.preventDefault();
+    this.submitting = true;
+    window.csClient.setSettings(this.notify_as_starrer).then(() => {
+      showToastMessage('Settings saved.');
+    }).catch(() => {
+      showToastMessage('Unable to save the settings. Please try again.');
+    }).finally(() => {
+      this.submitting = false;
+    });
+  }
+
+  handleChange() {
+    this.notify_as_starrer = !this.notify_as_starrer;
+  }
+
+  render() {
+    // TODO: Create precomiled main and forms css files,
+    // and import them instead of inlining them here
+    return html`
+      <link rel="stylesheet" href="/static/css/main.css">
+      <link rel="stylesheet" href="/static/css/forms.css">
+      <div id="subheader">
+        <h2>User preferences</h2>
+      </div>
+      <section>
+        <form name="user_pref_form" @submit=${this.handleSubmit}>
+          <table cellspacing=6>
+            <tbody>
+              <tr>
+                <th>
+                  <label for="id_notify_as_starrer">Notify as starrer:</label>
+                </th>
+                <td>
+                  <chromedash-checkbox
+                    id="id_notify_as_starrer"
+                    .name="notify_as_starrer"
+                    .size="small"
+                    ?checked=${this.notify_as_starrer}
+                    @input=${this.handleChange}>
+                  </chromedash-checkbox>
+                  <span class="helptext"> Send you notification emails for features that you starred?</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <input type="submit" value="Submit" ?disabled=${this.submitting}>
+        </form>
+      </section>
+      ${this.submitting ? html`
+        <div class="loading">
+          <div id="spinner"><img src="/static/img/ring.svg"></div>
+        </div>` : nothing}
+    `;
+  }
+}
+
+customElements.define('chromedash-settings-page', ChromedashSettingsPage);

--- a/static/elements/chromedash-settings-page_test.js
+++ b/static/elements/chromedash-settings-page_test.js
@@ -1,0 +1,81 @@
+import {html} from 'lit';
+import {assert, fixture} from '@open-wc/testing';
+import {ChromedashSettingsPage} from './chromedash-settings-page';
+import './chromedash-toast';
+import '../js-src/cs-client';
+import sinon from 'sinon';
+
+describe('chromedash-settings-page', () => {
+  /* window.csClient and <chromedash-toast> are initialized at _base.html
+   * which are not available here, so we initialize them before each test.
+   * We also stub out the API calls here so that they return test data. */
+  beforeEach(async () => {
+    await fixture(html`<chromedash-toast></chromedash-toast>`);
+    window.csClient = new ChromeStatusClient('fake_token', 1);
+    sinon.stub(window.csClient, 'getSettings');
+  });
+
+  afterEach(() => {
+    window.csClient.getSettings.restore();
+  });
+
+  it('user has not signed in and get user pref not found response', async () => {
+    window.csClient.getSettings.returns(Promise.reject(new Error('User preference not found')));
+    const component = await fixture(
+      html`<chromedash-settings-page></chromedash-settings-page>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashSettingsPage);
+
+    // error response would trigger the toast to show message
+    const toastEl = document.querySelector('chromedash-toast');
+    const toastMsgSpan = toastEl.shadowRoot.querySelector('span#msg');
+    assert.include(toastMsgSpan.innerHTML,
+      'Some errors occurred. Please refresh the page or try again later.');
+  });
+
+  it('user has notify_as_starrer value as true', async () => {
+    window.csClient.getSettings.returns(Promise.resolve({'notify_as_starrer': true}));
+    const component = await fixture(
+      html`<chromedash-settings-page></chromedash-settings-page>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashSettingsPage);
+
+    // header exists
+    const subheaderDiv = component.shadowRoot.querySelector('div#subheader');
+    assert.exists(subheaderDiv);
+    assert.include(subheaderDiv.innerHTML, 'User preferences');
+
+    // form exists and has a submit button
+    const formEl = component.shadowRoot.querySelector('form');
+    assert.exists(formEl);
+    assert.include(formEl.innerHTML, 'input type="submit"');
+
+    // checkbox exists and is checked
+    const checkboxEl = component.shadowRoot.querySelector('chromedash-checkbox');
+    assert.exists(checkboxEl);
+    assert.include(checkboxEl.outerHTML, 'checked');
+  });
+
+  it('user has notify_as_starrer value as false', async () => {
+    window.csClient.getSettings.returns(Promise.resolve({'notify_as_starrer': false}));
+    const component = await fixture(
+      html`<chromedash-settings-page></chromedash-settings-page>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashSettingsPage);
+
+    // header exists
+    const subheaderDiv = component.shadowRoot.querySelector('div#subheader');
+    assert.exists(subheaderDiv);
+    assert.include(subheaderDiv.innerHTML, 'User preferences');
+
+    // form exists and has a submit button
+    const formEl = component.shadowRoot.querySelector('form');
+    assert.exists(formEl);
+    assert.include(formEl.innerHTML, 'input type="submit"');
+
+    // checkbox exists and is not checked
+    const checkboxEl = component.shadowRoot.querySelector('chromedash-checkbox');
+    assert.exists(checkboxEl);
+    assert.notInclude(checkboxEl.outerHTML, 'checked');
+  });
+});

--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -161,6 +161,16 @@ class ChromeStatusClient {
       .then((res) => res.user);
   }
 
+  // Settings API
+
+  getSettings() {
+    return this.doGet('/currentuser/settings');
+  }
+
+  setSettings(notify) {
+    return this.doPost('/currentuser/settings', {notify: notify});
+  }
+
   // Star API
 
   getStars() {

--- a/templates/myfeatures.html
+++ b/templates/myfeatures.html
@@ -1,9 +1,6 @@
 {% extends "_base.html" %}
 {% load inline_file %}
 
-{% block css %}
-{% endblock %}
-
 {% block content %}
   <chromedash-myfeatures-page></chromedash-myfeatures-page>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,39 +1,5 @@
 {% extends "_base.html" %}
 
-{% block css %}
-  <link rel="stylesheet" href="/static/css/forms.css?v={{app_version}}">
-  <style>
-    th, td { padding: 4px; }
-    input[type="submit"] { margin: 20px; }
-  </style>
-{% endblock %}
-
-{% block subheader %}
-<div id="subheader">
-  <h2>User preferences</h2>
-</div>
-{% endblock %}
-
 {% block content %}
-<section>
-  <form name="user_pref_form" method="POST" action="{{current_path}}">
-    <input type="hidden" name="token" value="{{xsrf_token}}">
-    <table cellspacing=6>
-      {{ user_pref_form }}
-    </table>
-    <input type="submit" value="Submit">
-  </form>
-</section>
-{% endblock %}
-
-{% block js %}
-<script nonce="{{nonce}}">
-  document.body.classList.remove('loading');
-
-  {% if recently_saved %}
-    const toastEl = document.querySelector('chromedash-toast');
-    setTimeout(() => {toastEl.showMessage('Settings saved')}, 500);
-  {% endif %}
-
-</script>
+  <chromedash-settings-page></chromedash-settings-page>
 {% endblock %}


### PR DESCRIPTION
This PR converts the content of settings.html into a single component. Specifically,

1. `settings_api.py` and `settings_api_test.py` are created (under the /currentuser/settings route) for fetching user settings
2. `chromedash-settings-page.js` and `chromedash-settings-page_test.js` are created.
3. Improved the toast transition. Now, if the toast is open while another open toast instruction is fired, the previous toast would slide away before the new toast slides in. See the following video demo:

https://user-images.githubusercontent.com/11501902/177060325-9a01856c-1cd5-41f7-96ff-cf3e731a7730.mov

 