### PR TITLE
Fix feature creation page category and feature_type fields.

### DIFF
--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -553,6 +553,8 @@ class ChromedashForm(forms.Form):
 
             # Get value and checked for the field
             value = field.widget.value_from_datadict(self.data, self.files, self.add_prefix(name))
+            if value is None:
+              value = field.initial
 
             row_template = normal_row
             checked = False

--- a/pages/guideforms_test.py
+++ b/pages/guideforms_test.py
@@ -26,7 +26,7 @@ from internals import models
 
 
 TestForm = guideforms.define_form_class_using_shared_fields(
-    'TestForm', ('name', 'summary'))
+    'TestForm', ('name', 'summary', 'category'))
 
 TEST_TEMPLATE = '''
 <!DOCTYPE html>
@@ -59,6 +59,8 @@ class ChromedashFormTest(unittest.TestCase):
     self.assertIn('value="this is a feature name"', actual)
     self.assertIn('name="summary"', actual)
     self.assertIn('value="this is a summary"', actual)
+    # Initial value MISC (2) is used because feature_dict has no category.
+    self.assertIn('name="category" value="2"', actual)
 
   def test__escaping(self):
     """Our forms render properly even with tricky input."""

--- a/static/elements/chromedash-guide-new-page.js
+++ b/static/elements/chromedash-guide-new-page.js
@@ -101,8 +101,8 @@ export class ChromedashGuideNewPage extends LitElement {
 
             ${unsafeHTML(this.overviewForm)}
 
-            <chromedash-form-field 
-              name="feature_type"
+            <chromedash-form-field
+              name="feature_type_radio_group"
               class="choices"
               field=${`
                 <label for="id_feature_type_0">

--- a/static/elements/chromedash-guide-new-page_test.js
+++ b/static/elements/chromedash-guide-new-page_test.js
@@ -20,7 +20,7 @@ describe('chromedash-guide-new-page', () => {
 
     // feature type chromedash-form-field exists and is with four options
     const featureTypeFormField = component.shadowRoot.querySelector(
-      'chromedash-form-field[name="feature_type"]');
+      'chromedash-form-field[name="feature_type_radio_group"]');
     assert.include(featureTypeFormField.outerHTML, 'New feature incubation');
     assert.include(featureTypeFormField.outerHTML, 'Existing feature implementation');
     assert.include(featureTypeFormField.outerHTML, 'Web developer-facing change to existing code');

--- a/static/elements/form-field-enums.js
+++ b/static/elements/form-field-enums.js
@@ -31,7 +31,7 @@ export const FEATURE_CATEGORIES = {
 export const FEATURE_TYPES = {
   FEATURE_TYPE_INCUBATE_ID: [0, 'New feature incubation'],
   FEATURE_TYPE_EXISTING_ID: [1, 'Existing feature implementation'],
-  FEATURE_TYPE_CODE_CHANGE_ID: [2, 'Web developer facing change to exi[sting code'],
+  FEATURE_TYPE_CODE_CHANGE_ID: [2, 'Web developer facing change to existing code'],
   FEATURE_TYPE_DEPRECATION_ID: [3, 'Feature deprecation'],
 };
 

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -111,6 +111,14 @@ export const ALL_FIELDS = {
         Select the feature type.`,
   },
 
+  'feature_type_radio_group': {
+    type: 'radios',
+    choices: FEATURE_TYPES,
+    label: 'Feature type',
+    help_text: html`
+        Select the feature type.`,
+  },
+
   'set_stage': {
     type: 'checkbox',
     label: 'Set to this stage',


### PR DESCRIPTION
We got our wires crossed in some recent changes to the /guide/new page and the processing of select fields.  The result was that:
1. The /guide/new page in HEAD is showing a `<select>` instead of the desired radio buttons, and 
2. The category `<select>` had a value of "None" which shows no item selected.  If a user did not select a value, the form POSTs `None` which causes a 500 in form POST processing.

The cause of (1) is that Kevin's version of /guide/new worked when tested by itself, but when combined with Dan's concurrently developed PR to process select fields in JS code caused Kevin's radio buttons to be ignored and a `<select>` element generated.

The cause of (2) was a lack of handling a form field definitions initial value in ChromedashForm.   I'm not sure why this didn't show up before.  It might have simply not been noticed because the /guide/new page is the only page that relies on form field initial values rather than NDB model field default values.

In this PR:
* Change the name of the radio button group to a different name, allowing it to match a new spec in form-field-specs.js that does not have `type: "select"`.  This allows the radio button group HTML markup to be passed through and rendered.
* In ChromedashForm, check for a value of None and use the form field default instead.
