### PR TITLE
Fix SPA roadmap page and toast bugs

### DIFF
--- a/static/elements/chromedash-app.js
+++ b/static/elements/chromedash-app.js
@@ -8,8 +8,41 @@ class ChromedashApp extends LitElement {
     return [
       ...SHARED_STYLES,
       css`
+        .main-toolbar {
+          display: flex;
+          position: relative;
+          padding: 0;
+        }
+
+        #app-content-container {
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+        }
+
+        #content {
+          margin: var(--content-padding);
+          position: relative;
+        }
+
+        #content-flex-wrapper {
+          display: flex;
+          justify-content: center;
+          width: 100%;
+        }
+
+        #content-component-wrapper {
+          width: var(--max-content-width);
+          max-width: 95%;
+        }
         #content-component-wrapper[wide] {
           width: 100%;
+        }
+
+        @media only screen and (min-width: 701px) {
+          .main-toolbar .toolbar-content {
+            width: 100%;
+          }
         }
     `];
   }
@@ -118,8 +151,9 @@ class ChromedashApp extends LitElement {
               .timestamp=${this.bannerTime}>
             </chromedash-banner>
             <div id="content-flex-wrapper">
-              <div id="content-component-wrapper" 
-                ?wide=${this.currentPage && this.currentPage.tagName == 'CHROMEDASH-ROADMAP'}>
+              <div id="content-component-wrapper"
+                ?wide=${this.pageComponent &&
+                  this.pageComponent.tagName == 'CHROMEDASH-ROADMAP-PAGE'}>
                 ${this.pageComponent}
               </div>
             </div>
@@ -128,8 +162,6 @@ class ChromedashApp extends LitElement {
         </div>
         <chromedash-footer></chromedash-footer>
       </div>
-
-      <chromedash-toast msg="Welcome to chromestatus.com!"></chromedash-toast>
     `;
   }
 }

--- a/static/elements/chromedash-app.js
+++ b/static/elements/chromedash-app.js
@@ -50,16 +50,17 @@ class ChromedashApp extends LitElement {
     page('/spa', () => page.redirect('/roadmap'));
     page('/roadmap', (ctx) => {
       this.pageComponent = document.createElement('chromedash-roadmap-page');
+      this.contextLink = ctx.path;
       this.currentPage = ctx.path;
     });
     page('/myfeatures', (ctx) => {
       this.pageComponent = document.createElement('chromedash-myfeatures-page');
-      this.contextLink = '/myfeatures';
+      this.contextLink = ctx.path;
       this.currentPage = ctx.path;
     });
     page('/features', (ctx) => {
       this.pageComponent = document.createElement('chromedash-all-features-page');
-      this.contextLink = '/features';
+      this.contextLink = ctx.path;
       this.currentPage = ctx.path;
     });
     page('/feature/:featureId', (ctx) => {
@@ -118,7 +119,7 @@ class ChromedashApp extends LitElement {
             </chromedash-banner>
             <div id="content-flex-wrapper">
               <div id="content-component-wrapper" 
-                ?wide=${this.currentPage=='/roadmap'}>
+                ?wide=${this.currentPage && this.currentPage.tagName == 'CHROMEDASH-ROADMAP'}>
                 ${this.pageComponent}
               </div>
             </div>

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -29,33 +29,6 @@ body {
   width: 100%;
 }
 
-#site-banner {
-  display: none;
-  background: $chromium-color-center;
-  color: #fff;
-  position: fixed;
-  z-index: 1;
-  -webkit-tap-highlight-color: transparent;
-  user-select: none;
-  cursor: pointer;
-  text-transform: capitalize;
-  text-align: center;
-  transform: rotate(35deg);
-  right: -40px;
-  top: 20px;
-  padding: 10px 40px 8px 60px;
-  box-shadow: inset 0px 5px 6px -3px rgba(0, 0, 0, 0.4);
-
-  iron-icon {
-    margin-right: var(--content-padding-half);
-  }
-
-  a {
-    color: currentcolor;
-    text-decoration: none;
-  }
-}
-
 .main-toolbar {
   display: flex;
   position: relative;
@@ -85,14 +58,6 @@ body {
 
   }
 }
-
-#container {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  width: 100%;
-}
-
 
 #app-content-container {
   display: flex;
@@ -169,13 +134,6 @@ body {
     width: 100%;
     left: 0;
     margin: 0;
-  }
-}
-
-// When banner doesn't block navigation buttons.
-@media only screen and (min-width: 1100px) {
-  #site-banner {
-    display: block;
   }
 }
 

--- a/templates/spa.html
+++ b/templates/spa.html
@@ -78,6 +78,8 @@ limitations under the License.
     bannerTime="{{banner_time}}">
   </chromedash-app>
 
+  <chromedash-toast msg="Welcome to chromestatus.com!"></chromedash-toast>
+
   <script src="https://www.googletagmanager.com/gtag/js?id=UA-179341418-1" async nonce="{{nonce}}"></script>
 
   {% comment %}


### PR DESCRIPTION
This PR fixes several bugs in the SPA that I found so far, including:

1. Going to the feature page from the roadmap page results in wrong page width. This is fixed by only enabling a full width app when the current page component is specifically `<chromedash-roadmap-page>`)
2. The back button on the feature page would not link to the roadmap page when entering the feature page from roadmap. This is fixed by updating the contextLink for the /roadmap route as well.
3. The toast does not work in SPA because it's in the shadowRoot of the app component, and the document.querySelector cannot find it. This is fixed by putting `<chromedash-toast>` directly in the spa.html. In the future, we can implement the strategy we used for approval dialogs on toast so that it doesn't have to appear in the html.
4. Moving `chromedash-app`-specific css from main.scss to the app component. However these cannot be removed from main.scss yet because it's still used in the MPA version. I think in a later PR, I will merge `main.scss` and `shared.scss`, and we can retire `main.scss`.
5. Removed more unused css (for #site-banner and #container) in main.scss.