### PR TITLE
Clarify in the UI that samples can be "demos and samples".

### DIFF
--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -415,7 +415,7 @@ ALL_FIELDS = {
         widget=ChromedashTextarea()),
 
     'sample_links': MultiUrlField(
-        label='Samples links', required=False,
+        label='Demo and sample links', required=False,
         widget=ChromedashTextarea(attrs=MULTI_URL_FIELD_ATTRS)),
 
     'non_oss_deps': forms.CharField(
@@ -519,7 +519,7 @@ class ChromedashForm(forms.Form):
     def simple_html_output(self, normal_row):
         """
         Output HTML. Used by override of as_table() to support chromedash uses only.
-        Simplified to drop support for hidden form fields and errors at the top, 
+        Simplified to drop support for hidden form fields and errors at the top,
         which we are not using.
         Added field 'name' property for use in the normal_row template.
         """

--- a/static/elements/chromedash-feature-page.js
+++ b/static/elements/chromedash-feature-page.js
@@ -298,7 +298,7 @@ export class ChromedashFeaturePage extends LitElement {
 
       ${this.feature.resources && this.feature.resources.samples ? html`
         <section id="demo">
-          <h3>${this.feature.resources.samples.length == 1 ? 'Demo' : 'Demos'}</h3>
+          <h3>Demos and samples</h3>
           <ul>
             ${this.feature.resources.samples.map((sampleLink) => html`
               <li><a href="${sampleLink}">${sampleLink}</a></li>

--- a/static/elements/chromedash-feature.js
+++ b/static/elements/chromedash-feature.js
@@ -451,19 +451,18 @@ class ChromedashFeature extends LitElement {
           <section>
             <h3>Developer resources</h3>
             <div class="resources">
-              <label>Documentation/samples:</label>
               ${this._hasDocLinks ? html`
                 <div class="doc_links">
+                  <label>Documentation:</label>
                   <chromedash-multi-links
                       .links="${this.feature.resources.docs}"
                       title="Doc"></chromedash-multi-links>
                 </div>
                 ` : nothing}
-              ${this._hasDocLinks && this._hasSampleLinks ?
-                html`<span>,</span>` : nothing}
               ${this._hasSampleLinks ? html`
                 <div class="sample_links">
-                  <chromedash-multi-links title="Sample"
+                  <label>Demos and samples:</label>
+                  <chromedash-multi-links title="Link"
                       .links="${this.feature.resources.samples}"
                       ></chromedash-multi-links>
                 </div>

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -32,9 +32,9 @@ export const ALL_FIELDS = {
   'summary': {
     label: 'Summary',
     help_text: html`
-       <p style="margin-top:0">Text in the beta release post, the enterprise release notes, 
+       <p style="margin-top:0">Text in the beta release post, the enterprise release notes,
         and other external sources will be based on this text.</p>
-  
+
         <p>Write from a web developer's point of view. Begin with one line
         explaining what the feature does. Add one or two lines explaining
         how this feature helps developers. Write in a matter-of-fact
@@ -136,9 +136,9 @@ export const ALL_FIELDS = {
   'motivation': {
     label: 'Motivation',
     help_text: html`
-        Explain why the web needs this change. It may be useful 
-        to describe what web developers are forced to do without 
-        it. When possible, add links to your explainer 
+        Explain why the web needs this change. It may be useful
+        to describe what web developers are forced to do without
+        it. When possible, add links to your explainer
         backing up your claims.
         <br/><br/>
         This text is sometimes included with the summary in the
@@ -146,7 +146,7 @@ export const ALL_FIELDS = {
         documents. Write in a matter-of-fact manner and in the
         present tense.
         <br/><br/>
-        <a target="_blank" 
+        <a target="_blank"
             href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#motivation-example">
           Example</a>`,
   },
@@ -164,7 +164,7 @@ export const ALL_FIELDS = {
         present tense.
         <br/><br/>
         Please see
-        <a target="_blank" 
+        <a target="_blank"
             href="https://docs.google.com/a/chromium.org/document/d/1LdqUfUILyzM5WEcOgeAWGupQILKrZHidEXrUxevyi_Y/edit?usp=sharing">
           Removal guidelines</a>.`,
   },
@@ -209,10 +209,10 @@ export const ALL_FIELDS = {
 
   'spec_mentors': {
     help_text: html`
-        Experienced 
+        Experienced
         <a target="_blank"
             href="https://www.chromium.org/blink/spec-mentors">
-          spec mentors</a> 
+          spec mentors</a>
         are available to help you improve your feature spec.`,
   },
 
@@ -251,7 +251,7 @@ export const ALL_FIELDS = {
   },
 
   'tag_review': {
-    help_text: html`Link(s) to TAG review(s), or explanation why this is 
+    help_text: html`Link(s) to TAG review(s), or explanation why this is
                 not needed.`,
   },
 
@@ -260,47 +260,47 @@ export const ALL_FIELDS = {
   },
 
   'intent_to_ship_url': {
-    help_text: html`After you have started the "Intent to Ship" discussion 
+    help_text: html`After you have started the "Intent to Ship" discussion
                 thread, link to it here.`,
   },
 
   'ready_for_trial_url': {
-    help_text: html`After you have started the "Ready for Trial" discussion 
+    help_text: html`After you have started the "Ready for Trial" discussion
                 thread, link to it here.`,
   },
 
   'intent_to_experiment_url': {
-    help_text: html`After you have started the "Intent to Experiment" 
+    help_text: html`After you have started the "Intent to Experiment"
                  discussion thread, link to it here.`,
   },
 
   'intent_to_extend_experiment_url': {
-    help_text: html`If this feature has an "Intent to Extend Experiment" 
+    help_text: html`If this feature has an "Intent to Extend Experiment"
                  discussion thread, link to it here.`,
   },
 
   'r4dt_url': {
-    help_text: html`After you have started the "Request for Deprecation Trial" 
+    help_text: html`After you have started the "Request for Deprecation Trial"
                 discussion thread, link to it here.`,
   },
 
   'interop_compat_risks': {
     help_text: html`
-      Describe the degree of 
-      <a target="_blank" 
+      Describe the degree of
+      <a target="_blank"
           href="https://www.chromium.org/blink/guidelines/web-platform-changes-guidelines#TOC-Finding-balance">
-        interoperability risk</a>. 
-      For a new feature, the main risk is 
-      that it fails to become an interoperable part of the web platform 
-      if other browsers do not implement it. For a removal, please review our 
-      <a target="_blank" 
+        interoperability risk</a>.
+      For a new feature, the main risk is
+      that it fails to become an interoperable part of the web platform
+      if other browsers do not implement it. For a removal, please review our
+      <a target="_blank"
           href="https://docs.google.com/document/d/1RC-pBBvsazYfCNNUSkPqAVpSpNJ96U8trhNkfV0v9fk/edit">
       principles of web compatibility</a>.<br>
       <br>
-      Please include citation links below where possible. Examples include 
-      resolutions from relevant standards bodies (e.g. W3C working group), 
-      tracking bugs, or links to online conversations. 
-      <a target="_blank" 
+      Please include citation links below where possible. Examples include
+      resolutions from relevant standards bodies (e.g. W3C working group),
+      tracking bugs, or links to online conversations.
+      <a target="_blank"
           href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#interoperability-and-compatibility-risks-example">
         Example</a>.`,
   },
@@ -332,7 +332,7 @@ export const ALL_FIELDS = {
 
   'web_dev_views': {
     help_text: html`
-      If unsure, default to "No signals". 
+      If unsure, default to "No signals".
       See <a target="_blank" href="https://goo.gle/developer-signals">
       https://goo.gle/developer-signals</a>`,
   },
@@ -344,7 +344,7 @@ export const ALL_FIELDS = {
 
   'web_dev_views_notes': {
     help_text: html`
-      Reference known representative examples of opinions, 
+      Reference known representative examples of opinions,
       both positive and negative.`,
   },
 
@@ -355,111 +355,111 @@ export const ALL_FIELDS = {
 
   'ergonomics_risks': {
     help_text: html`
-      Are there any other platform APIs this feature will frequently be 
-      used in tandem with? Could the default usage of this API make it 
-      hard for Chrome to maintain good performance (i.e. synchronous 
+      Are there any other platform APIs this feature will frequently be
+      used in tandem with? Could the default usage of this API make it
+      hard for Chrome to maintain good performance (i.e. synchronous
       return, must run on a certain thread, guaranteed return timing)?`,
   },
 
   'activation_risks': {
     help_text: html`
-      Will it be challenging for developers to take advantage of this 
-      feature immediately, as-is? Would this feature benefit from 
-      having polyfills, significant documentation and outreach, and/or 
+      Will it be challenging for developers to take advantage of this
+      feature immediately, as-is? Would this feature benefit from
+      having polyfills, significant documentation and outreach, and/or
       libraries built on top of it to make it easier to use?`,
   },
 
   'security_risks': {
     help_text: html`
-      List any security considerations that were taken into account 
+      List any security considerations that were taken into account
       when designing this feature.`,
   },
 
   'webview_risks': {
     help_text: html`
-      Does this feature deprecate or change behavior of existing APIs, 
-      such that it has potentially high risk for Android WebView-based 
-      applications? 
+      Does this feature deprecate or change behavior of existing APIs,
+      such that it has potentially high risk for Android WebView-based
+      applications?
       (See <a target="_blank"
           href="https://new.chromium.org/developers/webview-changes/">
-        here</a> 
-      for a definition of "potentially high risk", 
-      information on why changes to this platform carry higher 
-      risk, and general rules of thumb for which changes have higher or 
+        here</a>
+      for a definition of "potentially high risk",
+      information on why changes to this platform carry higher
+      risk, and general rules of thumb for which changes have higher or
       lower risk) If so:
       <ul>
-        <li>Please use a base::Feature killswitch 
+        <li>Please use a base::Feature killswitch
           (<a target="_blank"
               href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/common/features.h"
-              >examples here</a>) 
+              >examples here</a>)
           that can be flipped off in case of compat issues</li>
         <li>Consider contacting android-webview-dev@chromium.org for advice</li>
-        <li>If you are not sure, just put "not sure" as the answer and 
+        <li>If you are not sure, just put "not sure" as the answer and
           the API owners can help during the review of your Intent to Ship</li>
       </ul>`,
   },
 
   'experiment_goals': {
     help_text: html`
-      Which pieces of the API surface are you looking to gain insight on? 
-      What metrics/measurement/feedback will you be using to validate 
-      designs? Double check that your experiment makes sense given that 
-      a large developer (e.g. a Google product or Facebook) likely 
-      can't use it in production due to the limits enforced by origin 
+      Which pieces of the API surface are you looking to gain insight on?
+      What metrics/measurement/feedback will you be using to validate
+      designs? Double check that your experiment makes sense given that
+      a large developer (e.g. a Google product or Facebook) likely
+      can't use it in production due to the limits enforced by origin
       trials.
       <br/><br/>
-      If you send an Intent to Extend Origin Trial, highlight 
-      areas for experimentation. They should not be an exact copy of the goals 
+      If you send an Intent to Extend Origin Trial, highlight
+      areas for experimentation. They should not be an exact copy of the goals
       from the first Intent to Experiment.`,
   },
 
   'experiment_timeline': {
     help_text: html`
-      When does the experiment start and expire? 
-      Deprecated: 
+      When does the experiment start and expire?
+      Deprecated:
       Please use the numeric fields above instead.`,
   },
 
   'ot_milestone_desktop_start': {
     help_text: html`
-      First desktop milestone that will support an origin 
+      First desktop milestone that will support an origin
       trial of this feature.`,
   },
 
   'ot_milestone_desktop_end': {
     help_text: html`
-      Last desktop milestone that will support an origin 
+      Last desktop milestone that will support an origin
       trial of this feature.`,
   },
 
   'ot_milestone_android_start': {
     help_text: html`
-      First android milestone that will support an origin 
+      First android milestone that will support an origin
       trial of this feature.`,
   },
 
   'ot_milestone_android_end': {
     help_text: html`
-      Last android milestone that will support an origin 
+      Last android milestone that will support an origin
       trial of this feature.`,
   },
 
   'ot_milestone_webview_start': {
     help_text: html`
-      First WebView milestone that will support an origin 
+      First WebView milestone that will support an origin
       trial of this feature.`,
   },
 
   'ot_milestone_webview_end': {
     help_text: html`
-      Last WebView milestone that will support an origin 
+      Last WebView milestone that will support an origin
       trial of this feature.`,
   },
 
   'experiment_risks': {
     help_text: html`
-      When this experiment comes to an end are there any risks to the 
-      sites that were using it, for example losing access to important 
+      When this experiment comes to an end are there any risks to the
+      sites that were using it, for example losing access to important
       storage due to an experimental storage API?`,
   },
 
@@ -471,72 +471,72 @@ export const ALL_FIELDS = {
 
   'ongoing_constraints': {
     help_text: html`
-      Do you anticipate adding any ongoing technical constraints to 
-      the codebase while implementing this feature? We prefer to avoid 
-      features that require or assume a specific architecture. 
+      Do you anticipate adding any ongoing technical constraints to
+      the codebase while implementing this feature? We prefer to avoid
+      features that require or assume a specific architecture.
       For most features, the answer is "None."`,
   },
 
   'origin_trial_feedback_url': {
     help_text: html`
-      If your feature was available as an origin trial, link to a summary 
+      If your feature was available as an origin trial, link to a summary
       of usage and developer feedback. If not, leave this empty.`,
   },
 
   'anticipated_spec_changes': {
     help_text: html`
-      Open questions about a feature may be a source of future web compat 
-      or interop issues. Please list open issues (e.g. links to known 
-      github issues in the repo for the feature specification) whose 
-      resolution may introduce web compat/interop risk (e.g., changing 
-      the naming or structure of the API in a 
+      Open questions about a feature may be a source of future web compat
+      or interop issues. Please list open issues (e.g. links to known
+      github issues in the repo for the feature specification) whose
+      resolution may introduce web compat/interop risk (e.g., changing
+      the naming or structure of the API in a
       non-backward-compatible way).`,
   },
 
   'finch_url': {
     help_text: html`
-      If your feature will roll out gradually via a 
-      <a href="go/finch" targe="_blank">Finch experiment</a>, 
+      If your feature will roll out gradually via a
+      <a href="go/finch" targe="_blank">Finch experiment</a>,
       link to it here.`,
   },
 
   'i2e_lgtms': {
     help_text: html`
-      Full email address of API owner who LGTM\'d the 
+      Full email address of API owner who LGTM\'d the
       Intent to Experiment email thread.`,
   },
 
   'i2s_lgtms': {
     help_text: html`
-      Comma separated list of 
-      email addresses of API owners who LGTM'd 
+      Comma separated list of
+      email addresses of API owners who LGTM'd
       the Intent to Ship email thread.  `,
   },
 
   'r4dt_lgtms': {
     help_text: html`
-      Full email addresses of API owners who LGTM\'d 
+      Full email addresses of API owners who LGTM\'d
       the Request for Deprecation Trial email thread.`,
   },
 
   'debuggability': {
     help_text: html`
-      Description of the DevTools debugging support for your feature. 
-      Please follow 
-      <a target="_blank" 
+      Description of the DevTools debugging support for your feature.
+      Please follow
+      <a target="_blank"
           href="https://goo.gle/devtools-checklist">
         DevTools support checklist</a> for guidance.`,
   },
 
   'all_platforms': {
     help_text: html`
-      Will this feature be supported on all six Blink platforms 
+      Will this feature be supported on all six Blink platforms
       (Windows, Mac, Linux, Chrome OS, Android, and Android WebView)?`,
   },
 
   'all_platforms_descr': {
     help_text: html`
-      Explain why this feature is, or is not, 
+      Explain why this feature is, or is not,
       supported on all platforms.`,
   },
 
@@ -547,29 +547,29 @@ export const ALL_FIELDS = {
 
   'wpt_descr': {
     help_text: html`
-      Please link to the <a href="https://wpt.fyi/results">results on 
-      wpt.fyi</a>. If any part of the feature is not tested by 
-      web-platform-tests, please include links to issues, e.g. a 
-      web-platform-tests issue with the "infra" label explaining why a 
-      certain thing cannot be tested 
-      (<a href="https://github.com/w3c/web-platform-tests/issues/3867">example</a>), 
-      a spec issue for some change that would make it possible to test. 
-      (<a href="https://github.com/whatwg/fullscreen/issues/70">example</a>), 
-      or a Chromium issue to upstream some existing tests 
+      Please link to the <a href="https://wpt.fyi/results">results on
+      wpt.fyi</a>. If any part of the feature is not tested by
+      web-platform-tests, please include links to issues, e.g. a
+      web-platform-tests issue with the "infra" label explaining why a
+      certain thing cannot be tested
+      (<a href="https://github.com/w3c/web-platform-tests/issues/3867">example</a>),
+      a spec issue for some change that would make it possible to test.
+      (<a href="https://github.com/whatwg/fullscreen/issues/70">example</a>),
+      or a Chromium issue to upstream some existing tests
       (<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=695486">example</a>).`,
   },
 
   'sample_links': {
     help_text: html`
-      Links to samples (one URL per line).`,
+      Links to demos and samples (one URL per line).`,
   },
 
   'non_oss_deps': {
     help_text: html`
-      Does the feature depend on any code or APIs outside the Chromium 
-      open source repository and its open-source dependencies to 
-      function? (e.g. server-side APIs, operating system APIs 
-      tailored to this feature or closed-source code bundles) 
+      Does the feature depend on any code or APIs outside the Chromium
+      open source repository and its open-source dependencies to
+      function? (e.g. server-side APIs, operating system APIs
+      tailored to this feature or closed-source code bundles)
       Yes or no. If yes, explain why this is necessary.`,
   },
 
@@ -596,11 +596,11 @@ export const ALL_FIELDS = {
 
   'requires_embedder_support': {
     help_text: html`
-       Will this feature require support in //chrome?  
-       That includes any code in //chrome, even if that is for 
-       functionality on top of the spec.  Other //content embedders 
-       will need to be aware of that functionality. 
-       Please add a row to this 
+       Will this feature require support in //chrome?
+       That includes any code in //chrome, even if that is for
+       functionality on top of the spec.  Other //content embedders
+       will need to be aware of that functionality.
+       Please add a row to this
        <a target="_blank"
           href="https://docs.google.com/spreadsheets/d/1QV4SW4JBG3IyLzaonohUhim7nzncwK4ioop2cgUYevw/edit#gid=0">
         tracking spreadsheet</a>.`,
@@ -608,38 +608,38 @@ export const ALL_FIELDS = {
 
   'devtrial_instructions': {
     help_text: html`
-        Link to a HOWTO or FAQ describing how developers can get started 
-        using this feature in a DevTrial. 
+        Link to a HOWTO or FAQ describing how developers can get started
+        using this feature in a DevTrial.
         <br/><br/>
-        <a target="_blank" 
+        <a target="_blank"
             href="https://github.com/samuelgoto/WebID/blob/master/HOWTO.md">
-          Example 1</a>.  
-        <a target="_blank" 
+          Example 1</a>.
+        <a target="_blank"
             href="https://github.com/WICG/idle-detection/blob/main/HOWTO.md">
           Example 2</a>.`,
   },
 
   'dt_milestone_desktop_start': {
     help_text: html`
-      First milestone that allows web developers to try 
-      this feature on desktop platforms by setting a flag. 
-      When flags are enabled by default in preparation for 
+      First milestone that allows web developers to try
+      this feature on desktop platforms by setting a flag.
+      When flags are enabled by default in preparation for
       shipping or removal, please use the fields in the ship stage.`,
   },
 
   'dt_milestone_android_start': {
     help_text: html`
-      First milestone that allows web developers to try 
-      this feature on desktop platforms by setting a flag. 
-      When flags are enabled by default in preparation for 
+      First milestone that allows web developers to try
+      this feature on desktop platforms by setting a flag.
+      When flags are enabled by default in preparation for
       shipping or removal, please use the fields in the ship stage.`,
   },
 
   'dt_milestone_ios_start': {
     help_text: html`
-      First milestone that allows web developers to try 
-      this feature on desktop platforms by setting a flag. 
-      When flags are enabled by default in preparation for 
+      First milestone that allows web developers to try
+      this feature on desktop platforms by setting a flag.
+      When flags are enabled by default in preparation for
       shipping or removal, please use the fields in the ship stage.`,
   },
 

--- a/static/sass/elements/chromedash-feature-css.js
+++ b/static/sass/elements/chromedash-feature-css.js
@@ -224,13 +224,8 @@ export const FEATURE_CSS = [
     section .comments html-echo {
       white-space: pre-wrap;
     }
-    section .doc_links,
-    section .sample_links,
     section .owner {
       flex-shrink: 1 !important;
-    }
-    section .sample_links {
-      margin-left: 8px;
     }
     .sidebyside {
       display: flex;
@@ -239,8 +234,8 @@ export const FEATURE_CSS = [
     .sidebyside .flex {
       flex: 0 0 calc(50% - 16px);
     }
-    .resources label {
-      margin-right: 8px;
+    .resources div {
+      margin-top: var(--content-padding-half);
     }
     @media only screen and (max-width: 700px) {
       :host {
@@ -272,11 +267,6 @@ export const FEATURE_CSS = [
         display: block;
       }
     }
-    @media only screen and (min-width: 701px) {
-      .resources {
-        display: flex;
-        align-items: center;
-      }
     }
   `,
 ];


### PR DESCRIPTION
In today's team meeting, Joe pointed out that the labels for "Demos" and "Samples" are used interchangeably and inconsistently.

In this PR:
* Label the editing field "Demo and sample links", with help text "Links to demos and samples."
* On the feature detail page, label them "Demos and samples"
* On the feature card, separate documentation links and label these "Demos and samples"