### PR TITLE
Add extra help for feature name and summary.

### DIFF
--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -93,6 +93,7 @@ export class ChromedashFormField extends LitElement {
                 <sl-icon-button
                   name="plus-square"
                   label="Toggle extra help"
+                  style="position:absolute"
                   @click="${this.toggleExtraHelp}"
                   >+</sl-icon-button
                 >
@@ -104,7 +105,11 @@ export class ChromedashFormField extends LitElement {
       ${extraHelpText ?
         html` <tr>
             <td colspan="2" class="extrahelp">
-              <sl-details summary=""> ${extraHelpText} </sl-details>
+              <sl-details summary="">
+                <span class="helptext">
+                  ${extraHelpText}
+                </span>
+              </sl-details>
             </td>
           </tr>` :
         ''}

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -28,14 +28,24 @@ export const ALL_FIELDS = {
   'name': {
     label: 'Feature name',
     help_text: html`
-        <p>Capitalize only the first letter and the beginnings of proper nouns.</p>
-        <a target="_blank"
-            href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#feature-name">
-          Learn more</a>.
-        <a target="_blank"
-            href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#feature-name-example">
-          Example</a>.
-      `,
+        <p>Capitalize only the first letter and the beginnings of proper nouns.</p>`,
+    extra_help: html`
+    <p>
+    Each feature should have a unique name that is written as a noun phrase.
+    </p>
+    <ul>
+      <li>Capitalize only the first letter and the beginnings of proper nouns.</li>
+      <li>Avoid using verbs such as "add", "enhance", "deprecate", or "delete". Instead, simply name the feature itself and use the feature type and stage fields to indicate the intent of change.</li>
+      <li>Do not include markup or markdown.</li>
+      <li>Write keywords and identifiers as they would appear to a web developer, not as they are in source code. For example, a method implemented as NewInterface#dostuff would be written as in JavaScript: NewInterface.doStuff().</li>
+    </ul>
+
+    <h4>Examples</h4>
+    <ul>
+      <li>Conversion Measurement API</li>
+      <li>CSS Flexbox: New intrinsic size algorithm</li>
+      <li>Permissions-Policy header</li>
+    </ul>`,
   },
 
   'summary': {
@@ -49,14 +59,32 @@ export const ALL_FIELDS = {
         manner and in the present tense. (This summary will be visible long after
         your project is finished.) Avoid language such as "a new feature" and
         "we propose".</p>
-
-        <a target="_blank"
-            href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#summary">
-          Learn more</a>.
-        <a target="_blank"
-            href="https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#example-1">
-          Example</a>.
       `,
+    extra_help: html`
+    <p>
+    Provide a one sentence description followed by one or two lines explaining how this feature works and how it helps web developers.
+    </p>
+
+    <p>
+    Note: This text communicates with more than just the rest of Chromium development. It's the part most visible to external readers and is used as the basis for the text in the beta release posts.
+    </p>
+
+    <ul>
+      <li>Write from a web developer's point of view, not a browser developer's</li>
+      <li>Do not use markup or markdown.</li>
+      <li>Do not use hard or soft returns.</li>
+      <li>Avoid phrases such as "a new feature". Every feature on the site was new when it was created. You don't need to repeat that information.</li>
+
+      <li>The first line should be a sentence fragment beginning with a verb. (See below.) This is the rare exception to the requirement to always use complete sentences.</li>
+
+      <li>"Conformance with spec" is not adequate. Most if not all features are in conformance to spec.</li>
+    </ul>
+
+    <h4>Example</h4>
+    <blockquote>
+    Splits the HTTP cache using the top frame origin (and possibly subframe origin) to prevent documents from one origin from knowing whether a resource from another origin was cached. The HTTP cache is currently one per profile, with a single namespace for all resources and subresources regardless of origin or renderer process. Splitting the cache on top frame origins helps the browser deflect side-channel attacks where one site can detect resources in another site's cache.
+    </blockquote>
+    `,
   },
 
   'owner': {

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -36,14 +36,14 @@ export const ALL_FIELDS = {
     <ul>
       <li>Capitalize only the first letter and the beginnings of proper nouns.</li>
       <li>Avoid using verbs such as "add", "enhance", "deprecate", or "delete". Instead, simply name the feature itself and use the feature type and stage fields to indicate the intent of change.</li>
-      <li>Do not include markup or markdown.</li>
+      <li>Do not include markup or markdown because they will not be rendered..</li>
       <li>Write keywords and identifiers as they would appear to a web developer, not as they are in source code. For example, a method implemented as NewInterface#dostuff would be written as in JavaScript: NewInterface.doStuff().</li>
     </ul>
 
     <h4>Examples</h4>
     <ul>
       <li>Conversion Measurement API</li>
-      <li>CSS Flexbox: New intrinsic size algorithm</li>
+      <li>CSS Flexbox: intrinsic size algorithm</li>
       <li>Permissions-Policy header</li>
     </ul>`,
   },
@@ -66,13 +66,13 @@ export const ALL_FIELDS = {
     </p>
 
     <p>
-    Note: This text communicates with more than just the rest of Chromium development. It's the part most visible to external readers and is used as the basis for the text in the beta release posts.
+    Note: This text communicates with more than just the rest of Chromium development. It's the part most visible to external readers and is used in the beta release announcement, enterprise release notes, and other commuinications.
     </p>
 
     <ul>
       <li>Write from a web developer's point of view, not a browser developer's</li>
-      <li>Do not use markup or markdown.</li>
-      <li>Do not use hard or soft returns.</li>
+      <li>Do not use markup or markdown because they will not be rendered.</li>
+      <li>Do not use hard or soft returns because they will not be rendered.</li>
       <li>Avoid phrases such as "a new feature". Every feature on the site was new when it was created. You don't need to repeat that information.</li>
 
       <li>The first line should be a sentence fragment beginning with a verb. (See below.) This is the rare exception to the requirement to always use complete sentences.</li>

--- a/static/sass/forms-css.js
+++ b/static/sass/forms-css.js
@@ -25,7 +25,6 @@ export const FORM_STYLES = [
     table .helptext {
       display: block;
       font-size: small;
-      max-width: 40em;
       margin-top: 2px;
     }
 
@@ -150,14 +149,9 @@ export const FORM_STYLES = [
       max-width: 35em;
     }
 
-    chromedash-form-field td.extrahelp {
-      padding: 0 10px;
-    }
-
     chromedash-form-field .helptext {
       display: block;
       font-size: small;
-      max-width: 40em;
       margin-top: 2px;
     }
 
@@ -166,6 +160,25 @@ export const FORM_STYLES = [
     }
     chromedash-form-field .helptext > *:last-child {
       margin-bottom: 0;
+    }
+
+    chromedash-form-field .helptext p {
+      margin: 1em 0;
+    }
+
+    chromedash-form-field .helptext ul {
+      margin: 1em 0;
+    }
+
+    chromedash-form-field .helptext li {
+      list-style: circle;
+      margin-left: 2em;
+    }
+
+    chromedash-form-field .helptext blockquote {
+      margin: 1em;
+      border: 1px solid lightgrey;
+      padding: 0.5em;
     }
 
     chromedash-form-field .errorlist {
@@ -192,14 +205,11 @@ export const FORM_STYLES = [
       margin: 4px;
     }
 
-    chromedash-form-field sl-details > *:first-child {
-      margin-top: 0;
+    chromedash-form-field td.extrahelp {
+      padding-left: 2em;
     }
-    chromedash-form-field sl-details > *:last-child {
-      margin-bottom: 0;
+    chromedash-form-field .extrahelp > span {
+      margin: 0;
     }
 
-    chromedash-form-field .helptext p {
-      margin: 1em 0;
-    }
   `];


### PR DESCRIPTION
This PR adds the extra_help attribute for a few of the feature form fields based on the [EditingHelp](https://github.com/GoogleChrome/chromium-dashboard/wiki/EditingHelp#feature-name) document.

Note that, for help_text and extra_help, the current style which attempts to remove the margin-top and margin-bottom for the first and last child of those text blocks will fail to do what I expected in the case that there is text not enclosed in an element.  So unless we can find an alternative way to remove the extra margin, we have to unsure that text with multiple blocks should wrap each block with `<p>...</p>` or whatever.