### PR TITLE
Use strong consistency when checking if approval resolves a review.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -1444,7 +1444,10 @@ class Approval(DictModel):
       query = query.filter(Approval.state.IN(states))
     if set_by is not None:
       query = query.filter(Approval.set_by == set_by)
-    approvals = query.fetch(limit)
+    # Query with STRONG consistency because ndb defaults to
+    # EVENTUAL consistency and we run this query immediately after
+    # saving the user's change that we want included in the query.
+    approvals = query.fetch(limit, read_consistency=ndb.STRONG)
     return approvals
 
   @classmethod


### PR DESCRIPTION
I was wrong about the consistency of our queries.  We do need to specify read_consistency=ndb.STRONG in cases where it matters.

The 'Firestore in Datastore mode' server does default to strong consistency:
"Eventual consistency: Datastore queries become strongly consistent unless you explicitly request eventual consistency"
https://cloud.google.com/datastore/docs/firestore-or-datastore

However, the Google Cloud NDB library that we use to access the server defaults to explicitly requesting eventual consistency.
"read_consistency – If not in a transaction, defaults to ndb.EVENTUAL for potentially faster query results without having to wait for Datastore to apply pending changes to all returned records. Otherwise consistency with current transaction is maintained."
https://googleapis.dev/python/python-ndb/latest/query.html?highlight=consistency#google.cloud.ndb.query.Query.fetch

We need to be on the lookout for code paths that puts an entity to ndb and then immediately query for results that are expected to include the updated entity.  Eventual consistency defects are hard to spot because they happen infrequently and typically result in correct behavior rather than an error.
