### PR TITLE
Sort approval values by date

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -1061,7 +1061,7 @@ class Approval(DictModel):
       cls, feature_id=None, field_id=None, states=None, set_by=None,
       limit=None):
     """Return the requested approvals."""
-    query = Approval.query()
+    query = Approval.query().order(Approval.set_on)
     if feature_id is not None:
       query = query.filter(Approval.feature_id == feature_id)
     if field_id is not None:

--- a/internals/models_test.py
+++ b/internals/models_test.py
@@ -422,6 +422,12 @@ class ApprovalTest(testing_config.CustomTestCase):
         set_on=datetime.datetime.now(),
         set_by='two@example.com')
     self.appr_2.put()
+    self.appr_3 = models.Approval(
+        feature_id=self.feature_1_id, field_id=1,
+        state=models.Approval.APPROVED,
+        set_on=datetime.datetime.now() + datetime.timedelta(1),
+        set_by='three@example.com')
+    self.appr_3.put()
 
   def tearDown(self):
     self.feature_1.key.delete()
@@ -431,9 +437,12 @@ class ApprovalTest(testing_config.CustomTestCase):
   def test_get_approvals(self):
     """We can retrieve Approval entities."""
     actual = models.Approval.get_approvals(feature_id=self.feature_1_id)
-    self.assertEqual(2, len(actual))
+    self.assertEqual(3, len(actual))
     self.assertEqual(models.Approval.REVIEW_REQUESTED, actual[0].state)
     self.assertEqual(models.Approval.APPROVED, actual[1].state)
+    self.assertEqual(
+        sorted(actual, key=lambda appr: appr.set_on),
+        actual)
 
     actual = models.Approval.get_approvals(field_id=1)
     self.assertEqual(models.Approval.REVIEW_REQUESTED, actual[0].state)
@@ -462,7 +471,7 @@ class ApprovalTest(testing_config.CustomTestCase):
         self.feature_1_id, 2, models.Approval.REVIEW_REQUESTED,
         'owner@example.com')
     self.assertEqual(
-        3,
+        4,
         len(models.Approval.query().fetch(None)))
 
   def test_clear_request(self):


### PR DESCRIPTION
During the API Owners meeting this morning I realized that the individual approval values listed in the approvals dialog box seem to be sorted by the email address of the person who set the value rather than by the time it was set.   It would make more sense to order them by time because the request for review would be first and then the review responses would come after it.

The needed index already exists on both staging and prod.