### PR TITLE
Fix roadmap page API call when showing unlisted.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -886,7 +886,7 @@ class Feature(DictModel):
         ramcache.set(KEY, feature)
 
     return feature
-  
+
   @classmethod
   def filter_unlisted(self, feature_list):
     """Filters a feature list to display only features the user should see."""
@@ -901,7 +901,7 @@ class Feature(DictModel):
           ('browsers' in f and email in f['browsers']['chrome']['owners']) or
           (email in f.get('editors', []))):
         listed_features.append(f)
-    
+
     return listed_features
 
   @classmethod
@@ -1156,7 +1156,7 @@ class Feature(DictModel):
 
       for feature in android_dev_trial_features:
         all_features[IMPLEMENTATION_STATUS[BEHIND_A_FLAG]].append(feature)
-      
+
       # Construct results as: {type: [json_feature, ...], ...}.
       for shipping_type in all_features:
         all_features[shipping_type].sort(key=lambda f: f.name)
@@ -1164,15 +1164,12 @@ class Feature(DictModel):
             f for f in all_features[shipping_type] if not f.deleted]
         features_by_type[shipping_type] = [
             f.format_for_template() for f in all_features[shipping_type]]
-      
+
       ramcache.set(cache_key, features_by_type)
 
     for shipping_type in features_by_type:
       if not show_unlisted:
         features_by_type[shipping_type] = self.filter_unlisted(features_by_type[shipping_type])
-      else:
-        features_by_type[shipping_type] = all_features[shipping_type].copy()
-
 
     return features_by_type
 


### PR DESCRIPTION
When testing locally signed in to a site admin account I found that the roadmap page would not load.
An exception happed in the JSON request to `/api/v0/features?milestone=...`
`TypeError: Object of type Feature is not JSON serializable`

I believe the root cause was the else clause where one part of `all_features` was copied and assigned to `features_by_type`.  The difference between these two dictionaries is that (1) `features_by_type` is filtered by permissions, and also that (2) it has all python dictionaries ready to be serialized for the JSON response rather than the NDB Feature model instances.   Copying from one dict to the other introduced Feature model instances where dictionaries were expect.   In fact, I don't think that this else-clause was needed because the needed info is already in `features_by_type`.