### PR TITLE
Several small tweaks to accuracy verification

### DIFF
--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -72,9 +72,10 @@ export const ALL_FIELDS = {
 
   'accurate_as_of': {
     type: 'checkbox',
-    label: 'Confirm Accuracy',
+    label: 'Confirm accuracy',
     help_text: html`
-        This information is accurate as of today. 
+        Check this box to indicate that feature information is accurate
+        as of today.
         (Selecting this avoids reminder emails for four weeks.)`,
   },
 


### PR DESCRIPTION
This PR fixes a few small things that I noticed while testing this feature locally:
* The cron job was returning an HTML page rather than JSON with a message.  Our Flask UI handlers typically return dictionary of web page template data from get_template_data().  Returning JSON is a special case for a UI page, it can be done by setting JSONIFY = True.
* The class variable TEMPLATE_PATH is typically used for web page templates.  I renamed it to EMAIL_TEMPLATE_PATH to avoid confusion (and to prevent it from being used to generate a web page in case JSONIFY is ever removed).
* Note that it doesn't really matter what is returned from a /cron handler because nothing looks at the response other than to check that it is status 200, but the above tweaks make it work as intended.
*  Used sentence case for the field name to match our other field names.  Some of the field names have a capital for Chrome or Android and such, but that's because those are proper nouns.
* Tweaked the help text for the accurate_as_of checkbox to make it read more like instructions.
*