### PR TITLE
Create scheduled DataStore backups.

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -11,3 +11,6 @@ cron:
 - description: sort metrics and load into memcache without request time limits
   url: /data/featurepopularity?refresh=1
   schedule: every 30 minutes synchronized
+- description: Trigger a DataStore export for backup.
+  url: /cron/export_backup
+  schedule: every day 03:00

--- a/internals/data_backup.py
+++ b/internals/data_backup.py
@@ -15,6 +15,7 @@ import os
 
 from googleapiclient.discovery import build
 from googleapiclient.discovery_cache.base import Cache
+import settings
 
 from framework import basehandlers
 
@@ -32,11 +33,11 @@ class BackupExportHandler(basehandlers.FlaskHandler):
   """Triggers a new Datastore export."""
 
   def get_template_data(self):
-    bucket = os.environ.get("BACKUP_BUCKET")
+    bucket = settings.BACKUP_BUCKET
     # The default cache (file_cache) is unavailable when using oauth2client >= 4.0.0 or google-auth,
     # and it will log worrisome messages unless given another interface to use.
     datastore = build("datastore", "v1", cache=MemoryCache())
-    project_id = os.environ.get("GOOGLE_CLOUD_PROJECT")
+    project_id = settings.APP_ID
 
     # No entity filters are used to back up all entities.
     request_body = {"outputUrlPrefix": bucket, "entityFilter": {}}

--- a/internals/data_backup.py
+++ b/internals/data_backup.py
@@ -1,0 +1,48 @@
+# Copyright 2022 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+from googleapiclient.discovery import build
+from googleapiclient.discovery_cache.base import Cache
+
+from framework import basehandlers
+
+class MemoryCache(Cache):
+    _CACHE = {}
+
+    def get(self, url):
+        return MemoryCache._CACHE.get(url)
+
+    def set(self, url, content):
+        MemoryCache._CACHE[url] = content
+
+
+class BackupExportHandler(basehandlers.FlaskHandler):
+  """Triggers a new Datastore export."""
+
+  def get_template_data(self):
+    bucket = os.environ.get("BACKUP_BUCKET")
+    # The default cache (file_cache) is unavailable when using oauth2client >= 4.0.0 or google-auth,
+    # and it will log worrisome messages unless given another interface to use.
+    datastore = build("datastore", "v1", cache=MemoryCache())
+    project_id = os.environ.get("GOOGLE_CLOUD_PROJECT")
+
+    # No entity filters are used to back up all entities.
+    request_body = {"outputUrlPrefix": bucket, "entityFilter": {}}
+
+    export_request = datastore.projects().export(
+      projectId=project_id, body=request_body
+    )
+    response = export_request.execute()
+    return response

--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ from framework import sendemail
 from internals import detect_intent
 from internals import fetchmetrics
 from internals import notifier
+from internals import data_backup
 from pages import blink_handler
 from pages import featuredetail
 from pages import featurelist
@@ -188,6 +189,7 @@ internals_routes = [
   ('/cron/metrics', fetchmetrics.YesterdayHandler),
   ('/cron/histograms', fetchmetrics.HistogramsHandler),
   ('/cron/update_blink_components', fetchmetrics.BlinkComponentHandler),
+  ('/cron/export_backup', data_backup.BackupExportHandler),
 
   ('/tasks/email-subscribers', notifier.FeatureChangeHandler),
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ appengine-python-standard>=1.0.0
 html5lib==1.1
 Django==3.2.14
 funcsigs==1.0.2
+google-api-python-client==2.47.0
 google-python-cloud-debugger==2.18
 google-cloud-tasks==2.7.0
 google-cloud-ndb==1.11.1

--- a/settings.py
+++ b/settings.py
@@ -98,10 +98,12 @@ elif APP_ID == 'cr-status':
       'apps.googleusercontent.com')
   INBOUND_EMAIL_ADDR = 'chromestatus@cr-status.appspotmail.com'
   REVIEW_COMMENT_MAILING_LIST = 'blink-dev@chromium.org'
+  BACKUP_BUCKET = 'cr-status-backups'
 elif APP_ID == 'cr-status-staging':
   STAGING = True
   SEND_EMAIL = True
   APP_TITLE = 'Chrome Platform Status Staging'
+  BACKUP_BUCKET = 'cr-staging-backups'
 else:
   logging.error('Unexpected app ID %r, please configure settings.py.', APP_ID)
 


### PR DESCRIPTION
Addresses #917

This PR implements a new scheduled job that runs daily to export the project's DataStore data to a backup bucket. This data is set to persist for 60 days before being deleted.

Created following the [GCP schedule export guide](https://cloud.google.com/datastore/docs/schedule-export).