### PR TITLE
Register our form listener after shoelace.

### DIFF
--- a/static/js-src/shared.js
+++ b/static/js-src/shared.js
@@ -33,4 +33,7 @@ gtag('config', 'UA-179341418-1');
 // our listener tries to programatically submit the form.
 // Ten seconds should be enough time, and there is no rush since
 // XSRF tokens don't expire until much more time has passsed.
-window.setTimeout(window.csClient.addFormSubmitListner, 10 * 1000);
+// TODO(jrobbins): Make this event-driven rather than a timeout.
+window.setTimeout(
+    window.csClient.addFormSubmitListner.bind(window.csClient),
+    10 * 1000);

--- a/static/js-src/shared.js
+++ b/static/js-src/shared.js
@@ -27,4 +27,10 @@ gtag('config', 'UA-179341418-1');
 // End Google Analytics
 
 
-window.csClient.addFormSubmitListner();
+// Make sure that our form handler for XSRF token updates gets
+// registered after all the Shoelace form listeners are registered
+// so that failed form validation cancels the submit event before
+// our listener tries to programatically submit the form.
+// Ten seconds should be enough time, and there is no rush since
+// XSRF tokens don't expire until much more time has passsed.
+window.setTimeout(window.csClient.addFormSubmitListner, 10 * 1000);


### PR DESCRIPTION
Our code in HEAD is back in the situation where a form validation error can be displayed, but then the form submits anyway.

IIRC that was resolved last time by tweaking the order in which JS code was loaded so that our listener gets loaded after the Shoelace form elements add their form listeners.

This PR basically sticks with that strategy but does it via setTimeout.