### PR TITLE
Enforce max-width to the stack rank search bar

### DIFF
--- a/static/elements/chromedash-stack-rank-page.js
+++ b/static/elements/chromedash-stack-rank-page.js
@@ -23,6 +23,7 @@ export class ChromedashStackRankPage extends LitElement {
 
         #datalist-input {
           width: 30em;
+          max-width: 100%;
           border-radius: 10px;
           height: 25px;
           margin-bottom: var(--content-padding);


### PR DESCRIPTION
This PR simply adds a max-width of 100% to the stack rank search bar. Currently, the search bar can go out of screen at small views. This will constrain its max length to the page width, which I think looks better and enables easier scrolls on mobile.

## Before
<img width="320" alt="Screen Shot 2022-07-27 at 12 57 34 PM" src="https://user-images.githubusercontent.com/11501902/181306000-a340372d-ed47-4b28-99b9-9e877c6d8fa3.png">
<img width="320" alt="Screen Shot 2022-07-27 at 12 57 40 PM" src="https://user-images.githubusercontent.com/11501902/181306025-04bc9a7b-e9fc-4641-bc7f-4109e574d99c.png">

## After
<img width="320" alt="Screen Shot 2022-07-27 at 12 54 49 PM" src="https://user-images.githubusercontent.com/11501902/181306044-0f6b9ef4-1908-4320-b923-ae3cbfdd213f.png">

