### PR TITLE
Add indexes needed for sorting by approval dates.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -56,6 +56,17 @@ indexes:
   - name: "state"
   - name: "set_on"
     direction: desc
+- kind: "Approval"
+  properties:
+  - name: "state"
+  - name: "set_on"
+    direction: desc
+  - name: "feature_id"
+- kind: "Approval"
+  properties:
+  - name: "state"
+  - name: "set_on"
+  - name: "feature_id"
 - kind: "Feature"
   properties:
   - name: "deleted"


### PR DESCRIPTION
These are needed for my previous change #2082.
These were suggested in the error logs when I tested on staging.
After deploying these on staging, the queries work there.