### PR TITLE
More UI changes to stack rank and timeline pages

### DIFF
--- a/static/elements/chromedash-feature-page.js
+++ b/static/elements/chromedash-feature-page.js
@@ -42,11 +42,20 @@ export class ChromedashFeaturePage extends LitElement {
           margin-right: 5px;
         }
 
+        li {
+          list-style: none;
+        }
+
         #consensus li {
           display: flex;
         }
         #consensus li label {
           width: 125px;
+        }
+
+        #breadcrumbs a {
+          text-decoration: none;
+          color: inherit;
         }
 
         sl-skeleton {
@@ -435,14 +444,11 @@ export class ChromedashFeaturePage extends LitElement {
   }
 
   render() {
-    // TODO: Create precomiled main, forms, and guide css files,
-    // and import them instead of inlining them here
+    // TODO: Create precomiled main css file and import it instead of inlining it here
     // TODO: create another element - chromedash-feature-highlights
     // for all the content of the <div id="feature"> part of the page
     return html`
       <link rel="stylesheet" href="/static/css/main.css">
-      <link rel="stylesheet" href="/static/css/forms.css">
-      <link rel="stylesheet" href="/static/css/guide.css">
       ${this.loading ?
         this.renderSkeletons() :
         html`

--- a/static/elements/chromedash-header.js
+++ b/static/elements/chromedash-header.js
@@ -1,7 +1,7 @@
 import {LitElement, html, css, nothing} from 'lit';
 import {showToastMessage} from './utils';
-
 import {SHARED_STYLES} from '../sass/shared-css.js';
+
 
 export class ChromedashHeader extends LitElement {
   static get styles() {
@@ -172,6 +172,7 @@ export class ChromedashHeader extends LitElement {
       google_sign_in_client_id: {type: String},
       currentPage: {type: String},
       user: {type: Object},
+      loading: {type: Boolean},
     };
   }
 
@@ -179,16 +180,20 @@ export class ChromedashHeader extends LitElement {
     super();
     this.appTitle = '';
     this.google_sign_in_client_id = '',
-    this.user = null;
+    this.user = {};
+    this.loading = true;
   }
 
   connectedCallback() {
     super.connectedCallback();
+    this.loading = true;
     window.csClient.getPermissions().then((user) => {
       this.user = user;
       if (!this.user) this.initializeGoogleSignIn();
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
+    }).finally(() => {
+      this.loading = false;
     });
 
     // TODO(kevinshen56714): this can be passed in from SPA router
@@ -250,6 +255,7 @@ export class ChromedashHeader extends LitElement {
           </a>
           <ul>
             <li><a href="/metrics/css/popularity">CSS</a></li>
+            <li><a href="/metrics/css/animated">CSS Animation</a></li>
             <li><a href="/metrics/feature/popularity">JS/HTML</a></li>
           </ul>
         </div>
@@ -292,10 +298,12 @@ export class ChromedashHeader extends LitElement {
           </hgroup>
         </aside>
         <nav>
-          <div class="flex-container flex-container-outer">
-            ${this.renderTabs()}
-            ${this.renderAccountMenu()}
-          </div>
+          ${!this.loading ? html`
+            <div class="flex-container flex-container-outer">
+              ${this.renderTabs()}
+              ${this.renderAccountMenu()}
+            </div>
+          ` : nothing}
         </nav>
       </header>
     `;

--- a/static/elements/chromedash-stack-rank-page.js
+++ b/static/elements/chromedash-stack-rank-page.js
@@ -1,6 +1,5 @@
 import {LitElement, css, html} from 'lit';
 import './chromedash-stack-rank';
-
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
 
@@ -10,79 +9,25 @@ export class ChromedashStackRankPage extends LitElement {
       ...SHARED_STYLES,
       css`
         h3 {
-          margin-bottom: var(--content-padding);
+          margin: var(--content-padding) 0;
+          font-weight: 500;
+          color: #000;
         }
 
-        .drawer-content-wrapper {
-          max-width: var(--app-drawer-width);
-        }
-
-        #column-container {
-          display: flex;
-          align-items: stretch;
-          flex-direction: row;
-        }
-
-        #drawer-column {
-          padding: 1em 2em 1em 1em;
-          margin-left: 8px;
-        }
-
-        #content-column {
-          flex: 1;
-          padding-left: 2em;
-        }
-
-        .data-panel {
-          max-width: var(--max-content-width);
-        }
-        .data-panel .description {
+        .description {
           margin-bottom: 1em;
         }
-
-        .metric-nav {
-          list-style-type: none;
-        }
-        .metric-nav h3:not(:first-of-type) {
-          margin-top: calc(var(--content-padding) * 2);
-        }
-        .metric-nav li {
-          padding: 0.5em;
-          margin-bottom: 10px;
+        .description #highlighted-text {
+          font-weight: 500;
         }
 
-        @media only screen and (max-width: 1200px) {
-          .metric-nav {
-            display: none
-          }
-
-          #column-container {
-            flex-direction: column;
-          }
-
-          #content-column {
-            padding-left: var(--content-padding-half);
-            padding-right: var(--content-padding-half);
-          }
-
-          #drawer-column {
-            padding: 0;
-          }
-
-          #subheader {
-            margin: var(--content-padding) 0;
-            text-align: center;
-          }
-
-          .data-panel {
-            margin: 0 10px;
-          }
-        }
-
-        @media only screen and (min-width: 1200px) {
-          #horizontal-sub-nav {
-            display: none
-          }
+        #datalist-input {
+          width: 30em;
+          border-radius: 10px;
+          height: 25px;
+          margin-bottom: var(--content-padding);
+          padding-left: 10px;
+          font-size: 15px;
         }
       `];
   }
@@ -91,7 +36,7 @@ export class ChromedashStackRankPage extends LitElement {
     return {
       type: {type: String}, // "css" or "feature"
       view: {type: String}, // "popularity" or "animated"
-      props: {attribute: false},
+      viewList: {attribute: false},
     };
   }
 
@@ -99,7 +44,7 @@ export class ChromedashStackRankPage extends LitElement {
     super();
     this.type = '';
     this.view = '';
-    this.props = [];
+    this.viewList = [];
   }
 
   connectedCallback() {
@@ -116,80 +61,21 @@ export class ChromedashStackRankPage extends LitElement {
     document.body.classList.remove('loading');
 
     fetch(endpoint).then((res) => res.json()).then((props) => {
-      this.props = props;
+      for (let i = 0, item; item = props[i]; ++i) {
+        item.percentage = (item.day_percentage * 100).toFixed(6);
+      }
+      this.viewList = props.filter((item) => {
+        return !['ERROR', 'PageVisits', 'PageDestruction'].includes(item.property_name);
+      });
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });
   }
 
-  renderCSSNavBar() {
-    return html`
-      <ul class="metric-nav">
-        <h3>All properties</h3>
-        <li><a href="/metrics/css/popularity">Stack rank</a></li>
-        <li><a href="/metrics/css/timeline/popularity">Timeline</a></li>
-        <h3>Animated properties</h3>
-        <li><a href="/metrics/css/animated">Stack rank</a></li>
-        <li><a href="/metrics/css/timeline/animated">Timeline</a></li>
-      </ul>
-
-      <div id="horizontal-sub-nav">
-        <nav class="data-panel">
-          <table>
-            <tr>
-              <td>View All Properties As:</td>
-              <td>
-                <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a>
-                |
-                <a href="/metrics/css/popularity" class="sub-nav-links">Stack Rank</a>
-              </td>
-            </tr>
-          </table>
-        </nav>
-
-        <nav class="data-panel">
-          <table>
-            <tr>
-              <td>View Animated Properties As:</td>
-              <td>
-                <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a>
-                |
-                <a href="/metrics/css/animated" class="sub-nav-links">Stack Rank</a>
-              </td>
-            </tr>
-          </table>
-        </nav>
-      </div>
-    `;
-  }
-
-  renderJSNavBar() {
-    return html`
-      <ul class="metric-nav">
-        <h3>All features</h3>
-        <li><a href="/metrics/feature/popularity">Stack rank</a></li>
-        <li><a href="/metrics/feature/timeline/popularity">Timeline</a></li>
-      </ul>
-
-      <div id="horizontal-sub-nav">
-        <nav class="data-panel">
-          <table>
-            <tr>
-              <td>View As:</td>
-              <td>
-                <a href="/metrics/feature/timeline/popularity" class="sub-nav-links"
-                  >Timeline</a
-                >
-                |
-                <a href="/metrics/feature/popularity" class="sub-nav-links"
-                  >Stack Rank</a
-                >
-              </td>
-            </tr>
-          </table>
-        </nav>
-      </div>
-    `;
+  handleSearchBarChange(e) {
+    const inputValue = e.currentTarget.value;
+    const property = this.viewList.find((item) => item.property_name === inputValue);
+    window.location.href = `/metrics/${this.type}/timeline/${this.view}/${property.bucket_id}`;
   }
 
   renderSubheader() {
@@ -200,25 +86,33 @@ export class ChromedashStackRankPage extends LitElement {
     return html`<h2>${subTitleText}</h2>`;
   }
 
+  renderSearchBar() {
+    return html`
+      <input id="datalist-input" type="search" list="features"
+        placeholder=${this.viewList.length ? 'Select or search a property for detailed stats' : 'loading...'} 
+        @change="${this.handleSearchBarChange}" />
+      <datalist id="features">
+        ${this.viewList.map((item) => html`
+          <option value="${item.property_name}" dataset-debug-bucket-id="${item.bucket_id}"></option>
+        `)}
+      </datalist>
+    `;
+  }
+
   renderDataPanel() {
     return html`
-      <h3>About this data</h3>
+      <h3>Data from last 24 hours</h3>
       <p class="description">
-        We've been using Chrome's <a href="https://cs.chromium.org/chromium/src/tools/metrics/histograms/enums.xml"
-        target="_blank" rel="noopener">anonymous usage statistics</a> to count the occurrences of certain
-        ${this.type == 'css'? 'CSS properties': 'HTML and JavaScript features'} in the wild. The numbers on
-        this page indicate the <b>percentages of Chrome page loads (across all channels and platforms) that use the
-        corresponding ${this.type == 'css'? 'property': 'feature'} at least once</b>.
-
-        Newly added use counters that are not on Chrome stable yet only have data from the Chrome channels they're
-        on, which makes them hard to compare to older use counters.
-
-        Data is ~24 hrs old.
+        The percentage numbers indicate the <span id="highlighted-text">percentage of Chrome page loads
+        (across all channels and platforms) that use the ${this.type == 'css'? 'property': 'feature'}
+        at least once</span>. Data is collected via Chrome's
+        <a href="https://cs.chromium.org/chromium/src/tools/metrics/histograms/enums.xml"
+        target="_blank" rel="noopener">anonymous usage statistics</a>.
       </p>
       <chromedash-stack-rank 
         .type=${this.type}
         .view=${this.view}
-        .props=${this.props}>
+        .viewList=${this.viewList}>
       </chromedash-stack-rank>
     `;
   }
@@ -227,19 +121,11 @@ export class ChromedashStackRankPage extends LitElement {
     // TODO: Create a precomiled main css file and import it instead of inlining it here
     return html`
       <link rel="stylesheet" href="/static/css/main.css">
-      <div id="column-container">
-        <div id="drawer-column">
-          ${this.type == 'css' ? this.renderCSSNavBar() : this.renderJSNavBar()}
-        </div>
-        <div id="content-column">
-          <div id="subheader">
-            ${this.renderSubheader()}
-          </div>
-          <div class="data-panel">
-            ${this.renderDataPanel()}
-          </div>
-        </div>
+      <div id="subheader">
+        ${this.renderSubheader()}
       </div>
+      ${this.renderSearchBar()}
+      ${this.renderDataPanel()}
     `;
   }
 }

--- a/static/elements/chromedash-stack-rank.js
+++ b/static/elements/chromedash-stack-rank.js
@@ -1,15 +1,14 @@
 import {LitElement, css, html} from 'lit';
-
 import '@polymer/iron-icon';
 import './chromedash-x-meter';
 import {SHARED_STYLES} from '../sass/shared-css.js';
+
 
 class ChromedashStackRank extends LitElement {
   static get properties() {
     return {
       type: {type: String},
       view: {type: String},
-      props: {attribute: false},
       viewList: {attribute: false},
       maxPercentage: {attribute: false},
       sortType: {type: String},
@@ -20,7 +19,6 @@ class ChromedashStackRank extends LitElement {
   constructor() {
     super();
     this.type = '';
-    this.props = [];
     this.viewList = [];
     this.maxPercentage = 100;
     this.sortType = 'percentage';
@@ -143,15 +141,7 @@ class ChromedashStackRank extends LitElement {
   }
 
   willUpdate(changedProperties) {
-    if (!changedProperties.has('props') || !this.props.length) return;
-
-    for (let i = 0, item; item = this.props[i]; ++i) {
-      item.percentage = (item.day_percentage * 100).toFixed(6);
-    }
-
-    this.viewList = this.props.filter((item) => {
-      return !['ERROR', 'PageVisits', 'PageDestruction'].includes(item.property_name);
-    });
+    if (!changedProperties.has('viewList') || !this.viewList.length) return;
 
     this.maxPercentage = this.viewList.reduce((accum, currVal) => {
       return Math.max(accum, currVal.percentage);
@@ -192,7 +182,7 @@ class ChromedashStackRank extends LitElement {
         <p class="title-text">Showing <span>${this.viewList.length}</span> properties</p>
         <div id="dropdown-selection">
           <sl-dropdown>
-            <sl-button slot="trigger" variant="text">
+            <sl-button slot="trigger" variant="text" ?disabled=${!this.viewList.length}>
               <iron-icon icon="chromestatus:sort"></iron-icon>
               SORT BY
             </sl-button>

--- a/static/elements/chromedash-timeline-page.js
+++ b/static/elements/chromedash-timeline-page.js
@@ -12,77 +12,14 @@ export class ChromedashTimelinePage extends LitElement {
         h3 {
           margin-bottom: var(--content-padding);
         }
-
-        .drawer-content-wrapper {
-          max-width: var(--app-drawer-width);
-        }
-
-        #column-container {
-          display: flex;
-          align-items: stretch;
-          flex-direction: row;
-        }
-
-        #drawer-column {
-          padding: 1em 2em 1em 1em;
-          margin-left: 8px;
-        }
-
-        #content-column {
-          flex: 1;
-          padding-left: 2em;
-        }
-
-        .data-panel {
-          max-width: var(--max-content-width);
-        }
-        .data-panel .description {
+        
+        .description {
           margin-bottom: 1em;
         }
 
-        .metric-nav {
-          list-style-type: none;
-        }
-        .metric-nav h3:not(:first-of-type) {
-          margin-top: calc(var(--content-padding) * 2);
-        }
-        .metric-nav li {
-          padding: 0.5em;
-          margin-bottom: 10px;
-        }
-
-        @media only screen and (max-width: 1200px) {
-          .metric-nav {
-            display: none
-          }
-
-          #column-container {
-            flex-direction: column;
-          }
-
-          #content-column {
-            padding-left: var(--content-padding-half);
-            padding-right: var(--content-padding-half);
-          }
-
-          #drawer-column {
-            padding: 0;
-          }
-
-          #subheader {
-            margin: var(--content-padding) 0;
-            text-align: center;
-          }
-
-          .data-panel {
-            margin: 0 10px;
-          }
-        }
-
-        @media only screen and (min-width: 1200px) {
-          #horizontal-sub-nav {
-            display: none
-          }
+        #breadcrumbs a {
+          text-decoration: none;
+          color: inherit;
         }
       `];
   }
@@ -122,87 +59,22 @@ export class ChromedashTimelinePage extends LitElement {
     });
   }
 
-  renderCSSNavBar() {
-    return html`
-      <ul class="metric-nav">
-        <h3>All properties</h3>
-        <li><a href="/metrics/css/popularity">Stack rank</a></li>
-        <li><a href="/metrics/css/timeline/popularity">Timeline</a></li>
-        <h3>Animated properties</h3>
-        <li><a href="/metrics/css/animated">Stack rank</a></li>
-        <li><a href="/metrics/css/timeline/animated">Timeline</a></li>
-      </ul>
-
-      <div id="horizontal-sub-nav">
-        <nav class="data-panel">
-          <table>
-            <tr>
-              <td>View All Properties As:</td>
-              <td>
-                <a href="/metrics/css/timeline/popularity" class="sub-nav-links">Timeline</a>
-                |
-                <a href="/metrics/css/popularity" class="sub-nav-links">Stack Rank</a>
-              </td>
-            </tr>
-          </table>
-        </nav>
-
-        <nav class="data-panel">
-          <table>
-            <tr>
-              <td>View Animated Properties As:</td>
-              <td>
-                <a href="/metrics/css/timeline/animated" class="sub-nav-links">Timeline</a>
-                |
-                <a href="/metrics/css/animated" class="sub-nav-links">Stack Rank</a>
-              </td>
-            </tr>
-          </table>
-        </nav>
-      </div>
-    `;
-  }
-
-  renderJSNavBar() {
-    return html`
-      <ul class="metric-nav">
-        <h3>All features</h3>
-        <li><a href="/metrics/feature/popularity">Stack rank</a></li>
-        <li><a href="/metrics/feature/timeline/popularity">Timeline</a></li>
-      </ul>
-
-      <div id="horizontal-sub-nav">
-        <nav class="data-panel">
-          <table>
-            <tr>
-              <td>View As:</td>
-              <td>
-                <a href="/metrics/feature/timeline/popularity" class="sub-nav-links"
-                  >Timeline</a
-                >
-                |
-                <a href="/metrics/feature/popularity" class="sub-nav-links"
-                  >Stack Rank</a
-                >
-              </td>
-            </tr>
-          </table>
-        </nav>
-      </div>
-    `;
-  }
-
   renderSubheader() {
     const typeText = this.type == 'css'? 'CSS': 'HTML & JavaScript';
     const viewText = this.view == 'animated' ? 'animated' : 'all';
     const propText = this.type == 'css' ? 'properties' : 'features';
     const subTitleText = `${typeText} usage metrics > ${viewText} ${propText} > timeline`;
-    return html`<h2>${subTitleText}</h2>`;
+    return html`
+      <h2 id="breadcrumbs">
+        <a href="/metrics/${this.type}/${this.view}">
+          <iron-icon icon="chromestatus:arrow-back"></iron-icon>
+        </a>${subTitleText}
+      </h2>
+    `;
   }
 
   renderDataPanel() {
     return html`
-      <p class="description">To begin, select a feature in the dropdown below.</p>
       <chromedash-timeline
         .type=${this.type}
         .view=${this.view}
@@ -215,19 +87,10 @@ export class ChromedashTimelinePage extends LitElement {
     // TODO: Create a precomiled main css file and import it instead of inlining it here
     return html`
       <link rel="stylesheet" href="/static/css/main.css">
-      <div id="column-container">
-        <div id="drawer-column">
-          ${this.type == 'css' ? this.renderCSSNavBar() : this.renderJSNavBar()}
-        </div>
-        <div id="content-column">
-          <div id="subheader">
-            ${this.renderSubheader()}
-          </div>
-          <div class="data-panel">
-            ${this.renderDataPanel()}
-          </div>
-        </div>
+      <div id="subheader">
+        ${this.renderSubheader()}
       </div>
+      ${this.renderDataPanel()}
     `;
   }
 }

--- a/static/elements/chromedash-timeline.js
+++ b/static/elements/chromedash-timeline.js
@@ -1,7 +1,7 @@
 import {LitElement, css, html} from 'lit';
 import {showToastMessage} from './utils.js';
-
 import {SHARED_STYLES} from '../sass/shared-css.js';
+
 
 class ChromedashTimeline extends LitElement {
   static get properties() {
@@ -41,7 +41,7 @@ class ChromedashTimeline extends LitElement {
       #chart {
         margin-top: 15px;
         width: 100%;
-        height: 400px;
+        height: 450px;
         background: var(--table-alternate-background);
         border-radius: var(--border-radius);
       }
@@ -54,6 +54,8 @@ class ChromedashTimeline extends LitElement {
 
       .header_title {
         margin: 32px 0 15px 0;
+        font-weight: 500;
+        color: #000;
       }
 
       .description {
@@ -83,6 +85,10 @@ class ChromedashTimeline extends LitElement {
 
       #datalist-input {
         width: 20em;
+        border-radius: 10px;
+        height: 25px;
+        padding-left: 10px;
+        font-size: 15px;
       }
 
       sl-progress-bar {

--- a/static/sass/metrics.scss
+++ b/static/sass/metrics.scss
@@ -1,3 +1,0 @@
-#content-component-wrapper {
-  width: auto;
-}

--- a/static/sass/shared-css.js
+++ b/static/sass/shared-css.js
@@ -55,7 +55,7 @@ export const SHARED_STYLES = [
     cursor: pointer;
   }
 
-  input:not([type="submit"]):not([type="search"]),
+  input:not([type="submit"]),
   textarea {
     border: 1px solid var(--bar-border-color);
   }

--- a/templates/metrics/css/animated.html
+++ b/templates/metrics/css/animated.html
@@ -1,11 +1,6 @@
 {% extends "_base.html" %}
 {% load inline_file %}
 
-{% block css %}
-  {# TODO(kevinshen56714): remove this after redesigning the nav bar #}
-  <style>{% inline_file "/static/css/metrics.css" %}</style>
-{% endblock %}
-
 {% block content %}
   <chromedash-stack-rank-page 
     type="css"

--- a/templates/metrics/css/popularity.html
+++ b/templates/metrics/css/popularity.html
@@ -1,11 +1,6 @@
 {% extends "_base.html" %}
 {% load inline_file %}
 
-{% block css %}
-  {# TODO(kevinshen56714): remove this after redesigning the nav bar #}
-  <style>{% inline_file "/static/css/metrics.css" %}</style>
-{% endblock %}
-
 {% block content %}
   <chromedash-stack-rank-page 
     type="css"

--- a/templates/metrics/css/timeline/animated.html
+++ b/templates/metrics/css/timeline/animated.html
@@ -1,11 +1,6 @@
 {% extends "_base.html" %}
 {% load inline_file %}
 
-{% block css %}
-  {# TODO(kevinshen56714): remove this after redesigning the nav bar #}
-  <style>{% inline_file "/static/css/metrics.css" %}</style>
-{% endblock %}
-
 {% block preload %}
 <script src="https://www.gstatic.com/charts/loader.js"></script>
 {% endblock %}

--- a/templates/metrics/css/timeline/popularity.html
+++ b/templates/metrics/css/timeline/popularity.html
@@ -1,11 +1,6 @@
 {% extends "_base.html" %}
 {% load inline_file %}
 
-{% block css %}
-  {# TODO(kevinshen56714): remove this after redesigning the nav bar #}
-  <style>{% inline_file "/static/css/metrics.css" %}</style>
-{% endblock %}
-
 {% block preload %}
 <script src="https://www.gstatic.com/charts/loader.js"></script>
 {% endblock %}

--- a/templates/metrics/feature/popularity.html
+++ b/templates/metrics/feature/popularity.html
@@ -1,11 +1,6 @@
 {% extends "_base.html" %}
 {% load inline_file %}
 
-{% block css %}
-  {# TODO(kevinshen56714): remove this after redesigning the nav bar #}
-  <style>{% inline_file "/static/css/metrics.css" %}</style>
-{% endblock %}
-
 {% block content %}
   <chromedash-stack-rank-page 
     type="feature"

--- a/templates/metrics/feature/timeline/popularity.html
+++ b/templates/metrics/feature/timeline/popularity.html
@@ -1,11 +1,6 @@
 {% extends "_base.html" %}
 {% load inline_file %}
 
-{% block css %}
-  {# TODO(kevinshen56714): remove this after redesigning the nav bar #}
-  <style>{% inline_file "/static/css/metrics.css" %}</style>
-{% endblock %}
-
 {% block preload %}
 <script src="https://www.gstatic.com/charts/loader.js"></script>
 {% endblock %}


### PR DESCRIPTION
This PR completes the metric page UI refactor. The changes include:

1. Removed the side nav bar for both stack rank and timeline pages.
2. Added "CSS Animation" option to the "Stats" menu in the header.
3. Added a search bar to the stack rank page as one of the options to go to the timeline page.
4. Added a left arrow button in front of the title of the timeline page as a way to go back to the corresponding stack rank page.
5. Removed the `metrics.scss` file (it was needed because of the side nav bar)

These changes simplify the metric page navigation by removing the unnecessary side nav bar and adding new ways to navigate (also avoid users accessing an empty timeline page). The results are as below:

## Stack rank page
<img width="1280" alt="Screen Shot 2022-07-19 at 9 36 57 PM" src="https://user-images.githubusercontent.com/11501902/179877011-715a4371-7d6f-444d-9b12-bce8db4c7bb6.png">

## Timeline page
<img width="1279" alt="Screen Shot 2022-07-19 at 9 37 12 PM" src="https://user-images.githubusercontent.com/11501902/179877015-d4be10fb-fa58-4b6b-9810-56008d550bcb.png">
