### PR TITLE
Add form for feature owners to verify feature data accuracy

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -281,7 +281,7 @@ class FeatureAccuracyHandler(basehandlers.FlaskHandler):
     features_to_notify = self._determine_features_to_notify()
     email_tasks = self._build_email_tasks(features_to_notify)
     send_emails(email_tasks)
-    return {'message': f'{len(email_tasks)} emails sent or logged.'}
+    return {'message': f'{len(email_tasks)} email(s) sent or logged.'}
     
   def _determine_features_to_notify(self):
     # 'current' milestone is the next stable milestone that hasn't landed.

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -278,12 +278,6 @@ class FeatureAccuracyHandler(basehandlers.FlaskHandler):
   def get_template_data(self):
     """Sends notifications to users requesting feature updates for accuracy."""
 
-    # Do not send notifications until client-side changes are made.
-    # TODO(danielrsmith): This check should be removed when the new page to
-    # verify data accuracy is implemented.
-    if not self.SEND_NOTIFICATIONS:
-      return {'message': '0 emails sent or logged.'}
-
     features_to_notify = self._determine_features_to_notify()
     email_tasks = self._build_email_tasks(features_to_notify)
     send_emails(email_tasks)

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -380,13 +380,6 @@ class EmailFormattingTest(testing_config.CustomTestCase):
         True, self.feature_2, self.changes)
 
 
-class MockResponse:
-  """Creates a fake response object for testing."""
-  def __init__(self, status_code=200, text='{}'):
-    self.status_code = status_code
-    self.text = text
-
-
 class FeatureStarTest(testing_config.CustomTestCase):
 
   def setUp(self):
@@ -479,13 +472,46 @@ class FeatureStarTest(testing_config.CustomTestCase):
         [app_user_1.email, app_user_2.email],
         [au.email for au in actual])
 
+
+class MockResponse:
+  """Creates a fake response object for testing."""
+  def __init__(self, status_code=200, text='{}'):
+    self.status_code = status_code
+    self.text = text
+
+
+class FeatureAccuracyHandlerTest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.feature_1 = models.Feature(
+        name='feature one', summary='sum', owner=['feature_owner@example.com'],
+        category=1, visibility=1,
+        standardization=1, web_dev_views=1, impl_status_chrome=1,
+        ot_milestone_desktop_start=100)
+    self.feature_1.put()
+    self.feature_2 = models.Feature(
+        name='feature two', summary='sum',
+        owner=['owner_1@example.com', 'owner_2@example.com'],
+        category=1, visibility=1, standardization=1,
+        web_dev_views=1, impl_status_chrome=1, shipped_milestone=150)
+    self.feature_2.put()
+    self.feature_3 = models.Feature(
+        name='feature three', summary='sum', category=1, visibility=1,
+        standardization=1, web_dev_views=1, impl_status_chrome=1)
+    self.feature_3.put()
+  
+  def tearDown(self):
+    self.feature_1.key.delete()
+    self.feature_2.key.delete()
+    self.feature_3.key.delete()
+
   @mock.patch('requests.get')
   def test_determine_features_to_notify__no_features(self, mock_get):
     mock_return = MockResponse(text='{"mstones":[{"mstone": "40"}]}')
     mock_get.return_value = mock_return
     accuracy_notifier = notifier.FeatureAccuracyHandler()
     result = accuracy_notifier.get_template_data()
-    expected = {'message': '0 emails sent or logged.'}
+    expected = {'message': '0 email(s) sent or logged.'}
     self.assertEqual(result, expected)
   
   @mock.patch('requests.get')
@@ -494,7 +520,16 @@ class FeatureStarTest(testing_config.CustomTestCase):
     mock_get.return_value = mock_return
     accuracy_notifier = notifier.FeatureAccuracyHandler()
     result = accuracy_notifier.get_template_data()
-    expected = {'message': '0 emails sent or logged.'}
+    expected = {'message': '1 email(s) sent or logged.'}
+    self.assertEqual(result, expected)
+
+  @mock.patch('requests.get')
+  def test_determine_features_to_notify__multiple_owners(self, mock_get):
+    mock_return = MockResponse(text='{"mstones":[{"mstone": "148"}]}')
+    mock_get.return_value = mock_return
+    accuracy_notifier = notifier.FeatureAccuracyHandler()
+    result = accuracy_notifier.get_template_data()
+    expected = {'message': '2 email(s) sent or logged.'}
     self.assertEqual(result, expected)
 
 

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -380,6 +380,13 @@ class EmailFormattingTest(testing_config.CustomTestCase):
         True, self.feature_2, self.changes)
 
 
+class MockResponse:
+  """Creates a fake response object for testing."""
+  def __init__(self, status_code=200, text='{}'):
+    self.status_code = status_code
+    self.text = text
+
+
 class FeatureStarTest(testing_config.CustomTestCase):
 
   def setUp(self):
@@ -473,8 +480,18 @@ class FeatureStarTest(testing_config.CustomTestCase):
         [au.email for au in actual])
 
   @mock.patch('requests.get')
-  def test_determine_features_to_notify(self, mock_get):
-    mock_get.return_value = '{"mstones":[{"mstone": "100"}]}'
+  def test_determine_features_to_notify__no_features(self, mock_get):
+    mock_return = MockResponse(text='{"mstones":[{"mstone": "40"}]}')
+    mock_get.return_value = mock_return
+    accuracy_notifier = notifier.FeatureAccuracyHandler()
+    result = accuracy_notifier.get_template_data()
+    expected = {'message': '0 emails sent or logged.'}
+    self.assertEqual(result, expected)
+  
+  @mock.patch('requests.get')
+  def test_determine_features_to_notify__valid_features(self, mock_get):
+    mock_return = MockResponse(text='{"mstones":[{"mstone": "100"}]}')
+    mock_get.return_value = mock_return
     accuracy_notifier = notifier.FeatureAccuracyHandler()
     result = accuracy_notifier.get_template_data()
     expected = {'message': '0 emails sent or logged.'}

--- a/main.py
+++ b/main.py
@@ -145,6 +145,7 @@ page_routes = [
     ('/guide/edit/<int:feature_id>', guide.ProcessOverview),
     ('/guide/stage/<int:feature_id>/<int:stage_id>', guide.FeatureEditStage),
     ('/guide/editall/<int:feature_id>', guide.FeatureEditAllFields),
+    ('/guide/verify_accuracy/<int:feature_id>', guide.FeatureVerifyAccuracy),
 
     ('/admin/features/launch/<int:feature_id>',
      intentpreview.IntentEmailPreviewHandler),

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -622,15 +622,11 @@ class FeatureVerifyAccuracy(FeatureEditStage):
     f, _ = self.get_feature_and_process(feature_id)
     feature_edit_dict = f.format_for_edit()
 
-    fields_title = "Accuracy last verified at time of creation."
+    forms_title = "Accuracy last verified at time of creation."
     if f.accurate_as_of is not None:
       date = f.accurate_as_of.strftime("%Y-%m-%d")
-      fields_title = f"Accuracy last verified {date}."
-
-    form_section_list = (fields_title, guideforms.Verify_Accuracy),
-    forms = [
-        (section_name, form_class(feature_edit_dict))
-        for section_name, form_class in form_section_list]
+      forms_title = f"Accuracy last verified {date}."
+    forms = [(forms_title, guideforms.Verify_Accuracy(feature_edit_dict))]
     template_data = {
         'feature': f,
         'feature_id': f.key.integer_id(),

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -554,6 +554,8 @@ class FeatureEditStage(basehandlers.FlaskHandler):
 
     if self.touched('standardization'):
       feature.standardization = int(self.form.get('standardization'))
+    if self.form.get('accurate_as_of'):
+      feature.accurate_as_of = datetime.now()
     if self.touched('unlisted'):
       feature.unlisted = self.form.get('unlisted') == 'on'
     if self.touched('comments'):
@@ -609,5 +611,29 @@ class FeatureEditAllFields(FeatureEditStage):
         'feature': f,
         'feature_id': f.key.integer_id(),
         'flat_forms': flat_forms,
+    }
+    return template_data
+
+class FeatureVerifyAccuracy(FeatureEditStage):
+  TEMPLATE_PATH = 'guide/verify_accuracy.html'
+
+  @permissions.require_edit_feature
+  def get_template_data(self, feature_id):
+    f, _ = self.get_feature_and_process(feature_id)
+    feature_edit_dict = f.format_for_edit()
+
+    fields_title = "Accuracy last verified at time of creation."
+    if f.accurate_as_of is not None:
+      date = f.accurate_as_of.strftime("%Y-%m-%d")
+      fields_title = f"Accuracy last verified {date}."
+
+    form_section_list = (fields_title, guideforms.Verify_Accuracy),
+    forms = [
+        (section_name, form_class(feature_edit_dict))
+        for section_name, form_class in form_section_list]
+    template_data = {
+        'feature': f,
+        'feature_id': f.key.integer_id(),
+        'forms': forms,
     }
     return template_data

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -449,3 +449,33 @@ class FeatureEditAllFieldsTemplateTest(TestWithFeature):
         self.template_data, self.full_template_path)
     parser = html5lib.HTMLParser(strict=True)
     document = parser.parse(template_text)
+
+class FeatureEditAllFieldsTemplateTest(TestWithFeature):
+
+  HANDLER_CLASS = guide.FeatureVerifyAccuracy
+
+  def setUp(self):
+    super(FeatureEditAllFieldsTemplateTest, self).setUp()
+    self.feature_1 = models.Feature(
+        name='feature one', summary='sum', owner=['user1@google.com'],
+        category=1, visibility=1, standardization=1,
+        web_dev_views=models.DEV_NO_SIGNALS, impl_status_chrome=1)
+    self.feature_1.put()
+    self.stage = models.INTENT_INCUBATE  # Shows first form
+    testing_config.sign_in('user1@google.com', 1234567890)
+
+    with test_app.test_request_context(self.request_path):
+      self.template_data = self.handler.get_template_data(
+        self.feature_1.key.integer_id())
+      
+      self.template_data.update(self.handler.get_common_data())
+      self.template_data['nonce'] = 'fake nonce'
+      template_path = self.handler.get_template_path(self.template_data)
+      self.full_template_path = os.path.join(template_path)
+
+  def test_html_rendering(self):
+    """We can render the template with valid html."""
+    template_text = self.handler.render(
+        self.template_data, self.full_template_path)
+    parser = html5lib.HTMLParser(strict=True)
+    document = parser.parse(template_text)

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -450,12 +450,12 @@ class FeatureEditAllFieldsTemplateTest(TestWithFeature):
     parser = html5lib.HTMLParser(strict=True)
     document = parser.parse(template_text)
 
-class FeatureEditAllFieldsTemplateTest(TestWithFeature):
+class FeatureVerifyAccuracyTemplateTest(TestWithFeature):
 
   HANDLER_CLASS = guide.FeatureVerifyAccuracy
 
   def setUp(self):
-    super(FeatureEditAllFieldsTemplateTest, self).setUp()
+    super(FeatureVerifyAccuracyTemplateTest, self).setUp()
     self.feature_1 = models.Feature(
         name='feature one', summary='sum', owner=['user1@google.com'],
         category=1, visibility=1, standardization=1,
@@ -467,7 +467,7 @@ class FeatureEditAllFieldsTemplateTest(TestWithFeature):
     with test_app.test_request_context(self.request_path):
       self.template_data = self.handler.get_template_data(
         self.feature_1.key.integer_id())
-      
+
       self.template_data.update(self.handler.get_common_data())
       self.template_data['nonce'] = 'fake nonce'
       template_path = self.handler.get_template_path(self.template_data)

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -148,6 +148,11 @@ ALL_FIELDS = {
         required=False, label='',
         widget=forms.EmailInput(attrs=MULTI_EMAIL_FIELD_ATTRS)),
 
+    'accurate_as_of': forms.BooleanField(
+        label='',
+        widget=forms.CheckboxInput(attrs={'label': "Confirm accuracy"}),
+        required=False, initial=True),
+
     'category': forms.ChoiceField(
         required=False, label='',
         initial=models.MISC,
@@ -553,8 +558,15 @@ class ChromedashForm(forms.Form):
             if hasattr(field.widget, 'check_test'):
                 # Must be a checkbox field.
                 row_template = checkbox_row
-                if field.widget.check_test(value) :
+                if field.widget.check_test(value):
                     checked = True
+                
+                # accurate_as_of field should always be checked, regardless of
+                # the current value. This is only necessary if the feature
+                # has been created before this field was added.
+                if name == 'accurate_as_of':
+                    checked = True
+                    value = True
             
             # Create a 'class="..."' attribute if the row should have any
             # CSS classes applied.
@@ -867,6 +879,17 @@ Flat_Ship = define_form_class_using_shared_fields(
      'shipped_milestone', 'shipped_android_milestone',
      'shipped_ios_milestone', 'shipped_webview_milestone'))
 
+Verify_Accuracy = define_form_class_using_shared_fields(
+    'Verify_Accuracy',
+    ('summary', 'owner', 'editors', 'impl_status_chrome', 'intent_stage',
+    'dt_milestone_android_start', 'dt_milestone_desktop_start',
+    'dt_milestone_ios_start', 'ot_milestone_android_start',
+    'ot_milestone_android_end', 'ot_milestone_desktop_start',
+    'ot_milestone_desktop_end', 'ot_milestone_webview_start',
+    'ot_milestone_webview_end', 'shipped_android_milestone',
+    'shipped_ios_milestone', 'shipped_milestone', 'shipped_webview_milestone',
+    'accurate_as_of')
+)
 
 FIELD_NAME_TO_DISPLAY_TYPE = {
     'doc_links': 'urllist',
@@ -915,6 +938,8 @@ DISPLAY_IN_FEATURE_HIGHLIGHTS = [
     'bug_url',
     'comments',
 ]
+
+DISPLAY_IN_ACCURACY_VERIFICATION = ['accurate_as_of']
 
 DISPLAY_FIELDS_IN_STAGES = {
     'Metadata': make_display_specs(

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -939,11 +939,9 @@ DISPLAY_IN_FEATURE_HIGHLIGHTS = [
     'comments',
 ]
 
-DISPLAY_IN_ACCURACY_VERIFICATION = ['accurate_as_of']
-
 DISPLAY_FIELDS_IN_STAGES = {
     'Metadata': make_display_specs(
-        'category', 'feature_type', 'intent_stage',
+        'category', 'feature_type', 'intent_stage', 'accurate_as_of'
         ),
     models.INTENT_INCUBATE: make_display_specs(
         'initial_public_proposal_url', 'explainer_links',

--- a/pages/guideforms_test.py
+++ b/pages/guideforms_test.py
@@ -62,8 +62,7 @@ class DisplayFieldsTest(unittest.TestCase):
   def test_DISPLAY_FIELDS_IN_STAGES__complete_coverage(self):
     """Each field appears at least once."""
     fields_seen = set(guideforms.DISPLAY_IN_FEATURE_HIGHLIGHTS +
-                      guideforms.DEPRECATED_FIELDS +
-                      guideforms.DISPLAY_IN_ACCURACY_VERIFICATION)
+                      guideforms.DEPRECATED_FIELDS)
     for stage_id, field_spec_list in list(guideforms.DISPLAY_FIELDS_IN_STAGES.items()):
       for field_spec in field_spec_list:
         field_name = field_spec[0]

--- a/pages/guideforms_test.py
+++ b/pages/guideforms_test.py
@@ -62,7 +62,8 @@ class DisplayFieldsTest(unittest.TestCase):
   def test_DISPLAY_FIELDS_IN_STAGES__complete_coverage(self):
     """Each field appears at least once."""
     fields_seen = set(guideforms.DISPLAY_IN_FEATURE_HIGHLIGHTS +
-                      guideforms.DEPRECATED_FIELDS)
+                      guideforms.DEPRECATED_FIELDS +
+                      guideforms.DISPLAY_IN_ACCURACY_VERIFICATION)
     for stage_id, field_spec_list in list(guideforms.DISPLAY_FIELDS_IN_STAGES.items()):
       for field_spec in field_spec_list:
         field_name = field_spec[0]

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -74,7 +74,8 @@ export const ALL_FIELDS = {
     type: 'checkbox',
     label: 'Confirm Accuracy',
     help_text: html`
-        This data is accurate and up to date as of today.`,
+        This information is accurate as of today. 
+        (Selecting this avoids reminder emails for four weeks.)`,
   },
 
   'blink_components': {

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -70,6 +70,13 @@ export const ALL_FIELDS = {
         a link will be able to view the feature's detail page.`,
   },
 
+  'accurate_as_of': {
+    type: 'checkbox',
+    label: 'Confirm Accuracy',
+    help_text: html`
+        This data is accurate and up to date as of today.`,
+  },
+
   'blink_components': {
     label: 'Blink component',
     help_text: html`

--- a/templates/guide/verify_accuracy.html
+++ b/templates/guide/verify_accuracy.html
@@ -1,0 +1,55 @@
+{% extends "_base.html" %}
+{% block page_title %}{{ feature.name }} - {% endblock %}
+
+{% block css %}
+<link rel="stylesheet" href="/static/css/forms.css?v={{app_version}}">
+<link rel="stylesheet" href="/static/css/guide.css?v={{app_version}}">
+{% endblock %}
+
+{% block subheader %}
+<div id="subheader">
+  <h2 id="breadcrumbs">
+    <a href="/guide/edit/{{ feature_id }}">
+      <iron-icon icon="chromestatus:arrow-back"></iron-icon>
+      Verify feature data for {{ feature.name }}
+    </a>
+  </h2>
+</div>
+{% endblock %}
+
+{% block content %}
+<form name="feature_form" method="POST" action="{{current_path}}">
+  <input type="hidden" name="token" value="{{xsrf_token}}">
+  {% for section_name, form in forms %}
+    <h3>{{ section_name }}</h3>
+    <section class="flat_form">
+      <chromedash-form-table>
+        {{ form }}
+      </chromedash-form-table>
+    </section>
+  {% endfor %}
+
+  <section class="final_buttons">
+    <chromedash-form-table>
+      <chromedash-form-field>
+        <span slot="field">
+            <input class="button" type="submit" value="Submit">
+            <button id="cancel-button" data-id="{{ feature_id }}"
+                    type="reset">Cancel</button>
+        </span>
+      </chromedash-form-field>
+    </chromedash-form-table>
+  </section>
+</form>
+
+{% endblock %}
+
+{% block js %}
+<script nonce="{{nonce}}">
+  document.querySelector('#cancel-button').addEventListener('click', (e) => {
+    window.location.href = `/guide/edit/${e.currentTarget.dataset.id}`;
+  });
+
+  document.body.classList.remove('loading');
+</script>
+{% endblock %}


### PR DESCRIPTION
Second part of #2078

This change adds a new page that feature owners can use to verify the accuracy of their feature's data. This new page is linked in the notification email that feature owners will see when their feature is reaching an important milestone. The user can confirm that this data is accurate as of the current day, which will update the `accurate_as_of` field to the current day and time.