### PR TITLE
Remove a missed reference to chromedash-checkbox.

### DIFF
--- a/static/elements/chromedash-settings-page.js
+++ b/static/elements/chromedash-settings-page.js
@@ -9,7 +9,7 @@ export class ChromedashSettingsPage extends LitElement {
         td {
           padding: 4px;
         }
-      
+
         input[type="submit"] {
           margin: 20px;
         }
@@ -98,12 +98,12 @@ export class ChromedashSettingsPage extends LitElement {
                   <label for="id_notify_as_starrer">Notify as starrer:</label>
                 </th>
                 <td>
-                  <chromedash-checkbox
+                  <sl-checkbox
                     id="id_notify_as_starrer"
                     name="notify_as_starrer"
                     ?checked=${this.notify_as_starrer}
                     @input=${this.handleChange}>
-                  </chromedash-checkbox>
+                  </sl-checkbox>
                   <span class="helptext"> Send you notification emails for features that you starred?</span>
                 </td>
               </tr>

--- a/static/elements/chromedash-settings-page_test.js
+++ b/static/elements/chromedash-settings-page_test.js
@@ -51,7 +51,7 @@ describe('chromedash-settings-page', () => {
     assert.include(formEl.innerHTML, 'input type="submit"');
 
     // checkbox exists and is checked
-    const checkboxEl = component.shadowRoot.querySelector('chromedash-checkbox');
+    const checkboxEl = component.shadowRoot.querySelector('sl-checkbox');
     assert.exists(checkboxEl);
     assert.include(checkboxEl.outerHTML, 'checked');
   });
@@ -74,7 +74,7 @@ describe('chromedash-settings-page', () => {
     assert.include(formEl.innerHTML, 'input type="submit"');
 
     // checkbox exists and is not checked
-    const checkboxEl = component.shadowRoot.querySelector('chromedash-checkbox');
+    const checkboxEl = component.shadowRoot.querySelector('sl-checkbox');
     assert.exists(checkboxEl);
     assert.notInclude(checkboxEl.outerHTML, 'checked');
   });


### PR DESCRIPTION
I missed these references earlier.

I think that unit tests passed before because the settings page did not explicitly include chromedash-checkbox, so there was no import failure to raise an error.  In such a situation, the element does exist, even if it is not defined as a custom element.