### PR TITLE
Remove prereq of spec link for I2P.

### DIFF
--- a/internals/processes.py
+++ b/internals/processes.py
@@ -173,7 +173,7 @@ BLINK_PROCESS_STAGES = [
       ],
       [Action('Draft Intent to Prototype email', INTENT_EMAIL_URL,
               [PI_INITIAL_PUBLIC_PROPOSAL.name, PI_MOTIVATION.name,
-               PI_EXPLAINER.name, PI_SPEC_LINK.name])],
+               PI_EXPLAINER.name])],
       [approval_defs.PrototypeApproval],
       models.INTENT_INCUBATE, models.INTENT_IMPLEMENT),
 


### PR DESCRIPTION
The spec link should not be one of the prereqs for sending I2P email.

This addresses the bug identified in #2000 .

![image](https://user-images.githubusercontent.com/570125/178344907-222299c5-aa2b-46d7-b61b-309e7b4087fb.png)

