### PR TITLE
Fix passing user object from features.html to chromedash-featurelist.

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -335,10 +335,12 @@ class FlaskHandler(BaseHandler):
         'email': user.email(),
         'dismissed_cues': json.dumps(user_pref.dismissed_cues),
       }
+      common_data['user_json'] = json.dumps(common_data['user'])
       common_data['xsrf_token'] = xsrf.generate_token(user.email())
       common_data['xsrf_token_expires'] = xsrf.token_expires_sec()
     else:
       common_data['user'] = None
+      common_data['user_json'] = None
       common_data['xsrf_token'] = xsrf.generate_token(None)
       common_data['xsrf_token_expires'] = 0
     return common_data

--- a/static/elements/chromedash-roadmap-milestone-card.js
+++ b/static/elements/chromedash-roadmap-milestone-card.js
@@ -1,6 +1,6 @@
 import {LitElement, html, nothing} from 'lit';
 import {ROADMAP_MILESTONE_CARD_CSS} from
-  '../sass/elements/chromedash-roadmap-milestone-card-css.js';
+'../sass/elements/chromedash-roadmap-milestone-card-css.js';
 
 const REMOVED_STATUS = ['Removed'];
 const DEPRECATED_STATUS = ['Deprecated', 'No longer pursuing'];

--- a/templates/features.html
+++ b/templates/features.html
@@ -35,7 +35,7 @@
         </div>
       </div>
       <chromedash-featurelist
-        {% if user %} user="{{user}}" {% endif %}
+        {% if user %} user="{{user_json}}" {% endif %}
         {% if user %} signedInUser="{{user.email}}" {% endif %}
         {% if user.can_edit_all %}isSiteEditor{% endif %}
         {% if user %} editableFeatures="{{user.editable_features}}" {% endif %}


### PR DESCRIPTION
This fixes I problem that I did not catch in #2166.  The features.html template was changed to pass the `user` object to chromedash-featurelist.  However, that did not work because django will only expand strings and other simple datatypes when the name of a variable is used as a django template expression, it won't automatically convert a python dict to a JSON string.  So, I added a template variable to make that JSON string available.  From there, lit can accept a JSON string in an attribute and parse it into a JS object and assign that to a property.