### PR TITLE
Set up a partial SPA

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from flask import Flask
-import logging
-
 from api import accounts_api
 from api import approvals_api
 from api import channels_api
@@ -183,6 +180,8 @@ page_routes = [
 
     ('/settings', users.SettingsHandler),
     ('/admin/users/new', users.UserListHandler),
+
+    ('/spa', basehandlers.ConstHandler, {'template_path': 'spa.html'}),
 ]
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "lit": "^2",
         "node-fetch": ">=3.2.9",
         "node-sass": ">=4.13.1",
+        "page": "^1.11.6",
         "urijs": ">=1.19.11",
         "yargs-parser": ">=21.0.1"
       },
@@ -13275,6 +13276,27 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/page": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/page/-/page-1.11.6.tgz",
+      "integrity": "sha512-P6e2JfzkBrPeFCIPplLP7vDDiU84RUUZMrWdsH4ZBGJ8OosnwFkcUkBHp1DTIjuipLliw9yQn/ZJsXZvarsO+g==",
+      "dependencies": {
+        "path-to-regexp": "~1.2.1"
+      }
+    },
+    "node_modules/page/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+    },
+    "node_modules/page/node_modules/path-to-regexp": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz",
+      "integrity": "sha512-DBw9IhWfevR2zCVwEZURTuQNseCvu/Q9f5ZgqMCK0Rh61bDa4uyjPAOy9b55yKiPT59zZn+7uYKxmWwsguInwg==",
+      "dependencies": {
+        "isarray": "0.0.1"
       }
     },
     "node_modules/parent-module": {
@@ -28093,6 +28115,29 @@
       "requires": {
         "got": "^3.2.0",
         "registry-url": "^3.0.0"
+      }
+    },
+    "page": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/page/-/page-1.11.6.tgz",
+      "integrity": "sha512-P6e2JfzkBrPeFCIPplLP7vDDiU84RUUZMrWdsH4ZBGJ8OosnwFkcUkBHp1DTIjuipLliw9yQn/ZJsXZvarsO+g==",
+      "requires": {
+        "path-to-regexp": "~1.2.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+        },
+        "path-to-regexp": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz",
+          "integrity": "sha512-DBw9IhWfevR2zCVwEZURTuQNseCvu/Q9f5ZgqMCK0Rh61bDa4uyjPAOy9b55yKiPT59zZn+7uYKxmWwsguInwg==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
       }
     },
     "parent-module": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "clean-setup": "rm -rf node_modules cs-env; npm run setup",
     "deps": "source cs-env/bin/activate; pip install -r requirements.txt --upgrade; pip install -r requirements.dev.txt --upgrade",
     "dev-deps": "echo 'dev-deps is no longer needed'",
-
     "do-tests": "source cs-env/bin/activate; curl -X POST 'http://localhost:15606/reset' && python3 -m unittest discover -p '*_test.py'  -b",
     "start-emulator-persist": "gcloud beta emulators datastore start --host-port=:15606 --consistency=1.0",
     "start-emulator": "gcloud beta emulators datastore start --host-port=:15606 --no-store-on-disk --consistency=1.0",
@@ -21,7 +20,6 @@
     "start-app": "npm run build && ./scripts/start_server.sh",
     "start": "source cs-env/bin/activate; (npm run start-emulator-persist > /dev/null 2>&1 &); sleep 6; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run start-app; status=$?; npm run stop-emulator; exit $status",
     "stop": "killall cs-env/bin/python3.9",
-
     "test": "(npm run start-emulator > /dev/null 2>&1 &); sleep 6; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-tests; status=$?; npm run stop-emulator; exit $status",
     "webtest": "web-test-runner \"static/**/*_test.js\" --node-resolve --playwright --browsers chromium firefox",
     "do-coverage": "coverage3 erase && coverage3 run -m unittest discover -p '*_test.py' -b && coverage3 html",
@@ -29,7 +27,6 @@
     "view-coverage": "pushd htmlcov/; python3 -m http.server 8080; popd",
     "lint": "gulp lint-fix && lit-analyzer \"static/elements/chromedash-!(featurelist)*.js\"",
     "pylint": "pylint --output-format=parseable *py api/*py customtags/*py framework/*py internals/*py pages/*py",
-
     "staging": "./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'` cr-status-staging",
     "staging-rc": "./scripts/deploy_site.sh rc cr-status-staging",
     "deploy": "./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'`",
@@ -101,6 +98,7 @@
     "lit": "^2",
     "node-fetch": ">=3.2.9",
     "node-sass": ">=4.13.1",
+    "page": "^1.11.6",
     "urijs": ">=1.19.11",
     "yargs-parser": ">=21.0.1"
   }

--- a/static/components.js
+++ b/static/components.js
@@ -29,6 +29,7 @@ setBasePath('/static/shoelace');
 // chromedash components
 import './elements/icons';
 import './elements/chromedash-all-features-page';
+import './elements/chromedash-app';
 import './elements/chromedash-approvals-dialog';
 import './elements/chromedash-banner';
 import './elements/chromedash-callout';

--- a/static/elements/chromedash-app.js
+++ b/static/elements/chromedash-app.js
@@ -31,8 +31,8 @@ class ChromedashApp extends LitElement {
     this.appTitle = '';
     this.googleSignInClientId = '',
     this.currentPage = '';
-    this.message = '';
-    this.timestamp = null;
+    this.bannerMessage = '';
+    this.bannerTime = null;
     this.pageComponent = null;
     this.contextLink = '/features';
   }

--- a/static/elements/chromedash-app.js
+++ b/static/elements/chromedash-app.js
@@ -40,7 +40,6 @@ class ChromedashApp extends LitElement {
     page('/spa', () => page.redirect('/roadmap'));
     page('/roadmap', () => {
       this.pageComponent = document.createElement('chromedash-roadmap-page');
-      console.log(this.pageComponent);
     });
     page('/myfeatures', () => {
       this.pageComponent = document.createElement('chromedash-myfeatures-page');

--- a/static/elements/chromedash-app.js
+++ b/static/elements/chromedash-app.js
@@ -34,20 +34,24 @@ class ChromedashApp extends LitElement {
 
   setUpRoutes() {
     page.strict(true); // Be precise about trailing slashes in routes.
+    const header = document.querySelector('chromedash-header');
 
     // SPA routing rules.  Note that rules are considered in order.
     // And :var can match any string (including a slash) if there is no slash after it.
     page('/spa', () => page.redirect('/roadmap'));
     page('/roadmap', () => {
       this.pageComponent = document.createElement('chromedash-roadmap-page');
+      header.currentPage = '/roadmap';
     });
     page('/myfeatures', () => {
       this.pageComponent = document.createElement('chromedash-myfeatures-page');
       this.contextLink = '/myfeatures';
+      header.currentPage = '/myfeatures';
     });
     page('/features', () => {
       this.pageComponent = document.createElement('chromedash-all-features-page');
       this.contextLink = '/features';
+      header.currentPage = '/features';
     });
     page('/feature/:featureId', (ctx) => {
       this.pageComponent = document.createElement('chromedash-feature-page');
@@ -61,34 +65,40 @@ class ChromedashApp extends LitElement {
       this.pageComponent = document.createElement('chromedash-stack-rank-page');
       this.pageComponent.type = 'feature';
       this.pageComponent.view = 'popularity';
+      header.currentPage = '/metrics';
     });
     page('/metrics/css/popularity', () => {
       this.pageComponent = document.createElement('chromedash-stack-rank-page');
       this.pageComponent.type = 'css';
       this.pageComponent.view = 'popularity';
+      header.currentPage = '/metrics';
     });
     page('/metrics/css/animated', () => {
       this.pageComponent = document.createElement('chromedash-stack-rank-page');
       this.pageComponent.type = 'css';
       this.pageComponent.view = 'animated';
+      header.currentPage = '/metrics';
     });
     page('/metrics/feature/timeline/popularity/:bucketId', (ctx) => {
       this.pageComponent = document.createElement('chromedash-timeline-page');
       this.pageComponent.type = 'feature';
       this.pageComponent.view = 'popularity';
       this.pageComponent.selectedBucketId = ctx.params.bucketId;
+      header.currentPage = '/metrics';
     });
     page('/metrics/css/timeline/popularity/:bucketId', (ctx) => {
       this.pageComponent = document.createElement('chromedash-timeline-page');
       this.pageComponent.type = 'css';
       this.pageComponent.view = 'popularity';
       this.pageComponent.selectedBucketId = ctx.params.bucketId;
+      header.currentPage = '/metrics';
     });
     page('/metrics/css/timeline/animated/:bucketId', (ctx) => {
       this.pageComponent = document.createElement('chromedash-timeline-page');
       this.pageComponent.type = 'css';
       this.pageComponent.view = 'animated';
       this.pageComponent.selectedBucketId = ctx.params.bucketId;
+      header.currentPage = '/metrics';
     });
 
     page.start();

--- a/static/elements/chromedash-app.js
+++ b/static/elements/chromedash-app.js
@@ -39,66 +39,41 @@ class ChromedashApp extends LitElement {
     // SPA routing rules.  Note that rules are considered in order.
     // And :var can match any string (including a slash) if there is no slash after it.
     page('/spa', () => page.redirect('/roadmap'));
-    page('/roadmap', () => {
+    page('/roadmap', (ctx) => {
       this.pageComponent = document.createElement('chromedash-roadmap-page');
-      header.currentPage = '/roadmap';
+      header.currentPage = ctx.path;
     });
-    page('/myfeatures', () => {
+    page('/myfeatures', (ctx) => {
       this.pageComponent = document.createElement('chromedash-myfeatures-page');
       this.contextLink = '/myfeatures';
-      header.currentPage = '/myfeatures';
+      header.currentPage = ctx.path;
     });
-    page('/features', () => {
+    page('/features', (ctx) => {
       this.pageComponent = document.createElement('chromedash-all-features-page');
       this.contextLink = '/features';
-      header.currentPage = '/features';
+      header.currentPage = ctx.path;
     });
     page('/feature/:featureId', (ctx) => {
       this.pageComponent = document.createElement('chromedash-feature-page');
       this.pageComponent.featureId = ctx.params.featureId;
       this.pageComponent.contextLink = this.contextLink;
     });
-    page('/settings', () => {
+    page('/settings', (ctx) => {
       this.pageComponent = document.createElement('chromedash-settings-page');
+      header.currentPage = ctx.path;
     });
-    page('/metrics/feature/popularity', () => {
+    page('/metrics/:type/:view', (ctx) => {
       this.pageComponent = document.createElement('chromedash-stack-rank-page');
-      this.pageComponent.type = 'feature';
-      this.pageComponent.view = 'popularity';
-      header.currentPage = '/metrics';
+      this.pageComponent.type = ctx.params.type;
+      this.pageComponent.view = ctx.params.view;
+      header.currentPage = ctx.path;
     });
-    page('/metrics/css/popularity', () => {
-      this.pageComponent = document.createElement('chromedash-stack-rank-page');
-      this.pageComponent.type = 'css';
-      this.pageComponent.view = 'popularity';
-      header.currentPage = '/metrics';
-    });
-    page('/metrics/css/animated', () => {
-      this.pageComponent = document.createElement('chromedash-stack-rank-page');
-      this.pageComponent.type = 'css';
-      this.pageComponent.view = 'animated';
-      header.currentPage = '/metrics';
-    });
-    page('/metrics/feature/timeline/popularity/:bucketId', (ctx) => {
+    page('/metrics/:type/timeline/:view/:bucketId', (ctx) => {
       this.pageComponent = document.createElement('chromedash-timeline-page');
-      this.pageComponent.type = 'feature';
-      this.pageComponent.view = 'popularity';
+      this.pageComponent.type = ctx.params.type;
+      this.pageComponent.view = ctx.params.view;
       this.pageComponent.selectedBucketId = ctx.params.bucketId;
-      header.currentPage = '/metrics';
-    });
-    page('/metrics/css/timeline/popularity/:bucketId', (ctx) => {
-      this.pageComponent = document.createElement('chromedash-timeline-page');
-      this.pageComponent.type = 'css';
-      this.pageComponent.view = 'popularity';
-      this.pageComponent.selectedBucketId = ctx.params.bucketId;
-      header.currentPage = '/metrics';
-    });
-    page('/metrics/css/timeline/animated/:bucketId', (ctx) => {
-      this.pageComponent = document.createElement('chromedash-timeline-page');
-      this.pageComponent.type = 'css';
-      this.pageComponent.view = 'animated';
-      this.pageComponent.selectedBucketId = ctx.params.bucketId;
-      header.currentPage = '/metrics';
+      header.currentPage = ctx.path;
     });
 
     page.start();

--- a/static/elements/chromedash-app.js
+++ b/static/elements/chromedash-app.js
@@ -16,6 +16,11 @@ class ChromedashApp extends LitElement {
 
   static get properties() {
     return {
+      appTitle: {type: String},
+      googleSignInClientId: {type: String},
+      currentPage: {type: String},
+      bannerMessage: {type: String},
+      bannerTime: {type: Number},
       pageComponent: {type: Element},
       contextLink: {type: String}, // used for the back button in the feature page
     };
@@ -23,6 +28,11 @@ class ChromedashApp extends LitElement {
 
   constructor() {
     super();
+    this.appTitle = '';
+    this.googleSignInClientId = '',
+    this.currentPage = '';
+    this.message = '';
+    this.timestamp = null;
     this.pageComponent = null;
     this.contextLink = '/features';
   }
@@ -34,24 +44,23 @@ class ChromedashApp extends LitElement {
 
   setUpRoutes() {
     page.strict(true); // Be precise about trailing slashes in routes.
-    const header = document.querySelector('chromedash-header');
 
     // SPA routing rules.  Note that rules are considered in order.
     // And :var can match any string (including a slash) if there is no slash after it.
     page('/spa', () => page.redirect('/roadmap'));
     page('/roadmap', (ctx) => {
       this.pageComponent = document.createElement('chromedash-roadmap-page');
-      header.currentPage = ctx.path;
+      this.currentPage = ctx.path;
     });
     page('/myfeatures', (ctx) => {
       this.pageComponent = document.createElement('chromedash-myfeatures-page');
       this.contextLink = '/myfeatures';
-      header.currentPage = ctx.path;
+      this.currentPage = ctx.path;
     });
     page('/features', (ctx) => {
       this.pageComponent = document.createElement('chromedash-all-features-page');
       this.contextLink = '/features';
-      header.currentPage = ctx.path;
+      this.currentPage = ctx.path;
     });
     page('/feature/:featureId', (ctx) => {
       this.pageComponent = document.createElement('chromedash-feature-page');
@@ -60,20 +69,20 @@ class ChromedashApp extends LitElement {
     });
     page('/settings', (ctx) => {
       this.pageComponent = document.createElement('chromedash-settings-page');
-      header.currentPage = ctx.path;
+      this.currentPage = ctx.path;
     });
     page('/metrics/:type/:view', (ctx) => {
       this.pageComponent = document.createElement('chromedash-stack-rank-page');
       this.pageComponent.type = ctx.params.type;
       this.pageComponent.view = ctx.params.view;
-      header.currentPage = ctx.path;
+      this.currentPage = ctx.path;
     });
     page('/metrics/:type/timeline/:view/:bucketId', (ctx) => {
       this.pageComponent = document.createElement('chromedash-timeline-page');
       this.pageComponent.type = ctx.params.type;
       this.pageComponent.view = ctx.params.view;
       this.pageComponent.selectedBucketId = ctx.params.bucketId;
-      header.currentPage = ctx.path;
+      this.currentPage = ctx.path;
     });
 
     page.start();
@@ -81,13 +90,21 @@ class ChromedashApp extends LitElement {
 
   render() {
     // TODO: Create precomiled main css file and import it instead of inlining it here
+    // The <slot> below is for the Google sign-in button, this is because
+    // Google Identity Services Library cannot find elements in a shadow DOM,
+    // so we create signInButton element at the document level and insert it
     return html`
       <link rel="stylesheet" href="/static/css/main.css">
       <div id="app-content-container">
         <div>
           <div class="main-toolbar">
             <div class="toolbar-content">
-              <slot name="header"></slot>
+              <chromedash-header 
+                .appTitle=${this.appTitle}
+                .googleSignInClientId=${this.googleSignInClientId}
+                .currentPage=${this.currentPage}>
+                <slot></slot>
+              </chromedash-header>
             </div>
           </div>
 
@@ -95,10 +112,13 @@ class ChromedashApp extends LitElement {
             <div id="spinner">
               <img src="/static/img/ring.svg">
             </div>
-            <slot name="banner"></slot>
+            <chromedash-banner
+              .message=${this.bannerMessage}
+              .timestamp=${this.bannerTime}>
+            </chromedash-banner>
             <div id="content-flex-wrapper">
               <div id="content-component-wrapper" 
-                ?wide=${this.pageComponent && this.pageComponent.tagName == 'CHROMEDASH-ROADMAP-PAGE'}>
+                ?wide=${this.currentPage=='/roadmap'}>
                 ${this.pageComponent}
               </div>
             </div>

--- a/static/elements/chromedash-app.js
+++ b/static/elements/chromedash-app.js
@@ -1,0 +1,133 @@
+import {LitElement, css, html} from 'lit';
+import page from 'page';
+import {SHARED_STYLES} from '../sass/shared-css.js';
+
+
+class ChromedashApp extends LitElement {
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      css`
+        #content-component-wrapper[wide] {
+          width: 100%;
+        }
+    `];
+  }
+
+  static get properties() {
+    return {
+      pageComponent: {type: Element},
+      contextLink: {type: String}, // used for the back button in the feature page
+    };
+  }
+
+  constructor() {
+    super();
+    this.pageComponent = null;
+    this.contextLink = '/features';
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.setUpRoutes();
+  }
+
+  setUpRoutes() {
+    page.strict(true); // Be precise about trailing slashes in routes.
+
+    // SPA routing rules.  Note that rules are considered in order.
+    // And :var can match any string (including a slash) if there is no slash after it.
+    page('/spa', () => page.redirect('/roadmap'));
+    page('/roadmap', () => {
+      this.pageComponent = document.createElement('chromedash-roadmap-page');
+      console.log(this.pageComponent);
+    });
+    page('/myfeatures', () => {
+      this.pageComponent = document.createElement('chromedash-myfeatures-page');
+      this.contextLink = '/myfeatures';
+    });
+    page('/features', () => {
+      this.pageComponent = document.createElement('chromedash-all-features-page');
+      this.contextLink = '/features';
+    });
+    page('/feature/:featureId', (ctx) => {
+      this.pageComponent = document.createElement('chromedash-feature-page');
+      this.pageComponent.featureId = ctx.params.featureId;
+      this.pageComponent.contextLink = this.contextLink;
+    });
+    page('/settings', () => {
+      this.pageComponent = document.createElement('chromedash-settings-page');
+    });
+    page('/metrics/feature/popularity', () => {
+      this.pageComponent = document.createElement('chromedash-stack-rank-page');
+      this.pageComponent.type = 'feature';
+      this.pageComponent.view = 'popularity';
+    });
+    page('/metrics/css/popularity', () => {
+      this.pageComponent = document.createElement('chromedash-stack-rank-page');
+      this.pageComponent.type = 'css';
+      this.pageComponent.view = 'popularity';
+    });
+    page('/metrics/css/animated', () => {
+      this.pageComponent = document.createElement('chromedash-stack-rank-page');
+      this.pageComponent.type = 'css';
+      this.pageComponent.view = 'animated';
+    });
+    page('/metrics/feature/timeline/popularity/:bucketId', (ctx) => {
+      this.pageComponent = document.createElement('chromedash-timeline-page');
+      this.pageComponent.type = 'feature';
+      this.pageComponent.view = 'popularity';
+      this.pageComponent.selectedBucketId = ctx.params.bucketId;
+    });
+    page('/metrics/css/timeline/popularity/:bucketId', (ctx) => {
+      this.pageComponent = document.createElement('chromedash-timeline-page');
+      this.pageComponent.type = 'css';
+      this.pageComponent.view = 'popularity';
+      this.pageComponent.selectedBucketId = ctx.params.bucketId;
+    });
+    page('/metrics/css/timeline/animated/:bucketId', (ctx) => {
+      this.pageComponent = document.createElement('chromedash-timeline-page');
+      this.pageComponent.type = 'css';
+      this.pageComponent.view = 'animated';
+      this.pageComponent.selectedBucketId = ctx.params.bucketId;
+    });
+
+    page.start();
+  }
+
+  render() {
+    // TODO: Create precomiled main css file and import it instead of inlining it here
+    return html`
+      <link rel="stylesheet" href="/static/css/main.css">
+      <div id="app-content-container">
+        <div>
+          <div class="main-toolbar">
+            <div class="toolbar-content">
+              <slot name="header"></slot>
+            </div>
+          </div>
+
+          <div id="content">
+            <div id="spinner">
+              <img src="/static/img/ring.svg">
+            </div>
+            <slot name="banner"></slot>
+            <div id="content-flex-wrapper">
+              <div id="content-component-wrapper" 
+                ?wide=${this.pageComponent && this.pageComponent.tagName == 'CHROMEDASH-ROADMAP-PAGE'}>
+                ${this.pageComponent}
+              </div>
+            </div>
+          </div>
+
+        </div>
+        <chromedash-footer></chromedash-footer>
+      </div>
+
+      <chromedash-toast msg="Welcome to chromestatus.com!"></chromedash-toast>
+    `;
+  }
+}
+
+customElements.define('chromedash-app', ChromedashApp);
+

--- a/static/elements/chromedash-header.js
+++ b/static/elements/chromedash-header.js
@@ -210,7 +210,13 @@ export class ChromedashHeader extends LitElement {
     // in the light DOM of the header, which will be rendered in the <slot> below
     const signInButton = document.createElement('div');
     google.accounts.id.renderButton(signInButton, {type: 'standard'});
-    this.insertAdjacentElement('afterbegin', signInButton);
+    const appComponent = document.querySelector('chromedash-app');
+    if (appComponent) {
+      appComponent.insertAdjacentElement('afterbegin', signInButton); // for SPA
+    } else {
+      // TODO (kevinshen56714): remove this once SPA is set up
+      this.insertAdjacentElement('afterbegin', signInButton); // for MPA
+    }
   }
 
   handleCredentialResponse(credentialResponse) {

--- a/static/elements/chromedash-header.js
+++ b/static/elements/chromedash-header.js
@@ -180,6 +180,7 @@ export class ChromedashHeader extends LitElement {
     super();
     this.appTitle = '';
     this.googleSignInClientId = '',
+    this.currentPage = '';
     this.user = {};
     this.loading = true;
   }
@@ -195,9 +196,6 @@ export class ChromedashHeader extends LitElement {
     }).finally(() => {
       this.loading = false;
     });
-
-    // TODO(kevinshen56714): this can be passed in from SPA router
-    this.currentPage = window.location.pathname;
   }
 
   initializeGoogleSignIn() {

--- a/static/elements/chromedash-header.js
+++ b/static/elements/chromedash-header.js
@@ -169,7 +169,7 @@ export class ChromedashHeader extends LitElement {
   static get properties() {
     return {
       appTitle: {type: String},
-      google_sign_in_client_id: {type: String},
+      googleSignInClientId: {type: String},
       currentPage: {type: String},
       user: {type: Object},
       loading: {type: Boolean},
@@ -179,7 +179,7 @@ export class ChromedashHeader extends LitElement {
   constructor() {
     super();
     this.appTitle = '';
-    this.google_sign_in_client_id = '',
+    this.googleSignInClientId = '',
     this.user = {};
     this.loading = true;
   }
@@ -202,7 +202,7 @@ export class ChromedashHeader extends LitElement {
 
   initializeGoogleSignIn() {
     google.accounts.id.initialize({
-      client_id: this.google_sign_in_client_id,
+      client_id: this.googleSignInClientId,
       callback: this.handleCredentialResponse,
     });
     google.accounts.id.prompt();

--- a/static/elements/chromedash-timeline-page.js
+++ b/static/elements/chromedash-timeline-page.js
@@ -28,6 +28,7 @@ export class ChromedashTimelinePage extends LitElement {
       type: {type: String}, // "css" or "feature"
       view: {type: String}, // "popularity" or "animated"
       props: {attribute: false},
+      selectedBucketId: {attribute: false},
     };
   }
 
@@ -36,6 +37,7 @@ export class ChromedashTimelinePage extends LitElement {
     this.type = '';
     this.view = '';
     this.props = [];
+    this.selectedBucketId = '1';
   }
 
   connectedCallback() {
@@ -77,7 +79,8 @@ export class ChromedashTimelinePage extends LitElement {
       <chromedash-timeline
         .type=${this.type}
         .view=${this.view}
-        .props=${this.props}>
+        .props=${this.props}
+        .selectedBucketId=${this.selectedBucketId}>
       </chromedash-timeline>
     `;
   }

--- a/static/elements/chromedash-timeline.js
+++ b/static/elements/chromedash-timeline.js
@@ -121,6 +121,8 @@ class ChromedashTimeline extends LitElement {
     window.google.charts.load('current', {'packages': ['corechart']});
     window.google.charts.setOnLoadCallback(() => {
       // If there's an id in the URL, load the property it.
+      // TODO (kevinshen56714) - this can be removed once SPA is fully set up
+      // as the bucketId is passed in from the router.
       const lastSlash = location.pathname.lastIndexOf('/');
       if (lastSlash > 0) {
         const id = parseInt(location.pathname.substring(lastSlash + 1));

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -86,7 +86,8 @@ limitations under the License.
       <div class="main-toolbar">
         <div class="toolbar-content">
           <chromedash-header
-            appTitle="{{APP_TITLE}}" 
+            appTitle="{{APP_TITLE}}"
+            currentPage="{{current_path}}"
             google_sign_in_client_id="{{google_sign_in_client_id}}">
           </chromedash-header>
         </div>

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -88,7 +88,7 @@ limitations under the License.
           <chromedash-header
             appTitle="{{APP_TITLE}}"
             currentPage="{{current_path}}"
-            google_sign_in_client_id="{{google_sign_in_client_id}}">
+            googleSignInClientId="{{google_sign_in_client_id}}">
           </chromedash-header>
         </div>
       </div>

--- a/templates/spa.html
+++ b/templates/spa.html
@@ -71,9 +71,11 @@ limitations under the License.
 </head>
 
 <body class="loading">
-  <chromedash-app>
-    <chromedash-header slot="header" appTitle="{{APP_TITLE}}" googleSignInClientId="{{google_sign_in_client_id}}"></chromedash-header>
-    <chromedash-banner slot="banner" message="{{banner_message}}" timestamp="{{banner_time}}"></chromedash-banner>
+  <chromedash-app
+    appTitle="{{APP_TITLE}}"
+    googleSignInClientId="{{google_sign_in_client_id}}"
+    bannerMessage="{{banner_message}}"
+    bannerTime="{{banner_time}}">
   </chromedash-app>
 
   <script src="https://www.googletagmanager.com/gtag/js?id=UA-179341418-1" async nonce="{{nonce}}"></script>

--- a/templates/spa.html
+++ b/templates/spa.html
@@ -1,0 +1,95 @@
+{% load inline_file %}
+
+<!DOCTYPE html>
+<!--
+Copyright 2022 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>{% block page_title %}{% endblock %}{{ APP_TITLE }}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+
+  <meta name="theme-color" content="#366597">
+
+  <link rel="stylesheet" href="/static/css/base.css?v={{app_version}}" />
+
+  <link rel="icon" sizes="192x192" href="/static/img/crstatus_192.png">
+
+  <!-- iOS: run in full-screen mode and display upper status bar as translucent -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
+  <link rel="apple-touch-icon" href="/static/img/crstatus_128.png">
+  <link rel="apple-touch-icon-precomposed" href="/static/img/crstatus_128.png">
+  <link rel="shortcut icon" href="/static/img/crstatus_128.png">
+
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&amp;display=swap" rel="stylesheet">
+
+  <style>{% inline_file "/static/css/main.css" %}</style>
+
+  {# Google Identity Services library for OAuth #}
+  <script src="https://accounts.google.com/gsi/client" async defer nonce="{{nonce}}"></script>
+
+  {# Google Charts library for timeline pages #}
+  <script src="https://www.gstatic.com/charts/loader.js"></script>
+
+  <script nonce="{{nonce}}">
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get("loginStatus") == 'False') {
+      alert('Please log in.');
+    }
+  </script>
+  {# Loaded immediately because it is used by JS code on the page. #}
+  <script nonce="{{nonce}}">
+    {% inline_file "/static/js/metric.min.js" %}
+    {% inline_file "/static/js/cs-client.min.js" %}
+
+    window.csClient = new ChromeStatusClient(
+      '{{xsrf_token}}', {{ xsrf_token_expires }});
+  </script>
+
+  <script type="module" nonce="{{nonce}}" defer src="/static/dist/components.js?v={{app_version}}"></script>
+</head>
+
+<body class="loading">
+  <chromedash-app>
+    <chromedash-header slot="header" appTitle="{{APP_TITLE}}" googleSignInClientId="{{google_sign_in_client_id}}"></chromedash-header>
+    <chromedash-banner slot="banner" message="{{banner_message}}" timestamp="{{banner_time}}"></chromedash-banner>
+  </chromedash-app>
+
+  <script src="https://www.googletagmanager.com/gtag/js?id=UA-179341418-1" async nonce="{{nonce}}"></script>
+
+  {% comment %}
+  Note that the following script tag must include type="module" so that the form field event listeners
+  attached by shared.min.js will not be attached until after Shoelace event listeners are attached.
+  See https://github.com/GoogleChrome/chromium-dashboard/issues/2014
+  {% endcomment %}
+  <script type="module" nonce="{{nonce}}">
+    (function () {
+      'use strict';
+
+      {% inline_file "/static/js/shared.min.js" %}
+    })();
+  </script>
+</body>
+
+</html>

--- a/templates/spa.html
+++ b/templates/spa.html
@@ -20,7 +20,7 @@ limitations under the License.
 
 <head>
   <meta charset="utf-8">
-  <title>{% block page_title %}{% endblock %}{{ APP_TITLE }}</title>
+  <title>{{ APP_TITLE }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
 
   <meta name="theme-color" content="#366597">


### PR DESCRIPTION
This PR sets up a partial single-page app with currently available page components (all except for /guide and /admin pages). Changes include:

1. Installed Page.js for routing.
2. Added `chromedash-app.js` component as the app-level component in which the routing rules are defined.
3. Added `spa.html` as the SPA's entry html file. This file currently highly resembles `_base.html` but I think we can improve it by moving some of the js script into the app component js file in the future.
4. Added a /spa route in `main.py`. This is the temporary entry route to the SPA. The SPA router will redirect the app to /roadmap and take over the routing.

Overall, the SPA version enables a much smoother transitions (no reloads) between pages as excepted :). See the demo video below:

https://user-images.githubusercontent.com/11501902/180865138-751115fc-f4bc-434d-b5ba-903c3dc7d12b.mov


