### PR TITLE
Migrate remaining help_text to form-field-specs.js.

### DIFF
--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -90,15 +90,6 @@ class ChromedashTextarea(forms.widgets.Textarea):
             default_attrs.update(attrs)
         super().__init__(default_attrs)
 
-
-SHIPPED_HELP_TXT = (
-    'First milestone to ship with this status. Applies to: Enabled by '
-    'default, Browser Intervention, Deprecated and Removed.')
-
-SHIPPED_WEBVIEW_HELP_TXT = ('First milestone to ship with this status. '
-                            'Applies to Enabled by default, Browser '
-                            'Intervention, Deprecated, and Removed.')
-
 # Patterns from https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s01.html
 # Removing single quote ('), backtick (`), and pipe (|) since they are risky unless properly escaped everywhere.
 # Also removing ! and % because they have special meaning for some older email routing systems.
@@ -192,9 +183,9 @@ ALL_FIELDS = {
         initial=models.PROPOSAL_STD),
 
     'unlisted': forms.BooleanField(
-      label="Unlisted",
-      widget=forms.CheckboxInput(attrs={'label': "Unlisted"}),
-      required=False, initial=False),
+        label="Unlisted",
+        widget=forms.CheckboxInput(attrs={'label': "Unlisted"}),
+        required=False, initial=False),
 
     'spec_link': forms.URLField(
         required=False, label='Spec link',
@@ -216,26 +207,21 @@ ALL_FIELDS = {
     'security_review_status': forms.ChoiceField(
         required=False,
         choices=list(models.REVIEW_STATUS_CHOICES.items()),
-        initial=models.REVIEW_PENDING,
-        help_text=('Status of the security review.')),
+        initial=models.REVIEW_PENDING),
 
     'privacy_review_status': forms.ChoiceField(
         required=False,
         choices=list(models.REVIEW_STATUS_CHOICES.items()),
-        initial=models.REVIEW_PENDING,
-        help_text=('Status of the privacy review.')),
+        initial=models.REVIEW_PENDING),
 
     'tag_review': forms.CharField(
         label='TAG Review', required=False,
-        widget=ChromedashTextarea(attrs={'rows': 2}),
-        help_text=('Link(s) to TAG review(s), or explanation why this is '
-                   'not needed.')),
+        widget=ChromedashTextarea(attrs={'rows': 2})),
 
     'tag_review_status': forms.ChoiceField(
         required=False,
         choices=list(models.REVIEW_STATUS_CHOICES.items()),
-        initial=models.REVIEW_PENDING,
-        help_text=('Status of the tag review.')),
+        initial=models.REVIEW_PENDING),
 
     'intent_to_implement_url': forms.URLField(
         required=False, label='Intent to Prototype link',
@@ -243,70 +229,36 @@ ALL_FIELDS = {
 
     'intent_to_ship_url': forms.URLField(
         required=False, label='Intent to Ship link',
-        widget=forms.URLInput(attrs=URL_FIELD_ATTRS),
-        help_text=('After you have started the "Intent to Ship" discussion '
-                   'thread, link to it here.')),
+        widget=forms.URLInput(attrs=URL_FIELD_ATTRS)),
 
     'ready_for_trial_url': forms.URLField(
         required=False, label='Ready for Trial link',
-        widget=forms.URLInput(attrs=URL_FIELD_ATTRS),
-        help_text=('After you have started the "Ready for Trial" discussion '
-                   'thread, link to it here.')),
+        widget=forms.URLInput(attrs=URL_FIELD_ATTRS)),
 
     'intent_to_experiment_url': forms.URLField(
         required=False, label='Intent to Experiment link',
-        widget=forms.URLInput(attrs=URL_FIELD_ATTRS),
-        help_text=('After you have started the "Intent to Experiment" '
-                   ' discussion thread, link to it here.')),
+        widget=forms.URLInput(attrs=URL_FIELD_ATTRS)),
 
     'intent_to_extend_experiment_url': forms.URLField(
         required=False, label='Intent to Extend Experiment link',
-        widget=forms.URLInput(attrs=URL_FIELD_ATTRS),
-        help_text=('If this feature has an "Intent to Extend Experiment" '
-                   ' discussion thread, link to it here.')),
+        widget=forms.URLInput(attrs=URL_FIELD_ATTRS)),
 
     'r4dt_url': forms.URLField(  # Sets intent_to_experiment_url in DB
         required=False, label='Request for Deprecation Trial link',
-        widget=forms.URLInput(attrs=URL_FIELD_ATTRS),
-        help_text=('After you have started the "Request for Deprecation Trial" '
-                   'discussion thread, link to it here.')),
+        widget=forms.URLInput(attrs=URL_FIELD_ATTRS)),
 
     'interop_compat_risks': forms.CharField(
         required=False, label='Interoperability and Compatibility Risks',
-        widget=ChromedashTextarea(),
-        help_text=
-        ('Describe the degree of <a target="_blank" '
-         'href="https://www.chromium.org/blink/guidelines/'
-         'web-platform-changes-guidelines#TOC-Finding-balance'
-         '">interoperability risk</a>. For a new feature, the main risk is '
-         'that it fails to become an interoperable part of the web platform '
-         'if other browsers do not implement it. For a removal, please review '
-         'our <a target="_blank" href="'
-         'https://docs.google.com/document/d/'
-         '1RC-pBBvsazYfCNNUSkPqAVpSpNJ96U8trhNkfV0v9fk/edit">'
-         'principles of web compatibility</a>.<br>'
-         '<br>'
-         'Please include citation links below where possible. Examples include '
-         'resolutions from relevant standards bodies (e.g. W3C working group), '
-         'tracking bugs, or links to online conversations. '
-         '<a target="_blank" href="'
-         'https://github.com/GoogleChrome/chromium-dashboard/wiki/'
-         'EditingHelp#interoperability-and-compatibility-risks-example">'
-         'Example</a>.'
-        )),
+        widget=ChromedashTextarea()),
 
     'safari_views': forms.ChoiceField(
         required=False, label='Safari views',
         choices=list(models.VENDOR_VIEWS_WEBKIT.items()),
-        initial=models.NO_PUBLIC_SIGNALS,
-        help_text=(
-            'See <a target="_blank" href="https://bit.ly/blink-signals">'
-            'https://bit.ly/blink-signals</a>')),
+        initial=models.NO_PUBLIC_SIGNALS),
 
     'safari_views_link': forms.URLField(
         required=False, label='',
-        widget=forms.URLInput(attrs=URL_FIELD_ATTRS),
-        help_text='Citation link.'),
+        widget=forms.URLInput(attrs=URL_FIELD_ATTRS)),
 
     'safari_views_notes': forms.CharField(
         required=False, label='',
@@ -316,15 +268,11 @@ ALL_FIELDS = {
     'ff_views': forms.ChoiceField(
         required=False, label='Firefox views',
         choices=list(models.VENDOR_VIEWS_GECKO.items()),
-        initial=models.NO_PUBLIC_SIGNALS,
-        help_text=(
-            'See <a target="_blank" href="https://bit.ly/blink-signals">'
-            'https://bit.ly/blink-signals</a>')),
+        initial=models.NO_PUBLIC_SIGNALS),
 
     'ff_views_link': forms.URLField(
         required=False, label='',
-        widget=forms.URLInput(attrs=URL_FIELD_ATTRS),
-        help_text='Citation link.'),
+        widget=forms.URLInput(attrs=URL_FIELD_ATTRS)),
 
     'ff_views_notes': forms.CharField(
         required=False, label='',
@@ -334,90 +282,41 @@ ALL_FIELDS = {
     'web_dev_views': forms.ChoiceField(
         required=False, label='Web / Framework developer views',
         choices=list(models.WEB_DEV_VIEWS.items()),
-        initial=models.DEV_NO_SIGNALS,
-        help_text=(
-            'If unsure, default to "No signals". '
-            'See <a target="_blank" href="https://goo.gle/developer-signals">'
-            'https://goo.gle/developer-signals</a>')),
+        initial=models.DEV_NO_SIGNALS),
 
     'web_dev_views_link': forms.URLField(
         required=False, label='',
-        widget=forms.URLInput(attrs=URL_FIELD_ATTRS),
-        help_text='Citation link.'),
+        widget=forms.URLInput(attrs=URL_FIELD_ATTRS)),
 
     'web_dev_views_notes': forms.CharField(
         required=False, label='',
         widget=ChromedashTextarea(
-            attrs={'rows': 2, 'placeholder': 'Notes'}),
-        help_text=('Reference known representative examples of opinion, '
-                   'both positive and negative.')),
+            attrs={'rows': 2, 'placeholder': 'Notes'})),
 
     'other_views_notes': forms.CharField(
         required=False, label='Other views',
         widget=ChromedashTextarea(
-            attrs={'rows': 4, 'placeholder': 'Notes'}),
-        help_text=('For example, other browsers.')),
+            attrs={'rows': 4, 'placeholder': 'Notes'})),
 
     'ergonomics_risks': forms.CharField(
         label='Ergonomics Risks', required=False,
-        widget=ChromedashTextarea(),
-        help_text=
-        ('Are there any other platform APIs this feature will frequently be '
-         'used in tandem with? Could the default usage of this API make it '
-         'hard for Chrome to maintain good performance (i.e. synchronous '
-         'return, must run on a certain thread, guaranteed return timing)?')),
+        widget=ChromedashTextarea()),
 
     'activation_risks': forms.CharField(
         label='Activation Risks', required=False,
-        widget=ChromedashTextarea(),
-        help_text=
-        ('Will it be challenging for developers to take advantage of this '
-         'feature immediately, as-is? Would this feature benefit from '
-         'having polyfills, significant documentation and outreach, and/or '
-         'libraries built on top of it to make it easier to use?')),
+        widget=ChromedashTextarea()),
 
     'security_risks': forms.CharField(
         label='Security Risks', required=False,
-        widget=ChromedashTextarea(),
-        help_text=
-        ('List any security considerations that were taken into account '
-         'when designing this feature.')),
+        widget=ChromedashTextarea()),
 
     'webview_risks': forms.CharField(
         label='WebView application risks', required=False,
-        widget=ChromedashTextarea(),
-        help_text=
-        ('Does this intent deprecate or change behavior of existing APIs, '
-         'such that it has potentially high risk for Android WebView-based '
-         'applications? (See <a href="'
-         'https://new.chromium.org/developers/webview-changes/'
-         '" target="_blank">here</a> for a definition of "potentially high '
-         'risk", information on why changes to this platform carry higher '
-         'risk, and general rules of thumb for which changes have higher or '
-         'lower risk) If so:'
-         '<ul>'
-         '<li>Please use a base::Feature killswitch (<a href="'
-         'https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/common/features.h'
-         '" target="_blank">examples here</a>) that can '
-         'be flipped off in case of compat issues</li>'
-         '<li>Consider reaching out to android-webview-dev@chromium.org for '
-         'advice</li>'
-         '<li>If you are not sure, just put "not sure" as the answer here and '
-         'the API owners can help during the review of your intent-to-ship</li>'
-         '</ul>')),
+        widget=ChromedashTextarea()),
 
     'experiment_goals': forms.CharField(
         label='Experiment Goals', required=False,
-        widget=ChromedashTextarea(),
-        help_text=
-        ('Which pieces of the API surface are you looking to gain insight on? '
-         'What metrics/measurement/feedback will you be using to validate '
-         'designs? Double check that your experiment makes sense given that '
-         'a large developer (e.g. a Google product or Facebook) likely '
-         'can\'t use it in production due to the limits enforced by origin '
-         'trials.\n\nIf Intent to Extend Origin Trial, highlight new/different '
-         'areas for experimentation. Should not be an exact copy of goals '
-         'from the first Intent to Experiment.')),
+        widget=ChromedashTextarea()),
 
     # TODO(jrobbins): consider splitting this into start and end fields.
     'experiment_timeline': forms.CharField(
@@ -425,180 +324,99 @@ ALL_FIELDS = {
         widget=ChromedashTextarea(attrs={
             'rows': 2,
             'placeholder': 'This field is deprecated',
-            'disabled': 'disabled'}),
-        help_text=('When does the experiment start and expire? '
-                   'Deprecated: '
-                   'Please use the numeric fields above instead.')),
+            'disabled': 'disabled'})),
 
     # TODO(jrobbins and jmedley): Refine help text.
     'ot_milestone_desktop_start': forms.IntegerField(
         required=False, label='OT desktop start',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=('First desktop milestone that will support an origin '
-                   'trial of this feature.')),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
 
     'ot_milestone_desktop_end': forms.IntegerField(
         required=False, label='OT desktop end',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=('Last desktop milestone that will support an origin '
-                   'trial of this feature.')),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
 
     'ot_milestone_android_start': forms.IntegerField(
         required=False, label='OT Android start',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=('First android milestone that will support an origin '
-                   'trial of this feature.')),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
 
     'ot_milestone_android_end': forms.IntegerField(
         required=False, label='OT Android end',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=('Last android milestone that will support an origin '
-                   'trial of this feature.')),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
 
     'ot_milestone_webview_start': forms.IntegerField(
         required=False, label='OT WebView start',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=('First WebView milestone that will support an origin '
-                   'trial of this feature.')),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
 
     'ot_milestone_webview_end': forms.IntegerField(
         required=False, label='OT WebView end',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=('Last WebView milestone that will support an origin '
-                   'trial of this feature.')),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
 
     'experiment_risks': forms.CharField(
         label='Experiment Risks', required=False,
-        widget=ChromedashTextarea(),
-        help_text=
-        ('When this experiment comes to an end are there any risks to the '
-         'sites that were using it, for example losing access to important '
-         'storage due to an experimental storage API?')),
+        widget=ChromedashTextarea()),
 
     'experiment_extension_reason': forms.CharField(
         label='Experiment Extension Reason', required=False,
-        widget=ChromedashTextarea(),
-        help_text=
-        ('If this is a repeat experiment, explain why you want to extend this '
-         'experiment.  Also, fill in discussion link fields below.')),
+        widget=ChromedashTextarea()),
 
     'ongoing_constraints': forms.CharField(
         label='Ongoing Constraints', required=False,
-        widget=ChromedashTextarea(),
-        help_text=
-        ('Do you anticipate adding any ongoing technical constraints to '
-         'the codebase while implementing this feature? We prefer to avoid '
-         'features which require or assume a specific architecture. '
-         'For most features, the answer here is "None."')),
+        widget=ChromedashTextarea()),
 
     'origin_trial_feedback_url': forms.URLField(
         required=False, label='Origin trial feedback summary',
-        widget=forms.URLInput(attrs=URL_FIELD_ATTRS),
-        help_text=
-        ('If your feature was available as an origin trial, link to a summary '
-         'of usage and developer feedback. If not, leave this empty.')),
+        widget=forms.URLInput(attrs=URL_FIELD_ATTRS)),
 
     'anticipated_spec_changes': MultiUrlField(
         required=False, label='Anticipated spec changes',
-        widget=ChromedashTextarea(attrs=MULTI_URL_FIELD_ATTRS),
-        help_text=
-        ('Open questions about a feature may be a source of future web compat '
-         'or interop issues. Please list open issues (e.g. links to known '
-         'github issues in the project for the feature specification) whose '
-         'resolution may introduce web compat/interop risk (e.g., changing '
-         'to naming or structure of the API in a '
-         'non-backward-compatible way).')),
+        widget=ChromedashTextarea(attrs=MULTI_URL_FIELD_ATTRS)),
 
     'finch_url': forms.URLField(
         required=False, label='Finch experiment',
-        widget=forms.URLInput(attrs=URL_FIELD_ATTRS),
-        help_text=
-        ('If your feature will roll out gradually via a '
-         '<a href="go/finch" targe="_blank">Finch experiment</a>, '
-         'link to it here.')),
+        widget=forms.URLInput(attrs=URL_FIELD_ATTRS)),
 
     'i2e_lgtms': MultiEmailField(
         required=False, label='Intent to Experiment LGTM by',
-        widget=forms.EmailInput(attrs=MULTI_EMAIL_FIELD_ATTRS),
-        help_text=('Full email address of API owner who LGTM\'d the '
-                   'Intent to Experiment email thread.')),
+        widget=forms.EmailInput(attrs=MULTI_EMAIL_FIELD_ATTRS)),
 
     'i2s_lgtms': MultiEmailField(
         required=False, label='Intent to Ship LGTMs by',
-        widget=forms.EmailInput(attrs=MULTI_EMAIL_FIELD_ATTRS),
-        help_text=('Comma separated list of '
-                   'full email addresses of API owners who LGTM\'d '
-                   'the Intent to Ship email thread.')),
+        widget=forms.EmailInput(attrs=MULTI_EMAIL_FIELD_ATTRS)),
 
     'r4dt_lgtms': MultiEmailField(  # Sets i2e_lgtms field.
         required=False, label='Request for Deprecation Trial LGTM by',
-        widget=forms.EmailInput(attrs=MULTI_EMAIL_FIELD_ATTRS),
-        help_text=('Full email addresses of API owners who LGTM\'d '
-                   'the Request for Deprecation Trial email thread.')),
+        widget=forms.EmailInput(attrs=MULTI_EMAIL_FIELD_ATTRS)),
 
     'debuggability': forms.CharField(
         label='Debuggability', required=True,
-        widget=ChromedashTextarea(),
-        help_text=
-        ('Description of the DevTools debugging support for your feature. '
-         'Please follow <a target="_blank" '
-         'href="https://goo.gle/devtools-checklist">the '
-         'DevTools support checklist</a> for guidance.')),
+        widget=ChromedashTextarea()),
 
     'all_platforms': forms.BooleanField(
         label='Supported on all platforms?',
         widget=forms.CheckboxInput(attrs={'label': "Supported on all platforms"}),
-        required=False, initial=False, 
-        help_text=
-        ('Will this feature be supported on all six Blink platforms '
-         '(Windows, Mac, Linux, Chrome OS, Android, and Android WebView)?')),
+        required=False, initial=False),
 
     'all_platforms_descr': forms.CharField(
         label='Platform Support Explanation', required=False,
         widget=ChromedashTextarea(
-            attrs={'rows': 2}),
-            help_text=(
-                'Explain why this feature is, or is not, '
-                'supported on all platforms.')),
+            attrs={'rows': 2})),
 
     'wpt': forms.BooleanField(
         label='Web Platform Tests',
         widget=forms.CheckboxInput(attrs={'label': "Web Platform Tests"}),
-        required=False, initial=False, 
-        help_text='Is this feature fully tested in Web Platform Tests?'),
+        required=False, initial=False),
 
     'wpt_descr': forms.CharField(
         label='Web Platform Tests Description', required=False,
-        widget=ChromedashTextarea(),
-        help_text=
-        ('Please link to the <a href="https://wpt.fyi/results">results on '
-         'wpt.fyi</a>. If any part of the feature is not tested by '
-         'web-platform-tests. Please include links to issues, e.g. a '
-         'web-platform-tests issue with the "infra" label explaining why a '
-         'certain thing cannot be tested (<a '
-         'href="https://github.com/w3c/web-platform-tests/issues/3867">'
-         'example</a>), a spec issue for some change that would make it '
-         'possible to test. (<a href="'
-         'https://github.com/whatwg/fullscreen/issues/70">example</a>), or '
-         'a Chromium issue to upstream some existing tests (<a href="'
-         'https://bugs.chromium.org/p/chromium/issues/detail?id=695486">'
-         'example</a>).')),
+        widget=ChromedashTextarea()),
 
     'sample_links': MultiUrlField(
         label='Samples links', required=False,
-        widget=ChromedashTextarea(attrs=MULTI_URL_FIELD_ATTRS),
-        help_text='Links to samples (one URL per line).'),
+        widget=ChromedashTextarea(attrs=MULTI_URL_FIELD_ATTRS)),
 
     'non_oss_deps': forms.CharField(
         label='Non-OSS dependencies', required=False,
-        widget=ChromedashTextarea(),
-        help_text=
-        ('Does the feature depend on any code or APIs outside the Chromium '
-         'open source repository and its open-source dependencies to '
-         'function? (e.g. server-side APIs, operating system APIs '
-         'tailored to this feature or closed-source code bundles) '
-         'Yes or no. If yes, explain why this is necessary.'
-         )),
+        widget=ChromedashTextarea()),
 
     'bug_url': forms.URLField(
         required=False, label='Tracking bug URL',
@@ -621,8 +439,7 @@ ALL_FIELDS = {
 
     'devrel': MultiEmailField(
         required=False, label='Developer relations emails',
-        widget=forms.EmailInput(attrs=MULTI_EMAIL_FIELD_ATTRS),
-        help_text='Comma separated list of full email addresses.'),
+        widget=forms.EmailInput(attrs=MULTI_EMAIL_FIELD_ATTRS)),
 
     'impl_status_chrome': forms.ChoiceField(
         required=False, label='Implementation status',
@@ -630,76 +447,43 @@ ALL_FIELDS = {
 
     'shipped_milestone': forms.IntegerField(
         required=False, label='Chrome for desktop',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=SHIPPED_HELP_TXT),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
 
     'shipped_android_milestone': forms.IntegerField(
         required=False, label='Chrome for Android',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=SHIPPED_HELP_TXT),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
 
     'shipped_ios_milestone': forms.IntegerField(
         required=False, label='Chrome for iOS (RARE)',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=SHIPPED_HELP_TXT),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
 
     'shipped_webview_milestone': forms.IntegerField(
         required=False, label='Android Webview',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=SHIPPED_WEBVIEW_HELP_TXT),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
 
     'requires_embedder_support': forms.BooleanField(
       label='Requires Embedder Support',
       widget=forms.CheckboxInput(attrs={'label': "Requires Embedder Support"}),
-      required=False, initial=False,
-      help_text=(
-          'Will this feature require support in //chrome?  '
-          'That includes any code in //chrome, even if that is for '
-          'functionality on top of the spec.  Other //content embedders '
-          'will need to be aware of that functionality. '
-          'Please add a row to this '
-          '<a href="https://docs.google.com/spreadsheets/d/'
-          '1QV4SW4JBG3IyLzaonohUhim7nzncwK4ioop2cgUYevw/edit#gid=0'
-          '" target="_blank">tracking spreadsheet</a>.')),
+      required=False, initial=False),
 
     'devtrial_instructions': forms.URLField(
         required=False, label='DevTrial instructions',
-        widget=forms.URLInput(attrs=URL_FIELD_ATTRS),
-        help_text=(
-            'Link to a HOWTO or FAQ describing how developers can get started '
-            'using this feature in a DevTrial.  <a target="_blank" href="'
-            'https://github.com/samuelgoto/WebID/blob/master/HOWTO.md'
-            '">Example 1</a>.  <a target="_blank" href="'
-            'https://github.com/WICG/idle-detection/blob/main/HOWTO.md'
-            '">Example 2</a>.')),
+        widget=forms.URLInput(attrs=URL_FIELD_ATTRS)),
 
     'dt_milestone_desktop_start': forms.IntegerField(
         required=False, label='DevTrial on desktop',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=('First milestone that allows developers to try '
-                   'this feature on desktop platforms by setting a flag. '
-                   'When flags are enabled by default in preparation for '
-                   'removal, please use the fields in the ship stage.')),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
 
     'dt_milestone_android_start': forms.IntegerField(
         required=False, label='DevTrial on Android',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=('First milestone that allows developers to try '
-                   'this feature on desktop platforms by setting a flag. '
-                   'When flags are enabled by default in preparation for '
-                   'removal, please use the fields in the ship stage.')),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
 
     'dt_milestone_ios_start': forms.IntegerField(
         required=False, label='DevTrial on iOS (RARE)',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'}),
-        help_text=('First milestone that allows developers to try '
-                   'this feature on desktop platforms by setting a flag. '
-                   'When flags are enabled by default in preparation for '
-                   'removal, please use the fields in the ship stage.')),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
 
     'flag_name': forms.CharField(
-        label='Flag name', required=False,
-        help_text='Name of the flag that enables this feature.'),
+        label='Flag name', required=False),
 
     'prefixed': forms.BooleanField(
         label='Prefixed?',
@@ -728,7 +512,7 @@ METADATA_FIELDS = [
 ]
 
 class ChromedashForm(forms.Form):
-    def simple_html_output(self, normal_row, help_text_html):
+    def simple_html_output(self, normal_row):
         """
         Output HTML. Used by override of as_table() to support chromedash uses only.
         Simplified to drop support for hidden form fields and errors at the top, 
@@ -754,17 +538,11 @@ class ChromedashForm(forms.Form):
             else:
                 label = ''
 
-            if field.help_text:
-                help_text = help_text_html % field.help_text
-            else:
-                help_text = ''
-
             output.append(normal_row % {
                 'name': name,
                 'errors': bf_errors,
                 'label': label,
                 'field': bf,
-                'help_text': help_text,
                 'html_class_attr': html_class_attr,
                 'css_classes': css_classes,
                 'field_name': bf.html_name,
@@ -777,12 +555,8 @@ class ChromedashForm(forms.Form):
         label = '<span slot="label">%(label)s</span>'
         field = '<span slot="field">%(field)s</span>'
         error = '<span slot="error">%(errors)s</span>'
-        help = '<span slot="help">%(help_text)s</span>'
-        html = '<chromedash-form-field name="%(name)s" %(html_class_attr)s>' + label + field + error + help + '%(label)s' + '</chromedash-form-field>'
-        return self.simple_html_output(
-            normal_row=html,
-            help_text_html='<span class="helptext">%s</span>'
-        )
+        html = '<chromedash-form-field name="%(name)s" %(html_class_attr)s>' + label + field + error + '%(label)s' + '</chromedash-form-field>'
+        return self.simple_html_output(normal_row=html)
 
 def define_form_class_using_shared_fields(class_name, field_spec_list):
   """Define a new subsblass of forms.Form with the given fields, in order."""

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -329,27 +329,27 @@ ALL_FIELDS = {
     # TODO(jrobbins and jmedley): Refine help text.
     'ot_milestone_desktop_start': forms.IntegerField(
         required=False, label='OT desktop start',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone number'})),
 
     'ot_milestone_desktop_end': forms.IntegerField(
         required=False, label='OT desktop end',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone number'})),
 
     'ot_milestone_android_start': forms.IntegerField(
         required=False, label='OT Android start',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone number'})),
 
     'ot_milestone_android_end': forms.IntegerField(
         required=False, label='OT Android end',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone number'})),
 
     'ot_milestone_webview_start': forms.IntegerField(
         required=False, label='OT WebView start',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone number'})),
 
     'ot_milestone_webview_end': forms.IntegerField(
         required=False, label='OT WebView end',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone number'})),
 
     'experiment_risks': forms.CharField(
         label='Experiment Risks', required=False,
@@ -447,19 +447,19 @@ ALL_FIELDS = {
 
     'shipped_milestone': forms.IntegerField(
         required=False, label='Chrome for desktop',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone number'})),
 
     'shipped_android_milestone': forms.IntegerField(
         required=False, label='Chrome for Android',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone number'})),
 
     'shipped_ios_milestone': forms.IntegerField(
         required=False, label='Chrome for iOS (RARE)',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone number'})),
 
     'shipped_webview_milestone': forms.IntegerField(
         required=False, label='Android Webview',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone number'})),
 
     'requires_embedder_support': forms.BooleanField(
       label='Requires Embedder Support',
@@ -472,15 +472,15 @@ ALL_FIELDS = {
 
     'dt_milestone_desktop_start': forms.IntegerField(
         required=False, label='DevTrial on desktop',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone number'})),
 
     'dt_milestone_android_start': forms.IntegerField(
         required=False, label='DevTrial on Android',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone number'})),
 
     'dt_milestone_ios_start': forms.IntegerField(
         required=False, label='DevTrial on iOS (RARE)',
-        widget=forms.NumberInput(attrs={'placeholder': 'Milestone #'})),
+        widget=forms.NumberInput(attrs={'placeholder': 'Milestone number'})),
 
     'flag_name': forms.CharField(
         label='Flag name', required=False),

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -69,8 +69,9 @@ export class ChromedashFormField extends LitElement {
           <slot name="error" class="errorlist"></slot>
         </td>
         <td>
-          ${helpText}
-          <slot name="help" class="helptext"></slot>
+          <span class="helptext">
+            ${helpText}
+          </span>
         </td>
       </tr>`;
   }

--- a/static/elements/chromedash-form-field_test.js
+++ b/static/elements/chromedash-form-field_test.js
@@ -20,7 +20,6 @@ describe('chromedash-form-field', () => {
         <span slot="label">Label</span>
         <span slot="field">Field</span>
         <span slot="error">Error</span>
-        <span slot="help">Help</span>
       </chromedash-form-field>`);
     assert.exists(component);
     await component.updateComplete;
@@ -36,9 +35,5 @@ describe('chromedash-form-field', () => {
     const errorElements = slotAssignedElements(component, 'error');
     assert.exists(errorElements);
     assert.include(errorElements[0].innerHTML, 'Error');
-
-    const helpElements = slotAssignedElements(component, 'help');
-    assert.exists(helpElements);
-    assert.include(helpElements[0].innerHTML, 'Help');
   });
 });

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -1,9 +1,18 @@
 import {html} from 'lit';
 
+
+const SHIPPED_HELP_TXT = html`
+  First milestone to ship with this status. Applies to: Enabled by
+  default, Browser Intervention, Deprecated and Removed.`;
+
+const
+  SHIPPED_WEBVIEW_HELP_TXT = html`
+  First milestone to ship with this status.
+  Applies to Enabled by default, Browser
+  Intervention, Deprecated, and Removed.`;
+
 // Map of specifications for all form fields.
-// TODO:
-//   * Finish migrating remaining fields.
-//   * Migrate other properties.
+// TODO: Migrate other properties.
 export const ALL_FIELDS = {
 
   'name': {
@@ -175,11 +184,418 @@ export const ALL_FIELDS = {
         claims.`,
   },
 
-  'neasurement': {
+  'measurement': {
     help_text: html`
         It's important to measure the adoption and success of web-exposed
         features.  Note here what measurements you have added to track the
         success of this feature, such as a link to the UseCounter(s) you
         have set up.`,
   },
+
+  'security_review_status': {
+    help_text: html`
+        Status of the security review.`,
+  },
+
+  'privacy_review_status': {
+    help_text: html`Status of the privacy review.`,
+  },
+
+  'tag_review': {
+    help_text: html`Link(s) to TAG review(s), or explanation why this is 
+                not needed.`,
+  },
+
+  'tag_review_status': {
+    help_text: html`Status of the tag review.`,
+  },
+
+  'intent_to_ship_url': {
+    help_text: html`After you have started the "Intent to Ship" discussion 
+                thread, link to it here.`,
+  },
+
+  'ready_for_trial_url': {
+    help_text: html`After you have started the "Ready for Trial" discussion 
+                thread, link to it here.`,
+  },
+
+  'intent_to_experiment_url': {
+    help_text: html`After you have started the "Intent to Experiment" 
+                 discussion thread, link to it here.`,
+  },
+
+  'intent_to_extend_experiment_url': {
+    help_text: html`If this feature has an "Intent to Extend Experiment" 
+                 discussion thread, link to it here.`,
+  },
+
+  'r4dt_url': {
+    help_text: html`After you have started the "Request for Deprecation Trial" 
+                discussion thread, link to it here.`,
+  },
+
+  'interop_compat_risks': {
+    help_text: html`
+      Describe the degree of 
+      <a target="_blank" 
+          href="https://www.chromium.org/blink/guidelines/web-platform-changes-guidelines#TOC-Finding-balance">
+        interoperability risk</a>. 
+      For a new feature, the main risk is 
+      that it fails to become an interoperable part of the web platform 
+      if other browsers do not implement it. For a removal, please review our 
+      <a target="_blank" 
+          href="https://docs.google.com/document/d/1RC-pBBvsazYfCNNUSkPqAVpSpNJ96U8trhNkfV0v9fk/edit">
+      principles of web compatibility</a>.<br>
+      <br>
+      Please include citation links below where possible. Examples include 
+      resolutions from relevant standards bodies (e.g. W3C working group), 
+      tracking bugs, or links to online conversations. 
+      <a target="_blank" 
+          href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#interoperability-and-compatibility-risks-example">
+        Example</a>.`,
+  },
+
+  'safari_views': {
+    help_text: html`
+      See <a target="_blank" href="https://bit.ly/blink-signals">
+      https://bit.ly/blink-signals</a>`,
+  },
+
+  'safari_views_link': {
+    help_text: html`Citation link.`,
+  },
+
+  'safari_views_notes': {},
+
+  'ff_views': {
+    help_text: html`
+      See <a target="_blank" href="https://bit.ly/blink-signals">
+      https://bit.ly/blink-signals</a>`,
+  },
+
+  'ff_views_link': {
+    help_text: html`
+    Citation link.`,
+  },
+
+  'ff_views_notes': {},
+
+  'web_dev_views': {
+    help_text: html`
+      If unsure, default to "No signals". 
+      See <a target="_blank" href="https://goo.gle/developer-signals">
+      https://goo.gle/developer-signals</a>`,
+  },
+
+  'web_dev_views_link': {
+    help_text: html`
+      Citation link.`,
+  },
+
+  'web_dev_views_notes': {
+    help_text: html`
+      Reference known representative examples of opinion, 
+      both positive and negative.`,
+  },
+
+  'other_views_notes': {
+    help_text: html`
+      For example, other browsers.`,
+  },
+
+  'ergonomics_risks': {
+    help_text: html`
+      Are there any other platform APIs this feature will frequently be 
+      used in tandem with? Could the default usage of this API make it 
+      hard for Chrome to maintain good performance (i.e. synchronous 
+      return, must run on a certain thread, guaranteed return timing)?`,
+  },
+
+  'activation_risks': {
+    help_text: html`
+      Will it be challenging for developers to take advantage of this 
+      feature immediately, as-is? Would this feature benefit from 
+      having polyfills, significant documentation and outreach, and/or 
+      libraries built on top of it to make it easier to use?`,
+  },
+
+  'security_risks': {
+    help_text: html`
+      List any security considerations that were taken into account 
+      when designing this feature.`,
+  },
+
+  'webview_risks': {
+    help_text: html`
+      Does this intent deprecate or change behavior of existing APIs, 
+      such that it has potentially high risk for Android WebView-based 
+      applications? 
+      (See <a target="_blank"
+          href="https://new.chromium.org/developers/webview-changes/">
+        here</a> 
+      for a definition of "potentially high risk", 
+      information on why changes to this platform carry higher 
+      risk, and general rules of thumb for which changes have higher or 
+      lower risk) If so:
+      <ul>
+        <li>Please use a base::Feature killswitch 
+          (<a target="_blank"
+              href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/common/features.h"
+              >examples here</a>) 
+          that can be flipped off in case of compat issues</li>
+        <li>Consider reaching out to android-webview-dev@chromium.org for advice</li>
+        <li>If you are not sure, just put "not sure" as the answer here and 
+          the API owners can help during the review of your intent-to-ship</li>
+      </ul>`,
+  },
+
+  'experiment_goals': {
+    help_text: html`
+      Which pieces of the API surface are you looking to gain insight on? 
+      What metrics/measurement/feedback will you be using to validate 
+      designs? Double check that your experiment makes sense given that 
+      a large developer (e.g. a Google product or Facebook) likely 
+      can't use it in production due to the limits enforced by origin 
+      trials.\n\nIf Intent to Extend Origin Trial, highlight new/different 
+      areas for experimentation. Should not be an exact copy of goals 
+      from the first Intent to Experiment.`,
+  },
+
+  // TODO(jrobbins): consider splitting this into start and end fields.
+  'experiment_timeline': {
+    help_text: html`
+      When does the experiment start and expire? 
+      Deprecated: 
+      Please use the numeric fields above instead.`,
+  },
+
+  // TODO(jrobbins and jmedley): Refine help text.
+  'ot_milestone_desktop_start': {
+    help_text: html`
+      First desktop milestone that will support an origin 
+      trial of this feature.`,
+  },
+
+  'ot_milestone_desktop_end': {
+    help_text: html`
+      Last desktop milestone that will support an origin 
+      trial of this feature.`,
+  },
+
+  'ot_milestone_android_start': {
+    help_text: html`
+      First android milestone that will support an origin 
+      trial of this feature.`,
+  },
+
+  'ot_milestone_android_end': {
+    help_text: html`
+      Last android milestone that will support an origin 
+      trial of this feature.`,
+  },
+
+  'ot_milestone_webview_start': {
+    help_text: html`
+      First WebView milestone that will support an origin 
+      trial of this feature.`,
+  },
+
+  'ot_milestone_webview_end': {
+    help_text: html`
+      Last WebView milestone that will support an origin 
+      trial of this feature.`,
+  },
+
+  'experiment_risks': {
+    help_text: html`
+      When this experiment comes to an end are there any risks to the 
+      sites that were using it, for example losing access to important 
+      storage due to an experimental storage API?`,
+  },
+
+  'experiment_extension_reason': {
+    help_text: html`
+      If this is a repeat experiment, explain why you want to extend this 
+      experiment.  Also, fill in discussion link fields below.`,
+  },
+
+  'ongoing_constraints': {
+    help_text: html`
+      Do you anticipate adding any ongoing technical constraints to 
+      the codebase while implementing this feature? We prefer to avoid 
+      features which require or assume a specific architecture. 
+      For most features, the answer here is "None."`,
+  },
+
+  'origin_trial_feedback_url': {
+    help_text: html`
+      If your feature was available as an origin trial, link to a summary 
+      of usage and developer feedback. If not, leave this empty.`,
+  },
+
+  'anticipated_spec_changes': {
+    help_text: html`
+      Open questions about a feature may be a source of future web compat 
+      or interop issues. Please list open issues (e.g. links to known 
+      github issues in the project for the feature specification) whose 
+      resolution may introduce web compat/interop risk (e.g., changing 
+      to naming or structure of the API in a 
+      non-backward-compatible way).`,
+  },
+
+  'finch_url': {
+    help_text: html`
+      If your feature will roll out gradually via a 
+      <a href="go/finch" targe="_blank">Finch experiment</a>, 
+      link to it here.`,
+  },
+
+  'i2e_lgtms': {
+    help_text: html`
+      Full email address of API owner who LGTM\'d the 
+      Intent to Experiment email thread.`,
+  },
+
+  'i2s_lgtms': {
+    help_text: html`
+      Comma separated list of 
+      full email addresses of API owners who LGTM\'d 
+      the Intent to Ship email thread.`,
+  },
+
+  'r4dt_lgtms': {
+    help_text: html`
+      Full email addresses of API owners who LGTM\'d 
+      the Request for Deprecation Trial email thread.`,
+  },
+
+  'debuggability': {
+    help_text: html`
+      Description of the DevTools debugging support for your feature. 
+      Please follow 
+      <a target="_blank" 
+          href="https://goo.gle/devtools-checklist">
+        the DevTools support checklist</a> for guidance.`,
+  },
+
+  'all_platforms': {
+    help_text: html`
+      Will this feature be supported on all six Blink platforms 
+      (Windows, Mac, Linux, Chrome OS, Android, and Android WebView)?`,
+  },
+
+  'all_platforms_descr': {
+    help_text: html`
+      Explain why this feature is, or is not, 
+      supported on all platforms.`,
+  },
+
+  'wpt': {
+    help_text: html`
+      Is this feature fully tested in Web Platform Tests?`,
+  },
+
+  'wpt_descr': {
+    help_text: html`
+      Please link to the <a href="https://wpt.fyi/results">results on 
+      wpt.fyi</a>. If any part of the feature is not tested by 
+      web-platform-tests. Please include links to issues, e.g. a 
+      web-platform-tests issue with the "infra" label explaining why a 
+      certain thing cannot be tested 
+      (<a href="https://github.com/w3c/web-platform-tests/issues/3867">example</a>), 
+      a spec issue for some change that would make it possible to test. 
+      (<a href="https://github.com/whatwg/fullscreen/issues/70">example</a>), 
+      or a Chromium issue to upstream some existing tests 
+      (<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=695486">example</a>).`,
+  },
+
+  'sample_links': {
+    help_text: html`
+      Links to samples (one URL per line).`,
+  },
+
+  'non_oss_deps': {
+    help_text: html`
+      Does the feature depend on any code or APIs outside the Chromium 
+      open source repository and its open-source dependencies to 
+      function? (e.g. server-side APIs, operating system APIs 
+      tailored to this feature or closed-source code bundles) 
+      Yes or no. If yes, explain why this is necessary.`,
+  },
+
+  'devrel': {
+    help_text: html`
+      Comma separated list of full email addresses.`,
+  },
+
+  'shipped_milestone': {
+    help_text: SHIPPED_HELP_TXT,
+  },
+
+  'shipped_android_milestone': {
+    help_text: SHIPPED_HELP_TXT,
+  },
+
+  'shipped_ios_milestone': {
+    help_text: SHIPPED_HELP_TXT,
+  },
+
+  'shipped_webview_milestone': {
+    help_text: SHIPPED_WEBVIEW_HELP_TXT,
+  },
+
+  'requires_embedder_support': {
+    help_text: html`
+       Will this feature require support in //chrome?  
+       That includes any code in //chrome, even if that is for 
+       functionality on top of the spec.  Other //content embedders 
+       will need to be aware of that functionality. 
+       Please add a row to this 
+       <a target="_blank"
+          href="https://docs.google.com/spreadsheets/d/1QV4SW4JBG3IyLzaonohUhim7nzncwK4ioop2cgUYevw/edit#gid=0">
+        tracking spreadsheet</a>.`,
+  },
+
+  'devtrial_instructions': {
+    help_text: html`
+        Link to a HOWTO or FAQ describing how developers can get started 
+        using this feature in a DevTrial.  
+        <a target="_blank" 
+            href="https://github.com/samuelgoto/WebID/blob/master/HOWTO.md">
+          Example 1</a>.  
+        <a target="_blank" 
+            href="https://github.com/WICG/idle-detection/blob/main/HOWTO.md">
+          Example 2</a>.`,
+  },
+
+  'dt_milestone_desktop_start': {
+    help_text: html`
+      First milestone that allows developers to try 
+      this feature on desktop platforms by setting a flag. 
+      When flags are enabled by default in preparation for 
+      removal, please use the fields in the ship stage.`,
+  },
+
+  'dt_milestone_android_start': {
+    help_text: html`
+      First milestone that allows developers to try 
+      this feature on desktop platforms by setting a flag. 
+      When flags are enabled by default in preparation for 
+      removal, please use the fields in the ship stage.`,
+  },
+
+  'dt_milestone_ios_start': {
+    help_text: html`
+      First milestone that allows developers to try 
+      this feature on desktop platforms by setting a flag. 
+      When flags are enabled by default in preparation for 
+      removal, please use the fields in the ship stage.`,
+  },
+
+  'flag_name': {
+    help_text: html`
+      Name of the flag that enables this feature.'`,
+  },
+
 };

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -3,7 +3,7 @@ import {html} from 'lit';
 
 const SHIPPED_HELP_TXT = html`
   First milestone to ship with this status. Applies to: Enabled by
-  default, Browser Intervention, Deprecated and Removed.`;
+  default, Browser Intervention, Deprecated, and Removed.`;
 
 const
   SHIPPED_WEBVIEW_HELP_TXT = html`
@@ -18,40 +18,46 @@ export const ALL_FIELDS = {
   'name': {
     help_text: html`
         Capitalize only the first letter and the beginnings of proper nouns.
+        <br/><br>
         <a target="_blank"
             href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#feature-name">
-          Learn more</a>
+          Learn more</a>.
         <a target="_blank"
             href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#feature-name-example">
-          Example</a>
-      `},
+          Example</a>.
+      `,
+  },
 
   'summary': {
     help_text: html`
-        NOTE: Text in the beta release post, the enterprise release notes, 
-        and other external sources will be based on this text.
+       <p>Text in the beta release post, the enterprise release notes, 
+        and other external sources will be based on this text.</p>
   
-        Begin with one line explaining what the feature does. Add one or two 
-        lines explaining how this feature helps developers. Avoid language such 
-        as "a new feature". They all are or have been new features.
-  
-        Write it from a web developer's point of view.
-        Follow the example link below for more guidance.<br>
-        <a target="_blank" 
-            href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#summary-example">
-          Guidelines and example</a>.`,
+        <p>Write from a web developer's point of view. Begin with one line
+        explaining what the feature does. Add one or two lines explaining
+        how this feature helps developers. Write in a matter-of-fact
+        manner and in the present tense. (This summary will be visible long after
+        your project is finished.) Avoid language such as "a new feature" and
+        "we propose".</p>
+        <a target="_blank"
+            href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#summary">
+          Learn more</a>.
+        <a target="_blank"
+            href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#example-1">
+          Example</a>.
+      `,
   },
 
   'owner': {
     help_text: html`
-        Comma separated list of full email addresses. Prefer @chromium.org.`,
+        Comma separated list of full email addresses. Accounts
+        from @chromium.org are preferred.`,
   },
 
   'unlisted': {
     help_text: html`
-        Check this box for draft features that should not appear
-        in the feature list. Anyone with the link will be able to
-        view the feature on the detail page.`,
+        Check this box to hide draft emails in list views. Anyone with
+        a link will be able to view the feature's detail page.`,
   },
 
   'blink_components': {
@@ -71,7 +77,9 @@ export const ALL_FIELDS = {
 
   'intent_stage': {
     help_text: html`
-        Select the appropriate process stage.`,
+        Select the appropriate spec process stage. If you select
+        Dev trials, Origin Trial, or Shipped, be sure to set the
+        equivalent Implementation status.`,
   },
 
   'search_tags': {
@@ -81,19 +89,26 @@ export const ALL_FIELDS = {
 
   'impl_status_chrome': {
     help_text: html`
-        Implementation status in Chromium.`,
+        Select the appropriate Chromium development stage. If you
+        select In developer trial, Origin trial, or Enabled by
+        default, be sure to set the equivalent Process stage.`,
   },
 
   'bug_url': {
     help_text: html`
         Tracking bug url (https://bugs.chromium.org/...). This bug
         should have "Type=Feature" set and be world readable.
-        Note: This field only accepts one URL.`,
+        Note: This field only accepts one URL.
+        <br/><br>
+        <a target="_blank"
+            href="https://bugs.chromium.org/p/chromium/issues/entry">
+          Create tracking bug</a>`,
   },
 
   'launch_bug_url': {
     help_text: html`
         Launch bug url (https://bugs.chromium.org/...) to track launch approvals.
+        <br/><br>
         <a target="_blank"
             href="https://bugs.chromium.org/p/chromium/issues/entry?template=Chrome+Launch+Feature">
           Create launch bug</a>.`,
@@ -104,17 +119,30 @@ export const ALL_FIELDS = {
         Explain why the web needs this change. It may be useful 
         to describe what web developers are forced to do without 
         it. When possible, add links to your explainer 
-        backing up your claims. 
+        backing up your claims.
+        <br/><br>
+        This text is sometimes included with the summary in the
+        beta post, enterprise release notes and other external
+        documents. Write in a matter-of-fact manner and in the
+        present tense.
+        <br/><br>
         <a target="_blank" 
             href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#motivation-example">
-          Example</a>.`,
+          Example</a>`,
   },
 
   'deprecation_motivation': {
     help_text: html`
         Deprecations and removals must have strong reasons, backed up
-        by measurements.  There must be clear and actionable paths forward
-        for developers.  Please see
+        by measurements. There must be clear and actionable paths forward
+        for developers.
+        <br/><br>
+        This text is sometimes included with the summary in the
+        beta post, enterprise release notes and other external
+        documents. Write in a matter-of-fact manner and in the
+        present tense.
+        <br/><br>
+        Please see
         <a target="_blank" 
             href="https://docs.google.com/a/chromium.org/document/d/1LdqUfUILyzM5WEcOgeAWGupQILKrZHidEXrUxevyi_Y/edit?usp=sharing">
           Removal guidelines</a>.`,
@@ -137,9 +165,9 @@ export const ALL_FIELDS = {
 
   'spec_link': {
     help_text: html`
-        Link to spec, if and when available.  Please update the
-        chromestatus.com entry and the intent thread(s) with the
-        spec link when available.`,
+        Link to the spec, if and when available. When implementing
+        a spec update, please link to a heading in a published spec
+        rather than a pull request when possible.`,
   },
 
   'comments': {
@@ -295,7 +323,7 @@ export const ALL_FIELDS = {
 
   'web_dev_views_notes': {
     help_text: html`
-      Reference known representative examples of opinion, 
+      Reference known representative examples of opinions, 
       both positive and negative.`,
   },
 
@@ -328,7 +356,7 @@ export const ALL_FIELDS = {
 
   'webview_risks': {
     help_text: html`
-      Does this intent deprecate or change behavior of existing APIs, 
+      Does this feature deprecate or change behavior of existing APIs, 
       such that it has potentially high risk for Android WebView-based 
       applications? 
       (See <a target="_blank"
@@ -344,9 +372,9 @@ export const ALL_FIELDS = {
               href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/common/features.h"
               >examples here</a>) 
           that can be flipped off in case of compat issues</li>
-        <li>Consider reaching out to android-webview-dev@chromium.org for advice</li>
-        <li>If you are not sure, just put "not sure" as the answer here and 
-          the API owners can help during the review of your intent-to-ship</li>
+        <li>Consider contacting android-webview-dev@chromium.org for advice</li>
+        <li>If you are not sure, just put "not sure" as the answer and 
+          the API owners can help during the review of your Intent to Ship</li>
       </ul>`,
   },
 
@@ -357,12 +385,11 @@ export const ALL_FIELDS = {
       designs? Double check that your experiment makes sense given that 
       a large developer (e.g. a Google product or Facebook) likely 
       can't use it in production due to the limits enforced by origin 
-      trials.\n\nIf Intent to Extend Origin Trial, highlight new/different 
-      areas for experimentation. Should not be an exact copy of goals 
+      trials.\n\nIf you send an Intent to Extend Origin Trial, highlight 
+      areas for experimentation. They should not be an exact copy of the goals 
       from the first Intent to Experiment.`,
   },
 
-  // TODO(jrobbins): consider splitting this into start and end fields.
   'experiment_timeline': {
     help_text: html`
       When does the experiment start and expire? 
@@ -370,7 +397,6 @@ export const ALL_FIELDS = {
       Please use the numeric fields above instead.`,
   },
 
-  // TODO(jrobbins and jmedley): Refine help text.
   'ot_milestone_desktop_start': {
     help_text: html`
       First desktop milestone that will support an origin 
@@ -416,16 +442,16 @@ export const ALL_FIELDS = {
 
   'experiment_extension_reason': {
     help_text: html`
-      If this is a repeat experiment, explain why you want to extend this 
-      experiment.  Also, fill in discussion link fields below.`,
+      If this is a repeated or extended experiment, explain why it's
+      being repeated or extended.  Also, fill in discussion link fields below.`,
   },
 
   'ongoing_constraints': {
     help_text: html`
       Do you anticipate adding any ongoing technical constraints to 
       the codebase while implementing this feature? We prefer to avoid 
-      features which require or assume a specific architecture. 
-      For most features, the answer here is "None."`,
+      features that require or assume a specific architecture. 
+      For most features, the answer is "None."`,
   },
 
   'origin_trial_feedback_url': {
@@ -438,9 +464,9 @@ export const ALL_FIELDS = {
     help_text: html`
       Open questions about a feature may be a source of future web compat 
       or interop issues. Please list open issues (e.g. links to known 
-      github issues in the project for the feature specification) whose 
+      github issues in the repo for the feature specification) whose 
       resolution may introduce web compat/interop risk (e.g., changing 
-      to naming or structure of the API in a 
+      the naming or structure of the API in a 
       non-backward-compatible way).`,
   },
 
@@ -454,20 +480,24 @@ export const ALL_FIELDS = {
   'i2e_lgtms': {
     help_text: html`
       Full email address of API owner who LGTM\'d the 
-      Intent to Experiment email thread.`,
+      Intent to Experiment email thread. 
+      This field fills automatically
+      if you use the Chrome Status generated email text.`,
   },
 
   'i2s_lgtms': {
     help_text: html`
       Comma separated list of 
-      full email addresses of API owners who LGTM\'d 
-      the Intent to Ship email thread.`,
+      email addresses of API owners who LGTM'd 
+      the Intent to Ship email thread.  `,
   },
 
   'r4dt_lgtms': {
     help_text: html`
       Full email addresses of API owners who LGTM\'d 
-      the Request for Deprecation Trial email thread.`,
+      the Request for Deprecation Trial email thread.
+      This field fills automatically
+      if you use the Chrome Status generated email text.`,
   },
 
   'debuggability': {
@@ -476,7 +506,7 @@ export const ALL_FIELDS = {
       Please follow 
       <a target="_blank" 
           href="https://goo.gle/devtools-checklist">
-        the DevTools support checklist</a> for guidance.`,
+        DevTools support checklist</a> for guidance.`,
   },
 
   'all_platforms': {
@@ -500,7 +530,7 @@ export const ALL_FIELDS = {
     help_text: html`
       Please link to the <a href="https://wpt.fyi/results">results on 
       wpt.fyi</a>. If any part of the feature is not tested by 
-      web-platform-tests. Please include links to issues, e.g. a 
+      web-platform-tests, please include links to issues, e.g. a 
       web-platform-tests issue with the "infra" label explaining why a 
       certain thing cannot be tested 
       (<a href="https://github.com/w3c/web-platform-tests/issues/3867">example</a>), 
@@ -560,7 +590,8 @@ export const ALL_FIELDS = {
   'devtrial_instructions': {
     help_text: html`
         Link to a HOWTO or FAQ describing how developers can get started 
-        using this feature in a DevTrial.  
+        using this feature in a DevTrial. 
+        <br/><br>
         <a target="_blank" 
             href="https://github.com/samuelgoto/WebID/blob/master/HOWTO.md">
           Example 1</a>.  
@@ -571,31 +602,31 @@ export const ALL_FIELDS = {
 
   'dt_milestone_desktop_start': {
     help_text: html`
-      First milestone that allows developers to try 
+      First milestone that allows web developers to try 
       this feature on desktop platforms by setting a flag. 
       When flags are enabled by default in preparation for 
-      removal, please use the fields in the ship stage.`,
+      shipping or removal, please use the fields in the ship stage.`,
   },
 
   'dt_milestone_android_start': {
     help_text: html`
-      First milestone that allows developers to try 
+      First milestone that allows web developers to try 
       this feature on desktop platforms by setting a flag. 
       When flags are enabled by default in preparation for 
-      removal, please use the fields in the ship stage.`,
+      shipping or removal, please use the fields in the ship stage.`,
   },
 
   'dt_milestone_ios_start': {
     help_text: html`
-      First milestone that allows developers to try 
+      First milestone that allows web developers to try 
       this feature on desktop platforms by setting a flag. 
       When flags are enabled by default in preparation for 
-      removal, please use the fields in the ship stage.`,
+      shipping or removal, please use the fields in the ship stage.`,
   },
 
   'flag_name': {
     help_text: html`
-      Name of the flag that enables this feature.'`,
+      Name of the flag on chrome://flags that enables this feature.'`,
   },
 
 };

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -18,7 +18,7 @@ export const ALL_FIELDS = {
   'name': {
     help_text: html`
         Capitalize only the first letter and the beginnings of proper nouns.
-        <br/><br>
+        <br/><br/>
         <a target="_blank"
             href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#feature-name">
           Learn more</a>.
@@ -99,7 +99,7 @@ export const ALL_FIELDS = {
         Tracking bug url (https://bugs.chromium.org/...). This bug
         should have "Type=Feature" set and be world readable.
         Note: This field only accepts one URL.
-        <br/><br>
+        <br/><br/>
         <a target="_blank"
             href="https://bugs.chromium.org/p/chromium/issues/entry">
           Create tracking bug</a>`,
@@ -108,7 +108,7 @@ export const ALL_FIELDS = {
   'launch_bug_url': {
     help_text: html`
         Launch bug url (https://bugs.chromium.org/...) to track launch approvals.
-        <br/><br>
+        <br/><br/>
         <a target="_blank"
             href="https://bugs.chromium.org/p/chromium/issues/entry?template=Chrome+Launch+Feature">
           Create launch bug</a>.`,
@@ -120,12 +120,12 @@ export const ALL_FIELDS = {
         to describe what web developers are forced to do without 
         it. When possible, add links to your explainer 
         backing up your claims.
-        <br/><br>
+        <br/><br/>
         This text is sometimes included with the summary in the
         beta post, enterprise release notes and other external
         documents. Write in a matter-of-fact manner and in the
         present tense.
-        <br/><br>
+        <br/><br/>
         <a target="_blank" 
             href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#motivation-example">
           Example</a>`,
@@ -136,12 +136,12 @@ export const ALL_FIELDS = {
         Deprecations and removals must have strong reasons, backed up
         by measurements. There must be clear and actionable paths forward
         for developers.
-        <br/><br>
+        <br/><br/>
         This text is sometimes included with the summary in the
         beta post, enterprise release notes and other external
         documents. Write in a matter-of-fact manner and in the
         present tense.
-        <br/><br>
+        <br/><br/>
         Please see
         <a target="_blank" 
             href="https://docs.google.com/a/chromium.org/document/d/1LdqUfUILyzM5WEcOgeAWGupQILKrZHidEXrUxevyi_Y/edit?usp=sharing">
@@ -385,7 +385,9 @@ export const ALL_FIELDS = {
       designs? Double check that your experiment makes sense given that 
       a large developer (e.g. a Google product or Facebook) likely 
       can't use it in production due to the limits enforced by origin 
-      trials.\n\nIf you send an Intent to Extend Origin Trial, highlight 
+      trials.
+      <br/><br/>
+      If you send an Intent to Extend Origin Trial, highlight 
       areas for experimentation. They should not be an exact copy of the goals 
       from the first Intent to Experiment.`,
   },
@@ -480,9 +482,7 @@ export const ALL_FIELDS = {
   'i2e_lgtms': {
     help_text: html`
       Full email address of API owner who LGTM\'d the 
-      Intent to Experiment email thread. 
-      This field fills automatically
-      if you use the Chrome Status generated email text.`,
+      Intent to Experiment email thread.`,
   },
 
   'i2s_lgtms': {
@@ -495,9 +495,7 @@ export const ALL_FIELDS = {
   'r4dt_lgtms': {
     help_text: html`
       Full email addresses of API owners who LGTM\'d 
-      the Request for Deprecation Trial email thread.
-      This field fills automatically
-      if you use the Chrome Status generated email text.`,
+      the Request for Deprecation Trial email thread.`,
   },
 
   'debuggability': {
@@ -591,7 +589,7 @@ export const ALL_FIELDS = {
     help_text: html`
         Link to a HOWTO or FAQ describing how developers can get started 
         using this feature in a DevTrial. 
-        <br/><br>
+        <br/><br/>
         <a target="_blank" 
             href="https://github.com/samuelgoto/WebID/blob/master/HOWTO.md">
           Example 1</a>.  
@@ -626,7 +624,7 @@ export const ALL_FIELDS = {
 
   'flag_name': {
     help_text: html`
-      Name of the flag on chrome://flags that enables this feature.'`,
+      Name of the flag on chrome://flags that enables this feature.`,
   },
 
 };


### PR DESCRIPTION
In addition to migrating all the remaining help_text to the form-field-specs.js, we can simplify chromedash-form-field.js to not use the "help" slot, and simplify ChromedashForm in guideforms.py to not process any help text.