### PR TITLE
Add index that datastore says it needs for can_edit terms.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -204,8 +204,9 @@ indexes:
   - name: "name"
 - kind: Feature
   properties:
-  - name: owner
   - name: editors
+  - name: updated
+    direction: desc
 - kind: "FeatureObserver"
   properties:
   - name: "bucket_id"

--- a/static/elements/chromedash-feature-page_test.js
+++ b/static/elements/chromedash-feature-page_test.js
@@ -248,5 +248,4 @@ describe('chromedash-feature-page', () => {
     // Edit icon is not offered because the visitor cannot edit.
     assert.notInclude(subheaderDiv.innerHTML, 'icon="chromestatus:create"');
   });
-
 });


### PR DESCRIPTION
When running on staging, there is an error with the request for features in the "Features I can edit" box.

Logs shown an exception with the message:
```
no matching index found. recommended index is:
- kind: Feature
  properties:
  - name: editors
  - name: updated
    direction: desc
```
