### PR TITLE
In notifications, display full email addr rather than nickname.

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -63,8 +63,8 @@ def format_email_body(is_update, feature, changes):
 
   body_data = {
       'feature': feature,
-      'created_by_email': feature.created_by.email(),
-      'updated_by_email': feature.updated_by.email(),
+      'creator_email': feature.created_by.email(),
+      'updater_email': feature.updated_by.email(),
       'id': feature.key.integer_id(),
       'milestone': milestone_str,
       'status': models.IMPLEMENTATION_STATUS[feature.impl_status_chrome],

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -63,6 +63,8 @@ def format_email_body(is_update, feature, changes):
 
   body_data = {
       'feature': feature,
+      'created_by_email': feature.created_by.email(),
+      'updated_by_email': feature.updated_by.email(),
       'id': feature.key.integer_id(),
       'milestone': milestone_str,
       'status': models.IMPLEMENTATION_STATUS[feature.impl_status_chrome],

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -36,9 +36,9 @@ class EmailFormattingTest(testing_config.CustomTestCase):
         name='feature one', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1,
         created_by=ndb.User(
-            email='creator@example.com', _auth_domain='gmail.com'),
+            email='creator1@gmail.com', _auth_domain='gmail.com'),
         updated_by=ndb.User(
-            email='editor@example.com', _auth_domain='gmail.com'),
+            email='editor1@gmail.com', _auth_domain='gmail.com'),
         blink_components=['Blink'])
     self.feature_1.put()
     self.component_1 = models.BlinkComponent(name='Blink')
@@ -57,9 +57,9 @@ class EmailFormattingTest(testing_config.CustomTestCase):
         name='feature two', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1,
         created_by=ndb.User(
-            email='creator@example.com', _auth_domain='gmail.com'),
+            email='creator2@example.com', _auth_domain='gmail.com'),
         updated_by=ndb.User(
-            email='editor@example.com', _auth_domain='gmail.com'),
+            email='editor2@example.com', _auth_domain='gmail.com'),
         blink_components=['Blink'])
     self.feature_2.put()
 
@@ -72,7 +72,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     body_html = notifier.format_email_body(
         False, self.feature_1, [])
     self.assertIn('Blink', body_html)
-    self.assertIn('creator@example.com added', body_html)
+    self.assertIn('creator1@gmail.com added', body_html)
     self.assertIn('chromestatus.com/feature/%d' %
                   self.feature_1.key.integer_id(),
                   body_html)
@@ -83,7 +83,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     body_html = notifier.format_email_body(
         True, self.feature_1, [])
     self.assertIn('Blink', body_html)
-    self.assertIn('editor@example.com updated', body_html)
+    self.assertIn('editor1@gmail.com updated', body_html)
     self.assertNotIn('watcher_1,', body_html)
 
   def test_format_email_body__update_with_changes(self):

--- a/templates/new-feature-email.html
+++ b/templates/new-feature-email.html
@@ -1,5 +1,5 @@
 <p>
-  {{created_by_email}} added a new feature:
+  {{creator_email}} added a new feature:
 </p>
 
 <p><b><a href="https://chromestatus.com/feature/{{id}}"

--- a/templates/new-feature-email.html
+++ b/templates/new-feature-email.html
@@ -1,5 +1,5 @@
 <p>
-  {{feature.created_by}} added a new feature:
+  {{created_by_email}} added a new feature:
 </p>
 
 <p><b><a href="https://chromestatus.com/feature/{{id}}"

--- a/templates/update-feature-email.html
+++ b/templates/update-feature-email.html
@@ -1,5 +1,5 @@
 <p>
-  {{feature.updated_by}} updated this feature:
+  {{updated_by_email}} updated this feature:
 </p>
 
 <p>

--- a/templates/update-feature-email.html
+++ b/templates/update-feature-email.html
@@ -1,5 +1,5 @@
 <p>
-  {{updated_by_email}} updated this feature:
+  {{updater_email}} updated this feature:
 </p>
 
 <p>


### PR DESCRIPTION
This works around a problem identified by Joe in an email thread a few days ago.

He found that some email notifications only give the username of the user who created or edited a feature rather than their full email address.  That is a quirk of GAE user objects that display a nickname, which is just the username for @gmail.com accounts.

To get the full email address all the time, we need to call email(), however that cannot be done in a django template.  Rathe than be stuck on that, I called it in python code before rendering the template.