### PR TITLE
Fix 404 featurelist.css

### DIFF
--- a/static/elements/chromedash-featurelist.js
+++ b/static/elements/chromedash-featurelist.js
@@ -382,11 +382,6 @@ class ChromedashFeaturelist extends LitElement {
       filteredWithState = filteredWithState.slice(0, MAX_FEATURES_SHOWN);
     }
     return html`
-      <link rel="stylesheet" href="/static/css/elements/chromedash-featurelist.css">
-      <style>
-        .item {width: 100%}
-      </style>
-
       ${filteredWithState.map((item) => html`
           <div class="item">
             <div ?hidden="${this._computeMilestoneHidden(item.feature, this.features, this.filtered)}"


### PR DESCRIPTION
This resolves an old minor problem that I noticed while testing on staging.

The CSS for the feature list used to be in a file named chromedash-featurelist.css.  But, then we converted it to LitCss in #1816.  However, this <link> was never updated and it has been 404 for five months.  The page looks fine because the needed CSS is already compiled into our JS files.  Likewise, the <style> element is redundant because that is part of our LitCss.
