### PR TITLE
Migrate the rest of none-textarea form field to js

### DIFF
--- a/static/elements/chromedash-guide-editall-page.js
+++ b/static/elements/chromedash-guide-editall-page.js
@@ -92,7 +92,7 @@ export class ChromedashGuideEditallPage extends LitElement {
   renderSkeletons() {
     return html`
       <h3><sl-skeleton effect="sheen"></sl-skeleton></h3>
-      <section id="metadata">
+      <section class="flat_form">
         <h3><sl-skeleton effect="sheen"></sl-skeleton></h3>
         <p>
           <sl-skeleton effect="sheen"></sl-skeleton>
@@ -102,7 +102,7 @@ export class ChromedashGuideEditallPage extends LitElement {
         </p>
       </section>
       <h3><sl-skeleton effect="sheen"></sl-skeleton></h3>
-      <section id="metadata">
+      <section class="flat_form">
         <h3><sl-skeleton effect="sheen"></sl-skeleton></h3>
         <p>
           <sl-skeleton effect="sheen"></sl-skeleton>

--- a/static/elements/form-field-enums.js
+++ b/static/elements/form-field-enums.js
@@ -48,6 +48,20 @@ export const INTENT_STAGES = {
   INTENT_PARKED: [9, 'Parked'],
 };
 
+export const IMPLEMENTATION_STATUS = {
+  NO_ACTIVE_DEV: [1, 'No active development'],
+  PROPOSED: [2, 'Proposed'],
+  IN_DEVELOPMENT: [3, 'In development'],
+  BEHIND_A_FLAG: [4, 'In developer trial (Behind a flag)'],
+  ENABLED_BY_DEFAULT: [5, 'Enabled by default'],
+  DEPRECATED: [6, 'Deprecated'],
+  REMOVED: [7, 'Removed'],
+  ORIGIN_TRIAL: [8, 'Origin trial'],
+  INTERVENTION: [9, 'Browser Intervention'],
+  ON_HOLD: [10, 'On hold'],
+  NO_LONGER_PURSUING: [1000, 'No longer pursuing'],
+};
+
 export const STANDARD_MATURITY_CHOICES = {
   // No text for UNSET_STD==0. One of the values below will be set on first edit.
   UNKNOWN_STD: [1, 'Unknown standards status - check spec link for status'],

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -2,6 +2,7 @@ import {html} from 'lit';
 import {
   FEATURE_CATEGORIES,
   FEATURE_TYPES,
+  IMPLEMENTATION_STATUS,
   INTENT_STAGES,
   STANDARD_MATURITY_CHOICES,
   REVIEW_STATUS_CHOICES,
@@ -187,6 +188,8 @@ export const ALL_FIELDS = {
   },
 
   'impl_status_chrome': {
+    type: 'select',
+    choices: IMPLEMENTATION_STATUS,
     label: 'Implementation status',
     help_text: html`
         Select the appropriate Chromium development stage. If you
@@ -776,6 +779,7 @@ export const ALL_FIELDS = {
   },
 
   'wpt': {
+    type: 'checkbox',
     label: 'Web Platform Tests',
     help_text: html`
       Is this feature fully tested in Web Platform Tests?`,

--- a/static/sass/forms-css.js
+++ b/static/sass/forms-css.js
@@ -221,6 +221,7 @@ export const FORM_STYLES = [
     }
 
     h3 sl-skeleton {
+      margin-top: 1em;
       width: 30%;
       height: 1.5em;
     }

--- a/static/sass/forms.scss
+++ b/static/sass/forms.scss
@@ -211,6 +211,7 @@ sl-skeleton:nth-of-type(even) {
 }
 
 h3 sl-skeleton {
+  margin-top: 1em;
   width: 30%;
   height: 1.5em;
 }


### PR DESCRIPTION
This PR and #2187 migrate all the rest of none-textarea form fields to js. This PR specifically migrates the `impl_status_chrome` and `wpt` fields.

At the same time, I made some minor css changes to the sl-skeletons on the guide pages.