### PR TITLE
Make icons more finger-friendly.

### DIFF
--- a/static/elements/chromedash-feature-table.js
+++ b/static/elements/chromedash-feature-table.js
@@ -115,6 +115,12 @@ class ChromedashFeatureTable extends LitElement {
         white-space: nowrap;
         vertical-align: top;
       }
+      td.icon_col a {
+        padding: 2px 4px;
+      }
+      td.icon_col a:hover {
+        text-decoration: none;
+      }
       .quick_actions {
         white-space: nowrap;
         float: right;

--- a/static/sass/theme.scss
+++ b/static/sass/theme.scss
@@ -48,7 +48,7 @@
   --large-border-radius: 8px;
   --logo-color: var(--default-color);
   --logo-size: 32px;
-  --icon-size: 20px;
+  --icon-size: 22px;
   --link-color: var(--md-blue-700);
   --link-hover-color: var(--md-blue-900);
 


### PR DESCRIPTION
Feedback from one API Owner was that our icons on the my-features page are too small and crowded for use on mobile.

In this PR I try increasing the size of all our icons from 20 to 22px, and adding more padding around them on the my-features page.

Old:
![image](https://user-images.githubusercontent.com/17365/182498007-731d945d-c358-40d5-b7aa-f27cc3ca198c.png)

New:
![image](https://user-images.githubusercontent.com/17365/182498115-81ade11d-7066-4535-b87e-c89e1efddc1d.png)

Other pages in the app are also affected, but because the icon size increase is small, I don't think it is very noticeable.