### PR TITLE
Only set non-None reply_to header.

### DIFF
--- a/framework/sendemail.py
+++ b/framework/sendemail.py
@@ -68,7 +68,9 @@ def handle_outbound_mail_task():
         from_user, from_user, settings.APP_ID)
 
   message = mail.EmailMessage(
-      sender=sender, to=to, subject=subject, html=email_html, reply_to=reply_to)
+      sender=sender, to=to, subject=subject, html=email_html)
+  if reply_to:
+    message.reply_to = reply_to
   message.check_initialized()
 
   if references:
@@ -81,7 +83,8 @@ def handle_outbound_mail_task():
   logging.info('Sender: %s', message.sender)
   logging.info('To: %s', message.to)
   logging.info('Subject: %s', message.subject)
-  logging.info('Reply-To: %s', message.reply_to)
+  if reply_to:
+    logging.info('Reply-To: %s', message.reply_to)
   logging.info('References: %s', references or '(not included)')
   logging.info('In-Reply-To: %s', references or '(not included)')
   logging.info('Body:\n%s', message.html[:settings.MAX_LOG_LINE])

--- a/framework/sendemail_test.py
+++ b/framework/sendemail_test.py
@@ -57,7 +57,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
 
     mock_emailmessage_constructor.assert_called_once_with(
         sender=self.sender, to=self.to, subject=self.subject,
-        reply_to=None, html=self.html)
+        html=self.html)
     mock_message = mock_emailmessage_constructor.return_value
     mock_message.check_initialized.assert_called_once_with()
     mock_message.send.assert_called_once_with()
@@ -80,7 +80,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
     expected_to = 'cr-status-staging-emails+user+example.com@google.com'
     mock_emailmessage_constructor.assert_called_once_with(
         sender=self.sender, to=expected_to, subject=self.subject,
-        reply_to=None, html=self.html)
+        html=self.html)
     mock_message = mock_emailmessage_constructor.return_value
     mock_message.check_initialized.assert_called_once_with()
     mock_message.send.assert_called_once_with()
@@ -101,7 +101,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
     expected_to = 'cr-status-staging-emails+user+example.com@google.com'
     mock_emailmessage_constructor.assert_called_once_with(
         sender=self.sender, to=expected_to, subject=self.subject,
-        reply_to=None, html=self.html)
+        html=self.html)
     mock_message = mock_emailmessage_constructor.return_value
     mock_message.check_initialized.assert_called_once_with()
     mock_message.send.assert_not_called()


### PR DESCRIPTION
This should resolve an error that I see on the GAE Error Reporting page this morning.

I had assumed that the arguments to the EmailMessage constructor were like regular python keyword arguments that to default to None and so passing None would be the same as not passing the keyword argument at all.  It turns out that the EmailMessage constructor takes *kw and validates whatever is in there, so passing reply_to=None is an error.

I avoid the problem by setting reply_to after the EmailMessage is constructed, and only if we have a non-None value.