### PR TITLE
Add GCloud CLI update note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ There are some developing information in developer-documentation.md.
 
 - If you need to test or debug anything to do with dependencies, you can get a clean start by running `npm run clean-setup`.
 
+- Occasionally, the Google Cloud CLI will requires an update, which will cause a failure when trying to run the development server with `npm start`. An unrelated error message `Failed to connect to localhost port 15606 after 0 ms: Connection refused` will appear. Running the `gcloud components update` command will update as needed and resolve this issue.
+
 #### Blink components
 
 Chromestatus currently gets the list of Blink components from the file `hack_components.py`.


### PR DESCRIPTION
This has happened twice to me now where I have set up the dev environment as described, but I did not update my GCloud CLI component. Running `npm start` suppresses the error message that states to update the component before continuing, and an unrelated error will appear. This PR adds this corner case to the README notes just in case it is a problem for anyone else.