### PR TITLE
Add creator index and fix method args.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -207,6 +207,11 @@ indexes:
   - name: editors
   - name: updated
     direction: desc
+- kind: Feature
+  properties:
+  - name: creator
+  - name: updated
+    direction: desc
 - kind: "FeatureObserver"
   properties:
   - name: "bucket_id"

--- a/internals/write_creator.py
+++ b/internals/write_creator.py
@@ -6,7 +6,7 @@ from internals.models import Feature
 
 class UpdateCreatorHandler(FlaskHandler):
 
-  def get_template_data():
+  def get_template_data(self):
     """Writes string creator field from created_by user field."""
     q = Feature.query()
     features = q.fetch()
@@ -19,6 +19,6 @@ class UpdateCreatorHandler(FlaskHandler):
             email = feature.created_by.email()
         feature.creator = email
         feature.put(notify=False)
-    
+
     logging.info(f'{update_count} features updated with new creator field.')
     return 'Success'

--- a/internals/write_creator.py
+++ b/internals/write_creator.py
@@ -12,12 +12,14 @@ class UpdateCreatorHandler(FlaskHandler):
     features = q.fetch()
     update_count = 0
     for feature in features:
+      logging.info(f'considering {feature.name}.')
       if feature.created_by and not feature.creator:
         update_count += 1
         email = "Unknown"
         if feature.created_by:
             email = feature.created_by.email()
         feature.creator = email
+        logging.info(f'updating {feature.name}.')
         feature.put(notify=False)
 
     logging.info(f'{update_count} features updated with new creator field.')


### PR DESCRIPTION
This fixes two details that came up while I was testing the release:
* We do need a new index, as previously discussed that we might get it from a helpful error message on staging.
* Fix minor coding error, python methods always need `self`, even when it is not used.
* Add logging of progress so we can see what is happening just in case the first run exceeds GAE's 60s time limit.