### PR TITLE
Add OwnersFile models to store the API Owner file

### DIFF
--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -69,7 +69,7 @@ APPROVAL_FIELDS_BY_ID = {
 
 def fetch_owners(url):
   """Load a list of email addresses from an OWNERS file."""
-  raw_content = models.APIOwner.get_raw_api_owners(url)
+  raw_content = models.OwnersFile.get_raw_api_owners(url)
   if raw_content:
     return decode_raw_owner_content(raw_content)
 
@@ -79,7 +79,7 @@ def fetch_owners(url):
     logging.error('Got response %s', repr(response)[:settings.MAX_LOG_LINE])
     raise ValueError('Could not get OWNERS file')
 
-  models.APIOwner(url=url, raw_content=response.content).put()
+  models.OwnersFile(url=url, raw_content=response.content).put()
   return decode_raw_owner_content(response.content)
 
 

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -69,18 +69,23 @@ APPROVAL_FIELDS_BY_ID = {
 
 def fetch_owners(url):
   """Load a list of email addresses from an OWNERS file."""
-  cached_owners = ramcache.get(url)
-  if cached_owners:
-    return cached_owners
+  raw_content = models.APIOwner.get_raw_api_owners(url)
+  if raw_content:
+    return decode_raw_owner_content(raw_content)
 
-  owners = []
   response = requests.get(url)
   if response.status_code != 200:
     logging.error('Could not fetch %r', url)
     logging.error('Got response %s', repr(response)[:settings.MAX_LOG_LINE])
     raise ValueError('Could not get OWNERS file')
 
-  decoded = base64.b64decode(response.content).decode()
+  models.APIOwner(url=url, raw_content=response.content).put()
+  return decode_raw_owner_content(response.content)
+
+
+def decode_raw_owner_content(raw_content):
+  owners = []
+  decoded = base64.b64decode(raw_content).decode()
   for line in decoded.split('\n'):
     logging.info('got line: '  + line[:settings.MAX_LOG_LINE])
     if '#' in line:
@@ -89,7 +94,6 @@ def fetch_owners(url):
     if '@' in line and '.' in line:
       owners.append(line)
 
-  ramcache.set(url, owners, time=CACHE_EXPIRATION)
   return owners
 
 

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -27,7 +27,7 @@ from internals import approval_defs
 from internals import models
 
 
-class FetchOwnersTest(unittest.TestCase):
+class FetchOwnersTest(testing_config.CustomTestCase):
 
   @mock.patch('requests.get')
   def test__normal(self, mock_get):
@@ -81,7 +81,7 @@ MOCK_APPROVALS_BY_ID = {
 }
 
 
-class GetApproversTest(unittest.TestCase):
+class GetApproversTest(testing_config.CustomTestCase):
 
   @mock.patch('internals.approval_defs.APPROVAL_FIELDS_BY_ID',
               MOCK_APPROVALS_BY_ID)
@@ -103,7 +103,7 @@ class GetApproversTest(unittest.TestCase):
     self.assertEqual(actual, ['owner@example.com'])
 
 
-class IsValidFieldIdTest(unittest.TestCase):
+class IsValidFieldIdTest(testing_config.CustomTestCase):
 
   @mock.patch('internals.approval_defs.APPROVAL_FIELDS_BY_ID',
               MOCK_APPROVALS_BY_ID)
@@ -114,7 +114,7 @@ class IsValidFieldIdTest(unittest.TestCase):
     self.assertFalse(approval_defs.is_valid_field_id(3))
 
 
-class IsApprovedTest(unittest.TestCase):
+class IsApprovedTest(testing_config.CustomTestCase):
 
   def setUp(self):
     feature_1_id = 123456

--- a/internals/models.py
+++ b/internals/models.py
@@ -1749,25 +1749,27 @@ class OwnersFile(DictModel):
   def put(self):
     """Add the owner file's content in ndb and delete all other entities."""
     # Delete all other entities.
-    ndb.delete_multi(self.query(OwnersFile.url == self.url).fetch(keys_only=True))
-    return self.put()
+    ndb.delete_multi(OwnersFile.query(
+        OwnersFile.url == self.url).fetch(keys_only=True))
+    return super(OwnersFile, self).put()
 
   @classmethod
   def get_raw_api_owners(cls, url):
     """Retrieve raw the owner file's content, if it is created with an hour."""
     q = cls.query()
     q = q.filter(cls.url == url)
-    api_owner = q.fetch(1)
-    if not api_owner:
+    owners_file_list = q.fetch(1)
+    if not owners_file_list:
       logging.info('API_OWNERS content does not exist for URL %s.' % (url))
       return None
 
+    owners_file = owners_file_list[0]
     # Check if it is created within an hour.
     an_hour_before = datetime.datetime.now() - datetime.timedelta(hours=1)
-    if api_owner.created_on < an_hour_before:
+    if owners_file.created_on < an_hour_before:
       return None
 
-    return api_owner[0].raw_content
+    return owners_file.raw_content
 
 
 class HistogramModel(ndb.Model):

--- a/internals/models.py
+++ b/internals/models.py
@@ -1740,16 +1740,16 @@ class FeatureOwner(DictModel):
         component_name, remove_as_owner=True)
 
 
-class APIOwner(DictModel):
+class OwnersFile(DictModel):
   """Describes the properties to store raw API_OWNERS content."""
-  url = ndb.StringProperty()
-  raw_content = ndb.TextProperty()
+  url = ndb.StringProperty(required=True)
+  raw_content = ndb.TextProperty(required=True)
   created_on = ndb.DateTimeProperty(auto_now_add=True)
 
   def put(self):
     """Add API owner content in ndb and delete all other entities."""
     # Delete all other entities.
-    ndb.delete_multi(self.query().fetch(keys_only=True))
+    ndb.delete_multi(self.query(OwnersFile.url == self.url).fetch(keys_only=True))
     return self.put()
 
   @classmethod

--- a/internals/models.py
+++ b/internals/models.py
@@ -1747,14 +1747,14 @@ class OwnersFile(DictModel):
   created_on = ndb.DateTimeProperty(auto_now_add=True)
 
   def put(self):
-    """Add API owner content in ndb and delete all other entities."""
+    """Add the owner file's content in ndb and delete all other entities."""
     # Delete all other entities.
     ndb.delete_multi(self.query(OwnersFile.url == self.url).fetch(keys_only=True))
     return self.put()
 
   @classmethod
   def get_raw_api_owners(cls, url):
-    """Retrieve raw API owner content, if it is created with an hour."""
+    """Retrieve raw the owner file's content, if it is created with an hour."""
     q = cls.query()
     q = q.filter(cls.url == url)
     api_owner = q.fetch(1)

--- a/internals/models_test.py
+++ b/internals/models_test.py
@@ -736,3 +736,26 @@ class UserPrefTest(testing_config.CustomTestCase):
     user_prefs = models.UserPref.get_prefs_for_emails(emails)
     self.assertEqual(100, len(user_prefs))
     self.assertEqual('user_0@example.com', user_prefs[0].email)
+
+
+class APIOwnerTest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    now = datetime.datetime.now()
+    self.api_owner_1 = models.APIOwner(url='abc', raw_content='foo', created_on=now)
+    self.api_owner_1.put()
+
+    expired = now - datetime.timedelta(hours=3)
+    self.api_owner_2 = models.APIOwner(url='def', raw_content='bar', created_on=expired)
+    self.api_owner_2.put()
+
+  def tearDown(self):
+    self.api_owner_1.key.delete()
+    self.api_owner_1.key.delete()
+
+  def test_get_raw_api_owners(self):
+    raw_content = models.APIOwner.get_raw_api_owners('abc')
+    self.assertEqual('foo', raw_content)
+
+    expired_content = models.APIOwner.get_raw_api_owners('def')
+    self.assertEqual(None, raw_content)

--- a/internals/models_test.py
+++ b/internals/models_test.py
@@ -758,4 +758,4 @@ class OwnersFileTest(testing_config.CustomTestCase):
     self.assertEqual('foo', raw_content)
 
     expired_content = models.OwnersFile.get_raw_api_owners('def')
-    self.assertEqual(None, raw_content)
+    self.assertEqual(None, expired_content)

--- a/internals/models_test.py
+++ b/internals/models_test.py
@@ -738,15 +738,15 @@ class UserPrefTest(testing_config.CustomTestCase):
     self.assertEqual('user_0@example.com', user_prefs[0].email)
 
 
-class APIOwnerTest(testing_config.CustomTestCase):
+class OwnersFileTest(testing_config.CustomTestCase):
 
   def setUp(self):
     now = datetime.datetime.now()
-    self.api_owner_1 = models.APIOwner(url='abc', raw_content='foo', created_on=now)
+    self.api_owner_1 = models.OwnersFile(url='abc', raw_content='foo', created_on=now)
     self.api_owner_1.put()
 
     expired = now - datetime.timedelta(hours=3)
-    self.api_owner_2 = models.APIOwner(url='def', raw_content='bar', created_on=expired)
+    self.api_owner_2 = models.OwnersFile(url='def', raw_content='bar', created_on=expired)
     self.api_owner_2.put()
 
   def tearDown(self):
@@ -754,8 +754,8 @@ class APIOwnerTest(testing_config.CustomTestCase):
     self.api_owner_1.key.delete()
 
   def test_get_raw_api_owners(self):
-    raw_content = models.APIOwner.get_raw_api_owners('abc')
+    raw_content = models.OwnersFile.get_raw_api_owners('abc')
     self.assertEqual('foo', raw_content)
 
-    expired_content = models.APIOwner.get_raw_api_owners('def')
+    expired_content = models.OwnersFile.get_raw_api_owners('def')
     self.assertEqual(None, raw_content)


### PR DESCRIPTION
Fix #2084. 

Migrate `fetch_owners` from Ramcache to NDB and store the API_Owners file to ndb. Currently there should only be one entity for the OwnersFile ndb table.