### PR TITLE
Convert guide/editall page into a component

### DIFF
--- a/pages/guide.py
+++ b/pages/guide.py
@@ -606,12 +606,12 @@ class FeatureEditAllFields(FeatureEditStage):
     # TODO(jrobbins): make flat forms process specific?
     flat_form_section_list = FLAT_FORMS
     flat_forms = [
-        (section_name, form_class(feature_edit_dict))
+        (section_name, str(form_class(feature_edit_dict)))
         for section_name, form_class in flat_form_section_list]
     template_data = {
         'feature': f,
         'feature_id': f.key.integer_id(),
-        'flat_forms': flat_forms,
+        'flat_forms': json.dumps(flat_forms),
     }
     return template_data
 

--- a/static/components.js
+++ b/static/components.js
@@ -45,6 +45,7 @@ import './elements/chromedash-form-field';
 import './elements/chromedash-form-table';
 import './elements/chromedash-gantt';
 import './elements/chromedash-guide-edit-page';
+import './elements/chromedash-guide-editall-page';
 import './elements/chromedash-guide-metadata';
 import './elements/chromedash-guide-new-page';
 import './elements/chromedash-header';

--- a/static/elements/chromedash-guide-editall-page.js
+++ b/static/elements/chromedash-guide-editall-page.js
@@ -1,0 +1,172 @@
+import {LitElement, css, html} from 'lit';
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+import {showToastMessage} from './utils.js';
+import './chromedash-form-table';
+import './chromedash-form-field';
+import {SHARED_STYLES} from '../sass/shared-css.js';
+import {FORM_STYLES} from '../sass/forms-css.js';
+
+
+export class ChromedashGuideEditallPage extends LitElement {
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      ...FORM_STYLES,
+      css`
+        sl-skeleton {
+          margin-bottom: 1em;
+          width: 60%;
+        }
+        sl-skeleton:nth-of-type(even) {
+          width: 50%;
+        }
+
+        h3 sl-skeleton {
+          margin-top: 1em;
+          width: 30%;
+          height: 1.25em;
+        }
+    `];
+  }
+
+  static get properties() {
+    return {
+      featureId: {type: Number},
+      feature: {type: Object},
+      flatForms: {type: String},
+      loading: {type: Boolean},
+    };
+  }
+
+  constructor() {
+    super();
+    this.featureId = 0;
+    this.feature = {};
+    this.flatForms = '';
+    this.loading = true;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.fetchData();
+  }
+
+  fetchData() {
+    this.loading = true;
+    window.csClient.getFeature(this.featureId).then((feature) => {
+      this.feature = feature;
+      this.loading = false;
+
+      // TODO(kevinshen56714): Remove this once SPA index page is set up.
+      // Has to include this for now to remove the spinner at _base.html.
+      document.body.classList.remove('loading');
+    }).catch(() => {
+      showToastMessage('Some errors occurred. Please refresh the page or try again later.');
+    });
+  }
+
+  /* Add the form's event listener after Shoelace event listeners are attached
+   * see more at https://github.com/GoogleChrome/chromium-dashboard/issues/2014 */
+  firstUpdated() {
+    /* TODO(kevinshen56714): remove the timeout once the form fields are all
+     * migrated to frontend, we need it now because the unsafeHTML(this.overviewForm)
+     * delays the Shoelace event listener attachment */
+    setTimeout(() => {
+      const hiddenTokenField = this.shadowRoot.querySelector('input[name=token]');
+      hiddenTokenField.form.addEventListener('submit', (event) => {
+        this.handleFormSubmission(event, hiddenTokenField);
+      });
+    }, 1000);
+  }
+
+  handleFormSubmission(event, hiddenTokenField) {
+    event.preventDefault();
+
+    // get the XSRF token and update it if it's expired before submission
+    window.csClient.ensureTokenIsValid().then(() => {
+      hiddenTokenField.value = window.csClient.token;
+      event.target.submit();
+    });
+  }
+
+  handleCancelClick() {
+    window.location.href = `/guide/edit/${this.featureId}`;
+  }
+
+  renderSkeletons() {
+    return html`
+      <h3><sl-skeleton effect="sheen"></sl-skeleton></h3>
+      <section id="metadata">
+        <h3><sl-skeleton effect="sheen"></sl-skeleton></h3>
+        <p>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+        </p>
+      </section>
+      <h3><sl-skeleton effect="sheen"></sl-skeleton></h3>
+      <section id="metadata">
+        <h3><sl-skeleton effect="sheen"></sl-skeleton></h3>
+        <p>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+        </p>
+      </section>
+    `;
+  }
+
+  renderSubheader() {
+    return html`
+      <div id="subheader">
+        <h2 id="breadcrumbs">
+          <a href="/guide/edit/${this.featureId}">
+            <iron-icon icon="chromestatus:arrow-back"></iron-icon>
+            Edit feature: ${this.loading ? 'loading...' : this.feature.name}
+          </a>
+        </h2>
+      </div>
+    `;
+  }
+
+  renderForm() {
+    return html`
+      <form name="feature_form" method="POST" action="/guide/editall/${this.featureId}">
+        <input type="hidden" name="token">
+        ${JSON.parse(this.flatForms).map(([sectionName, flatForm]) => html`
+          <h3>${sectionName}</h3>
+          <section class="flat_form">
+            <chromedash-form-table>
+              ${unsafeHTML(flatForm)}
+            </chromedash-form-table>
+          </section>
+        `)}
+
+        <section class="final_buttons">
+          <chromedash-form-table>
+            <chromedash-form-field>
+              <span slot="field">
+                <input class="button" type="submit" value="Submit">
+                <button id="cancel-button" type="reset"
+                  @click=${this.handleCancelClick}>Cancel</button>
+              </span>
+            </chromedash-form-field>
+          </chromedash-form-table>
+        </section>
+      </form>
+    `;
+  }
+
+  render() {
+    // TODO: Create precomiled main css file and import it instead of inlining it here
+    return html`
+      <link rel="stylesheet" href="/static/css/main.css">
+      ${this.renderSubheader()}
+      ${this.loading ? this.renderSkeletons() : this.renderForm()}
+    `;
+  }
+}
+
+customElements.define('chromedash-guide-editall-page', ChromedashGuideEditallPage);

--- a/static/elements/chromedash-guide-editall-page_test.js
+++ b/static/elements/chromedash-guide-editall-page_test.js
@@ -1,0 +1,92 @@
+import {html} from 'lit';
+import {assert, fixture} from '@open-wc/testing';
+import {ChromedashGuideEditallPage} from './chromedash-guide-editall-page';
+import './chromedash-toast';
+import '../js-src/cs-client';
+import sinon from 'sinon';
+
+describe('chromedash-guide-editall-page', () => {
+  const validFeaturePromise = Promise.resolve({
+    id: 123456,
+    name: 'feature one',
+    summary: 'fake detailed summary',
+    category: 'fake category',
+    feature_type: 'fake feature type',
+    intent_stage: 'fake intent stage',
+    new_crbug_url: 'fake crbug link',
+    browsers: {
+      chrome: {
+        blink_components: ['Blink'],
+        owners: ['fake chrome owner one', 'fake chrome owner two'],
+        status: {text: 'fake chrome status text'},
+      },
+      ff: {view: {text: 'fake ff view text'}},
+      safari: {view: {text: 'fake safari view text'}},
+      webdev: {view: {text: 'fake webdev view text'}},
+    },
+    resources: {
+      samples: ['fake sample link one', 'fake sample link two'],
+      docs: ['fake doc link one', 'fake doc link two'],
+    },
+    standards: {
+      spec: 'fake spec link',
+      maturity: {text: 'Unknown standards status - check spec link for status'},
+    },
+    tags: ['tag_one'],
+  });
+  /* TODO: create a proper fake data once the form generation is migrated to frontend */
+  const flatForms = '[["fake section name", ""]]';
+
+  /* window.csClient and <chromedash-toast> are initialized at _base.html
+   * which are not available here, so we initialize them before each test.
+   * We also stub out the API calls here so that they return test data. */
+  beforeEach(async () => {
+    await fixture(html`<chromedash-toast></chromedash-toast>`);
+    window.csClient = new ChromeStatusClient('fake_token', 1);
+    sinon.stub(window.csClient, 'getFeature');
+  });
+
+  afterEach(() => {
+    window.csClient.getFeature.restore();
+  });
+
+  it('renders with no data', async () => {
+    const invalidFeaturePromise = Promise.reject(new Error('Got error response from server'));
+    window.csClient.getFeature.withArgs(0).returns(invalidFeaturePromise);
+
+    const component = await fixture(
+      html`<chromedash-guide-editall-page></chromedash-guide-editall-page>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashGuideEditallPage);
+
+    // invalid feature requests would trigger the toast to show message
+    const toastEl = document.querySelector('chromedash-toast');
+    const toastMsgSpan = toastEl.shadowRoot.querySelector('span#msg');
+    assert.include(toastMsgSpan.innerHTML,
+      'Some errors occurred. Please refresh the page or try again later.');
+  });
+
+  it('renders with fake data', async () => {
+    const featureId = 123456;
+    window.csClient.getFeature.withArgs(featureId).returns(validFeaturePromise);
+
+    const component = await fixture(
+      html`<chromedash-guide-editall-page
+             .featureId=${featureId}
+             .flatForms=${flatForms}>
+           </chromedash-guide-editall-page>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashGuideEditallPage);
+
+    const subheaderDiv = component.shadowRoot.querySelector('div#subheader');
+    assert.exists(subheaderDiv);
+    // subheader title is correct and clickable
+    assert.include(subheaderDiv.innerHTML, 'href="/guide/edit/123456"');
+    assert.include(subheaderDiv.innerHTML, 'Edit feature:');
+
+    const featureForm = component.shadowRoot.querySelector('form[name="feature_form"]');
+    assert.exists(featureForm);
+    assert.include(featureForm.innerHTML, '<input type="hidden" name="token">');
+    assert.include(featureForm.innerHTML, '<section class="final_buttons">');
+  });
+});

--- a/static/elements/chromedash-guide-editall-page_test.js
+++ b/static/elements/chromedash-guide-editall-page_test.js
@@ -84,6 +84,7 @@ describe('chromedash-guide-editall-page', () => {
     assert.include(subheaderDiv.innerHTML, 'href="/guide/edit/123456"');
     assert.include(subheaderDiv.innerHTML, 'Edit feature:');
 
+    // feature form, hidden token field, and submit/cancel buttons exist
     const featureForm = component.shadowRoot.querySelector('form[name="feature_form"]');
     assert.exists(featureForm);
     assert.include(featureForm.innerHTML, '<input type="hidden" name="token">');

--- a/templates/guide/editall.html
+++ b/templates/guide/editall.html
@@ -1,54 +1,9 @@
 {% extends "_base.html" %}
 {% block page_title %}{{ feature.name }} - {% endblock %}
 
-{% block css %}
-<link rel="stylesheet" href="/static/css/forms.css?v={{app_version}}">
-{% endblock %}
-
-{% block subheader %}
-<div id="subheader">
-  <h2 id="breadcrumbs">
-    <a href="/guide/edit/{{ feature_id }}">
-      <iron-icon icon="chromestatus:arrow-back"></iron-icon>
-      Edit feature: {{ feature.name }}
-    </a>
-  </h2>
-</div>
-{% endblock %}
-
 {% block content %}
-<form name="feature_form" method="POST" action="{{current_path}}">
-  <input type="hidden" name="token" value="{{xsrf_token}}">
-  {% for section_name, flat_form in flat_forms %}
-    <h3>{{ section_name }}</h3>
-    <section class="flat_form">
-      <chromedash-form-table>
-        {{ flat_form }}
-      </chromedash-form-table>
-    </section>
-  {% endfor %}
-
-  <section class="final_buttons">
-    <chromedash-form-table>
-      <chromedash-form-field>
-        <span slot="field">
-            <input class="button" type="submit" value="Submit">
-            <button id="cancel-button" data-id="{{ feature_id }}"
-                    type="reset">Cancel</button>
-        </span>
-      </chromedash-form-field>
-    </chromedash-form-table>
-  </section>
-</form>
-
-{% endblock %}
-
-{% block js %}
-<script nonce="{{nonce}}">
-  document.querySelector('#cancel-button').addEventListener('click', (e) => {
-    window.location.href = `/guide/edit/${e.currentTarget.dataset.id}`;
-  });
-
-  document.body.classList.remove('loading');
-</script>
+  <chromedash-guide-editall-page 
+    featureId="{{ feature_id }}"
+    flatForms="{{ flat_forms }}">
+  </chromedash-guide-editall-page>
 {% endblock %}


### PR DESCRIPTION
This PR converts content in guide/editall.html into the `<chromedash-guide-editall-page>` component. The changes include:

1. Created chromedash-guide-editall-page.js and chromedash-guide-editall-page_test.js
2. Slightly modified the template data of editall.html  in guide.py so that the `flat_forms` can be passed into `<chromedash-guide-editall-page>` as string and then get JSON.parse() when rendering.
3. The guide/edit.html is now a single component file
4. Added loading skeletons for the page, see the snapshot below:
<img width="1278" alt="Screen Shot 2022-08-15 at 3 57 14 PM" src="https://user-images.githubusercontent.com/11501902/184756805-ca2b339c-9c82-4deb-93fc-0d03b003fcaf.png">
