### PR TITLE
Fix roadmap fetch bug in small views

### DIFF
--- a/static/elements/chromedash-roadmap-page.js
+++ b/static/elements/chromedash-roadmap-page.js
@@ -105,7 +105,7 @@ export class ChromedashRoadmapPage extends LitElement {
     // Fetch when second last card is displayed
     if (roadmap.lastMilestoneVisible - roadmap.lastFutureFetchedOn > 1) {
       roadmap.fetchNextBatch(roadmap.lastFutureFetchedOn + 1);
-    } else if (roadmap.lastPastFetchedOn - roadmap.lastMilestoneVisible == 0) {
+    } else if (roadmap.lastMilestoneVisible - roadmap.lastPastFetchedOn <= 0) {
       roadmap.fetchPreviousBatch(roadmap.lastPastFetchedOn - 1);
     }
   }


### PR DESCRIPTION
This fixes #2064. The roadmap's `lastMilestoneVisible` tracks what milestone is currently displayed and it depends on the number of cards displayed on the user's screen. In small views, this can be smaller than `lastPastFetchedOn`, leading to not triggering the fetching when previous button is pressed. This PR modified the criteria for fetching to cover such cases.