### PR TITLE
Make roadmap page the site homepage.

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -494,6 +494,7 @@ def FlaskApplication(import_name, routes, pattern_base='', debug=False):
   """Make a Flask app and add routes and handlers that work like webapp2."""
 
   app = flask.Flask(import_name)
+  app.original_wsgi_app = app.wsgi_app  # Only for unit tests.
   app.wsgi_app = ndb_wsgi_middleware(app.wsgi_app) # For Cloud NDB Context
   # For GAE legacy libraries
   app.wsgi_app = google.appengine.api.wrap_wsgi_app(app.wsgi_app)

--- a/main.py
+++ b/main.py
@@ -135,7 +135,7 @@ page_routes = [
     (r'/features_v2.json', featurelist.FeaturesJsonHandler),
 
     ('/', basehandlers.Redirector,
-     {'location': '/features'}),
+     {'location': '/roadmap'}),
 
     ('/newfeatures', newfeaturelist.NewFeatureListHandler),
     ('/features', featurelist.FeatureListHandler),

--- a/main_test.py
+++ b/main_test.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config  # Must be imported before the module under test.
+
+from unittest import mock
+from flask import testing
+
+import main
+
+
+
+class MainTest(testing_config.CustomTestCase):
+  """Set of unit tests for our page route registration and other setup."""
+
+  def test_app_exists(self):
+    """Just test that this file parses and creates an app object."""
+    self.assertIsNotNone(main.app)
+
+  def test_redirects(self):
+    """Redirect are working."""
+    main.app.wsgi_app = main.app.original_wsgi_app
+    test_client = testing.FlaskClient(main.app)
+
+    response = test_client.get('/')
+    self.assertEqual(302, response.status_code)
+    self.assertEqual('/roadmap', response.location)
+
+    response = test_client.get('/metrics')
+    self.assertEqual(302, response.status_code)
+    self.assertEqual('/metrics/css/popularity', response.location)
+
+    response = test_client.get('/metrics/css')
+    self.assertEqual(302, response.status_code)
+    self.assertEqual('/metrics/css/popularity', response.location)


### PR DESCRIPTION
This follows through on the last step of a long-term effort to revise the site information architecture.
Making the roadmap page be the home page for the site will make the site more useful for web developers, while reminding feature owners that their feature entries are being shown to web developers.

In this PR:
* Change the redirect for the site home page to go to the roadmap page rather than all features
* Add two simple unit tests for main.py