### PR TITLE
Remove custom subclass for stars.

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -193,7 +193,7 @@ def make_email_tasks(feature, is_update=False, changes=[]):
   return all_tasks
 
 
-class FeatureStar(core_models.DictModel):
+class FeatureStar(ndb.Model):
   """A FeatureStar represent one user's interest in one feature."""
   email = ndb.StringProperty(required=True)
   feature_id = ndb.IntegerProperty(required=True)


### PR DESCRIPTION
This is the last of the model classes that subclassed from DictModel without actually needing the serialization logic that that class provides.  In this case, stars_api.py was already constructing a wire format that consisted of only feature ID numbers that the user starred.