### PR TITLE
Refactor remaining models.py code into core_models.py

### DIFF
--- a/api/approvals_api_test.py
+++ b/api/approvals_api_test.py
@@ -20,7 +20,7 @@ from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 
 from api import approvals_api
-from internals import models
+from internals import core_models
 from internals import review_models
 
 test_app = flask.Flask(__name__)
@@ -31,7 +31,7 @@ NOW = datetime.datetime.now()
 class ApprovalsAPITest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_1.put()
@@ -211,7 +211,7 @@ class ApprovalsAPITest(testing_config.CustomTestCase):
 class ApprovalConfigsAPITest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_1.put()
@@ -221,7 +221,7 @@ class ApprovalConfigsAPITest(testing_config.CustomTestCase):
         owners=['one_a@example.com', 'one_b@example.com'])
     self.config_1.put()
 
-    self.feature_2 = models.Feature(
+    self.feature_2 = core_models.Feature(
         name='feature two', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_2.put()
@@ -231,7 +231,7 @@ class ApprovalConfigsAPITest(testing_config.CustomTestCase):
         owners=['two_a@example.com', 'two_b@example.com'])
     self.config_2.put()
 
-    self.feature_3 = models.Feature(
+    self.feature_3 = core_models.Feature(
         name='feature three', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_3.put()

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -21,7 +21,7 @@ from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 
 from api import comments_api
-from internals import models
+from internals import core_models
 from internals import review_models
 
 test_app = flask.Flask(__name__)
@@ -32,7 +32,7 @@ NOW = datetime.datetime.now()
 class CommentsAPITest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_1.put()

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -19,7 +19,7 @@ from framework import basehandlers
 from framework import permissions
 from framework import ramcache
 from framework import users
-from internals import models
+from internals import core_models
 from internals import search
 
 
@@ -27,7 +27,7 @@ class FeaturesAPI(basehandlers.APIHandler):
   """Features are the the main records that we track."""
 
   def get_one_feature(self, feature_id):
-    features = models.Feature.get_by_ids([feature_id])
+    features = core_models.Feature.get_by_ids([feature_id])
     if not features:
       self.abort(404, msg='Feature %r not found' % feature_id)
     return features[0]
@@ -42,7 +42,7 @@ class FeaturesAPI(basehandlers.APIHandler):
     if self.request.args.get('milestone') is not None:
       try:
         milestone = int(self.request.args.get('milestone'))
-        features_by_type = models.Feature.get_in_milestone(
+        features_by_type = core_models.Feature.get_in_milestone(
           show_unlisted=show_unlisted_features,
           milestone=milestone)
         total_count = sum(len(features_by_type[t]) for t in features_by_type)

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -20,7 +20,7 @@ import werkzeug.exceptions  # Flask HTTP stuff.
 
 from api import features_api
 from internals import core_enums
-from internals import models
+from internals import core_models
 from internals import user_models
 from framework import ramcache
 
@@ -30,7 +30,7 @@ test_app = flask.Flask(__name__)
 class FeaturesAPITestDelete(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1,
         intent_stage=core_enums.INTENT_IMPLEMENT)
@@ -59,7 +59,7 @@ class FeaturesAPITestDelete(testing_config.CustomTestCase):
       actual_json = self.handler.do_delete(self.feature_id)
     self.assertEqual({'message': 'Done'}, actual_json)
 
-    revised_feature = models.Feature.get_by_id(self.feature_id)
+    revised_feature = core_models.Feature.get_by_id(self.feature_id)
     self.assertTrue(revised_feature.deleted)
 
   def test_delete__forbidden(self):
@@ -70,7 +70,7 @@ class FeaturesAPITestDelete(testing_config.CustomTestCase):
       with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.do_delete(self.feature_id)
 
-    revised_feature = models.Feature.get_by_id(self.feature_id)
+    revised_feature = core_models.Feature.get_by_id(self.feature_id)
     self.assertFalse(revised_feature.deleted)
 
   def test_delete__invalid(self):
@@ -81,7 +81,7 @@ class FeaturesAPITestDelete(testing_config.CustomTestCase):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_delete(None)
 
-    revised_feature = models.Feature.get_by_id(self.feature_id)
+    revised_feature = core_models.Feature.get_by_id(self.feature_id)
     self.assertFalse(revised_feature.deleted)
 
   def test_delete__not_found(self):
@@ -92,14 +92,14 @@ class FeaturesAPITestDelete(testing_config.CustomTestCase):
       with self.assertRaises(werkzeug.exceptions.NotFound):
         self.handler.do_delete(self.feature_id + 1)
 
-    revised_feature = models.Feature.get_by_id(self.feature_id)
+    revised_feature = core_models.Feature.get_by_id(self.feature_id)
     self.assertFalse(revised_feature.deleted)
 
 
 class FeaturesAPITestGet(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum Z',
         owner=['feature_owner@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
@@ -108,7 +108,7 @@ class FeaturesAPITestGet(testing_config.CustomTestCase):
     self.feature_1.put()
     self.feature_1_id = self.feature_1.key.integer_id()
 
-    self.feature_2 = models.Feature(
+    self.feature_2 = core_models.Feature(
         name='feature two', summary='sum K',
         owner=['other_owner@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
@@ -117,7 +117,7 @@ class FeaturesAPITestGet(testing_config.CustomTestCase):
     self.feature_2.put()
     self.feature_2_id = self.feature_2.key.integer_id()
 
-    self.feature_3 = models.Feature(
+    self.feature_3 = core_models.Feature(
         name='feature three', summary='sum A',
         owner=['other_owner@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,

--- a/api/processes_api.py
+++ b/api/processes_api.py
@@ -15,7 +15,7 @@
 
 
 from framework import basehandlers
-from internals import models
+from internals import core_models
 from internals import processes
 
 
@@ -24,7 +24,7 @@ class ProcessesAPI(basehandlers.APIHandler):
 
   def do_get(self, feature_id):
     """Return the process of the feature."""
-    f = models.Feature.get_by_id(feature_id)
+    f = core_models.Feature.get_by_id(feature_id)
     if f is None:
       self.abort(404, msg=f'Feature {feature_id} not found')
 
@@ -41,7 +41,7 @@ class ProgressAPI(basehandlers.APIHandler):
 
   def do_get(self, feature_id):
     """Return the progress of the feature."""
-    f = models.Feature.get_by_id(feature_id)
+    f = core_models.Feature.get_by_id(feature_id)
     if f is None:
       self.abort(404, msg=f'Feature {feature_id} not found')
 

--- a/api/processes_api_test.py
+++ b/api/processes_api_test.py
@@ -19,7 +19,7 @@ import flask
 
 from api import processes_api
 from framework import ramcache
-from internals import models
+from internals import core_models
 from internals import processes
 from internals import core_enums
 
@@ -29,12 +29,12 @@ test_app = flask.Flask(__name__)
 class ProcessesAPITest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_1.put()
     self.feature_id = self.feature_1.key.integer_id()
-    
+
     self.handler = processes_api.ProcessesAPI()
     self.request_path = f'/api/v0/features/{self.feature_id}/process'
 
@@ -86,7 +86,7 @@ class ProcessesAPITest(testing_config.CustomTestCase):
 class ProgressAPITest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum Z',
         owner=['feature_owner@example.com'],
         ready_for_trial_url='fake ready for trial url',
@@ -97,7 +97,7 @@ class ProgressAPITest(testing_config.CustomTestCase):
         shipped_milestone=1)
     self.feature_1.put()
     self.feature_id = self.feature_1.key.integer_id()
-    
+
     self.handler = processes_api.ProgressAPI()
     self.request_path = f'/api/v0/features/{self.feature_id}/progress'
 

--- a/api/stars_api.py
+++ b/api/stars_api.py
@@ -19,7 +19,7 @@
 import logging
 
 from framework import basehandlers
-from internals import models
+from internals import core_models
 from internals import notifier
 
 

--- a/api/stars_api_test.py
+++ b/api/stars_api_test.py
@@ -19,7 +19,7 @@ from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 
 from api import stars_api
-from internals import models
+from internals import core_models
 from internals import notifier
 
 test_app = flask.Flask(__name__)
@@ -28,7 +28,7 @@ test_app = flask.Flask(__name__)
 class StarsAPITest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_1.put()
@@ -103,23 +103,23 @@ class StarsAPITest(testing_config.CustomTestCase):
     with test_app.test_request_context(self.request_path, json=params):
       self.handler.do_post()  # Original request
 
-    updated_feature = models.Feature.get_by_id(feature_id)
+    updated_feature = core_models.Feature.get_by_id(feature_id)
     self.assertEqual(1, updated_feature.star_count)
 
     with test_app.test_request_context(self.request_path, json=params):
       self.handler.do_post()  # Duplicate request
-    updated_feature = models.Feature.get_by_id(feature_id)
+    updated_feature = core_models.Feature.get_by_id(feature_id)
     self.assertEqual(1, updated_feature.star_count)  # Still 1, not 2.
 
     params = {"featureId": feature_id, "starred": False}
     with test_app.test_request_context(self.request_path, json=params):
       self.handler.do_post()  # Original request
-    updated_feature = models.Feature.get_by_id(feature_id)
+    updated_feature = core_models.Feature.get_by_id(feature_id)
     self.assertEqual(0, updated_feature.star_count)
 
     with test_app.test_request_context(self.request_path, json=params):
       self.handler.do_post()  # Duplicate request
-    updated_feature = models.Feature.get_by_id(feature_id)
+    updated_feature = core_models.Feature.get_by_id(feature_id)
     self.assertEqual(0, updated_feature.star_count)  # Still 0, not negative.
 
   def test_post__unmatched_unstar(self):
@@ -132,7 +132,7 @@ class StarsAPITest(testing_config.CustomTestCase):
     params = {"featureId": feature_id, "starred": False}
     with test_app.test_request_context(self.request_path, json=params):
       self.handler.do_post()  # Out-of-step request
-    updated_feature = models.Feature.get_by_id(feature_id)
+    updated_feature = core_models.Feature.get_by_id(feature_id)
     self.assertEqual(0, updated_feature.star_count)  # Still 0, not negative.
 
   def test_post__normal(self):
@@ -143,11 +143,11 @@ class StarsAPITest(testing_config.CustomTestCase):
     params = {"featureId": feature_id}
     with test_app.test_request_context(self.request_path, json=params):
       self.handler.do_post()
-    updated_feature = models.Feature.get_by_id(feature_id)
+    updated_feature = core_models.Feature.get_by_id(feature_id)
     self.assertEqual(1, updated_feature.star_count)
 
     params = {"featureId": feature_id, "starred": False}
     with test_app.test_request_context(self.request_path, json=params):
       self.handler.do_post()
-    updated_feature = models.Feature.get_by_id(feature_id)
+    updated_feature = core_models.Feature.get_by_id(feature_id)
     self.assertEqual(0, updated_feature.star_count)

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -35,7 +35,7 @@ from framework import users
 from framework import utils
 from framework import xsrf
 from internals import approval_defs
-from internals import models
+from internals import core_models
 from internals import user_models
 
 from django.template.loader import render_to_string
@@ -130,7 +130,7 @@ class BaseHandler(flask.views.MethodView):
                   self.get_int_param('featureId', required=required))
     if not required and not feature_id:
       return None
-    feature = models.Feature.get_by_id(feature_id)
+    feature = core_models.Feature.get_by_id(feature_id)
     if required and not feature:
       self.abort(404, msg='Feature not found')
     user = self.get_current_user()

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -19,7 +19,7 @@ import flask
 
 import settings
 from framework import users
-from internals import models
+from internals import core_models
 from internals import user_models
 
 
@@ -83,7 +83,7 @@ def strict_can_edit_feature(user, feature_id):
   if app_user is not None and (app_user.is_admin or app_user.is_site_editor):
     return True
 
-  feature = models.Feature.get_by_id(feature_id)
+  feature = core_models.Feature.get_by_id(feature_id)
   if not feature:
     return False
 

--- a/framework/permissions_test.py
+++ b/framework/permissions_test.py
@@ -22,7 +22,7 @@ from framework import users
 
 from framework import basehandlers
 from framework import permissions
-from internals import models
+from internals import core_models
 from internals import user_models
 
 
@@ -76,7 +76,7 @@ class PermissionFunctionTests(testing_config.CustomTestCase):
     self.users.append(self.feature_editor)
 
     # Feature for checking permissions against
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum',
         creator="feature_creator@example.com",
         owner=['feature_owner@example.com'],

--- a/internals/core_enums_test.py
+++ b/internals/core_enums_test.py
@@ -1,0 +1,57 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config  # Must be imported before the module under test.
+
+import datetime
+from unittest import mock
+from framework import ramcache
+from framework import users
+
+from internals import core_enums
+
+
+class EnumsFunctionsTest(testing_config.CustomTestCase):
+
+  def test_convert_enum_int_to_string__not_an_enum(self):
+    """If the property is not an enum, just use the property value."""
+    actual = core_enums.convert_enum_int_to_string(
+        'name', 'not an int')
+    self.assertEqual('not an int', actual)
+
+    actual = core_enums.convert_enum_int_to_string(
+        'unknown property', 'something')
+    self.assertEqual('something', actual)
+
+  def test_convert_enum_int_to_string__not_an_int(self):
+    """We don't crash or convert when given non-numeric values."""
+    actual = core_enums.convert_enum_int_to_string(
+        'impl_status_chrome', {'something': 'non-numeric'})
+    self.assertEqual(
+        {'something': 'non-numeric'},
+        actual)
+
+  def test_convert_enum_int_to_string__enum_found(self):
+    """We use the human-reable string if it is defined."""
+    actual = core_enums.convert_enum_int_to_string(
+        'impl_status_chrome', core_enums.NO_ACTIVE_DEV)
+    self.assertEqual(
+        core_enums.IMPLEMENTATION_STATUS[core_enums.NO_ACTIVE_DEV],
+        actual)
+
+  def test_convert_enum_int_to_string__enum_not_found(self):
+    """If we somehow don't have an emum string, use the ordinal."""
+    actual = core_enums.convert_enum_int_to_string(
+        'impl_status_chrome', 99)
+    self.assertEqual(99, actual)

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -42,6 +42,7 @@ def del_none(d):
       del_none(value)
   return d
 
+
 class DictModel(ndb.Model):
   # def to_dict(self):
   #   return dict([(p, str(getattr(self, p))) for p in self.properties()])

--- a/internals/core_models_test.py
+++ b/internals/core_models_test.py
@@ -19,7 +19,8 @@ from unittest import mock
 from framework import ramcache
 from framework import users
 
-from internals import models
+from internals import core_enums
+from internals import core_models
 
 
 class MockQuery(object):
@@ -33,73 +34,41 @@ class MockQuery(object):
 
 class ModelsFunctionsTest(testing_config.CustomTestCase):
 
-  def test_convert_enum_int_to_string__not_an_enum(self):
-    """If the property is not an enum, just use the property value."""
-    actual = models.convert_enum_int_to_string(
-        'name', 'not an int')
-    self.assertEqual('not an int', actual)
-
-    actual = models.convert_enum_int_to_string(
-        'unknown property', 'something')
-    self.assertEqual('something', actual)
-
-  def test_convert_enum_int_to_string__not_an_int(self):
-    """We don't crash or convert when given non-numeric values."""
-    actual = models.convert_enum_int_to_string(
-        'impl_status_chrome', {'something': 'non-numeric'})
-    self.assertEqual(
-        {'something': 'non-numeric'},
-        actual)
-
-  def test_convert_enum_int_to_string__enum_found(self):
-    """We use the human-reable string if it is defined."""
-    actual = models.convert_enum_int_to_string(
-        'impl_status_chrome', models.NO_ACTIVE_DEV)
-    self.assertEqual(
-        models.IMPLEMENTATION_STATUS[models.NO_ACTIVE_DEV],
-        actual)
-
-  def test_convert_enum_int_to_string__enum_not_found(self):
-    """If we somehow don't have an emum string, use the ordinal."""
-    actual = models.convert_enum_int_to_string(
-        'impl_status_chrome', 99)
-    self.assertEqual(99, actual)
-
   def test_del_none(self):
     d = {}
     self.assertEqual(
         {},
-        models.del_none(d))
+        core_models.del_none(d))
 
     d = {1: 'one', 2: None, 3: {33: None}, 4:{44: 44, 45: None}}
     self.assertEqual(
         {1: 'one', 3: {}, 4: {44: 44}},
-        models.del_none(d))
+        core_models.del_none(d))
 
 
 class FeatureTest(testing_config.CustomTestCase):
 
   def setUp(self):
     ramcache.SharedInvalidate.check_for_distributed_invalidation()
-    self.feature_2 = models.Feature(
+    self.feature_2 = core_models.Feature(
         name='feature b', summary='sum', owner=['feature_owner@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
         impl_status_chrome=3)
     self.feature_2.put()
 
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature a', summary='sum', owner=['feature_owner@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
         impl_status_chrome=3)
     self.feature_1.put()
 
-    self.feature_4 = models.Feature(
+    self.feature_4 = core_models.Feature(
         name='feature d', summary='sum', owner=['feature_owner@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
         impl_status_chrome=2)
     self.feature_4.put()
 
-    self.feature_3 = models.Feature(
+    self.feature_3 = core_models.Feature(
         name='feature c', summary='sum', owner=['feature_owner@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
         impl_status_chrome=2)
@@ -114,7 +83,7 @@ class FeatureTest(testing_config.CustomTestCase):
 
   def test_get_all__normal(self):
     """We can retrieve a list of all features with no filter."""
-    actual = models.Feature.get_all(update_cache=True)
+    actual = core_models.Feature.get_all(update_cache=True)
     names = [f['name'] for f in actual]
     self.assertEqual(
         ['feature c', 'feature d', 'feature a', 'feature b'],
@@ -122,7 +91,7 @@ class FeatureTest(testing_config.CustomTestCase):
 
     self.feature_1.summary = 'revised summary'
     self.feature_1.put()  # Changes updated field.
-    actual = models.Feature.get_all(update_cache=True)
+    actual = core_models.Feature.get_all(update_cache=True)
     names = [f['name'] for f in actual]
     self.assertEqual(
         ['feature a', 'feature c', 'feature d', 'feature b'],
@@ -130,17 +99,17 @@ class FeatureTest(testing_config.CustomTestCase):
 
   def test_get_all__category(self):
     """We can retrieve a list of all features of a given category."""
-    actual = models.Feature.get_all(
-        filterby=('category', models.CSS), update_cache=True)
+    actual = core_models.Feature.get_all(
+        filterby=('category', core_enums.CSS), update_cache=True)
     names = [f['name'] for f in actual]
     self.assertEqual(
         [],
         names)
 
-    self.feature_1.category = models.CSS
+    self.feature_1.category = core_enums.CSS
     self.feature_1.put()  # Changes updated field.
-    actual = models.Feature.get_all(
-        filterby=('category', models.CSS), update_cache=True)
+    actual = core_models.Feature.get_all(
+        filterby=('category', core_enums.CSS), update_cache=True)
     names = [f['name'] for f in actual]
     self.assertEqual(
         ['feature a'],
@@ -148,7 +117,7 @@ class FeatureTest(testing_config.CustomTestCase):
 
   def test_get_all__owner(self):
     """We can retrieve a list of all features with a given owner."""
-    actual = models.Feature.get_all(
+    actual = core_models.Feature.get_all(
         filterby=('owner', 'owner@example.com'), update_cache=True)
     names = [f['name'] for f in actual]
     self.assertEqual(
@@ -157,7 +126,7 @@ class FeatureTest(testing_config.CustomTestCase):
 
     self.feature_1.owner = ['owner@example.com']
     self.feature_1.put()  # Changes updated field.
-    actual = models.Feature.get_all(
+    actual = core_models.Feature.get_all(
         filterby=('owner', 'owner@example.com'), update_cache=True)
     names = [f['name'] for f in actual]
     self.assertEqual(
@@ -170,7 +139,7 @@ class FeatureTest(testing_config.CustomTestCase):
     self.feature_2.owner = ['feature_owner@example.com']
     self.feature_2.put()
     testing_config.sign_in('feature_owner@example.com', 1234567890)
-    actual = models.Feature.get_all(update_cache=True)
+    actual = core_models.Feature.get_all(update_cache=True)
     names = [f['name'] for f in actual]
     testing_config.sign_out()
     self.assertEqual(
@@ -182,7 +151,7 @@ class FeatureTest(testing_config.CustomTestCase):
     self.feature_2.editors = ['feature_editor@example.com']
     self.feature_2.put()
     testing_config.sign_in("feature_editor@example.com", 1234567890)
-    actual = models.Feature.get_all(update_cache=True)
+    actual = core_models.Feature.get_all(update_cache=True)
     names = [f['name'] for f in actual]
     testing_config.sign_out()
     self.assertEqual(
@@ -190,14 +159,14 @@ class FeatureTest(testing_config.CustomTestCase):
 
   def test_get_by_ids__empty(self):
     """A request to load zero features returns zero results."""
-    actual = models.Feature.get_by_ids([])
+    actual = core_models.Feature.get_by_ids([])
     self.assertEqual([], actual)
 
   def test_get_by_ids__cache_miss(self):
     """We can load features from datastore, and cache them for later."""
     ramcache.global_cache.clear()
 
-    actual = models.Feature.get_by_ids([
+    actual = core_models.Feature.get_by_ids([
         self.feature_1.key.integer_id(),
         self.feature_2.key.integer_id()])
 
@@ -205,9 +174,9 @@ class FeatureTest(testing_config.CustomTestCase):
     self.assertEqual('feature a', actual[0]['name'])
     self.assertEqual('feature b', actual[1]['name'])
 
-    lookup_key_1 = '%s|%s' % (models.Feature.DEFAULT_CACHE_KEY,
+    lookup_key_1 = '%s|%s' % (core_models.Feature.DEFAULT_CACHE_KEY,
                               self.feature_1.key.integer_id())
-    lookup_key_2 = '%s|%s' % (models.Feature.DEFAULT_CACHE_KEY,
+    lookup_key_2 = '%s|%s' % (core_models.Feature.DEFAULT_CACHE_KEY,
                               self.feature_2.key.integer_id())
     self.assertEqual('feature a', ramcache.get(lookup_key_1)['name'])
     self.assertEqual('feature b', ramcache.get(lookup_key_2)['name'])
@@ -216,7 +185,7 @@ class FeatureTest(testing_config.CustomTestCase):
     """We can load features from ramcache."""
     ramcache.global_cache.clear()
     cache_key = '%s|%s' % (
-        models.Feature.DEFAULT_CACHE_KEY, self.feature_1.key.integer_id())
+        core_models.Feature.DEFAULT_CACHE_KEY, self.feature_1.key.integer_id())
     cached_feature = {
       'name': 'fake cached_feature',
       'id': self.feature_1.key.integer_id(),
@@ -224,14 +193,14 @@ class FeatureTest(testing_config.CustomTestCase):
     }
     ramcache.set(cache_key, cached_feature)
 
-    actual = models.Feature.get_by_ids([self.feature_1.key.integer_id()])
+    actual = core_models.Feature.get_by_ids([self.feature_1.key.integer_id()])
 
     self.assertEqual(1, len(actual))
     self.assertEqual(cached_feature, actual[0])
 
   def test_get_by_ids__batch_order(self):
     """Features are returned in the order of the given IDs."""
-    actual = models.Feature.get_by_ids([
+    actual = core_models.Feature.get_by_ids([
         self.feature_4.key.integer_id(),
         self.feature_1.key.integer_id(),
         self.feature_3.key.integer_id(),
@@ -248,12 +217,12 @@ class FeatureTest(testing_config.CustomTestCase):
     """We should no longer be able to trigger bug #1647."""
     # Cache one to try to trigger the bug.
     ramcache.global_cache.clear()
-    models.Feature.get_by_ids([
+    core_models.Feature.get_by_ids([
         self.feature_2.key.integer_id(),
         ])
 
     # Now do the lookup, but it would cache feature_2 at the key for feature_3.
-    models.Feature.get_by_ids([
+    core_models.Feature.get_by_ids([
         self.feature_4.key.integer_id(),
         self.feature_1.key.integer_id(),
         self.feature_3.key.integer_id(),
@@ -261,7 +230,7 @@ class FeatureTest(testing_config.CustomTestCase):
     ])
 
     # This would read the incorrect cache entry and use it.
-    actual = models.Feature.get_by_ids([
+    actual = core_models.Feature.get_by_ids([
         self.feature_4.key.integer_id(),
         self.feature_1.key.integer_id(),
         self.feature_3.key.integer_id(),
@@ -276,7 +245,7 @@ class FeatureTest(testing_config.CustomTestCase):
 
   def test_get_chronological__normal(self):
     """We can retrieve a list of features."""
-    actual = models.Feature.get_chronological()
+    actual = core_models.Feature.get_chronological()
     names = [f['name'] for f in actual]
     self.assertEqual(
         ['feature c', 'feature d', 'feature a', 'feature b'],
@@ -290,7 +259,7 @@ class FeatureTest(testing_config.CustomTestCase):
     """Unlisted features are not included in the list."""
     self.feature_2.unlisted = True
     self.feature_2.put()
-    actual = models.Feature.get_chronological()
+    actual = core_models.Feature.get_chronological()
     names = [f['name'] for f in actual]
     self.assertEqual(
         ['feature c', 'feature d', 'feature a'],
@@ -300,7 +269,7 @@ class FeatureTest(testing_config.CustomTestCase):
     """Unlisted features are included for users with edit access."""
     self.feature_2.unlisted = True
     self.feature_2.put()
-    actual = models.Feature.get_chronological(show_unlisted=True)
+    actual = core_models.Feature.get_chronological(show_unlisted=True)
     names = [f['name'] for f in actual]
     self.assertEqual(
         ['feature c', 'feature d', 'feature a', 'feature b'],
@@ -324,7 +293,7 @@ class FeatureTest(testing_config.CustomTestCase):
     self.feature_4.shipped_milestone = 2
     self.feature_4.put()
 
-    actual = models.Feature.get_in_milestone(milestone=1)
+    actual = core_models.Feature.get_in_milestone(milestone=1)
     removed = [f['name'] for f in actual['Removed']]
     enabled_by_default = [f['name'] for f in actual['Enabled by default']]
     self.assertEqual(
@@ -336,7 +305,7 @@ class FeatureTest(testing_config.CustomTestCase):
     self.assertEqual(6, len(actual))
 
     cache_key = '%s|%s|%s' % (
-        models.Feature.DEFAULT_CACHE_KEY, 'milestone', 1)
+        core_models.Feature.DEFAULT_CACHE_KEY, 'milestone', 1)
     cached_result = ramcache.get(cache_key)
     self.assertEqual(cached_result, actual)
 
@@ -360,7 +329,7 @@ class FeatureTest(testing_config.CustomTestCase):
     self.feature_4.shipped_milestone = 2
     self.feature_4.put()
 
-    actual = models.Feature.get_in_milestone(milestone=1)
+    actual = core_models.Feature.get_in_milestone(milestone=1)
     self.assertEqual(
         0,
         len(actual['Removed']))
@@ -384,7 +353,8 @@ class FeatureTest(testing_config.CustomTestCase):
     self.feature_4.shipped_milestone = 2
     self.feature_4.put()
 
-    actual = models.Feature.get_in_milestone(milestone=1, show_unlisted=True)
+    actual = core_models.Feature.get_in_milestone(
+        milestone=1, show_unlisted=True)
     self.assertEqual(
         1,
         len(actual['Removed']))
@@ -392,11 +362,11 @@ class FeatureTest(testing_config.CustomTestCase):
   def test_get_in_milestone__cached(self):
     """If there is something in the cache, we use it."""
     cache_key = '%s|%s|%s' % (
-        models.Feature.DEFAULT_CACHE_KEY, 'milestone', 1)
+        core_models.Feature.DEFAULT_CACHE_KEY, 'milestone', 1)
     cached_test_feature = {'test': [{'name': 'test_feature', 'unlisted': False}]}
     ramcache.set(cache_key, cached_test_feature)
 
-    actual = models.Feature.get_in_milestone(milestone=1)
+    actual = core_models.Feature.get_in_milestone(milestone=1)
     self.assertEqual(
         cached_test_feature,
         actual)

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -21,7 +21,7 @@ from framework import basehandlers
 from framework import permissions
 from framework import users
 from internals import approval_defs
-from internals import models
+from internals import core_models
 from internals import review_models
 
 
@@ -204,7 +204,7 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     """
     # If the message had a link to a chromestatus entry, use its ID.
     if feature_id:
-      return models.Feature.get_by_id(feature_id), None
+      return core_models.Feature.get_by_id(feature_id), None
 
     # If there is also no thread_url, then give up.
     if not thread_url:
@@ -213,21 +213,21 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     # Find the feature by querying for the previously saved discussion link.
     matching_features = []
     if approval_field == approval_defs.PrototypeApproval:
-      query = models.Feature.query(
-          models.Feature.intent_to_implement_url == thread_url)
+      query = core_models.Feature.query(
+          core_models.Feature.intent_to_implement_url == thread_url)
       matching_features = query.fetch()
     # TODO(jrobbins): Ready-for-trial threads
     elif approval_field == approval_defs.ExperimentApproval:
-      query = models.Feature.query(
-          models.Feature.intent_to_experiment_url == thread_url)
+      query = core_models.Feature.query(
+          core_models.Feature.intent_to_experiment_url == thread_url)
       matching_features = query.fetch()
     elif approval_field == approval_defs.ExtendExperimentApproval:
-      query = models.Feature.query(
-          models.Feature.intent_to_extend_experiment_url == thread_url)
+      query = core_models.Feature.query(
+          core_models.Feature.intent_to_extend_experiment_url == thread_url)
       matching_features = query.fetch()
     elif approval_field == approval_defs.ShipApproval:
-      query = models.Feature.query(
-          models.Feature.intent_to_ship_url == thread_url)
+      query = core_models.Feature.query(
+          core_models.Feature.intent_to_ship_url == thread_url)
       matching_features = query.fetch()
     else:
       return None, 'Unsupported approval field'

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -21,7 +21,7 @@ import werkzeug
 from internals import approval_defs
 from internals import core_enums
 from internals import detect_intent
-from internals import models
+from internals import core_models
 from internals import review_models
 
 test_app = flask.Flask(__name__)
@@ -30,7 +30,7 @@ test_app = flask.Flask(__name__)
 class FunctionTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='detailed sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1,
         intent_stage=core_enums.INTENT_IMPLEMENT)
@@ -323,7 +323,7 @@ class FunctionTest(testing_config.CustomTestCase):
 class IntentEmailHandlerTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='detailed sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1,
         intent_stage=core_enums.INTENT_IMPLEMENT)

--- a/internals/fetchchannels.py
+++ b/internals/fetchchannels.py
@@ -13,14 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-
 import json
 import requests
 
 from framework import ramcache
-# Note: this file cannot import models because it would be circular.
+# Note: this file cannot import core_models because it would be circular.
 
 
 def get_omaha_data():

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -36,7 +36,7 @@ from framework import users
 import settings
 from internals import approval_defs
 from internals import core_enums
-from internals import models
+from internals import core_models
 from internals import user_models
 
 
@@ -193,7 +193,7 @@ def make_email_tasks(feature, is_update=False, changes=[]):
   return all_tasks
 
 
-class FeatureStar(models.DictModel):
+class FeatureStar(core_models.DictModel):
   """A FeatureStar represent one user's interest in one feature."""
   email = ndb.StringProperty(required=True)
   feature_id = ndb.IntegerProperty(required=True)
@@ -221,7 +221,7 @@ class FeatureStar(models.DictModel):
     else:
       return  # No need to update anything in datastore
 
-    feature = models.Feature.get_by_id(feature_id)
+    feature = core_models.Feature.get_by_id(feature_id)
     feature.star_count += 1 if starred else -1
     if feature.star_count < 0:
       logging.error('count would be < 0: %r', (email, feature_id, starred))
@@ -298,7 +298,8 @@ class FeatureAccuracyHandler(basehandlers.FlaskHandler):
     mstone_info = json.loads(resp.text)
     mstone = int(mstone_info['mstones'][0]['mstone'])
 
-    features = models.Feature.query(models.Feature.deleted == False).fetch(None)
+    features = core_models.Feature.query(
+        core_models.Feature.deleted == False).fetch(None)
     features_to_notify = []
     now = datetime.now()
     accuracy_as_of_delta = timedelta(weeks=self.ACCURACY_AS_OF_WEEKS)
@@ -360,7 +361,7 @@ class FeatureChangeHandler(basehandlers.FlaskHandler):
 
     # Email feature subscribers if the feature exists and there were
     # actually changes to it.
-    feature = models.Feature.get_by_id(feature['id'])
+    feature = core_models.Feature.get_by_id(feature['id'])
     if feature and (is_update and len(changes) or not is_update):
       email_tasks = make_email_tasks(
           feature, is_update=is_update, changes=changes)

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -24,7 +24,8 @@ from google.cloud import ndb
 from framework import users
 
 from internals import approval_defs
-from internals import models
+from internals import core_enums
+from internals import core_models
 from internals import notifier
 from internals import user_models
 import settings
@@ -33,7 +34,7 @@ import settings
 class EmailFormattingTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', owner=['feature_owner@example.com'],
         ot_milestone_desktop_start=100,
         editors=['feature_editor@example.com', 'owner_1@example.com'],
@@ -56,7 +57,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.watcher_1.put()
     self.changes = [dict(prop_name='test_prop', new_val='test new value',
                     old_val='test old value')]
-    self.feature_2 = models.Feature(
+    self.feature_2 = core_models.Feature(
         name='feature two', summary='sum', owner=['feature_owner@example.com'],
         editors=['feature_editor@example.com', 'owner_1@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
@@ -384,15 +385,15 @@ class EmailFormattingTest(testing_config.CustomTestCase):
 class FeatureStarTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_1.put()
-    self.feature_2 = models.Feature(
+    self.feature_2 = core_models.Feature(
         name='feature two', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_2.put()
-    self.feature_3 = models.Feature(
+    self.feature_3 = core_models.Feature(
         name='feature three', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_3.put()
@@ -418,7 +419,7 @@ class FeatureStarTest(testing_config.CustomTestCase):
     self.assertEqual(email, actual.email)
     self.assertEqual(feature_id, actual.feature_id)
     self.assertTrue(actual.starred)
-    updated_feature = models.Feature.get_by_id(feature_id)
+    updated_feature = core_models.Feature.get_by_id(feature_id)
     self.assertEqual(1, updated_feature.star_count)
 
     notifier.FeatureStar.set_star(email, feature_id, starred=False)
@@ -426,7 +427,7 @@ class FeatureStarTest(testing_config.CustomTestCase):
     self.assertEqual(email, actual.email)
     self.assertEqual(feature_id, actual.feature_id)
     self.assertFalse(actual.starred)
-    updated_feature = models.Feature.get_by_id(feature_id)
+    updated_feature = core_models.Feature.get_by_id(feature_id)
     self.assertEqual(0, updated_feature.star_count)
 
   def test_get_user_stars__no_stars(self):
@@ -484,19 +485,19 @@ class MockResponse:
 class FeatureAccuracyHandlerTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', owner=['feature_owner@example.com'],
         category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1,
         ot_milestone_desktop_start=100)
     self.feature_1.put()
-    self.feature_2 = models.Feature(
+    self.feature_2 = core_models.Feature(
         name='feature two', summary='sum',
         owner=['owner_1@example.com', 'owner_2@example.com'],
         category=1, visibility=1, standardization=1,
         web_dev_views=1, impl_status_chrome=1, shipped_milestone=150)
     self.feature_2.put()
-    self.feature_3 = models.Feature(
+    self.feature_3 = core_models.Feature(
         name='feature three', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_3.put()
@@ -540,7 +541,7 @@ class FunctionsTest(testing_config.CustomTestCase):
     quoted_msg_id = 'xxx%3Dyyy%40mail.gmail.com'
     impl_url = notifier.BLINK_DEV_ARCHIVE_URL_PREFIX + '123' + quoted_msg_id
     expr_url = notifier.TEST_ARCHIVE_URL_PREFIX + '456' + quoted_msg_id
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1,
         intent_to_implement_url=impl_url,
@@ -606,7 +607,7 @@ class FunctionsTest(testing_config.CustomTestCase):
 
   def test_generate_thread_subject__deprecation(self):
     """Deprecation intents use different subjects for most intents."""
-    self.feature_1.feature_type = models.FEATURE_TYPE_DEPRECATION_ID
+    self.feature_1.feature_type = core_enums.FEATURE_TYPE_DEPRECATION_ID
     self.assertEqual(
         'Intent to Deprecate and Remove: feature one',
         notifier.generate_thread_subject(

--- a/internals/processes.py
+++ b/internals/processes.py
@@ -17,7 +17,7 @@ import collections
 
 from internals import approval_defs
 from internals import core_enums
-from internals import models
+from internals import core_models
 
 
 Process = collections.namedtuple(

--- a/internals/processes_test.py
+++ b/internals/processes_test.py
@@ -19,7 +19,7 @@ from unittest import mock
 
 from internals import approval_defs
 from internals import core_enums
-from internals import models
+from internals import core_models
 from internals import processes
 
 
@@ -140,7 +140,7 @@ class ProcessesWellFormedTest(testing_config.CustomTestCase):
 class ProgressDetectorsTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=core_enums.DEV_NO_SIGNALS,
         impl_status_chrome=1,

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -19,14 +19,14 @@ from unittest import mock
 from framework import ramcache
 from framework import users
 
-from internals import models
+from internals import core_models
 from internals import review_models
 
 
 class ApprovalTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature a', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=3)
     self.feature_1.put()
@@ -111,7 +111,7 @@ class ApprovalTest(testing_config.CustomTestCase):
 class CommentTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature a', summary='sum',  owner=['feature_owner@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
         impl_status_chrome=3)
@@ -128,7 +128,7 @@ class CommentTest(testing_config.CustomTestCase):
         content='some other text')
     self.comment_1_2.put()
 
-    self.feature_2 = models.Feature(
+    self.feature_2 = core_models.Feature(
         name='feature b', summary='sum', owner=['feature_owner@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
         impl_status_chrome=3)

--- a/internals/search.py
+++ b/internals/search.py
@@ -20,7 +20,7 @@ import re
 from framework import users
 from framework import utils
 from internals import approval_defs
-from internals import models
+from internals import core_models
 from internals import notifier
 from internals import review_models
 from internals import search_queries
@@ -68,7 +68,7 @@ def process_access_me_query(field):
   if not user:
     return []
   # Checks if the user's email exists in the given field.
-  features = models.Feature.get_all(filterby=(field, user.email()))
+  features = core_models.Feature.get_all(filterby=(field, user.email()))
   feature_ids = [f['id'] for f in features]
   return feature_ids
 
@@ -238,7 +238,7 @@ def process_query(
   paginated_id_list = sorted_id_list[start : start + num]
 
   # 6. Fetch the actual issues that have those IDs in the sorted results.
-  features_on_page = models.Feature.get_by_ids(paginated_id_list)
+  features_on_page = core_models.Feature.get_by_ids(paginated_id_list)
 
   logging.info('features_on_page is %r', features_on_page)
   return features_on_page, total_count

--- a/internals/search_queries.py
+++ b/internals/search_queries.py
@@ -15,7 +15,7 @@
 import logging
 
 from framework import utils
-from internals import models
+from internals import core_models
 from internals import review_models
 
 
@@ -27,7 +27,7 @@ def single_field_query_async(
     logging.info('Ignoring field name %r', field_name)
     return []
   # TODO(jrobbins): support sorting by any fields of other model classes.
-  query = models.Feature.query()
+  query = core_models.Feature.query()
   # Note: We don't exclude deleted features, that's done by process_query.
 
   # TODO(jrobbins): Handle ":" operator as substrings for text fields.
@@ -69,7 +69,7 @@ def total_order_query_async(sort_spec):
   if descending:
     field = -field
   # TODO(jrobbins): support sorting by any fields of other model classes.
-  query = models.Feature.query().order(field)
+  query = core_models.Feature.query().order(field)
 
   keys_promise = query.fetch_async(keys_only=True)
   return keys_promise
@@ -108,92 +108,101 @@ def sorted_by_review_date(descending):
 
 
 QUERIABLE_FIELDS = {
-    'created.when': models.Feature.created,
-    'updated.when': models.Feature.updated,
-    'deleted': models.Feature.deleted,
+    'created.when': core_models.Feature.created,
+    'updated.when': core_models.Feature.updated,
+    'deleted': core_models.Feature.deleted,
 
     # TODO(jrobbins): We cannot query user fields because Cloud NDB does not
     # seem to support it.  We should migrate these to string fields.
     #'created.by': Feature.created_by,
     #'updated.by': Feature.updated_by,
 
-    'category': models.Feature.category,
-    'name': models.Feature.name,
-    'feature_type': models.Feature.feature_type,
-    'intent_stage': models.Feature.intent_stage,
-    'summary': models.Feature.summary,
-    'unlisted': models.Feature.unlisted,
-    'motivation': models.Feature.motivation,
-    'star_count': models.Feature.star_count,
-    'tags': models.Feature.search_tags,
-    'owner': models.Feature.owner,
-    'creator': models.Feature.creator,
-    'browsers.chrome.owners': models.Feature.owner,
-    'editors': models.Feature.editors,
-    'intent_to_implement_url': models.Feature.intent_to_implement_url,
-    'intent_to_ship_url': models.Feature.intent_to_ship_url,
-    'ready_for_trial_url': models.Feature.ready_for_trial_url,
-    'intent_to_experiment_url': models.Feature.intent_to_experiment_url,
+    'category': core_models.Feature.category,
+    'name': core_models.Feature.name,
+    'feature_type': core_models.Feature.feature_type,
+    'intent_stage': core_models.Feature.intent_stage,
+    'summary': core_models.Feature.summary,
+    'unlisted': core_models.Feature.unlisted,
+    'motivation': core_models.Feature.motivation,
+    'star_count': core_models.Feature.star_count,
+    'tags': core_models.Feature.search_tags,
+    'owner': core_models.Feature.owner,
+    'creator': core_models.Feature.creator,
+    'browsers.chrome.owners': core_models.Feature.owner,
+    'editors': core_models.Feature.editors,
+    'intent_to_implement_url': core_models.Feature.intent_to_implement_url,
+    'intent_to_ship_url': core_models.Feature.intent_to_ship_url,
+    'ready_for_trial_url': core_models.Feature.ready_for_trial_url,
+    'intent_to_experiment_url': core_models.Feature.intent_to_experiment_url,
     'intent_to_extend_experiment_url':
-        models.Feature.intent_to_extend_experiment_url,
-    'i2e_lgtms': models.Feature.i2e_lgtms,
-    'i2s_lgtms': models.Feature.i2s_lgtms,
-    'browsers.chrome.bug': models.Feature.bug_url,
-    'launch_bug_url': models.Feature.launch_bug_url,
-    'initial_public_proposal_url': models.Feature.initial_public_proposal_url,
-    'browsers.chrome.blink_components': models.Feature.blink_components,
-    'browsers.chrome.devrel': models.Feature.devrel,
-    'browsers.chrome.prefixed': models.Feature.prefixed,
+        core_models.Feature.intent_to_extend_experiment_url,
+    'i2e_lgtms': core_models.Feature.i2e_lgtms,
+    'i2s_lgtms': core_models.Feature.i2s_lgtms,
+    'browsers.chrome.bug': core_models.Feature.bug_url,
+    'launch_bug_url': core_models.Feature.launch_bug_url,
+    'initial_public_proposal_url':
+        core_models.Feature.initial_public_proposal_url,
+    'browsers.chrome.blink_components': core_models.Feature.blink_components,
+    'browsers.chrome.devrel': core_models.Feature.devrel,
+    'browsers.chrome.prefixed': core_models.Feature.prefixed,
 
-    'browsers.chrome.status': models.Feature.impl_status_chrome,
-    'browsers.chrome.desktop': models.Feature.shipped_milestone,
-    'browsers.chrome.android': models.Feature.shipped_android_milestone,
-    'browsers.chrome.ios': models.Feature.shipped_ios_milestone,
-    'browsers.chrome.webview': models.Feature.shipped_webview_milestone,
-    'requires_embedder_support': models.Feature.requires_embedder_support,
+    'browsers.chrome.status': core_models.Feature.impl_status_chrome,
+    'browsers.chrome.desktop': core_models.Feature.shipped_milestone,
+    'browsers.chrome.android': core_models.Feature.shipped_android_milestone,
+    'browsers.chrome.ios': core_models.Feature.shipped_ios_milestone,
+    'browsers.chrome.webview': core_models.Feature.shipped_webview_milestone,
+    'requires_embedder_support': core_models.Feature.requires_embedder_support,
 
-    'browsers.chrome.flag_name': models.Feature.flag_name,
-    'all_platforms': models.Feature.all_platforms,
-    'all_platforms_descr': models.Feature.all_platforms_descr,
-    'wpt': models.Feature.wpt,
+    'browsers.chrome.flag_name': core_models.Feature.flag_name,
+    'all_platforms': core_models.Feature.all_platforms,
+    'all_platforms_descr': core_models.Feature.all_platforms_descr,
+    'wpt': core_models.Feature.wpt,
     'browsers.chrome.devtrial.desktop.start':
-        models.Feature.dt_milestone_desktop_start,
+        core_models.Feature.dt_milestone_desktop_start,
     'browsers.chrome.devtrial.android.start':
-        models.Feature.dt_milestone_android_start,
+        core_models.Feature.dt_milestone_android_start,
     'browsers.chrome.devtrial.ios.start':
-        models.Feature.dt_milestone_ios_start,
+        core_models.Feature.dt_milestone_ios_start,
     'browsers.chrome.devtrial.webview.start':
-        models.Feature.dt_milestone_webview_start,
+        core_models.Feature.dt_milestone_webview_start,
 
-    'standards.maturity': models.Feature.standard_maturity,
-    'standards.spec': models.Feature.spec_link,
-    'standards.anticipated_spec_changes': models.Feature.anticipated_spec_changes,
-    'api_spec': models.Feature.api_spec,
-    'spec_mentors': models.Feature.spec_mentors,
-    'security_review_status': models.Feature.security_review_status,
-    'privacy_review_status': models.Feature.privacy_review_status,
-    'tag_review.url': models.Feature.tag_review,
-    'tag_review.status': models.Feature.tag_review_status,
-    'explainer': models.Feature.explainer_links,
+    'standards.maturity': core_models.Feature.standard_maturity,
+    'standards.spec': core_models.Feature.spec_link,
+    'standards.anticipated_spec_changes':
+        core_models.Feature.anticipated_spec_changes,
+    'api_spec': core_models.Feature.api_spec,
+    'spec_mentors': core_models.Feature.spec_mentors,
+    'security_review_status': core_models.Feature.security_review_status,
+    'privacy_review_status': core_models.Feature.privacy_review_status,
+    'tag_review.url': core_models.Feature.tag_review,
+    'tag_review.status': core_models.Feature.tag_review_status,
+    'explainer': core_models.Feature.explainer_links,
 
-    'browsers.ff.view': models.Feature.ff_views,
-    'browsers.safari.view': models.Feature.safari_views,
-    'browsers.webdev.view': models.Feature.web_dev_views,
-    'browsers.ff.view.url': models.Feature.ff_views_link,
-    'browsers.safari.view.url': models.Feature.safari_views_link,
-    'browsers.webdev.url.url': models.Feature.web_dev_views_link,
+    'browsers.ff.view': core_models.Feature.ff_views,
+    'browsers.safari.view': core_models.Feature.safari_views,
+    'browsers.webdev.view': core_models.Feature.web_dev_views,
+    'browsers.ff.view.url': core_models.Feature.ff_views_link,
+    'browsers.safari.view.url': core_models.Feature.safari_views_link,
+    'browsers.webdev.url.url': core_models.Feature.web_dev_views_link,
 
-    'resources.docs': models.Feature.doc_links,
-    'non_oss_deps': models.Feature.non_oss_deps,
+    'resources.docs': core_models.Feature.doc_links,
+    'non_oss_deps': core_models.Feature.non_oss_deps,
 
-    'browsers.chrome.ot.desktop.start': models.Feature.ot_milestone_desktop_start,
-    'browsers.chrome.ot.desktop.end': models.Feature.ot_milestone_desktop_end,
-    'browsers.chrome.ot.android.start': models.Feature.ot_milestone_android_start,
-    'browsers.chrome.ot.android.end': models.Feature.ot_milestone_android_end,
-    'browsers.chrome.ot.webview.start': models.Feature.ot_milestone_webview_start,
-    'browsers.chrome.ot.webview.end': models.Feature.ot_milestone_webview_end,
-    'browsers.chrome.ot.feedback_url': models.Feature.origin_trial_feedback_url,
-    'finch_url': models.Feature.finch_url,
+    'browsers.chrome.ot.desktop.start':
+        core_models.Feature.ot_milestone_desktop_start,
+    'browsers.chrome.ot.desktop.end':
+        core_models.Feature.ot_milestone_desktop_end,
+    'browsers.chrome.ot.android.start':
+        core_models.Feature.ot_milestone_android_start,
+    'browsers.chrome.ot.android.end':
+        core_models.Feature.ot_milestone_android_end,
+    'browsers.chrome.ot.webview.start':
+        core_models.Feature.ot_milestone_webview_start,
+    'browsers.chrome.ot.webview.end':
+        core_models.Feature.ot_milestone_webview_end,
+    'browsers.chrome.ot.feedback_url':
+        core_models.Feature.origin_trial_feedback_url,
+    'finch_url': core_models.Feature.finch_url,
     }
 
 SORTABLE_FIELDS = QUERIABLE_FIELDS.copy()

--- a/internals/search_queries_test.py
+++ b/internals/search_queries_test.py
@@ -18,7 +18,7 @@ import datetime
 from unittest import mock
 from framework import ramcache
 
-from internals import models
+from internals import core_models
 from internals import review_models
 from internals import search_queries
 
@@ -28,14 +28,14 @@ class SearchFeaturesTest(testing_config.CustomTestCase):
   def setUp(self):
     ramcache.SharedInvalidate.check_for_distributed_invalidation()
 
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature a', summary='sum', owner=['owner@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
         impl_status_chrome=3)
     self.feature_1.put()
     self.feature_1_id = self.feature_1.key.integer_id()
 
-    self.feature_2 = models.Feature(
+    self.feature_2 = core_models.Feature(
         name='feature b', summary='sum', owner=['owner@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
         impl_status_chrome=3)

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -17,7 +17,7 @@ import testing_config  # Must be imported before the module under test.
 import datetime
 from unittest import mock
 
-from internals import models
+from internals import core_models
 from internals import notifier
 from internals import review_models
 from internals import search
@@ -26,13 +26,13 @@ from internals import search
 class SearchFunctionsTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature 1', summary='sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=3)
     self.feature_1.owner = ['owner@example.com']
     self.feature_1.editors = ['editor@example.com']
     self.feature_1.put()
-    self.feature_2 = models.Feature(
+    self.feature_2 = core_models.Feature(
         name='feature 2', summary='sum', category=2, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=3)
     self.feature_2.owner = ['owner@example.com']

--- a/pages/blink_handler.py
+++ b/pages/blink_handler.py
@@ -22,7 +22,7 @@ import os
 
 from framework import basehandlers
 from framework import permissions
-from internals import models
+from internals import core_models
 from internals import user_models
 import settings
 from api.channels_api import construct_chrome_channels_details
@@ -111,7 +111,7 @@ class SubscribersHandler(basehandlers.FlaskHandler):
   def get_template_data(self):
     users = user_models.FeatureOwner.query().order(
         user_models.FeatureOwner.name).fetch(None)
-    feature_list = models.Feature.get_chronological()
+    feature_list = core_models.Feature.get_chronological()
 
     milestone = self.request.args.get('milestone') or None
     if milestone:

--- a/pages/featuredetail.py
+++ b/pages/featuredetail.py
@@ -21,7 +21,7 @@ import logging
 
 from framework import basehandlers
 from pages import guideforms
-from internals import models
+from internals import core_models
 from internals import processes
 
 
@@ -30,7 +30,7 @@ class FeatureDetailHandler(basehandlers.FlaskHandler):
   TEMPLATE_PATH = 'feature.html'
 
   def get_template_data(self, feature_id):
-    f = models.Feature.get_by_id(feature_id)
+    f = core_models.Feature.get_by_id(feature_id)
     if f is None:
       self.abort(404, msg='Feature not found')
 

--- a/pages/featuredetail_test.py
+++ b/pages/featuredetail_test.py
@@ -21,7 +21,7 @@ import werkzeug
 import html5lib
 
 from internals import core_enums
-from internals import models
+from internals import core_models
 from framework import ramcache
 from pages import featuredetail
 
@@ -34,7 +34,7 @@ class TestWithFeature(testing_config.CustomTestCase):
   HANDLER_CLASS = 'subclasses fill this in'
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='detailed sum', category=1, visibility=1,
         standardization=1, web_dev_views=1, impl_status_chrome=1,
         intent_stage=core_enums.INTENT_IMPLEMENT)

--- a/pages/featurelist.py
+++ b/pages/featurelist.py
@@ -20,7 +20,7 @@ import settings
 from framework import basehandlers
 from framework import permissions
 from framework import utils
-from internals import models
+from internals import core_models
 from internals import core_enums
 from framework import ramcache
 
@@ -35,7 +35,7 @@ class FeaturesJsonHandler(basehandlers.FlaskHandler):
 
   def get_template_data(self, version=2):
     user = users.get_current_user()
-    feature_list = models.Feature.get_chronological(
+    feature_list = core_models.Feature.get_chronological(
         version=version,
         show_unlisted=permissions.can_edit_feature(user, None))
     return feature_list
@@ -77,7 +77,7 @@ class FeatureListXMLHandler(basehandlers.FlaskHandler):
   def get_template_data(self):
     status = self.request.args.get('status', None)
     if status:
-      feature_list = models.Feature.get_all_with_statuses(status.split(','))
+      feature_list = core_models.Feature.get_all_with_statuses(status.split(','))
     else:
       filterby = None
       category = self.request.args.get('category', None)
@@ -97,7 +97,7 @@ class FeatureListXMLHandler(basehandlers.FlaskHandler):
             filterby = ('category', k)
             break
 
-      feature_list = models.Feature.get_all( # cached
+      feature_list = core_models.Feature.get_all( # cached
           limit=max_items,
           filterby=filterby,
           order='-updated',

--- a/pages/featurelist_test.py
+++ b/pages/featurelist_test.py
@@ -21,7 +21,8 @@ import werkzeug
 import html5lib
 
 from framework import ramcache
-from internals import models
+from internals import core_enums
+from internals import core_models
 from internals import user_models
 from pages import featurelist
 
@@ -41,10 +42,10 @@ class TestWithFeature(testing_config.CustomTestCase):
     self.app_admin.is_admin = True
     self.app_admin.put()
 
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='detailed sum', owner=['owner@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
-        impl_status_chrome=1, intent_stage=models.INTENT_IMPLEMENT)
+        impl_status_chrome=1, intent_stage=core_enums.INTENT_IMPLEMENT)
     self.feature_1.put()
     self.feature_id = self.feature_1.key.integer_id()
 

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -32,7 +32,7 @@ from framework import permissions
 from framework import utils
 from pages import guideforms
 from internals import core_enums
-from internals import models
+from internals import core_models
 from internals import processes
 import settings
 
@@ -135,7 +135,7 @@ class FeatureNew(basehandlers.FlaskHandler):
     signed_in_user = ndb.User(
         email=self.get_current_user().email(),
         _auth_domain='gmail.com')
-    feature = models.Feature(
+    feature = core_models.Feature(
         category=int(self.form.get('category')),
         name=self.form.get('name'),
         feature_type=feature_type,
@@ -177,7 +177,7 @@ class ProcessOverview(basehandlers.FlaskHandler):
   @permissions.require_edit_feature
   def get_template_data(self, feature_id):
 
-    f = models.Feature.get_by_id(int(feature_id))
+    f = core_models.Feature.get_by_id(int(feature_id))
     if f is None:
       self.abort(404, msg='Feature not found')
 
@@ -242,7 +242,7 @@ class FeatureEditStage(basehandlers.FlaskHandler):
 
   def get_feature_and_process(self, feature_id):
     """Look up the feature that the user wants to edit, and its process."""
-    f = models.Feature.get_by_id(feature_id)
+    f = core_models.Feature.get_by_id(feature_id)
     if f is None:
       self.abort(404, msg='Feature not found')
 
@@ -299,7 +299,7 @@ class FeatureEditStage(basehandlers.FlaskHandler):
   def process_post_data(self, feature_id, stage_id=0):
 
     if feature_id:
-      feature = models.Feature.get_by_id(feature_id)
+      feature = core_models.Feature.get_by_id(feature_id)
       if feature is None:
         self.abort(404, msg='Feature not found')
       else:

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -22,7 +22,7 @@ import html5lib
 
 from framework import ramcache
 from internals import core_enums
-from internals import models
+from internals import core_models
 from pages import guide
 
 
@@ -104,7 +104,7 @@ class FeatureNewTest(testing_config.CustomTestCase):
     location = actual_response.headers['location']
     self.assertTrue(location.startswith('/guide/edit/'))
     new_feature_id = int(location.split('/')[-1])
-    feature = models.Feature.get_by_id(new_feature_id)
+    feature = core_models.Feature.get_by_id(new_feature_id)
     self.assertEqual(1, feature.category)
     self.assertEqual('Feature name', feature.name)
     self.assertEqual('Feature summary', feature.summary)
@@ -137,7 +137,7 @@ class FeatureNewTemplateTest(TestWithFeature):
 class ProcessOverviewTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', owner=['user1@google.com'],
         category=1, visibility=1, standardization=1,
         web_dev_views=core_enums.DEV_NO_SIGNALS, impl_status_chrome=1)
@@ -209,7 +209,7 @@ class ProcessOverviewTemplateTest(TestWithFeature):
   def setUp(self):
     super(ProcessOverviewTemplateTest, self).setUp()
 
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', owner=['user1@google.com'],
         category=1, visibility=1, standardization=1,
         web_dev_views=core_enums.DEV_NO_SIGNALS, impl_status_chrome=1)
@@ -243,7 +243,7 @@ class ProcessOverviewTemplateTest(TestWithFeature):
 class FeatureEditStageTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', owner=['user1@google.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
         impl_status_chrome=1)
@@ -382,7 +382,8 @@ class FeatureEditStageTest(testing_config.CustomTestCase):
     location = actual_response.headers['location']
     self.assertEqual('/guide/edit/%d' % self.feature_1.key.integer_id(),
                      location)
-    revised_feature = models.Feature.get_by_id(self.feature_1.key.integer_id())
+    revised_feature = core_models.Feature.get_by_id(
+        self.feature_1.key.integer_id())
     self.assertEqual(2, revised_feature.category)
     self.assertEqual('Revised feature name', revised_feature.name)
     self.assertEqual('Revised feature summary', revised_feature.summary)
@@ -395,7 +396,7 @@ class FeatureEditStageTemplateTest(TestWithFeature):
 
   def setUp(self):
     super(FeatureEditStageTemplateTest, self).setUp()
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', owner=['user1@google.com'],
         category=1, visibility=1, standardization=1,
         web_dev_views=core_enums.DEV_NO_SIGNALS, impl_status_chrome=1)
@@ -427,7 +428,7 @@ class FeatureEditAllFieldsTemplateTest(TestWithFeature):
 
   def setUp(self):
     super(FeatureEditAllFieldsTemplateTest, self).setUp()
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', owner=['user1@google.com'],
         category=1, visibility=1, standardization=1,
         web_dev_views=core_enums.DEV_NO_SIGNALS, impl_status_chrome=1)
@@ -457,7 +458,7 @@ class FeatureVerifyAccuracyTemplateTest(TestWithFeature):
 
   def setUp(self):
     super(FeatureVerifyAccuracyTemplateTest, self).setUp()
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', owner=['user1@google.com'],
         category=1, visibility=1, standardization=1,
         web_dev_views=core_enums.DEV_NO_SIGNALS, impl_status_chrome=1)

--- a/pages/guideforms_test.py
+++ b/pages/guideforms_test.py
@@ -22,7 +22,7 @@ from django.core.exceptions import ValidationError
 from django.template import engines
 
 from pages import guideforms
-from internals import models
+from internals import core_models
 
 
 TestForm = guideforms.define_form_class_using_shared_fields(

--- a/pages/intentpreview.py
+++ b/pages/intentpreview.py
@@ -17,7 +17,7 @@
 from framework import users
 
 from internals import core_enums
-from internals import models
+from internals import core_models
 from framework import basehandlers
 from framework import permissions
 from internals import processes

--- a/pages/intentpreview_test.py
+++ b/pages/intentpreview_test.py
@@ -23,7 +23,7 @@ import html5lib
 
 from pages import intentpreview
 from internals import core_enums
-from internals import models
+from internals import core_models
 
 test_app = flask.Flask(__name__)
 
@@ -31,7 +31,7 @@ test_app = flask.Flask(__name__)
 class IntentEmailPreviewHandlerTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', owner=['user1@google.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
         impl_status_chrome=1, intent_stage=core_enums.INTENT_IMPLEMENT)
@@ -187,7 +187,7 @@ class IntentEmailPreviewTemplateTest(testing_config.CustomTestCase):
 
   def setUp(self):
     super(IntentEmailPreviewTemplateTest, self).setUp()
-    self.feature_1 = models.Feature(
+    self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', owner=['user1@google.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
         impl_status_chrome=1, intent_stage=core_enums.INTENT_IMPLEMENT)

--- a/scripts/fix_data.py
+++ b/scripts/fix_data.py
@@ -19,10 +19,10 @@ deadline errors, run it a few times until there's no more.
 
 """
 
-from internals import models
+from internals import metrics_models
 
-allCssPropertyHistograms = models.CssPropertyHistogram.get_all()
-allFeatureObserverHistograms = models.FeatureObserverHistogram.get_all()
+allCssPropertyHistograms = metrics_models.CssPropertyHistogram.get_all()
+allFeatureObserverHistograms = metrics_models.FeatureObserverHistogram.get_all()
 
 def CorrectCSSPropertyName(bucket_id):
   if bucket_id in allCssPropertyHistograms:
@@ -36,10 +36,10 @@ def CorrectFeaturePropertyName(bucket_id):
 
 
 def FetchAllCSSPropertiesWithError(bucket_id=None):
-  q = models.StableInstance.query()
+  q = metrics_models.StableInstance.query()
   if bucket_id:
-    q = q.filter(models.StableInstance.bucket_id == bucket_id)
-  q = q.filter(models.StableInstance.property_name == 'ERROR')
+    q = q.filter(metrics_models.StableInstance.bucket_id == bucket_id)
+  q = q.filter(metrics_models.StableInstance.property_name == 'ERROR')
 
   props = q.fetch(None)
 
@@ -49,10 +49,10 @@ def FetchAllCSSPropertiesWithError(bucket_id=None):
   return props
 
 def FetchAllFeaturesWithError(bucket_id=None):
-  q = models.FeatureObserver.query()
+  q = metrics_models.FeatureObserver.query()
   if bucket_id:
-    q = q.filter(models.FeatureObserver.bucket_id == bucket_id)
-  q = q.filter(models.FeatureObserver.property_name == 'ERROR')
+    q = q.filter(metrics_models.FeatureObserver.bucket_id == bucket_id)
+  q = q.filter(metrics_models.FeatureObserver.property_name == 'ERROR')
   return q.fetch(None)
 
 def fix_up(props, corrector_func):


### PR DESCRIPTION
This wraps up the source code organization changes for the schema revamp.

In this PR:
* Rename internals/models.py to internals/core_models.py
* Update all references
* Move some unit test cases to the appropriate file
* Fix some references in the scripts directory that were previously missed