### PR TITLE
Reviews are only pending in state REVIEW_REQUESTED.

### DIFF
--- a/internals/models.py
+++ b/internals/models.py
@@ -985,7 +985,6 @@ class Approval(DictModel):
       NOT_APPROVED: 'not_approved',
   }
 
-  PENDING_STATES = [REVIEW_REQUESTED, REVIEW_STARTED, NEED_INFO]
   FINAL_STATES = [NA, APPROVED, NOT_APPROVED]
 
   feature_id = ndb.IntegerProperty(required=True)

--- a/internals/search.py
+++ b/internals/search.py
@@ -43,7 +43,7 @@ def process_pending_approval_me_query():
 
   approvable_fields_ids = approval_defs.fields_approvable_by(user)
   pending_approvals = models.Approval.get_approvals(
-      states=models.Approval.PENDING_STATES)
+      states=[models.Approval.REVIEW_REQUESTED])
   pending_approvals = [pa for pa in pending_approvals
                        if pa.field_id in approvable_fields_ids]
 


### PR DESCRIPTION
The API Owners had previously requested that a review that is otherwise approved by still has a NEED_INFO or REVIEW_STARTED vote should not be listed in the "Features pending my approval" box.  

I decided to follow through on that now because there is also a bug that can cause a 500: If a feature has a approval with a state of NEED_INFO but no approval with state REVIEW_REQUESTED, then our current code would include that feature in the result of `process_pending_approval_me_query()` but that feature would not be included in the result of `search_queries.total_order_query_async()` because the requested date only looks at REVIEW_REQUESTED.  That means that some of the results to display cannot be found in list that we use for sorting order, resulting in a KeyError exception.

In this PR:
* Change the query for features-pending-my-review to only look for REVIEW_REQUIRED
* Remove the now unneeded PENDING_STATES constant
* Update unit tests (and make them do real queries rather than mocks)

