### PR TITLE
Feature owners and editors receive notification of changes.

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -152,6 +152,14 @@ def make_email_tasks(feature, is_update=False, changes=[]):
   addr_reasons = collections.defaultdict(list)  # [{email_addr: [reason,...]}]
 
   accumulate_reasons(
+    addr_reasons, feature.owner,
+    'You are listed as an owner of this feature'
+  )
+  accumulate_reasons(
+    addr_reasons, feature.editors,
+    'You are listed as an editor of this feature'
+  )
+  accumulate_reasons(
       addr_reasons, feature_watchers,
       'You are watching all feature changes')
 

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -220,7 +220,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     (feature_editor_task, feature_owner_task, component_owner_task,
      watcher_task) = actual_tasks
 
-    # Notification to feature editor.
+    # Notification to feature owner.
     self.assertEqual('feature_owner@example.com', feature_owner_task['to'])
     self.assertEqual('new feature: feature one', feature_owner_task['subject'])
     self.assertIn('mock body html', feature_owner_task['html'])
@@ -263,7 +263,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     (feature_editor_task, feature_owner_task, component_owner_task,
      watcher_task) = actual_tasks
 
-    # Notification to feature editor.
+    # Notification to feature owner.
     self.assertEqual('feature_owner@example.com', feature_owner_task['to'])
     self.assertEqual('updated feature: feature one',
       feature_owner_task['subject'])
@@ -310,7 +310,8 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.assertEqual(5, len(actual_tasks))
     (feature_editor_task, feature_owner_task, component_owner_task,
      starrer_task, watcher_task) = actual_tasks
-    # Notification to feature editor.
+
+    # Notification to feature owner.
     self.assertEqual('feature_owner@example.com', feature_owner_task['to'])
     self.assertEqual('updated feature: feature one',
       feature_owner_task['subject'])


### PR DESCRIPTION
This is a change listed in the new permissions design where feature editors will receive email notifications of feature changes. Additionally, feature owners have been added to the list of users who receive change notifications.