### PR TITLE
Add logging to investiage failure to remove review requests.

### DIFF
--- a/api/approvals_api.py
+++ b/api/approvals_api.py
@@ -56,6 +56,9 @@ class ApprovalsAPI(basehandlers.APIHandler):
 
     all_approval_values = models.Approval.get_approvals(
         feature_id=feature_id, field_id=field_id)
+    logging.info(
+        'found approvals %r',
+        [appr.key.integer_id() for appr in all_approval_values])
     if approval_defs.is_resolved(all_approval_values, field_id):
       models.Approval.clear_request(feature_id, field_id)
 

--- a/internals/models.py
+++ b/internals/models.py
@@ -1492,12 +1492,14 @@ class Approval(DictModel):
       existing.set_on = now
       existing.state = new_state
       existing.put()
+      logging.info('existing approval is %r', existing.key.integer_id())
       return
 
     new_appr = Approval(
         feature_id=feature_id, field_id=field_id, state=new_state,
         set_on=now, set_by=set_by_email)
     new_appr.put()
+    logging.info('new_appr is %r', new_appr.key.integer_id())
 
   @classmethod
   def clear_request(cls, feature_id, field_id):


### PR DESCRIPTION
Sometimes there is a pending review on the my-features page for API owners and it just stays there even though it already has all the needed approvals.   This PR does not solve that problem, it just adds logging to see if there is a problem with getting the set of approval values.

It seems like it could be a datastore consistency problem, however we are on "Firestone in datastore mode" which is supposed to have strong consistency.
https://cloud.google.com/datastore/docs/firestore-or-datastore

![image](https://user-images.githubusercontent.com/17365/184018601-702753d9-f685-4562-9f99-b2b6115dd968.png)
