### PR TITLE
Temporary editing permissions

### DIFF
--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -74,6 +74,27 @@ def can_edit_feature(user, feature):
   return can_edit_any_feature(user)
 
 
+def strict_can_edit_feature(user, feature_id):
+  """Return True if the user is allowed to edit the given feature."""
+  if not feature_id or not user:
+    return False
+
+  # If the user is an admin or site editor, they can edit this feature.
+  app_user = models.AppUser.get_app_user(user.email())
+  if app_user is not None and (app_user.is_admin or app_user.is_admin):
+    return True
+
+  feature = models.Feature.get_by_id(feature_id)
+  if not feature:
+    return False
+  
+  email = user.email()
+  # Check if the user is an owner, editor, or creator for this feature.
+  # If yes, the feature can be edited.
+  return (email in feature.owner or
+          email in feature.editors or email == feature.creator)
+
+
 def can_approve_feature(user, feature, approvers):
   """Return True if the user is allowed to approve the given feature."""
   # TODO(jrobbins): make this per-feature

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -81,7 +81,7 @@ def strict_can_edit_feature(user, feature_id):
 
   # If the user is an admin or site editor, they can edit this feature.
   app_user = models.AppUser.get_app_user(user.email())
-  if app_user is not None and (app_user.is_admin or app_user.is_admin):
+  if app_user is not None and (app_user.is_admin or app_user.is_site_editor):
     return True
 
   feature = models.Feature.get_by_id(feature_id)

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -569,12 +569,12 @@ class FeatureEditStage(basehandlers.FlaskHandler):
     if self.touched('ongoing_constraints'):
       feature.ongoing_constraints = self.form.get('ongoing_constraints')
     
-    # Add user who updated to list of editors.
+    # Add user who updated to list of editors if not currently an editor.
     # TODO(danielrsmith): This should be removed when enabling new permissions.
-    email = self.get_current_user().email()
-    if (email not in feature.editors and email not in feature.owner and
-        email != feature.creator):
-      feature.editors.append(email)
+    associated_with_feature = permissions.strict_can_edit_feature(
+      self.get_current_user(), feature_id)
+    if not associated_with_feature:
+      feature.editors.append(self.get_current_user().email())
 
     feature.updated_by = ndb.User(
         email=self.get_current_user().email(),

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -568,6 +568,13 @@ class FeatureEditStage(basehandlers.FlaskHandler):
           'experiment_extension_reason')
     if self.touched('ongoing_constraints'):
       feature.ongoing_constraints = self.form.get('ongoing_constraints')
+    
+    # Add user who updated to list of editors.
+    # TODO(danielrsmith): This should be removed when enabling new permissions.
+    email = self.get_current_user().email()
+    if (email not in feature.editors and email not in feature.owner and
+        email != feature.creator):
+      feature.editors.append(email)
 
     feature.updated_by = ndb.User(
         email=self.get_current_user().email(),


### PR DESCRIPTION
Before the new permissions system is implemented, users who make changes to a feature will be added to the list of feature editors if they are not already an editor, owner, or the creator of the feature. This change should be removed when the new permissions system is officially implemented.