### PR TITLE
Turn off mangle var names in minify rollup settings

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -94,7 +94,7 @@ gulp.task('rollup', () => {
       rollupBabel({
         plugins: ["@babel/plugin-syntax-dynamic-import"]
       }),
-      rollupMinify({comments: false}),
+      rollupMinify({mangle: false, comments: false}),
     ],
   }).then(bundle => {
     return bundle.write({


### PR DESCRIPTION
This change turns off variable [name mangling](https://babeljs.io/docs/en/babel-plugin-minify-mangle-names) when minifying files. This process occasionally causes errors at the rollup step.
```
Starting 'rollup'...
'rollup' errored after 7.05 s
TypeError: unknown: Cannot read property 'add' of undefined
```