### PR TITLE
Emails should not autolink

### DIFF
--- a/static/elements/autolink.js
+++ b/static/elements/autolink.js
@@ -17,7 +17,7 @@ const PROJECT_LOCALID_RE_PROJECT_GROUP = 6;
 const PROJECT_LOCALID_RE_ID_GROUP = 8;
 const SHORT_LINK_RE = /(^|[^-\/._])\b(https?:\/\/|ftp:\/\/|mailto:)?(go|g|shortn|who|teams)\/([^\s<]+)/gi;
 const NUMERIC_SHORT_LINK_RE = /(^|[^-\/._])\b(https?:\/\/|ftp:\/\/)?(b|t|o|omg|cl|cr|fxr|fxrev|fxb|tqr)\/([0-9]+)/gi;
-const IMPLIED_LINK_RE = /(^|[^-\/._])\b[a-z]((-|\.)?[a-z0-9])+\.(com|net|org|edu|dev)\b(\/[^\s<]*)?/gi;
+const IMPLIED_LINK_RE = /(?!@)(^|[^-\/._])\b[a-z]((-|\.)?[a-z0-9])+\.(com|net|org|edu|dev)\b(\/[^\s<]*)?/gi;
 const IS_LINK_RE = /()\b(https?:\/\/|ftp:\/\/|mailto:)([^\s<]+)/gi;
 const LINK_TRAILING_CHARS = [
   [null, ':'],

--- a/static/elements/utils_test.js
+++ b/static/elements/utils_test.js
@@ -20,7 +20,8 @@ describe('utils', () => {
 go/this-is-a-test.
 A bug cr/1234 exists and also cl/1234. Info at issue 1234 comment 3.
 AKA issue 1234 #c3. https://example.com/ --- testing. bug 1234 also.
-https://example.com#testing https://example.com/test?querystring=here&q=1234 ??.`;
+https://example.com#testing https://example.com/test?querystring=here&q=1234 ??.
+send requests to user@example.com or just check out request.net`;
       const expected = [
         'This is a test & result of the autolinking.',
         '\n',
@@ -45,7 +46,9 @@ https://example.com#testing https://example.com/test?querystring=here&q=1234 ??.
         html`<a href="${'https://example.com#testing'}" target="_blank" rel="noopener noreferrer">${'https://example.com#testing'}</a>`,
         ' ',
         html`<a href="${'https://example.com/test?querystring=here&q=1234'}" target="_blank" rel="noopener noreferrer">${'https://example.com/test?querystring=here&q=1234'}</a>`,
-        ' ??.',
+        ' ??.\nsend requests to user@example.com or just check out',
+        ' ',
+        html`<a href="${'https://request.net'}" target="_blank" rel="noopener noreferrer">${'request.net'}</a>`,
       ];
 
       const result = autolink(before);


### PR DESCRIPTION
Fixes an issue where the url half of emails are erroneously converted to anchor tags. No longer detects links that begin with `@`.