### PR TITLE
Constrain width of form field column.

### DIFF
--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -34,6 +34,7 @@ export class ChromedashFormField extends LitElement {
 
         td:first-of-type {
           width: 60%;
+          max-width: 35em;
         }
 
         .helptext {


### PR DESCRIPTION
The width: 60% style is not enough.  It seems to require a fixed size max-width, so this PR adds max-width: 35em.  This is necessary for the use of sl-select, when the selected item is wider than the available space.