### PR TITLE
Only convert URLs to anchor tags (autolinking)

### DIFF
--- a/static/elements/autolink.js
+++ b/static/elements/autolink.js
@@ -2,6 +2,8 @@
 // for use with text entries in WebStatus. Use this directly via './utils.js'
 // See: https://chromium.googlesource.com/infra/infra/+/refs/heads/main/appengine/monorail/static_src/autolink.js
 
+import {html} from 'lit';
+
 const CRBUG_DEFAULT_PROJECT = 'chromium';
 const CRBUG_URL = 'https://bugs.chromium.org';
 const CRBUG_LINK_RE = /(\b(https?:\/\/)?crbug\.com\/)((\b[-a-z0-9]+)(\/))?(\d+)\b(\#c[0-9]+)?/gi;
@@ -190,10 +192,10 @@ export function markupAutolinks(plainString) {
   });
   const result = textRuns.map(part => {
     if (part.tag === 'a') {
-      return `<a href="${part.href}" target="_blank" rel="noopener noreferrer">${part.content}</a>`;
+      return html`<a href="${part.href}" target="_blank" rel="noopener noreferrer">${part.content}</a>`;
     }
     return part.content;
-  }).join('');
+  });
   return result;
 }
 

--- a/static/elements/utils.js
+++ b/static/elements/utils.js
@@ -1,17 +1,15 @@
 // This file contains helper functions for our elements.
 
-import {html} from 'lit';
-import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import {markupAutolinks} from './autolink.js';
 
 let toastEl;
 
 /* Convert user-entered text into safe HTML with clickable links
- * where appropriate.  Returns a lit-html TemplateResult.
+ * where appropriate.  Returns an array with text and anchor tags.
  */
 export function autolink(s) {
-  const markup = markupAutolinks(s);
-  return html`${unsafeHTML(markup)}`;
+  const withLinks = markupAutolinks(s);
+  return withLinks;
 }
 
 export function showToastMessage(msg) {

--- a/static/elements/utils_test.js
+++ b/static/elements/utils_test.js
@@ -18,17 +18,24 @@ A bug cr/1234 exists and also cl/1234. Info at issue 1234 comment 3.
 AKA issue 1234 #c3. https://example.com/ --- testing. bug 1234 also.`;
       const expected = [
         'This is a test of the autolinking.',
+        '\n',
         html`<a href="http://go/this-is-a-test" target="_blank" rel="noopener noreferrer">go/this-is-a-test</a>`,
         '.',
-        'A bug ',
+        '\nA bug',
+        ' ',
         html`<a href="http://cr/1234" target="_blank" rel="noopener noreferrer">cr/1234</a>`,
-        ' exists and also ',
+        ' exists and also',
+        ' ',
         html`<a href="http://cl/1234" target="_blank" rel="noopener noreferrer">cl/1234</a>`,
         '. Info at ',
         html`<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234#c3" target="_blank" rel="noopener noreferrer">issue 1234 comment 3</a>`,
-        '.',
-        'AKA ',
-        html`<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234#c3" target="_blank" rel="noopener noreferrer">issue 1234 #c3</a>. <a href="https://example.com/" target="_blank" rel="noopener noreferrer">https://example.com/</a> --- testing. <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234" target="_blank" rel="noopener noreferrer">bug 1234</a>`,
+        '.\nAKA ',
+        html`<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234#c3" target="_blank" rel="noopener noreferrer">issue 1234 #c3</a>`,
+        '. ',
+        html`<a href="https://example.com/" target="_blank" rel="noopener noreferrer">https://example.com/</a>`,
+        ' --- testing. ',
+        html`<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234" target="_blank" rel="noopener noreferrer">bug 1234</a>`,
+        ' ',
         'also.',
       ];
 
@@ -42,9 +49,9 @@ go this-is-a-test.
 A bug cr /1234 exists and also /1234. This is an example sentence.
 AKA issue here 1234. example com --- testing.`;
       const expected = [
-        'This is a test of the autolinking.',
-        'go this-is-a-test.',
-        'A bug cr /1234 exists and also /1234. This is an example sentence.',
+        'This is a test of the autolinking.\n',
+        'go this-is-a-test.\n',
+        'A bug cr /1234 exists and also /1234. This is an example sentence.\n',
         'AKA issue here 1234. example com --- testing.',
       ];
 
@@ -59,9 +66,9 @@ go/this-is-a-test
 <script>Dangerous stuff</script>`;
       const expected = [
         '<b>Test</b>',
+        '\n',
         html`<a href="http://go/this-is-a-test" target="_blank" rel="noopener noreferrer">go/this-is-a-test</a>`,
-        '<p>Do not convert this</>',
-        '<script>Dangerous stuff</script>',
+        '\n<p>Do not convert this</p>\n<script>Dangerous stuff</script>',
       ];
 
       const result = autolink(before);

--- a/static/elements/utils_test.js
+++ b/static/elements/utils_test.js
@@ -42,9 +42,9 @@ https://example.com#testing https://example.com/test?querystring=here&q=1234 ??.
         html`<a href="${'https://bugs.chromium.org/p/chromium/issues/detail?id=1234'}" target="_blank" rel="noopener noreferrer">${'bug 1234'}</a>`,
         ' ',
         'also.\n',
-        html`<a href="https://example.com#testing" target="_blank" rel="noopener noreferrer">https://example.com#testing</a>`,
+        html`<a href="${'https://example.com#testing'}" target="_blank" rel="noopener noreferrer">${'https://example.com#testing'}</a>`,
         ' ',
-        html`<a href="https://example.com/test?querystring=here&q=1234" target="_blank" rel="noopener noreferrer">https://example.com/test?querystring=here&q=1234</a>`,
+        html`<a href="${'https://example.com/test?querystring=here&q=1234'}" target="_blank" rel="noopener noreferrer">${'https://example.com/test?querystring=here&q=1234'}</a>`,
         ' ??.',
       ];
 

--- a/static/elements/utils_test.js
+++ b/static/elements/utils_test.js
@@ -49,10 +49,10 @@ go this-is-a-test.
 A bug cr /1234 exists and also /1234. This is an example sentence.
 AKA issue here 1234. example com --- testing.`;
       const expected = [
-        'This is a test of the autolinking.\n',
-        'go this-is-a-test.\n',
-        'A bug cr /1234 exists and also /1234. This is an example sentence.\n',
-        'AKA issue here 1234. example com --- testing.',
+        'This is a test of the autolinking.\n' +
+          'go this-is-a-test.\n' +
+          'A bug cr /1234 exists and also /1234. This is an example sentence.\n' +
+          'AKA issue here 1234. example com --- testing.',
       ];
 
       const result = autolink(before);

--- a/static/elements/utils_test.js
+++ b/static/elements/utils_test.js
@@ -1,22 +1,39 @@
 import {html} from 'lit';
-import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import {autolink} from './utils';
 import {assert} from '@open-wc/testing';
 
+const compareAutolinkResult = (result, expected) => {
+  assert.equal(result.length, expected.length);
+  for (let i = 0; i < result.length; i++) {
+    assert.equal(result[i], expected[i]);
+  }
+};
+
 describe('utils', () => {
   describe('autolink', () => {
-    it('creates a tags for links', () => {
+    it('creates anchor tags for links', () => {
       const before = `This is a test of the autolinking.
 go/this-is-a-test.
 A bug cr/1234 exists and also cl/1234. Info at issue 1234 comment 3.
 AKA issue 1234 #c3. https://example.com/ --- testing. bug 1234 also.`;
-      const expected = html`${unsafeHTML(`This is a test of the autolinking.
-<a href="http://go/this-is-a-test" target="_blank" rel="noopener noreferrer">go/this-is-a-test</a>.
-A bug <a href="http://cr/1234" target="_blank" rel="noopener noreferrer">cr/1234</a> exists and also <a href="http://cl/1234" target="_blank" rel="noopener noreferrer">cl/1234</a>. Info at <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234#c3" target="_blank" rel="noopener noreferrer">issue 1234 comment 3</a>.
-AKA <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234#c3" target="_blank" rel="noopener noreferrer">issue 1234 #c3</a>. <a href="https://example.com/" target="_blank" rel="noopener noreferrer">https://example.com/</a> --- testing. <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234" target="_blank" rel="noopener noreferrer">bug 1234</a> also.`)}`;
+      const expected = [
+        'This is a test of the autolinking.',
+        html`<a href="http://go/this-is-a-test" target="_blank" rel="noopener noreferrer">go/this-is-a-test</a>`,
+        '.',
+        'A bug ',
+        html`<a href="http://cr/1234" target="_blank" rel="noopener noreferrer">cr/1234</a>`,
+        ' exists and also ',
+        html`<a href="http://cl/1234" target="_blank" rel="noopener noreferrer">cl/1234</a>`,
+        '. Info at ',
+        html`<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234#c3" target="_blank" rel="noopener noreferrer">issue 1234 comment 3</a>`,
+        '.',
+        'AKA ',
+        html`<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234#c3" target="_blank" rel="noopener noreferrer">issue 1234 #c3</a>. <a href="https://example.com/" target="_blank" rel="noopener noreferrer">https://example.com/</a> --- testing. <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234" target="_blank" rel="noopener noreferrer">bug 1234</a>`,
+        'also.',
+      ];
 
       const result = autolink(before);
-      assert.equal(result.toString(), expected.toString());
+      compareAutolinkResult(result, expected);
     });
 
     it('does not change text with no links', () => {
@@ -24,13 +41,31 @@ AKA <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234#c3" targ
 go this-is-a-test.
 A bug cr /1234 exists and also /1234. This is an example sentence.
 AKA issue here 1234. example com --- testing.`;
-      const expected = html`${unsafeHTML(`This is a test of the autolinking.
-go this-is-a-test.
-A bug cr /1234 exists and also /1234. This is an example sentence.
-AKA issue here 1234. example com --- testing.`)}`;
+      const expected = [
+        'This is a test of the autolinking.',
+        'go this-is-a-test.',
+        'A bug cr /1234 exists and also /1234. This is an example sentence.',
+        'AKA issue here 1234. example com --- testing.',
+      ];
 
       const result = autolink(before);
-      assert.equal(result.toString(), expected.toString());
+      compareAutolinkResult(result, expected);
+    });
+
+    it('does not convert any other tags to html', () => {
+      const before = `<b>Test</b>
+go/this-is-a-test
+<p>Do not convert this</p>
+<script>Dangerous stuff</script>`;
+      const expected = [
+        '<b>Test</b>',
+        html`<a href="http://go/this-is-a-test" target="_blank" rel="noopener noreferrer">go/this-is-a-test</a>`,
+        '<p>Do not convert this</>',
+        '<script>Dangerous stuff</script>',
+      ];
+
+      const result = autolink(before);
+      compareAutolinkResult(result, expected);
     });
   });
 });

--- a/static/elements/utils_test.js
+++ b/static/elements/utils_test.js
@@ -19,22 +19,22 @@ AKA issue 1234 #c3. https://example.com/ --- testing. bug 1234 also.`;
       const expected = [
         'This is a test of the autolinking.',
         '\n',
-        html`<a href="http://go/this-is-a-test" target="_blank" rel="noopener noreferrer">go/this-is-a-test</a>`,
+        html`<a href="${'http://go/this-is-a-test'}" target="_blank" rel="noopener noreferrer">${'go/this-is-a-test'}</a>`,
         '.',
         '\nA bug',
         ' ',
-        html`<a href="http://cr/1234" target="_blank" rel="noopener noreferrer">cr/1234</a>`,
+        html`<a href="${'http://cr/1234'}" target="_blank" rel="noopener noreferrer">${'cr/1234'}</a>`,
         ' exists and also',
         ' ',
-        html`<a href="http://cl/1234" target="_blank" rel="noopener noreferrer">cl/1234</a>`,
+        html`<a href="${'http://cl/1234'}" target="_blank" rel="noopener noreferrer">${'cl/1234'}</a>`,
         '. Info at ',
-        html`<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234#c3" target="_blank" rel="noopener noreferrer">issue 1234 comment 3</a>`,
+        html`<a href="${'https://bugs.chromium.org/p/chromium/issues/detail?id=1234#c3'}" target="_blank" rel="noopener noreferrer">${'issue 1234 comment 3'}</a>`,
         '.\nAKA ',
-        html`<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234#c3" target="_blank" rel="noopener noreferrer">issue 1234 #c3</a>`,
+        html`<a href="${'https://bugs.chromium.org/p/chromium/issues/detail?id=1234#c3'}" target="_blank" rel="noopener noreferrer">${'issue 1234 #c3'}</a>`,
         '. ',
-        html`<a href="https://example.com/" target="_blank" rel="noopener noreferrer">https://example.com/</a>`,
+        html`<a href="${'https://example.com/'}" target="_blank" rel="noopener noreferrer">${'https://example.com/'}</a>`,
         ' --- testing. ',
-        html`<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1234" target="_blank" rel="noopener noreferrer">bug 1234</a>`,
+        html`<a href="${'https://bugs.chromium.org/p/chromium/issues/detail?id=1234'}" target="_blank" rel="noopener noreferrer">${'bug 1234'}</a>`,
         ' ',
         'also.',
       ];
@@ -67,7 +67,7 @@ go/this-is-a-test
       const expected = [
         '<b>Test</b>',
         '\n',
-        html`<a href="http://go/this-is-a-test" target="_blank" rel="noopener noreferrer">go/this-is-a-test</a>`,
+        html`<a href="${'http://go/this-is-a-test'}" target="_blank" rel="noopener noreferrer">${'go/this-is-a-test'}</a>`,
         '\n<p>Do not convert this</p>\n<script>Dangerous stuff</script>',
       ];
 

--- a/static/elements/utils_test.js
+++ b/static/elements/utils_test.js
@@ -16,12 +16,13 @@ const compareAutolinkResult = (result, expected) => {
 describe('utils', () => {
   describe('autolink', () => {
     it('creates anchor tags for links', () => {
-      const before = `This is a test of the autolinking.
+      const before = `This is a test & result of the autolinking.
 go/this-is-a-test.
 A bug cr/1234 exists and also cl/1234. Info at issue 1234 comment 3.
-AKA issue 1234 #c3. https://example.com/ --- testing. bug 1234 also.`;
+AKA issue 1234 #c3. https://example.com/ --- testing. bug 1234 also.
+https://example.com#testing https://example.com/test?querystring=here&q=1234 ??.`;
       const expected = [
-        'This is a test of the autolinking.',
+        'This is a test & result of the autolinking.',
         '\n',
         html`<a href="${'http://go/this-is-a-test'}" target="_blank" rel="noopener noreferrer">${'go/this-is-a-test'}</a>`,
         '.',
@@ -40,7 +41,11 @@ AKA issue 1234 #c3. https://example.com/ --- testing. bug 1234 also.`;
         ' --- testing. ',
         html`<a href="${'https://bugs.chromium.org/p/chromium/issues/detail?id=1234'}" target="_blank" rel="noopener noreferrer">${'bug 1234'}</a>`,
         ' ',
-        'also.',
+        'also.\n',
+        html`<a href="https://example.com#testing" target="_blank" rel="noopener noreferrer">https://example.com#testing</a>`,
+        ' ',
+        html`<a href="https://example.com/test?querystring=here&q=1234" target="_blank" rel="noopener noreferrer">https://example.com/test?querystring=here&q=1234</a>`,
+        ' ??.',
       ];
 
       const result = autolink(before);

--- a/static/elements/utils_test.js
+++ b/static/elements/utils_test.js
@@ -5,7 +5,11 @@ import {assert} from '@open-wc/testing';
 const compareAutolinkResult = (result, expected) => {
   assert.equal(result.length, expected.length);
   for (let i = 0; i < result.length; i++) {
-    assert.equal(result[i], expected[i]);
+    if (typeof result[i] === 'string') {
+      assert.equal(result[i], expected[i]);
+    } else {
+      assert.deepEqual(result[i], expected[i]);
+    }
   }
 };
 


### PR DESCRIPTION
Any text area using the autolink utility will no longer convert any html-like text to an html tag. Only links will be generated.

![Screen Shot 2022-08-29 at 11 04 42 AM](https://user-images.githubusercontent.com/56164590/187268670-1e960be8-c540-4873-acd0-95994e828dcd.png)
