### PR TITLE
Add last_visit field to AppUser

### DIFF
--- a/api/login_api.py
+++ b/api/login_api.py
@@ -37,6 +37,7 @@ class LoginAPI(basehandlers.APIHandler):
           token, requests.Request(),
           settings.GOOGLE_SIGN_IN_CLIENT_ID)
       users.add_signed_user_info_to_session(idinfo['email'])
+      self._update_last_visit_field(idinfo['email'])
       message = "Done"
       # print(idinfo['email'], file=sys.stderr)
     except ValueError:

--- a/api/token_refresh_api.py
+++ b/api/token_refresh_api.py
@@ -45,4 +45,5 @@ class TokenRefreshAPI(basehandlers.APIHandler):
         'token': xsrf.generate_token(user.email()),
         'token_expires_sec': xsrf.token_expires_sec(),
         }
+    self._update_last_visit_field(user.email())
     return result

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
 import json
 import logging
 import os
@@ -205,6 +206,15 @@ class APIHandler(BaseHandler):
     if self.do_delete.__code__ is not APIHandler.do_delete.__code__:
       valid_methods.append('DELETE')
     return valid_methods
+
+  def _update_last_visit_field(self, email):
+    """Updates the AppUser last_visit field to log the user's last visit"""
+    app_user = models.AppUser.get_app_user(email)
+    if not app_user:
+      return False
+    app_user.last_visit = datetime.now()
+    app_user.put()
+    return True
 
   def do_get(self, **kwargs):
     """Subclasses should implement this method to handle a GET request."""

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -305,6 +305,12 @@ class APIHandlerTests(testing_config.CustomTestCase):
   def setUp(self):
     self.handler = basehandlers.APIHandler()
 
+    self.appuser = models.AppUser(email='user@example.com')
+    self.appuser.put()
+  
+  def tearDown(self):
+    self.appuser.key.delete()
+
   def test_get_headers(self):
     """We always use some standard headers."""
     with test_app.test_request_context('/path'):
@@ -410,6 +416,17 @@ class APIHandlerTests(testing_config.CustomTestCase):
       with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.require_signed_in_and_xsrf_token()
     mock_validate_token.assert_not_called()
+
+  def test_update_last_visit_field__valid_user(self):
+    """Update the last_visit field of a valid user."""
+    updated_user = self.handler._update_last_visit_field("user@example.com")
+    self.assertNotEqual(self.appuser.last_visit, None)
+    self.assertTrue(updated_user)
+
+  def test_update_last_field__no_user(self):
+    """Don't update last_visit field if the user is unknown."""
+    updated_invalid_user = self.handler._update_last_visit_field("invaliduser@example.com")
+    self.assertFalse(updated_invalid_user)
 
 
 class FlaskHandlerTests(testing_config.CustomTestCase):

--- a/internals/models.py
+++ b/internals/models.py
@@ -1682,6 +1682,7 @@ class AppUser(DictModel):
   is_site_editor = ndb.BooleanProperty(default=False)
   created = ndb.DateTimeProperty(auto_now_add=True)
   updated = ndb.DateTimeProperty(auto_now=True)
+  last_visit = ndb.DateTimeProperty()
 
   def put(self, **kwargs):
     """when we update an AppUser, also invalidate ramcache."""


### PR DESCRIPTION
Adds a new field `last_visit` to AppUser entities that represents the last time the user logged in or refreshed their xsrf token. Added functionality to update this field automatically.