### PR TITLE
Add Reply-To header to email notifications.

### DIFF
--- a/framework/sendemail.py
+++ b/framework/sendemail.py
@@ -56,6 +56,7 @@ def handle_outbound_mail_task():
   subject = get_param(flask.request, 'subject')
   email_html = get_param(flask.request, 'html')
   references = get_param(flask.request, 'references', required=False)
+  reply_to = get_param(flask.request, 'reply_to', required=False)
 
   if settings.SEND_ALL_EMAIL_TO and to != settings.REVIEW_COMMENT_MAILING_LIST:
     to_user, to_domain = to.split('@')
@@ -67,7 +68,7 @@ def handle_outbound_mail_task():
         from_user, from_user, settings.APP_ID)
 
   message = mail.EmailMessage(
-      sender=sender, to=to, subject=subject, html=email_html)
+      sender=sender, to=to, subject=subject, html=email_html, reply_to=reply_to)
   message.check_initialized()
 
   if references:
@@ -80,6 +81,7 @@ def handle_outbound_mail_task():
   logging.info('Sender: %s', message.sender)
   logging.info('To: %s', message.to)
   logging.info('Subject: %s', message.subject)
+  logging.info('Reply-To: %s', message.reply_to)
   logging.info('References: %s', references or '(not included)')
   logging.info('In-Reply-To: %s', references or '(not included)')
   logging.info('Body:\n%s', message.html[:settings.MAX_LOG_LINE])

--- a/framework/sendemail_test.py
+++ b/framework/sendemail_test.py
@@ -57,7 +57,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
 
     mock_emailmessage_constructor.assert_called_once_with(
         sender=self.sender, to=self.to, subject=self.subject,
-        html=self.html)
+        reply_to=None, html=self.html)
     mock_message = mock_emailmessage_constructor.return_value
     mock_message.check_initialized.assert_called_once_with()
     mock_message.send.assert_called_once_with()
@@ -80,7 +80,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
     expected_to = 'cr-status-staging-emails+user+example.com@google.com'
     mock_emailmessage_constructor.assert_called_once_with(
         sender=self.sender, to=expected_to, subject=self.subject,
-        html=self.html)
+        reply_to=None, html=self.html)
     mock_message = mock_emailmessage_constructor.return_value
     mock_message.check_initialized.assert_called_once_with()
     mock_message.send.assert_called_once_with()
@@ -101,7 +101,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
     expected_to = 'cr-status-staging-emails+user+example.com@google.com'
     mock_emailmessage_constructor.assert_called_once_with(
         sender=self.sender, to=expected_to, subject=self.subject,
-        html=self.html)
+        reply_to=None, html=self.html)
     mock_message = mock_emailmessage_constructor.return_value
     mock_message.check_initialized.assert_called_once_with()
     mock_message.send.assert_not_called()

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -22,6 +22,7 @@ import json
 import os
 import urllib
 
+from framework import permissions
 from framework import ramcache
 from google.cloud import ndb
 import requests
@@ -31,6 +32,7 @@ from django.utils.html import conditional_escape as escape
 
 from framework import basehandlers
 from framework import cloud_tasks_helpers
+from framework import users
 import settings
 from internals import approval_defs
 from internals import models
@@ -86,7 +88,8 @@ def accumulate_reasons(addr_reasons, user_list, reason):
       addr_reasons[user.email].append(reason)
 
 
-def convert_reasons_to_task(addr, reasons, email_html, subject):
+def convert_reasons_to_task(
+    addr, reasons, email_html, subject, triggering_user_email):
   """Add a task dict to task_list for each user who has not already got one."""
   assert reasons, 'We are emailing someone without any reason'
   footer_lines = ['<p>You are receiving this email because:</p>', '<ul>']
@@ -96,9 +99,16 @@ def convert_reasons_to_task(addr, reasons, email_html, subject):
   footer_lines.append('<p><a href="%ssettings">Unsubscribe</a></p>' %
                       settings.SITE_URL)
   email_html_with_footer = email_html + '\n\n' + '\n'.join(footer_lines)
+
+  reply_to = None
+  recipient_user = users.User(email=addr)
+  if permissions.can_create_feature(recipient_user):
+    reply_to = triggering_user_email
+
   one_email_task = {
       'to': addr,
       'subject': subject,
+      'reply_to': reply_to,
       'html': email_html_with_footer
   }
   return one_email_task
@@ -134,8 +144,10 @@ def make_email_tasks(feature, is_update=False, changes=[]):
   email_html = format_email_body(is_update, feature, changes)
   if is_update:
     subject = 'updated feature: %s' % feature.name
+    triggering_user_email = feature.updated_by.email()
   else:
     subject = 'new feature: %s' % feature.name
+    triggering_user_email = feature.created_by.email()
 
   addr_reasons = collections.defaultdict(list)  # [{email_addr: [reason,...]}]
 
@@ -165,7 +177,8 @@ def make_email_tasks(feature, is_update=False, changes=[]):
   for reason, sub_addrs in rule_results.items():
     accumulate_reasons(addr_reasons, sub_addrs, reason)
 
-  all_tasks = [convert_reasons_to_task(addr, reasons, email_html, subject)
+  all_tasks = [convert_reasons_to_task(
+                   addr, reasons, email_html, subject, triggering_user_email)
                for addr, reasons in sorted(addr_reasons.items())]
   return all_tasks
 
@@ -264,8 +277,10 @@ class FeatureChangeHandler(basehandlers.FlaskHandler):
               'Would send the following email:\n'
               'To: %s\n'
               'Subject: %s\n'
+              'Reply-To: %s\n'
               'Body:\n%s',
               one_email_dict['to'], one_email_dict['subject'],
+              one_email_dict['reply_to'],
               one_email_dict['html'][:settings.MAX_LOG_LINE])
 
     return {'message': 'Done'}

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -162,7 +162,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.assertIn('reason 2', actual['html'])
 
   def test_convert_reasons_to_task__can_reply(self):
-    """Is the user is allowed to reply, set reply_to to the triggerer."""
+    """If the user is allowed to reply, set reply_to to the triggerer."""
     actual = notifier.convert_reasons_to_task(
         'user@chromium.org', ['reason 1', 'reason 2'], 'html', 'subject',
         'triggerer@example.com')

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -144,19 +144,34 @@ class EmailFormattingTest(testing_config.CustomTestCase):
 
   def test_convert_reasons_to_task__no_reasons(self):
     with self.assertRaises(AssertionError):
-      notifier.convert_reasons_to_task('addr', [], 'html', 'subject')
+      notifier.convert_reasons_to_task(
+          'addr', [], 'html', 'subject', 'triggerer')
 
   def test_convert_reasons_to_task__normal(self):
     actual = notifier.convert_reasons_to_task(
-        'addr', ['reason 1', 'reason 2'], 'html', 'subject')
+        'addr', ['reason 1', 'reason 2'], 'html', 'subject',
+        'triggerer@example.com')
     self.assertCountEqual(
-        ['to', 'subject', 'html'],
+        ['to', 'subject', 'html', 'reply_to'],
         list(actual.keys()))
     self.assertEqual('addr', actual['to'])
     self.assertEqual('subject', actual['subject'])
+    self.assertEqual(None, actual['reply_to'])  # Lacks perm to reply.
     self.assertIn('html', actual['html'])
     self.assertIn('reason 1', actual['html'])
     self.assertIn('reason 2', actual['html'])
+
+  def test_convert_reasons_to_task__can_reply(self):
+    """Is the user is allowed to reply, set reply_to to the triggerer."""
+    actual = notifier.convert_reasons_to_task(
+        'user@chromium.org', ['reason 1', 'reason 2'], 'html', 'subject',
+        'triggerer@example.com')
+    self.assertCountEqual(
+        ['to', 'subject', 'html', 'reply_to'],
+        list(actual.keys()))
+    self.assertEqual('user@chromium.org', actual['to'])
+    self.assertEqual('subject', actual['subject'])
+    self.assertEqual('triggerer@example.com', actual['reply_to'])
 
   def test_apply_subscription_rules__relevant_match(self):
     """When a feature and change match a rule, a reason is returned."""


### PR DESCRIPTION
This should resolve issue #2020.  Basically, he would find it easier to follow up with feature owners who made a change if he could just use the Reply button in gmail to contact the user who made a change.

In this PR:
* In sendemail.py: set the Reply-To header in the outbound email message based on what is set in the task.
* In notifier.py: If the email is being sent to a user who is trusted to reply, then use the address of the user who made the change (and therefore triggered the notification) as the reply_to value in the task.
* Update unit tests