### PR TITLE
Change NEED_INFO to NEEDS_WORK.

### DIFF
--- a/api/approvals_api_test.py
+++ b/api/approvals_api_test.py
@@ -47,7 +47,7 @@ class ApprovalsAPITest(testing_config.CustomTestCase):
     self.appr_1_2 = review_models.Approval(
         feature_id=self.feature_id, field_id=2,
         set_by='owner2@example.com', set_on=NOW,
-        state=review_models.Approval.NEED_INFO)
+        state=review_models.Approval.NEEDS_WORK)
 
     self.expected1 = {
         'feature_id': self.feature_id,
@@ -61,7 +61,7 @@ class ApprovalsAPITest(testing_config.CustomTestCase):
         'field_id': 2,
         'set_by': 'owner2@example.com',
         'set_on': str(NOW),
-        'state': review_models.Approval.NEED_INFO,
+        'state': review_models.Approval.NEEDS_WORK,
         }
 
   def tearDown(self):
@@ -160,7 +160,7 @@ class ApprovalsAPITest(testing_config.CustomTestCase):
   def test_post__feature_not_found(self):
     """Handler rejects requests that don't match an existing feature."""
     params = {'featureId': 12345, 'fieldId': 1,
-              'state': review_models.Approval.NEED_INFO }
+              'state': review_models.Approval.NEEDS_WORK }
     with test_app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.NotFound):
         self.handler.do_post()
@@ -170,7 +170,7 @@ class ApprovalsAPITest(testing_config.CustomTestCase):
     """Handler rejects requests from anon users and non-approvers."""
     mock_get_approvers.return_value = ['owner1@example.com']
     params = {'featureId': self.feature_id, 'fieldId': 1,
-              'state': review_models.Approval.NEED_INFO}
+              'state': review_models.Approval.NEEDS_WORK}
 
     testing_config.sign_out()
     with test_app.test_request_context(self.request_path, json=params):
@@ -193,7 +193,7 @@ class ApprovalsAPITest(testing_config.CustomTestCase):
     mock_get_approvers.return_value = ['owner1@example.com']
     testing_config.sign_in('owner1@example.com', 123567890)
     params = {'featureId': self.feature_id, 'fieldId': 1,
-              'state': review_models.Approval.NEED_INFO}
+              'state': review_models.Approval.NEEDS_WORK}
     with test_app.test_request_context(self.request_path, json=params):
       actual = self.handler.do_post()
 
@@ -205,7 +205,7 @@ class ApprovalsAPITest(testing_config.CustomTestCase):
     self.assertEqual(appr.feature_id, self.feature_id)
     self.assertEqual(appr.field_id, 1)
     self.assertEqual(appr.set_by, 'owner1@example.com')
-    self.assertEqual(appr.state, review_models.Approval.NEED_INFO)
+    self.assertEqual(appr.state, review_models.Approval.NEEDS_WORK)
 
 
 class ApprovalConfigsAPITest(testing_config.CustomTestCase):

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -138,7 +138,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
   def test_post__feature_not_found(self):
     """Handler rejects requests that don't match an existing feature."""
     bad_path = '/api/v0/features/12345/approvals/1/comments'
-    params = {'state': review_models.Approval.NEED_INFO }
+    params = {'state': review_models.Approval.NEEDS_WORK }
     with test_app.test_request_context(bad_path, json=params):
       with self.assertRaises(werkzeug.exceptions.NotFound):
         self.handler.do_post(12345, self.field_id)
@@ -147,7 +147,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
   def test_post__forbidden(self, mock_get_approvers):
     """Handler rejects requests from anon users and non-approvers."""
     mock_get_approvers.return_value = ['owner1@example.com']
-    params = {'state': review_models.Approval.NEED_INFO}
+    params = {'state': review_models.Approval.NEEDS_WORK}
 
     testing_config.sign_out()
     with test_app.test_request_context(self.request_path, json=params):
@@ -210,7 +210,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
     """Handler adds comment and updates approval value."""
     mock_get_approvers.return_value = ['owner1@example.com']
     testing_config.sign_in('owner1@example.com', 123567890)
-    params = {'state': review_models.Approval.NEED_INFO}
+    params = {'state': review_models.Approval.NEEDS_WORK}
     with test_app.test_request_context(self.request_path, json=params):
       actual = self.handler.do_post(self.feature_id, self.field_id)
 
@@ -222,13 +222,13 @@ class CommentsAPITest(testing_config.CustomTestCase):
     self.assertEqual(appr.feature_id, self.feature_id)
     self.assertEqual(appr.field_id, 1)
     self.assertEqual(appr.set_by, 'owner1@example.com')
-    self.assertEqual(appr.state, review_models.Approval.NEED_INFO)
+    self.assertEqual(appr.state, review_models.Approval.NEEDS_WORK)
     updated_comments = review_models.Comment.get_comments(
         self.feature_id, self.field_id)
     cmnt = updated_comments[0]
     self.assertEqual(None, cmnt.content)
     self.assertEqual(review_models.Approval.APPROVED, cmnt.old_approval_state)
-    self.assertEqual(review_models.Approval.NEED_INFO, cmnt.new_approval_state)
+    self.assertEqual(review_models.Approval.NEEDS_WORK, cmnt.new_approval_state)
 
   @mock.patch('internals.approval_defs.get_approvers')
   def test_post__comment_only(self, mock_get_approvers):

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -24,7 +24,7 @@ class Approval(ndb.Model):
   NA = 1
   REVIEW_REQUESTED = 2
   REVIEW_STARTED = 3
-  NEED_INFO = 4
+  NEEDS_WORK = 4
   APPROVED = 5
   NOT_APPROVED = 6
   APPROVAL_VALUES = {
@@ -32,7 +32,7 @@ class Approval(ndb.Model):
       NA: 'na',
       REVIEW_REQUESTED: 'review_requested',
       REVIEW_STARTED: 'review_started',
-      NEED_INFO: 'need_info',
+      NEEDS_WORK: 'needs_work',
       APPROVED: 'approved',
       NOT_APPROVED: 'not_approved',
   }
@@ -215,7 +215,7 @@ class Vote(ndb.Model):  # copy from Approval
   NA = 1
   REVIEW_REQUESTED = 2
   REVIEW_STARTED = 3
-  NEED_INFO = 4
+  NEEDS_WORK = 4
   APPROVED = 5
   NOT_APPROVED = 6
   VOTE_VALUES = {
@@ -223,7 +223,7 @@ class Vote(ndb.Model):  # copy from Approval
       NA: 'na',
       REVIEW_REQUESTED: 'review_requested',
       REVIEW_STARTED: 'review_started',
-      NEED_INFO: 'need_info',
+      NEEDS_WORK: 'needs_work',
       APPROVED: 'approved',
       NOT_APPROVED: 'not_approved',
   }

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -116,7 +116,7 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
         set_by='feature_owner@example', set_on=time_1).put()
     review_models.Approval(
         feature_id=self.feature_1.key.integer_id(),
-        field_id=1, state=review_models.Approval.NEED_INFO,
+        field_id=1, state=review_models.Approval.NEEDS_WORK,
         set_by='feature_owner@example.com', set_on=time_2).put()
 
     feature_ids = search.process_pending_approval_me_query()

--- a/static/elements/chromedash-approvals-dialog.js
+++ b/static/elements/chromedash-approvals-dialog.js
@@ -9,7 +9,7 @@ export const STATE_NAMES = [
   [1, 'N/a or Ack'],
   [2, 'Review requested'],
   [3, 'Review started'],
-  [4, 'Need info'],
+  [4, 'Needs work'],
   [5, 'Approved'],
   [6, 'Not approved'],
 ];


### PR DESCRIPTION
This is a follow-up to Joe's review comment on review_models.py.
Monorail FLT uses "Need Info" but go/launch uses "Needs Work".   I think the term "Needs Work" is a better description of what is happening when a review asks for a clarification or rework.  Also, in the future, our users will be concurrently using chromestatus and go/launch, so we should be consistent with the terms that go/launch uses.

This is just a code and minor UI change, not a data schema change.  So, there is no data migration needed.