### PR TITLE
Make the loading skeleton sheen contrast higher

### DIFF
--- a/static/sass/shared-css.js
+++ b/static/sass/shared-css.js
@@ -161,4 +161,9 @@ export const SHARED_STYLES = [
   sl-details::part(content) {
     padding: 0;
   }
+
+  sl-skeleton {
+    --color: #eee;
+    --sheen-color: #ccc;
+  }
 `];

--- a/static/sass/shared.scss
+++ b/static/sass/shared.scss
@@ -145,3 +145,8 @@ sl-details::part(header) {
 sl-details::part(content) {
   padding: 0;
 }
+
+sl-skeleton {
+  --color: #eee;
+  --sheen-color: #ccc;
+}


### PR DESCRIPTION
This makes the loading sheen effect slightly more obvious (higher contrast).

![skeleton-sheen](https://user-images.githubusercontent.com/11501902/180254706-cf2a20b5-cbf5-4972-a2bb-e183163715fc.gif)