### PR TITLE
Handle form submission for forms in shadowDOMs

### DIFF
--- a/static/elements/chromedash-guide-metadata.js
+++ b/static/elements/chromedash-guide-metadata.js
@@ -72,7 +72,6 @@ export class ChromedashGuideMetadata extends LitElement {
       user: {type: Object},
       featureId: {type: Number},
       feature: {type: Object},
-      xsrfToken: {type: String},
       overviewForm: {type: String},
       editing: {type: Boolean},
       loading: {type: Boolean},
@@ -84,7 +83,6 @@ export class ChromedashGuideMetadata extends LitElement {
     this.user = {};
     this.featureId = 0;
     this.feature = {};
-    this.xsrfToken = '';
     this.overviewForm = '';
     this.editing = false;
     this.loading = true;
@@ -93,6 +91,31 @@ export class ChromedashGuideMetadata extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.fetchData();
+  }
+
+  /* Add the form's event listener after Shoelace event listeners are attached
+   * see more at https://github.com/GoogleChrome/chromium-dashboard/issues/2014 */
+  updated() {
+    if (!this.editing) return;
+    /* TODO(kevinshen56714): remove the timeout once the form fields are all
+     * migrated to frontend, we need it now because the unsafeHTML(this.overviewForm)
+     * delays the Shoelace event listener attachment */
+    setTimeout(() => {
+      const hiddenTokenField = this.shadowRoot.querySelector('input[name=token]');
+      hiddenTokenField.form.addEventListener('submit', (event) => {
+        this.handleFormSubmission(event, hiddenTokenField);
+      });
+    }, 1000);
+  }
+
+  handleFormSubmission(event, hiddenTokenField) {
+    event.preventDefault();
+
+    // get the XSRF token and update it if it's expired before submission
+    window.csClient.ensureTokenIsValid().then(() => {
+      hiddenTokenField.value = window.csClient.token;
+      event.target.submit();
+    });
   }
 
   fetchData() {
@@ -242,7 +265,7 @@ export class ChromedashGuideMetadata extends LitElement {
     return html`
       <div id="metadata-editing">
         <form name="overview_form" method="POST" action="/guide/stage/${this.featureId}/0">
-          <input type="hidden" name="token" value=${this.xsrfToken}>
+          <input type="hidden" name="token">
 
           <chromedash-form-table>
             ${unsafeHTML(this.overviewForm)}

--- a/static/elements/chromedash-guide-metadata_test.js
+++ b/static/elements/chromedash-guide-metadata_test.js
@@ -6,7 +6,6 @@ import '../js-src/cs-client';
 import sinon from 'sinon';
 
 describe('chromedash-guide-metadata', () => {
-  const xsrfToken = 'fake_xsrf_token';
   const permissionsPromise = Promise.resolve({
     can_approve: false,
     can_create_feature: true,
@@ -89,7 +88,6 @@ describe('chromedash-guide-metadata', () => {
 
     const component = await fixture(
       html`<chromedash-guide-metadata
-             .xsrfToken=${xsrfToken}
              .featureId=${featureId}>
            </chromedash-guide-metadata>`);
     assert.exists(component);
@@ -125,7 +123,6 @@ describe('chromedash-guide-metadata', () => {
 
     const component = await fixture(
       html`<chromedash-guide-metadata
-             .xsrfToken=${xsrfToken}
              .featureId=${featureId}>
            </chromedash-guide-metadata>`);
     assert.exists(component);

--- a/static/elements/chromedash-guide-new-page.js
+++ b/static/elements/chromedash-guide-new-page.js
@@ -33,16 +33,12 @@ export class ChromedashGuideNewPage extends LitElement {
 
   static get properties() {
     return {
-      currentPath: {type: String},
-      xsrfToken: {type: String},
       overviewForm: {type: String},
     };
   }
 
   constructor() {
     super();
-    this.currentPath = '';
-    this.xsrfToken = '';
     this.overviewForm = '';
   }
 
@@ -52,6 +48,30 @@ export class ChromedashGuideNewPage extends LitElement {
     // TODO(kevinshen56714): Remove this once SPA index page is set up.
     // Has to include this for now to remove the spinner at _base.html.
     document.body.classList.remove('loading');
+  }
+
+  /* Add the form's event listener after Shoelace event listeners are attached
+   * see more at https://github.com/GoogleChrome/chromium-dashboard/issues/2014 */
+  firstUpdated() {
+    /* TODO(kevinshen56714): remove the timeout once the form fields are all
+     * migrated to frontend, we need it now because the unsafeHTML(this.overviewForm)
+     * delays the Shoelace event listener attachment */
+    setTimeout(() => {
+      const hiddenTokenField = this.shadowRoot.querySelector('input[name=token]');
+      hiddenTokenField.form.addEventListener('submit', (event) => {
+        this.handleFormSubmission(event, hiddenTokenField);
+      });
+    }, 1000);
+  }
+
+  handleFormSubmission(event, hiddenTokenField) {
+    event.preventDefault();
+
+    // get the XSRF token and update it if it's expired before submission
+    window.csClient.ensureTokenIsValid().then(() => {
+      hiddenTokenField.value = window.csClient.token;
+      event.target.submit();
+    });
   }
 
   renderSubHeader() {
@@ -68,8 +88,8 @@ export class ChromedashGuideNewPage extends LitElement {
   renderForm() {
     return html`
       <section id="stage_form">
-        <form name="overview_form" method="POST" action=${this.currentPath}>
-          <input type="hidden" name="token" value=${this.xsrfToken}>
+        <form name="overview_form" method="POST" action='/guide/new'>
+          <input type="hidden" name="token">
           <chromedash-form-table>
 
             <span>

--- a/static/elements/chromedash-guide-new-page_test.js
+++ b/static/elements/chromedash-guide-new-page_test.js
@@ -3,15 +3,9 @@ import {assert, fixture} from '@open-wc/testing';
 import {ChromedashGuideNewPage} from './chromedash-guide-new-page';
 
 describe('chromedash-guide-new-page', () => {
-  const xsrfToken = 'fake_xsrf_token';
-  const currentPath = '/guide/new';
-
   it('renders with fake data', async () => {
     const component = await fixture(
-      html`<chromedash-guide-new-page
-            .xsrfToken=${xsrfToken}
-            .currentPath=${currentPath}>
-           </chromedash-guide-new-page>`);
+      html`<chromedash-guide-new-page></chromedash-guide-new-page>`);
     assert.exists(component);
     assert.instanceOf(component, ChromedashGuideNewPage);
 
@@ -20,10 +14,9 @@ describe('chromedash-guide-new-page', () => {
     // Process and UI feedback link is clickable
     assert.include(subheaderDiv.innerHTML, 'href="https://github.com/GoogleChrome/chromium-dashboard/issues/new?labels=Feedback&amp;template=process-and-guide-ux-feedback.md"');
 
-    // overview form exists and is with correct currentPath and xsrf token
+    // overview form exists and is with action path
     const overviewForm = component.shadowRoot.querySelector('form[name="overview_form"]');
     assert.include(overviewForm.outerHTML, 'action="/guide/new"');
-    assert.include(overviewForm.innerHTML, 'value="fake_xsrf_token"');
 
     // feature type chromedash-form-field exists and is with four options
     const featureTypeFormField = component.shadowRoot.querySelector(

--- a/templates/guide/edit.html
+++ b/templates/guide/edit.html
@@ -25,7 +25,6 @@
 
 <chromedash-guide-metadata
   featureId="{{ feature_id }}"
-  xsrfToken="{{ xsrf_token }}"
   overviewForm="{% filter force_escape %} {{ overview_form }} {% endfilter %}">
 </chromedash-guide-metadata>
 

--- a/templates/guide/new.html
+++ b/templates/guide/new.html
@@ -1,9 +1,7 @@
 {% extends "_base.html" %}
 
 {% block content %}
-  <chromedash-guide-new-page 
-    xsrfToken="{{ xsrf_token }}"
-    currentPath="{{ current_path }}"
+  <chromedash-guide-new-page
     overviewForm="{% filter force_escape %} {{ overview_form }} {% endfilter %}">
   </chromedash-guide-new-page>
 {% endblock %}


### PR DESCRIPTION
The code in cs-client.js that looks for all the `<form>` elements in the document and adds submit event listeners won't work when forms are inside of shadowDOM trees because it's using document.querySelectorAll('input[name=token]'). This PR fixes it by registering and handling form submission event within the components. The changes include:

1. In chromedash-guide-new-page.js and chromedash-guide-metadata.js, the addEventListener('submit') is called for the forms upon `firstUpdated()` or `updated()`. This allows the form's event listener to be added after Shoelace event listeners are attached. And the callback function `handleFormSubmission()` does the xsrf token attachment and expiration check.
2. With this method, the validation works fine for form fields not in the `${unsafeHTML(this.overviewForm)}`. I found that we need an extra timeout after `firstUpdated()` or `updated()` for the Shoelace event listeners within `${unsafeHTML(this.overviewForm)}` to be attached. I believe this would not be needed once the temporary unsafeHTML workaround is removed.
3. Since the `handleFormSubmission()` would attach xsrf token to the hidden input value anyway from window.csClient, I removed the xsrfToken property in the components and stop passing in xsrf token into the components. And the unit tests are modified accordingly.
