### PR TITLE
Workaround conflict with Shoelace event listeners.

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -129,7 +129,12 @@ limitations under the License.
   <script src="https://www.googletagmanager.com/gtag/js?id=UA-179341418-1"
           async nonce="{{nonce}}"></script>
 
-  <script nonce="{{nonce}}">
+  {% comment %}
+  Note that the following script tag must include type="module" so that the form field event listeners
+  attached by shared.min.js will not be attached until after Shoelace event listeners are attached.
+  See https://github.com/GoogleChrome/chromium-dashboard/issues/2014
+  {% endcomment %}
+  <script type="module" nonce="{{nonce}}">
     (function() {
       'use strict';
 


### PR DESCRIPTION
This PR simply adds type="module" to the script tag that attaches event listeners to the form for each of the form fields.  This is required to correctly validate form fields before submission, and block submission if there are any invalid fields.