### PR TITLE
Speed up deployments by separating rc targets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Open the [Google Developer
 Console for the staging site](https://console.cloud.google.com/appengine/versions?project=cr-status-staging)
 and flip to the new version by selecting from the list and clicking *MIGRATE TRAFFIC*. Make sure to do this for both the 'default' service as well as for the 'notifier' service.
 
-Each deployment also uploads the same code to a version named `rc` for "Release candidate".  This is the only version that you can test using Google Sign-In at `https://rc-dot-cr-status-staging.appspot.com`.
+Alternatively, run `npm run staging-rc` to  upload the same code to a version named `rc` for "Release candidate".  This is the only version that you can test using Google Sign-In at `https://rc-dot-cr-status-staging.appspot.com`.
 
 If manual testing on the staging server looks good, then repeat the same steps to deploy to prod:
 

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "lint": "gulp lint-fix && lit-analyzer \"static/elements/chromedash-!(featurelist)*.js\"",
     "pylint": "pylint --output-format=parseable *py api/*py customtags/*py framework/*py internals/*py pages/*py",
 
-    "staging": "npm run build && ./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'` cr-status-staging && ./scripts/deploy_site.sh rc cr-status-staging",
-    "deploy": "npm run build && ./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'` && ./scripts/deploy_site.sh rc"
+    "staging": "./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'` cr-status-staging",
+    "staging-rc": "./scripts/deploy_site.sh rc cr-status-staging",
+    "deploy": "./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'`",
+    "deploy-rc": "./scripts/deploy_site.sh rc"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This speeds up our deployment steps by only deploying the "rc" version when it is explicitly desired.

I set up the "rc" version so that we could test signing in before making the new version live.  However, in practice I find that I usually just go ahead and make the new version live on staging and then test signing in after that.  So, we can deploy in half the time by not deploying "rc" unless it is explicitly requested by running `npm run staging-rc`.

Also, we were compiling JS twice because deploy_site.sh runs gulp.

In this PR:
* Split out -rc targets
* Avoid calling the build target because deploy_site.sh will run gulp
* Update REAME.md