### PR TITLE
Generate text, url, multi-email, and number inputs through JS

### DIFF
--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -549,7 +549,7 @@ class ChromedashForm(forms.Form):
             # Get value and checked for the field
             value = field.widget.value_from_datadict(self.data, self.files, self.add_prefix(name))
             if value is None:
-              value = field.initial
+              value = bf.initial
 
             row_template = normal_row
             checked = False

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -77,10 +77,6 @@ class MultiUrlField(forms.Field):
         for url in value:
             validate_url(url.strip())
 
-class ChromedashTextInput(forms.widgets.Input):
-    template_name = 'django/forms/widgets/text.html'
-
-
 class ChromedashTextarea(forms.widgets.Textarea):
     template_name = 'django/forms/widgets/chromedash-textarea.html'
 
@@ -134,8 +130,7 @@ MULTI_URL_FIELD_ATTRS = {
 # stage-specific fields without repeating the details and help text.
 ALL_FIELDS = {
     'name': forms.CharField(
-        required=True, label='',
-        widget=ChromedashTextInput()),
+        required=True, label=''),
 
     'summary': forms.CharField(
         required=True, label='',

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -82,11 +82,15 @@ export class ChromedashFormField extends LitElement {
         </sl-select>
       `;
     } else if (type === 'input') {
-      let inputType = 'text';
+      let inputType = '';
       let title = '';
       let placeholder;
       let pattern;
       switch (fieldProps.input_type) {
+        case 'text':
+          inputType = 'text';
+          break;
+
         case 'url':
           inputType = 'url';
           title = 'Enter a full URL https://...';
@@ -107,6 +111,9 @@ export class ChromedashFormField extends LitElement {
           inputType = 'number';
           placeholder = 'Milestone number';
           break;
+
+        default:
+          console.error(`Invalid input type: ${fieldProps.input_type}`);
       }
       fieldHTML = html`
         <sl-input 

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -2,7 +2,15 @@ import {LitElement, html} from 'lit';
 import {ALL_FIELDS} from './form-field-specs';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 
+
+/* Patterns from https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s01.html
+ * Removing single quote ('), backtick (`), and pipe (|) since they are risky unless properly escaped everywhere.
+ * Also removing ! and % because they have special meaning for some older email routing systems. */
+const USER_REGEX = '[A-Za-z0-9_#$&*+/=?{}~^.-]+';
 const DOMAIN_REGEX = String.raw`(([A-Za-z0-9-]+\.)+[A-Za-z]{2,6})`;
+
+const EMAIL_ADDRESS_REGEX = USER_REGEX + '@' + DOMAIN_REGEX;
+const EMAIL_ADDRESSES_REGEX = EMAIL_ADDRESS_REGEX + '([ ]*,[ ]*' + EMAIL_ADDRESS_REGEX + ')*';
 
 // Simple http URLs
 const PORTNUM_REGEX = '(:[0-9]+)?';
@@ -73,30 +81,44 @@ export class ChromedashFormField extends LitElement {
           )}
         </sl-select>
       `;
-    } else if (type === 'text_input') {
+    } else if (type === 'input') {
+      let inputType = 'text';
+      let title = '';
+      let placeholder;
+      let pattern;
+      switch (fieldProps.input_type) {
+        case 'url':
+          inputType = 'url';
+          title = 'Enter a full URL https://...';
+          placeholder = 'https://...';
+          pattern = URL_PADDED_REGEX;
+          break;
+
+        case 'multi-email':
+          /* Don't specify type="email" because browsers consider multiple emails
+          * invalid, regardles of the multiple attribute. */
+          inputType = 'text';
+          title = 'Enter one or more comma-separated complete email addresses.';
+          placeholder = 'user1@domain.com, user2@chromium.org';
+          pattern = EMAIL_ADDRESSES_REGEX;
+          break;
+
+        case 'milestone-number':
+          inputType = 'number';
+          placeholder = 'Milestone number';
+          break;
+      }
       fieldHTML = html`
         <sl-input 
-          type="text"
+          type="${inputType}"
           name="${this.name}"
           id="id_${this.name}"
           size="small"
           autocomplete="off"
-          value="${this.value === 'None' ? '' : this.value}"
-          ?required=${fieldProps.required}>
-        </sl-input>
-      `;
-    } else if (type === 'url_input') {
-      fieldHTML = html`
-        <sl-input 
-          type="url"
-          name="${this.name}"
-          id="id_${this.name}"
-          size="small"
-          autocomplete="off"
-          value="${this.value === 'None' ? '' : this.value}"
-          title="Enter a full URL https://..."
-          placeholder="https://..."
-          pattern=${URL_PADDED_REGEX}
+          .title=${title}
+          .placeholder=${placeholder}
+          .pattern=${pattern}
+          .value=${this.value === 'None' ? '' : this.value}
           ?required=${fieldProps.required}>
         </sl-input>
       `;

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -2,6 +2,14 @@ import {LitElement, html} from 'lit';
 import {ALL_FIELDS} from './form-field-specs';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 
+const DOMAIN_REGEX = String.raw`(([A-Za-z0-9-]+\.)+[A-Za-z]{2,6})`;
+
+// Simple http URLs
+const PORTNUM_REGEX = '(:[0-9]+)?';
+const URL_REGEX = '(https?)://' + DOMAIN_REGEX + PORTNUM_REGEX + String.raw`(/[^\s]*)?`;
+const URL_PADDED_REGEX = String.raw`\s*` + URL_REGEX + String.raw`\s*`;
+
+
 export class ChromedashFormField extends LitElement {
   static get properties() {
     return {
@@ -64,6 +72,33 @@ export class ChromedashFormField extends LitElement {
             `,
           )}
         </sl-select>
+      `;
+    } else if (type === 'text_input') {
+      fieldHTML = html`
+        <sl-input 
+          type="text"
+          name="${this.name}"
+          id="id_${this.name}"
+          size="small"
+          autocomplete="off"
+          value="${this.value === 'None' ? '' : this.value}"
+          ?required=${fieldProps.required}>
+        </sl-input>
+      `;
+    } else if (type === 'url_input') {
+      fieldHTML = html`
+        <sl-input 
+          type="url"
+          name="${this.name}"
+          id="id_${this.name}"
+          size="small"
+          autocomplete="off"
+          value="${this.value === 'None' ? '' : this.value}"
+          title="Enter a full URL https://..."
+          placeholder="https://..."
+          pattern=${URL_PADDED_REGEX}
+          ?required=${fieldProps.required}>
+        </sl-input>
       `;
     } else {
       // Temporary workaround until we migrate the generation of

--- a/static/elements/form-field-enums.js
+++ b/static/elements/form-field-enums.js
@@ -31,7 +31,7 @@ export const FEATURE_CATEGORIES = {
 export const FEATURE_TYPES = {
   FEATURE_TYPE_INCUBATE_ID: [0, 'New feature incubation'],
   FEATURE_TYPE_EXISTING_ID: [1, 'Existing feature implementation'],
-  FEATURE_TYPE_CODE_CHANGE_ID: [2, 'Web developer facing change to exi[sting code'],
+  FEATURE_TYPE_CODE_CHANGE_ID: [2, 'Web developer facing change to existing code'],
   FEATURE_TYPE_DEPRECATION_ID: [3, 'Feature deprecation'],
 };
 

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -27,6 +27,7 @@ export const ALL_FIELDS = {
 
   'name': {
     type: 'input',
+    input_type: 'text',
     required: true,
     label: 'Feature name',
     help_text: html`
@@ -148,6 +149,7 @@ export const ALL_FIELDS = {
 
   'search_tags': {
     type: 'input',
+    input_type: 'text',
     required: false,
     label: 'Search tags',
     help_text: html`
@@ -890,6 +892,8 @@ export const ALL_FIELDS = {
 
   'flag_name': {
     type: 'input',
+    input_type: 'text',
+    required: false,
     label: 'Flag name',
     help_text: html`
       Name of the flag on chrome://flags that enables this feature.`,

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -26,6 +26,8 @@ const
 export const ALL_FIELDS = {
 
   'name': {
+    type: 'text_input',
+    required: true,
     label: 'Feature name',
     help_text: html`
         <p>Capitalize only the first letter and the beginnings of proper nouns.</p>
@@ -131,6 +133,8 @@ export const ALL_FIELDS = {
   },
 
   'search_tags': {
+    type: 'text_input',
+    required: false,
     label: 'Search tags',
     help_text: html`
         Comma separated keywords used only in search.`,
@@ -145,6 +149,8 @@ export const ALL_FIELDS = {
   },
 
   'bug_url': {
+    type: 'url_input',
+    required: false,
     label: 'Tracking bug URL',
     help_text: html`
         Tracking bug url (https://bugs.chromium.org/...).
@@ -158,6 +164,8 @@ export const ALL_FIELDS = {
   },
 
   'launch_bug_url': {
+    type: 'url_input',
+    required: false,
     label: 'Launch bug URL',
     help_text: html`
         Launch bug url (https://bugs.chromium.org/...) to track launch approvals.
@@ -204,6 +212,8 @@ export const ALL_FIELDS = {
   },
 
   'initial_public_proposal_url': {
+    type: 'url_input',
+    required: false,
     label: 'Initial public proposal URL',
     help_text: html`
         Link to the first public proposal to create this feature, e.g.,
@@ -221,6 +231,8 @@ export const ALL_FIELDS = {
   },
 
   'spec_link': {
+    type: 'url_input',
+    required: false,
     label: 'Spec link',
     help_text: html`
         Link to the spec, if and when available. When implementing
@@ -261,6 +273,8 @@ export const ALL_FIELDS = {
   },
 
   'intent_to_implement_url': {
+    type: 'url_input',
+    required: false,
     label: 'Intent to Prototype link',
     help_text: html`
         After you have started the "Intent to Prototype"
@@ -317,24 +331,32 @@ export const ALL_FIELDS = {
   },
 
   'intent_to_ship_url': {
+    type: 'url_input',
+    required: false,
     label: 'Intent to Ship link',
     help_text: html`After you have started the "Intent to Ship" discussion
                 thread, link to it here.`,
   },
 
   'ready_for_trial_url': {
+    type: 'url_input',
+    required: false,
     label: 'Ready for Trial link',
     help_text: html`After you have started the "Ready for Trial" discussion
                 thread, link to it here.`,
   },
 
   'intent_to_experiment_url': {
+    type: 'url_input',
+    required: false,
     label: 'Intent to Experiment link',
     help_text: html`After you have started the "Intent to Experiment"
                  discussion thread, link to it here.`,
   },
 
   'intent_to_extend_experiment_url': {
+    type: 'url_input',
+    required: false,
     label: 'Intent to Extend Experiment link',
     help_text: html`If this feature has an "Intent to Extend Experiment"
                  discussion thread, link to it here.`,
@@ -342,6 +364,8 @@ export const ALL_FIELDS = {
 
   'r4dt_url': {
     // Sets intent_to_experiment_url in DB
+    type: 'url_input',
+    required: false,
     label: 'Request for Deprecation Trial link',
     help_text: html`After you have started the "Request for Deprecation Trial"
                 discussion thread, link to it here.`,
@@ -379,6 +403,8 @@ export const ALL_FIELDS = {
   },
 
   'safari_views_link': {
+    type: 'url_input',
+    required: false,
     label: '',
     help_text: html`Citation link.`,
   },
@@ -398,6 +424,8 @@ export const ALL_FIELDS = {
   },
 
   'ff_views_link': {
+    type: 'url_input',
+    required: false,
     label: '',
     help_text: html`
     Citation link.`,
@@ -419,6 +447,8 @@ export const ALL_FIELDS = {
   },
 
   'web_dev_views_link': {
+    type: 'url_input',
+    required: false,
     label: '',
     help_text: html`
       Citation link.`,
@@ -577,6 +607,8 @@ export const ALL_FIELDS = {
   },
 
   'origin_trial_feedback_url': {
+    type: 'url_input',
+    required: false,
     label: 'Origin trial feedback summary',
     help_text: html`
       If your feature was available as an origin trial, link to a summary
@@ -595,6 +627,8 @@ export const ALL_FIELDS = {
   },
 
   'finch_url': {
+    type: 'url_input',
+    required: false,
     label: 'Finch experiment',
     help_text: html`
       If your feature will roll out gradually via a
@@ -728,6 +762,8 @@ export const ALL_FIELDS = {
   },
 
   'devtrial_instructions': {
+    type: 'url_input',
+    required: false,
     label: 'DevTrial instructions',
     help_text: html`
         Link to a HOWTO or FAQ describing how developers can get started

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -26,7 +26,7 @@ const
 export const ALL_FIELDS = {
 
   'name': {
-    type: 'text_input',
+    type: 'input',
     required: true,
     label: 'Feature name',
     help_text: html`
@@ -62,6 +62,9 @@ export const ALL_FIELDS = {
   },
 
   'owner': {
+    type: 'input',
+    input_type: 'multi-email',
+    required: true,
     label: 'Feature owners',
     help_text: html`
         Comma separated list of full email addresses. Accounts
@@ -69,6 +72,9 @@ export const ALL_FIELDS = {
   },
 
   'editors': {
+    type: 'input',
+    input_type: 'multi-email',
+    required: false,
     label: 'Feature editors',
     help_text: html`
         Comma separated list of full email addresses. These users will be allowed to edit this feature, but will not be listed as feature owners.`,
@@ -133,7 +139,7 @@ export const ALL_FIELDS = {
   },
 
   'search_tags': {
-    type: 'text_input',
+    type: 'input',
     required: false,
     label: 'Search tags',
     help_text: html`
@@ -149,7 +155,8 @@ export const ALL_FIELDS = {
   },
 
   'bug_url': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: 'Tracking bug URL',
     help_text: html`
@@ -164,7 +171,8 @@ export const ALL_FIELDS = {
   },
 
   'launch_bug_url': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: 'Launch bug URL',
     help_text: html`
@@ -212,7 +220,8 @@ export const ALL_FIELDS = {
   },
 
   'initial_public_proposal_url': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: 'Initial public proposal URL',
     help_text: html`
@@ -231,7 +240,8 @@ export const ALL_FIELDS = {
   },
 
   'spec_link': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: 'Spec link',
     help_text: html`
@@ -263,6 +273,9 @@ export const ALL_FIELDS = {
   },
 
   'spec_mentors': {
+    type: 'input',
+    input_type: 'multi-email',
+    required: false,
     label: 'Spec mentor',
     help_text: html`
         Experienced
@@ -273,7 +286,8 @@ export const ALL_FIELDS = {
   },
 
   'intent_to_implement_url': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: 'Intent to Prototype link',
     help_text: html`
@@ -331,7 +345,8 @@ export const ALL_FIELDS = {
   },
 
   'intent_to_ship_url': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: 'Intent to Ship link',
     help_text: html`After you have started the "Intent to Ship" discussion
@@ -339,7 +354,8 @@ export const ALL_FIELDS = {
   },
 
   'ready_for_trial_url': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: 'Ready for Trial link',
     help_text: html`After you have started the "Ready for Trial" discussion
@@ -347,7 +363,8 @@ export const ALL_FIELDS = {
   },
 
   'intent_to_experiment_url': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: 'Intent to Experiment link',
     help_text: html`After you have started the "Intent to Experiment"
@@ -355,7 +372,8 @@ export const ALL_FIELDS = {
   },
 
   'intent_to_extend_experiment_url': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: 'Intent to Extend Experiment link',
     help_text: html`If this feature has an "Intent to Extend Experiment"
@@ -364,7 +382,8 @@ export const ALL_FIELDS = {
 
   'r4dt_url': {
     // Sets intent_to_experiment_url in DB
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: 'Request for Deprecation Trial link',
     help_text: html`After you have started the "Request for Deprecation Trial"
@@ -403,7 +422,8 @@ export const ALL_FIELDS = {
   },
 
   'safari_views_link': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: '',
     help_text: html`Citation link.`,
@@ -424,7 +444,8 @@ export const ALL_FIELDS = {
   },
 
   'ff_views_link': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: '',
     help_text: html`
@@ -447,7 +468,8 @@ export const ALL_FIELDS = {
   },
 
   'web_dev_views_link': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: '',
     help_text: html`
@@ -541,6 +563,9 @@ export const ALL_FIELDS = {
   },
 
   'ot_milestone_desktop_start': {
+    type: 'input',
+    input_type: 'milestone-number',
+    required: false,
     label: 'OT desktop start',
     help_text: html`
       First desktop milestone that will support an origin
@@ -548,6 +573,9 @@ export const ALL_FIELDS = {
   },
 
   'ot_milestone_desktop_end': {
+    type: 'input',
+    input_type: 'milestone-number',
+    required: false,
     label: 'OT desktop end',
     help_text: html`
       Last desktop milestone that will support an origin
@@ -555,6 +583,9 @@ export const ALL_FIELDS = {
   },
 
   'ot_milestone_android_start': {
+    type: 'input',
+    input_type: 'milestone-number',
+    required: false,
     label: 'OT Android start',
     help_text: html`
       First android milestone that will support an origin
@@ -562,6 +593,9 @@ export const ALL_FIELDS = {
   },
 
   'ot_milestone_android_end': {
+    type: 'input',
+    input_type: 'milestone-number',
+    required: false,
     label: 'OT Android end',
     help_text: html`
       Last android milestone that will support an origin
@@ -569,6 +603,9 @@ export const ALL_FIELDS = {
   },
 
   'ot_milestone_webview_start': {
+    type: 'input',
+    input_type: 'milestone-number',
+    required: false,
     label: 'OT WebView start',
     help_text: html`
       First WebView milestone that will support an origin
@@ -576,6 +613,9 @@ export const ALL_FIELDS = {
   },
 
   'ot_milestone_webview_end': {
+    type: 'input',
+    input_type: 'milestone-number',
+    required: false,
     label: 'OT WebView end',
     help_text: html`
       Last WebView milestone that will support an origin
@@ -607,7 +647,8 @@ export const ALL_FIELDS = {
   },
 
   'origin_trial_feedback_url': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: 'Origin trial feedback summary',
     help_text: html`
@@ -627,7 +668,8 @@ export const ALL_FIELDS = {
   },
 
   'finch_url': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: 'Finch experiment',
     help_text: html`
@@ -637,6 +679,9 @@ export const ALL_FIELDS = {
   },
 
   'i2e_lgtms': {
+    type: 'input',
+    input_type: 'multi-email',
+    required: false,
     label: 'Intent to Experiment LGTM by',
     help_text: html`
       Full email address of API owner who LGTM\'d the
@@ -644,6 +689,9 @@ export const ALL_FIELDS = {
   },
 
   'i2s_lgtms': {
+    type: 'input',
+    input_type: 'multi-email',
+    required: false,
     label: 'Intent to Ship LGTMs by',
     help_text: html`
       Comma separated list of
@@ -653,6 +701,9 @@ export const ALL_FIELDS = {
 
   'r4dt_lgtms': {
     // Sets i2e_lgtms field.
+    type: 'input',
+    input_type: 'multi-email',
+    required: false,
     label: 'Request for Deprecation Trial LGTM by',
     help_text: html`
       Full email addresses of API owners who LGTM\'d
@@ -722,27 +773,42 @@ export const ALL_FIELDS = {
   },
 
   'devrel': {
+    type: 'input',
+    input_type: 'multi-email',
+    required: false,
     label: 'Developer relations emails',
     help_text: html`
       Comma separated list of full email addresses.`,
   },
 
   'shipped_milestone': {
+    type: 'input',
+    input_type: 'milestone-number',
+    required: false,
     label: 'Chrome for desktop',
     help_text: SHIPPED_HELP_TXT,
   },
 
   'shipped_android_milestone': {
+    type: 'input',
+    input_type: 'milestone-number',
+    required: false,
     label: 'Chrome for Android',
     help_text: SHIPPED_HELP_TXT,
   },
 
   'shipped_ios_milestone': {
+    type: 'input',
+    input_type: 'milestone-number',
+    required: false,
     label: 'Chrome for iOS (RARE)',
     help_text: SHIPPED_HELP_TXT,
   },
 
   'shipped_webview_milestone': {
+    type: 'input',
+    input_type: 'milestone-number',
+    required: false,
     label: 'Android Webview',
     help_text: SHIPPED_WEBVIEW_HELP_TXT,
   },
@@ -762,7 +828,8 @@ export const ALL_FIELDS = {
   },
 
   'devtrial_instructions': {
-    type: 'url_input',
+    type: 'input',
+    input_type: 'url',
     required: false,
     label: 'DevTrial instructions',
     help_text: html`
@@ -778,6 +845,9 @@ export const ALL_FIELDS = {
   },
 
   'dt_milestone_desktop_start': {
+    type: 'input',
+    input_type: 'milestone-number',
+    required: false,
     label: 'DevTrial on desktop',
     help_text: html`
       First milestone that allows web developers to try
@@ -787,6 +857,9 @@ export const ALL_FIELDS = {
   },
 
   'dt_milestone_android_start': {
+    type: 'input',
+    input_type: 'milestone-number',
+    required: false,
     label: 'DevTrial on Android',
     help_text: html`
       First milestone that allows web developers to try
@@ -796,6 +869,9 @@ export const ALL_FIELDS = {
   },
 
   'dt_milestone_ios_start': {
+    type: 'input',
+    input_type: 'milestone-number',
+    required: false,
     label: 'DevTrial on iOS (RARE)',
     help_text: html`
       First milestone that allows web developers to try
@@ -805,6 +881,7 @@ export const ALL_FIELDS = {
   },
 
   'flag_name': {
+    type: 'input',
     label: 'Flag name',
     help_text: html`
       Name of the flag on chrome://flags that enables this feature.`,


### PR DESCRIPTION
This resolves #2139. All the single-line `<input>` generation is migrated from guideforms.py to chromedash-form-field.js. 

The single line input types include: TextInput, URLInput, MultiEmailField, and NumberInput. These are distinguish by the `input_type` property specified in form-field-specs.js and rendered differently with different title, placeholder, ... etc specified in chromedash-form-field.js. 