### PR TITLE
Make content width larger

### DIFF
--- a/static/elements/chromedash-stack-rank-page.js
+++ b/static/elements/chromedash-stack-rank-page.js
@@ -51,7 +51,7 @@ export class ChromedashStackRankPage extends LitElement {
           margin-bottom: 10px;
         }
 
-        @media only screen and (max-width: 1100px) {
+        @media only screen and (max-width: 1200px) {
           .metric-nav {
             display: none
           }
@@ -79,7 +79,7 @@ export class ChromedashStackRankPage extends LitElement {
           }
         }
 
-        @media only screen and (min-width: 1100px) {
+        @media only screen and (min-width: 1200px) {
           #horizontal-sub-nav {
             display: none
           }

--- a/static/elements/chromedash-timeline-page.js
+++ b/static/elements/chromedash-timeline-page.js
@@ -51,7 +51,7 @@ export class ChromedashTimelinePage extends LitElement {
           margin-bottom: 10px;
         }
 
-        @media only screen and (max-width: 1100px) {
+        @media only screen and (max-width: 1200px) {
           .metric-nav {
             display: none
           }
@@ -79,7 +79,7 @@ export class ChromedashTimelinePage extends LitElement {
           }
         }
 
-        @media only screen and (min-width: 1100px) {
+        @media only screen and (min-width: 1200px) {
           #horizontal-sub-nav {
             display: none
           }

--- a/static/sass/_vars-css.js
+++ b/static/sass/_vars-css.js
@@ -41,5 +41,5 @@ export const VARS = css`
 
   --app-drawer-width: 200px;
   --header-height: 135px;
-  --max-content-width: 760px;
+  --max-content-width: 860px;
 }`;

--- a/static/sass/_vars.scss
+++ b/static/sass/_vars.scss
@@ -35,7 +35,7 @@ $default-border-radius: 3px;
 
 $app-drawer-width: 200px;
 $header-height: 135px;
-$max-content-width: 760px;
+$max-content-width: 860px;
 /* ----- */
 
 // @mixin width-max-content() {

--- a/static/sass/features/features.scss
+++ b/static/sass/features/features.scss
@@ -66,7 +66,7 @@ chromedash-featurelist {
   }
 }
 
-@media only screen and (max-width: 1100px) {
+@media only screen and (max-width: 1200px) {
   #column-container {
     flex-direction: column;
   }

--- a/static/sass/theme.scss
+++ b/static/sass/theme.scss
@@ -43,7 +43,7 @@
   --content-padding-half: 8px;
   --content-padding-quarter: 4px;
 
-  --max-content-width: 760px;
+  --max-content-width: 860px;
   --border-radius: 4px;
   --large-border-radius: 8px;
   --logo-color: var(--default-color);


### PR DESCRIPTION
As we discussed, the 760px content width is a little too narrow. This PR makes it to 860px wide and adjusts the @media rules for the side nav bars correspondingly.