### PR TITLE
Fix feature table width

### DIFF
--- a/static/elements/chromedash-feature-table.js
+++ b/static/elements/chromedash-feature-table.js
@@ -94,6 +94,9 @@ class ChromedashFeatureTable extends LitElement {
     return [
       ...SHARED_STYLES,
       css`
+      table {
+        width: 100%;
+      }
       tr {
         background: var(--table-row-background);
       }


### PR DESCRIPTION
The current feature tables are not expanded to 100% width during loading or when there's no content (one of the side effects that I didn't handle well when aligning content to center). This PR fixes feature table width to 100%.

## Before
![Before](https://user-images.githubusercontent.com/11501902/179621535-21aa51c7-aa47-43fa-813a-5905764bb97b.png)

## After
![After](https://user-images.githubusercontent.com/11501902/179621627-d1594b34-420c-48ca-bc6b-dbfedf42d8c8.png)

