### PR TITLE
Replace RSS with notice that it is not offered.

### DIFF
--- a/main.py
+++ b/main.py
@@ -137,7 +137,8 @@ page_routes = [
      {'template_path': 'new-feature-list.html'}),
     ('/features', featurelist.FeatureListHandler),
     ('/features/<int:feature_id>', featurelist.FeatureListHandler),
-    ('/features.xml', featurelist.FeatureListXMLHandler),
+    ('/features.xml', basehandlers.ConstHandler,
+     {'template_path': 'farewell-rss.xml'}),
 
     ('/guide/new', guide.FeatureNew),
     ('/guide/edit/<int:feature_id>', guide.ProcessOverview),

--- a/main_test.py
+++ b/main_test.py
@@ -68,6 +68,7 @@ class ConstTemplateTest(testing_config.CustomTestCase):
   def test_const_templates(self):
     """All the ConstHandler instances render valid HTML."""
     for route in main.page_routes:
-      if route[1] == basehandlers.ConstHandler:
+      if (route[1] == basehandlers.ConstHandler and
+          not route[0].endswith('.xml')):
         with self.subTest(path=route[0]):
           self.check_template(route)

--- a/pages/featurelist.py
+++ b/pages/featurelist.py
@@ -71,6 +71,7 @@ class FeatureListHandler(basehandlers.FlaskHandler):
     return template_data
 
 
+# TODO(jrobbins): Delete this some time after Oct 2022.
 class FeatureListXMLHandler(basehandlers.FlaskHandler):
 
   def get_template_data(self):

--- a/templates/farewell-rss.xml
+++ b/templates/farewell-rss.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xml:lang="en" xmlns="http://www.w3.org/2005/Atom">
+  <title>Chrome Platform Status - Features</title>
+  <link href="https://chromestatus.com/features" rel="alternate"></link>
+  <id>https://chromestatus.com/features</id>
+  <updated>2022-08-19T21:53:44Z</updated>
+
+  <entry>
+    <title>Please use our web UI</title>
+    <link href="https://chromestatus.com" rel="alternate"></link>
+    <published>2022-08-19T21:53:44Z</published>
+    <author><name>Chrome Platform Status</name></author>
+    <id>tag:chromestatus.com,2022-08-19</id>
+    <summary type="html">
+      ChromeStatus.com no longer offers an RSS feed.
+      To keep up to date with new features, please visit our website.
+      If you have a strong need for this RSS feed, please let us know
+      by filing an issue at https://github.com/GoogleChrome/chromium-dashboard/issues.
+    </summary>
+  </entry>
+
+</feed>

--- a/templates/features.html
+++ b/templates/features.html
@@ -4,13 +4,7 @@
 {% load cache %}
 
 {% block rss %}
-  <link rel="alternate" type="application/rss+xml" href="https://chromestatus.com/features.xml" title="All features" />
-  {% cache TEMPLATE_CACHE_TIME rssfeed %}
-    {% for k,v in categories %}
-    <link rel="alternate" type="application/rss+xml"
-          href="https://chromestatus.com/features.xml?category={{v}}" title='"{{k}}" features'>
-    {% endfor %}
-  {% endcache %}
+  <link rel="alternate" type="application/rss+xml" href="/features.xml" title="All features" />
 {% endblock %}
 
 {% block css %}


### PR DESCRIPTION
As discussed at this week's team meeting, we will stop offering RSS feeds.

To get feedback from any potential uses, we are replacing the feed with a final message that includes a link to our issue tracker.

In this PR:
* Simplify the set of RSS links offered in `<head>`.
* Switch the request handler to a ConstHandler that serves a new constant file.
* Added comments about a timeframe for deleting the rest of the code.
