### PR TITLE
Fix metrics JSONification.

### DIFF
--- a/api/metricsdata_test.py
+++ b/api/metricsdata_test.py
@@ -34,10 +34,6 @@ class MetricsFunctionTests(testing_config.CustomTestCase):
         day_percentage=0.0123456789, date=datetime.date.today(),
         bucket_id=1, property_name='prop')
 
-  def test_truncate_day_percentage(self):
-    updated_datapoint = metricsdata._truncate_day_percentage(self.datapoint)
-    self.assertEqual(0.01234568, updated_datapoint.day_percentage)
-
   def test_is_googler__anon(self):
     testing_config.sign_out()
     user = users.get_current_user()
@@ -53,17 +49,29 @@ class MetricsFunctionTests(testing_config.CustomTestCase):
     user = users.get_current_user()
     self.assertTrue(metricsdata._is_googler(user))
 
-  def test_clean_data__no_op(self):
+  def test_datapoints_to_json_dicts__googler(self):
     testing_config.sign_in('test@google.com', 111)
     datapoints = [self.datapoint]
-    updated_datapoints = metricsdata._clean_data(datapoints)
-    self.assertEqual(0.0123456789, list(updated_datapoints)[0].day_percentage)
+    actual = metricsdata._datapoints_to_json_dicts(datapoints)
+    expected = [{
+        'bucket_id': 1,
+        'date': str(datetime.date.today()),
+        'day_percentage': 0.0123456789,
+        'property_name': 'prop',
+        }]
+    self.assertEqual(expected, actual)
 
-  def test_clean_data__clean_datapoints(self):
-    testing_config.sign_out()
+  def test_datapoints_to_json_dicts__nongoogler(self):
+    testing_config.sign_in('test@example.com', 222)
     datapoints = [self.datapoint]
-    updated_datapoints = metricsdata._clean_data(datapoints)
-    self.assertEqual(0.01234568, list(updated_datapoints)[0].day_percentage)
+    actual = metricsdata._datapoints_to_json_dicts(datapoints)
+    expected = [{
+        'bucket_id': 1,
+        'date': str(datetime.date.today()),
+        'day_percentage': 0.01234568,  # rounded
+        'property_name': 'prop',
+        }]
+    self.assertEqual(expected, actual)
 
 
 class PopularityTimelineHandlerTests(testing_config.CustomTestCase):


### PR DESCRIPTION
This is the better fix to issue #2122.

In models.py most of our model classes subclassed from DictModel that had a special version of to_dict().   I tried using the standard version of to_dict() but that caused the error because the date format was different.

Rather than using a specialized to_dict() method as part of our model definitions, I feel that the wire format is really more the responsibility of the API code.  We had some wire format logic in api/metricsdata.py, but it was tweaking the output of to_dict(), which muddies the waters in my opinion.

In this PR:
* Keep the metrics_models.py classes subclassing from ndb.Model with no special version of to_dict().   No change in this PR.
* Rewrite the metricsdata.py wire format functions to stand alone and be explicit about what is being put into the wire format rather than what is being taken out of it.  Drop the unused formatted=False keyword parameter.
* Update unit tests