### PR TITLE
Populate blink components form field options via an API

### DIFF
--- a/api/blink_components_api.py
+++ b/api/blink_components_api.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from framework import basehandlers
+from internals import user_models
+
+
+class BlinkComponentsAPI(basehandlers.APIHandler):
+  """The list of blink components populates the "Blink component" select field
+  in the guide form"""
+
+  def do_get(self):
+    """Returns a dict with blink components as both keys and values."""
+    return {x: [x, x] for x in user_models.BlinkComponent.fetch_all_components()}

--- a/api/blink_components_api_test.py
+++ b/api/blink_components_api_test.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config  # Must be imported before the module under test.
+
+import flask
+
+from api import blink_components_api
+from internals import user_models
+
+test_app = flask.Flask(__name__)
+
+
+class BlinkComponentsAPITest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.handler = blink_components_api.BlinkComponentsAPI()
+    self.request_path = '/api/v0/blinkcomponents'
+
+  def test_get__anon(self):
+    """We can get blink components as an anonymous."""
+    testing_config.sign_out()
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_get()
+    self.assertEqual(user_models.BlinkComponent.fetch_all_components(), list(actual))
+
+  def test_get__signed_in(self):
+    """We can get blink components as a signed-in user."""
+    testing_config.sign_in('one@example.com', 123567890)
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_get()
+    self.assertEqual(user_models.BlinkComponent.fetch_all_components(), list(actual))

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@
 
 from api import accounts_api
 from api import approvals_api
+from api import blink_components_api
 from api import channels_api
 from api import comments_api
 from api import cues_api
@@ -96,6 +97,7 @@ api_routes = [
     (API_BASE + '/features/<int:feature_id>/process', processes_api.ProcessesAPI),
     (API_BASE + '/features/<int:feature_id>/progress', processes_api.ProgressAPI),
 
+    (API_BASE + '/blinkcomponents', blink_components_api.BlinkComponentsAPI),
     (API_BASE + '/fielddefs', fielddefs_api.FieldDefsAPI),
 
     (API_BASE + '/login', login_api.LoginAPI),

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -444,7 +444,7 @@ ALL_FIELDS = {
       required=False, label='',
       choices=[(x, x) for x in
                user_models.BlinkComponent.fetch_all_components()],
-      initial=[settings.DEFAULT_COMPONENT]),
+      initial=settings.DEFAULT_COMPONENT),
 
     'devrel': MultiEmailField(
         required=False, label='',

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -49,10 +49,10 @@ export class ChromedashFormField extends LitElement {
     if (this.name !== 'blink_components') return;
 
     // get the choice values from API when the field is blink component select field
-    this.loading =true;
+    this.loading = true;
     window.csClient.getBlinkComponents().then((componentChoices) => {
       this.componentChoices = componentChoices;
-      this.loading =false;
+      this.loading = false;
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -27,7 +27,36 @@ export class ChromedashFormField extends LitElement {
       errors: {type: String},
       stage: {type: String},
       disabled: {type: Boolean},
+      loading: {type: Boolean},
+      componentChoices: {type: Object}, // just for the blink component select field
     };
+  }
+
+  constructor() {
+    super();
+    this.name = '';
+    this.value = '';
+    this.field = '';
+    this.errors = '';
+    this.stage = '';
+    this.disabled = false;
+    this.loading = false;
+    this.componentChoices = {};
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    if (this.name !== 'blink_components') return;
+
+    console.log(this.value);
+    // get the choice values from API when the field is blink component select field
+    this.loading =true;
+    window.csClient.getBlinkComponents().then((componentChoices) => {
+      this.componentChoices = componentChoices;
+      this.loading =false;
+    }).catch(() => {
+      showToastMessage('Some errors occurred. Please refresh the page or try again later.');
+    });
   }
 
   toggleExtraHelp() {
@@ -48,7 +77,7 @@ export class ChromedashFormField extends LitElement {
     const helpText = fieldProps.help_text || '';
     const extraHelpText = fieldProps.extra_help || '';
     const type = fieldProps.type;
-    const choices = fieldProps.choices;
+    const choices = fieldProps.choices || this.componentChoices;
 
     // If type is checkbox, select, or input, then generate locally.
     let fieldHTML = '';
@@ -73,11 +102,11 @@ export class ChromedashFormField extends LitElement {
           id="id_${this.name}"
           value="${this.value}"
           size="small"
-          ?disabled=${this.disabled}
+          ?disabled=${this.disabled || this.loading}
         >
           ${Object.values(choices).map(
-            ([intValue, label]) => html`
-              <sl-menu-item value="${intValue}"> ${label} </sl-menu-item>
+            ([value, label]) => html`
+              <sl-menu-item value="${value}"> ${label} </sl-menu-item>
             `,
           )}
         </sl-select>

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -48,7 +48,6 @@ export class ChromedashFormField extends LitElement {
     super.connectedCallback();
     if (this.name !== 'blink_components') return;
 
-    console.log(this.value);
     // get the choice values from API when the field is blink component select field
     this.loading =true;
     window.csClient.getBlinkComponents().then((componentChoices) => {

--- a/static/elements/chromedash-roadmap-milestone-card.js
+++ b/static/elements/chromedash-roadmap-milestone-card.js
@@ -1,6 +1,6 @@
 import {LitElement, html, nothing} from 'lit';
 import {ROADMAP_MILESTONE_CARD_CSS} from
-'../sass/elements/chromedash-roadmap-milestone-card-css.js';
+  '../sass/elements/chromedash-roadmap-milestone-card-css.js';
 
 const REMOVED_STATUS = ['Removed'];
 const DEPRECATED_STATUS = ['Deprecated', 'No longer pursuing'];

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -127,6 +127,8 @@ export const ALL_FIELDS = {
   },
 
   'blink_components': {
+    type: 'select',
+    choices: undefined, // this gets replaced in chromedash-form-field via the blink component api
     label: 'Blink component',
     help_text: html`
         Select the most specific component. If unsure, leave as "Blink".`,

--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -288,6 +288,11 @@ class ChromeStatusClient {
     return this.doGet(`/features/${featureId}/progress`);
   }
 
+  // Blinkcomponents API
+  getBlinkComponents() {
+    return this.doGet(`/blinkcomponents`);
+  }
+
   // Fielddefs API
   getFieldDefs() {
     return this.doGet(`/fielddefs`);


### PR DESCRIPTION
This PR migrates the "Blink component" select form field definition to the frontend but with the choice options fetched via API. 

Specifically, in chromedash-form-field.js, if the name of the field is "blink_components", a list of blink components will be fetched via the new BlinkComponentsAPI (URI: /blinkcomponents) and then the select field options get populated. During fetching, the select field is disabled.