### PR TITLE
Fix JS lint warning.

### DIFF
--- a/static/elements/chromedash-app.js
+++ b/static/elements/chromedash-app.js
@@ -54,7 +54,7 @@ class ChromedashApp extends LitElement {
       currentPage: {type: String},
       bannerMessage: {type: String},
       bannerTime: {type: Number},
-      pageComponent: {type: Element},
+      pageComponent: {attribute: false},
       contextLink: {type: String}, // used for the back button in the feature page
     };
   }
@@ -133,7 +133,7 @@ class ChromedashApp extends LitElement {
         <div>
           <div class="main-toolbar">
             <div class="toolbar-content">
-              <chromedash-header 
+              <chromedash-header
                 .appTitle=${this.appTitle}
                 .googleSignInClientId=${this.googleSignInClientId}
                 .currentPage=${this.currentPage}>
@@ -167,4 +167,3 @@ class ChromedashApp extends LitElement {
 }
 
 customElements.define('chromedash-app', ChromedashApp);
-


### PR DESCRIPTION
When I was looking at a CI test log for another PR, I noticed that this file has a lint warning:
```
./static/elements/chromedash-app.js

    'Element' is not a valid type for the default converter. Have you considered '{attribute: false}' instead?
    57:  pageComponent: {type: Element},
    no-incompatible-property-type
```

This PR simply applies the suggested change.