### PR TITLE
Add gcloud component commands to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,23 @@ Chrome Platform Status
     git clone https://github.com/GoogleChrome/chromium-dashboard
 
 ### Installation
-1. Before you begin, make sure that you have a java JRE (version 8 or greater) installed. JRE is required to use the DataStore Emulator.
-1. Install global CLIs in the home directory
+1. Install gcloud and needed components:
+    1.  Before you begin, make sure that you have a java JRE (version 8 or greater) installed. JRE is required to use the DataStore Emulator.
     1. [Google App Engine SDK for Python](https://cloud.google.com/appengine/docs/standard/python3/setting-up-environment). Make sure to select Python 3.
+    1. `gcloud init`
+    1. `gcloud components install cloud-datastore-emulator`
+    1. `gcloud components install beta`
+1. Install other developer tools commands
     1. node and npm.
     1. Gulp: `npm install --global gulp-cli`
     1. Python virtual environment: `sudo apt install python3.9-venv`
-1. We recommend using an older node version, e.g. node 10
+1. We recommend using an older node version, e.g. node 12
     1. Use `node -v` to check the default node version
     2. `nvm use 12` to switch to node 12
 1. `cd chromium-dashboard`
 1. Install JS an python dependencies: `npm run setup`
+    1. Note: Whenever we make changes to package.json or requirements.txt, you will need to run `npm run clean-setup`.
+
 
 If you encounter any error during the installation process, the section **Notes** (later in this README.md) may help.
 


### PR DESCRIPTION
Somehow we forgot to mention that new developers need to set up these cloud components.

Also, a couple of other clarifications.