### PR TITLE
Move the new feature button to the heading.

### DIFF
--- a/static/elements/chromedash-header.js
+++ b/static/elements/chromedash-header.js
@@ -261,6 +261,11 @@ export class ChromedashHeader extends LitElement {
     return html`
       <div class="flex-container flex-container-inner-second">
       ${this.user ? html`
+        ${this.user.can_create_feature && !this.isCurrentPage('/guide/new') ? html`
+          <sl-button href="/guide/new" variant="primary" size="small">
+            Add feature
+          </sl-button>
+        `: nothing }
         <div class="nav-dropdown-container">
           <a class="nav-dropdown-trigger">
             ${this.user.email}

--- a/static/sass/features/features.scss
+++ b/static/sass/features/features.scss
@@ -64,11 +64,6 @@ chromedash-featurelist {
   .feature-count {
     min-width: 170px;
   }
-  .actionlinks {
-    .blue-button {
-      margin-left: 4px;
-    }
-  }
 }
 
 @media only screen and (max-width: 1100px) {

--- a/static/sass/features/features.scss
+++ b/static/sass/features/features.scss
@@ -83,11 +83,5 @@ chromedash-featurelist {
   #subheader {
     width: initial;
 
-    div.actionlinks {
-      flex: 1 0 0;
-      span {
-        display: none;
-      }
-    }
   }
 }

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -125,39 +125,6 @@ app-header {
       }
     }
 
-    &.actionlinks {
-      display: flex;
-      justify-content: flex-end;
-      flex: 1 0 auto;
-
-      .blue-button {
-        background: var(--primary-button-background);
-        color: var(--primary-button-color);
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        max-height: 35px;
-        min-width: 5.14em;
-        -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-        -webkit-tap-highlight-color: transparent;
-        text-decoration: none;
-        border: var(--button-border);
-        border-radius: var(--button-border-radius);
-        user-select: none;
-        cursor: pointer;
-        padding: 0.7em 0.57em;
-
-        iron-icon {
-          margin-right: $content-padding / 4;
-        }
-      }
-
-      .legend {
-        font-size: 18px;
-        cursor: pointer;
-        text-decoration: none;
-      }
-    }
   }
 }
 
@@ -210,7 +177,7 @@ app-header {
       width: 100%;
     }
   }
-  
+
   // Overrides styles set by app-header-layout so there's no visual
   // layout FOUC/jump as the drawer panel upgrades.
   app-header {

--- a/templates/features.html
+++ b/templates/features.html
@@ -39,13 +39,6 @@
             <iron-icon icon="chromestatus:help"></iron-icon>
           </button>
         </div>
-        <div class="actionlinks">
-          {% if user.can_create_feature %}
-          <a href="/guide/new" class="blue-button" title="Adds a new feature to the site">
-            <iron-icon icon="chromestatus:add-circle-outline"></iron-icon><span>Add new feature</span>
-          </a>
-          {% endif %}
-        </div>
       </div>
       <chromedash-featurelist
         {% if user %} signedInUser="{{user.email}}" {% endif %}


### PR DESCRIPTION
This addresses feedback from Joe that we should make the "Add feature" button easier to find before making the roadmap page the site home page.

In this PR:
* Remove the "Add new feature" button from the all features page, along with associated CSS.
* Add a "Add feature" sl-button in the header near the account menu, iff the user is signed in, has permission to create a feature, and is not already on the feature creation page.

![image](https://user-images.githubusercontent.com/17365/179086263-10227dc2-25ae-46ca-abdf-5f82a83f2e1a.png)
