### PR TITLE
Fix serving of farewell-rss.xml

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -485,9 +485,9 @@ class ConstHandler(FlaskHandler):
       return flask.redirect(settings.LOGIN_PAGE_URL), self.get_headers()
     if 'template_path' in defaults:
       template_path = defaults['template_path']
-      if '.html' not in template_path:
+      if not template_path.endswith(('.html', '.xml')):
         self.abort(
-            500, msg='template_path %r does not end with .html' % template_path)
+            500, msg=f'${template_path =} does not end with .html or .xml')
       return defaults
 
     return flask.jsonify(defaults)

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -62,6 +62,8 @@ test_app = basehandlers.FlaskApplication(
      ('/just_a_template', basehandlers.ConstHandler,
       {'template_path': 'test_template.html',
        'name': 'Guest'}),
+     ('/just_an_xml_template', basehandlers.ConstHandler,
+      {'template_path': 'farewell-rss.xml'}),
      ('/must_be_signed_in', basehandlers.ConstHandler,
       {'template_path': 'test_template.html',
        'require_signin': True}),
@@ -282,6 +284,16 @@ class ConstHandlerTests(testing_config.CustomTestCase):
 
     actual_text, actual_status, actual_headers = actual_tuple
     self.assertIn('Hi Guest,', actual_text)
+    self.assertEqual(200, actual_status)
+    self.assertNotIn('Access-Control-Allow-Origin', actual_headers)
+
+  def test_xml_template_found(self):
+    """We can run an XML template that requires no handler logic."""
+    with test_app.test_request_context('/just_an_xml_template'):
+      actual_tuple = test_app.dispatch_request()
+
+    actual_text, actual_status, actual_headers = actual_tuple
+    self.assertIn('RSS feed', actual_text)
     self.assertEqual(200, actual_status)
     self.assertNotIn('Access-Control-Allow-Origin', actual_headers)
 


### PR DESCRIPTION
I messed up in #2151.  I had been adding so many ConstHandlers for HTML templates that I thought I could add this one without testing it.   It turns out that ConstHandler checks the file suffix and only accepts `.html` files.   So, this PR makes it allow `.xml` files.