### PR TITLE
Make sorting more robust.

### DIFF
--- a/internals/search.py
+++ b/internals/search.py
@@ -175,6 +175,20 @@ def _resolve_promise_to_id_list(promise):
     return id_list
 
 
+def _sort_by_total_order(result_id_list, total_order_ids):
+  """Sort the result_ids according to their position in the total order.
+
+  If some result ID is not present in the total order, use the feature ID
+  value itself as the sorting value, which will effectively put those
+  features at the end of the list in order of creation.
+  """
+  total_order_dict = {f_id: idx for idx, f_id in enumerate(total_order_ids)}
+  sorted_id_list = sorted(
+      result_id_list,
+      key=lambda f_id: total_order_dict.get(f_id, f_id))
+  return sorted_id_list
+
+
 def process_query(
     user_query, sort_spec=None, show_unlisted=False, show_deleted=False,
     start=0, num=100):
@@ -217,10 +231,7 @@ def process_query(
   total_order_ids = _resolve_promise_to_id_list(total_order_promise)
 
   # 4. Sort the IDs according to their position in the complete sorted list.
-  total_order_dict = {f_id: idx for idx, f_id in enumerate(total_order_ids)}
-  sorted_id_list = sorted(
-      result_id_list,
-      key=lambda f_id: total_order_dict[f_id])
+  sorted_id_list = _sort_by_total_order(result_id_list, total_order_ids)
 
   # 5. Paginate
   paginated_id_list = sorted_id_list[start : start + num]

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -184,6 +184,32 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     self.assertEqual(actual[0], self.feature_1.key.integer_id())  # Most recent
     self.assertEqual(actual[1], self.feature_2.key.integer_id())
 
+  def test_sort_by_total_order__empty(self):
+    """Sorting an empty list works."""
+    feature_ids = []
+    total_order_ids = []
+    actual = search._sort_by_total_order(feature_ids, total_order_ids)
+    self.assertEqual([], actual)
+
+    total_order_ids = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+    actual = search._sort_by_total_order(feature_ids, total_order_ids)
+    self.assertEqual([], actual)
+
+  def test_sort_by_total_order__normal(self):
+    """We can sort the results according to the total order."""
+    feature_ids = [10, 1, 9, 4]
+    total_order_ids = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+    actual = search._sort_by_total_order(feature_ids, total_order_ids)
+    self.assertEqual([10, 9, 4, 1], actual)
+
+  def test_sort_by_total_order__unordered_at_end(self):
+    """If the results include features not present in the total order,
+    they are put at the end of the list in ID order."""
+    feature_ids = [999, 10, 998, 1, 9, 997, 4]
+    total_order_ids = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+    actual = search._sort_by_total_order(feature_ids, total_order_ids)
+    self.assertEqual([10, 9, 4, 1, 997, 998, 999], actual)
+
   @mock.patch('internals.search.process_pending_approval_me_query')
   @mock.patch('internals.search.process_starred_me_query')
   @mock.patch('internals.search.process_access_me_query')
@@ -232,7 +258,6 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     self.assertCountEqual(
         [f['name'] for f in actual],
         ['feature 1', 'feature 2'])
-
 
   @mock.patch('logging.warning')
   def test_process_query__bad(self, mock_warn):


### PR DESCRIPTION
In testing my recent change to the approvals dialog box, I found that it is possible for a defect (fixed in an earlier PR today) to cause a problem that raises an exception during search result sorting.  This PR makes sorting more robust, just in case there is ever a similar defect in the future, or in case we purposely implement a sorting query that defines an ordering for some features but leaves others as don't-care.

In this PR:
* A one-line change from `total_order_dict[f_id]` to `total_order_dict.get(f_id, f_id)`
* Add unit tests, and factor out a new function `_sort_by_total_order()` to make that part easier to test.