### PR TITLE
Migrate textarea form fields to JS

### DIFF
--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -76,6 +76,7 @@ export class ChromedashFormField extends LitElement {
     const helpText = fieldProps.help_text || '';
     const extraHelpText = fieldProps.extra_help || '';
     const type = fieldProps.type;
+    const attrs = fieldProps.attrs || {};
     const choices = fieldProps.choices || this.componentChoices;
 
     // If type is checkbox, select, or input, then generate locally.
@@ -157,6 +158,16 @@ export class ChromedashFormField extends LitElement {
           .value=${this.value === 'None' ? '' : this.value}
           ?required=${fieldProps.required}>
         </sl-input>
+      `;
+    } else if (type === 'textarea') {
+      fieldHTML = html`
+        <chromedash-textarea
+          name="${this.name}"
+          size="small"
+          .value=${this.value === 'None' ? '' : this.value}
+          .attrs=${attrs}
+          ?required=${fieldProps.required}>
+        </chromedash-textarea>
       `;
     } else {
       // Temporary workaround until we migrate the generation of

--- a/static/elements/chromedash-textarea.js
+++ b/static/elements/chromedash-textarea.js
@@ -5,6 +5,7 @@ export class ChromedashTextarea extends SlTextarea {
   static get properties() {
     return {
       ...super.properties,
+      attrs: {type: Object},
       multiple: {type: Boolean},
       pattern: {type: String},
       chromedash_single_pattern: {type: String},
@@ -14,6 +15,23 @@ export class ChromedashTextarea extends SlTextarea {
 
   constructor() {
     super();
+    this.attrs = {};
+    this.cols = 50;
+    this.rows = 10;
+
+    // This is the longest string that a cloud ndb StringProperty seems to accept.
+    // Fields that accept a URL list can be longer, provided that each individual
+    // URL is no more than this length.
+    this.maxlength = 1400;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    // Update attributes if provided
+    Object.keys(this.attrs).map((attr) => {
+      this.setAttribute(attr, this.attrs[attr]);
+    });
   }
 
   /**

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -12,6 +12,19 @@ import {
 } from './form-field-enums';
 
 
+const DOMAIN_REGEX = String.raw`(([A-Za-z0-9-]+\.)+[A-Za-z]{2,6})`;
+const PORTNUM_REGEX = '(:[0-9]+)?';
+const URL_REGEX = '(https?)://' + DOMAIN_REGEX + PORTNUM_REGEX + String.raw`(/[^\s]*)?`;
+
+const MULTI_URL_FIELD_ATTRS = {
+  title: 'Enter one or more full URLs, one per line:\nhttps://...\nhttps://...',
+  multiple: true,
+  placeholder: 'https://...\nhttps://...',
+  rows: 4, cols: 50, maxlength: 5000,
+  chromedash_single_pattern: URL_REGEX,
+  chromedash_split_pattern: String.raw`\s+`,
+};
+
 const SHIPPED_HELP_TXT = html`
   First milestone to ship with this status. Applies to: Enabled by
   default, Browser Intervention, Deprecated, and Removed.`;
@@ -53,6 +66,8 @@ export const ALL_FIELDS = {
   },
 
   'summary': {
+    type: 'textarea',
+    required: true,
     label: 'Summary',
     help_text: html`
        <p>Text in the beta release post, the enterprise release notes,
@@ -227,6 +242,8 @@ export const ALL_FIELDS = {
   },
 
   'motivation': {
+    type: 'textarea',
+    required: false,
     label: 'Motivation',
     help_text: html`
         Explain why the web needs this change. It may be useful
@@ -245,6 +262,8 @@ export const ALL_FIELDS = {
   },
 
   'deprecation_motivation': {
+    type: 'textarea',
+    required: false,
     label: 'Motivation',
     help_text: html`
         Deprecations and removals must have strong reasons, backed up
@@ -273,6 +292,9 @@ export const ALL_FIELDS = {
   },
 
   'explainer_links': {
+    type: 'textarea',
+    attrs: MULTI_URL_FIELD_ATTRS,
+    required: false,
     label: 'Explainer link(s)',
     help_text: html`
         Link to explainer(s) (one URL per line). You should have
@@ -294,6 +316,9 @@ export const ALL_FIELDS = {
   },
 
   'comments': {
+    type: 'textarea',
+    attrs: {row: 4},
+    required: false,
     label: 'Comments',
     help_text: html`
         Additional comments, caveats, info...`,
@@ -339,6 +364,8 @@ export const ALL_FIELDS = {
   },
 
   'doc_links': {
+    type: 'textarea',
+    required: false,
     label: 'Doc link(s)',
     help_text: html`
         Links to design doc(s) (one URL per line), if and when
@@ -351,6 +378,9 @@ export const ALL_FIELDS = {
   },
 
   'measurement': {
+    type: 'textarea',
+    attrs: {rows: 4},
+    required: false,
     label: 'Measurement',
     help_text: html`
         It's important to measure the adoption and success of web-exposed
@@ -375,6 +405,9 @@ export const ALL_FIELDS = {
   },
 
   'tag_review': {
+    type: 'textarea',
+    attrs: {rows: 2},
+    required: false,
     label: 'TAG Review',
     help_text: html`Link(s) to TAG review(s), or explanation why this is
                 not needed.`,
@@ -434,6 +467,8 @@ export const ALL_FIELDS = {
   },
 
   'interop_compat_risks': {
+    type: 'textarea',
+    required: false,
     label: 'Interoperability and Compatibility Risks',
     help_text: html`
       Describe the degree of
@@ -473,6 +508,9 @@ export const ALL_FIELDS = {
   },
 
   'safari_views_notes': {
+    type: 'textarea',
+    attrs: {row: 2, placeholder: 'Notes'},
+    required: false,
     label: '',
     help_text: '',
   },
@@ -496,6 +534,9 @@ export const ALL_FIELDS = {
   },
 
   'ff_views_notes': {
+    type: 'textarea',
+    attrs: {row: 2, placeholder: 'Notes'},
+    required: false,
     label: '',
     help_text: '',
   },
@@ -520,6 +561,9 @@ export const ALL_FIELDS = {
   },
 
   'web_dev_views_notes': {
+    type: 'textarea',
+    attrs: {row: 2, placeholder: 'Notes'},
+    required: false,
     label: '',
     help_text: html`
       Reference known representative examples of opinions,
@@ -527,12 +571,17 @@ export const ALL_FIELDS = {
   },
 
   'other_views_notes': {
+    type: 'textarea',
+    attrs: {row: 4, placeholder: 'Notes'},
+    required: false,
     label: 'Other views',
     help_text: html`
       For example, other browsers.`,
   },
 
   'ergonomics_risks': {
+    type: 'textarea',
+    required: false,
     label: 'Ergonomics Risks',
     help_text: html`
       Are there any other platform APIs this feature will frequently be
@@ -542,6 +591,8 @@ export const ALL_FIELDS = {
   },
 
   'activation_risks': {
+    type: 'textarea',
+    required: false,
     label: 'Activation Risks',
     help_text: html`
       Will it be challenging for developers to take advantage of this
@@ -551,6 +602,8 @@ export const ALL_FIELDS = {
   },
 
   'security_risks': {
+    type: 'textarea',
+    required: false,
     label: 'Security Risks',
     help_text: html`
       List any security considerations that were taken into account
@@ -558,6 +611,8 @@ export const ALL_FIELDS = {
   },
 
   'webview_risks': {
+    type: 'textarea',
+    required: false,
     label: 'WebView application risks',
     help_text: html`
       Does this feature deprecate or change behavior of existing APIs,
@@ -583,6 +638,8 @@ export const ALL_FIELDS = {
   },
 
   'experiment_goals': {
+    type: 'textarea',
+    required: false,
     label: 'Experiment Goals',
     help_text: html`
       Which pieces of the API surface are you looking to gain insight on?
@@ -598,6 +655,9 @@ export const ALL_FIELDS = {
   },
 
   'experiment_timeline': {
+    type: 'textarea',
+    attrs: {row: 2, placeholder: 'This field is deprecated', disabled: 'disabled'},
+    required: false,
     label: 'Experiment Timeline',
     help_text: html`
       When does the experiment start and expire?
@@ -666,6 +726,8 @@ export const ALL_FIELDS = {
   },
 
   'experiment_risks': {
+    type: 'textarea',
+    required: false,
     label: 'Experiment Risks',
     help_text: html`
       When this experiment comes to an end are there any risks to the
@@ -674,6 +736,8 @@ export const ALL_FIELDS = {
   },
 
   'experiment_extension_reason': {
+    type: 'textarea',
+    required: false,
     label: 'Experiment Extension Reason',
     help_text: html`
       If this is a repeated or extended experiment, explain why it's
@@ -681,6 +745,8 @@ export const ALL_FIELDS = {
   },
 
   'ongoing_constraints': {
+    type: 'textarea',
+    required: false,
     label: 'Ongoing Constraints',
     help_text: html`
       Do you anticipate adding any ongoing technical constraints to
@@ -700,6 +766,9 @@ export const ALL_FIELDS = {
   },
 
   'anticipated_spec_changes': {
+    type: 'textarea',
+    attrs: MULTI_URL_FIELD_ATTRS,
+    required: false,
     label: 'Anticipated spec changes',
     help_text: html`
       Open questions about a feature may be a source of future web compat
@@ -754,6 +823,8 @@ export const ALL_FIELDS = {
   },
 
   'debuggability': {
+    type: 'textarea',
+    required: true,
     label: 'Debuggability',
     help_text: html`
       Description of the DevTools debugging support for your feature.
@@ -772,6 +843,9 @@ export const ALL_FIELDS = {
   },
 
   'all_platforms_descr': {
+    type: 'textarea',
+    attrs: {rows: 2},
+    required: false,
     label: 'Platform Support Explanation',
     help_text: html`
       Explain why this feature is, or is not,
@@ -786,6 +860,8 @@ export const ALL_FIELDS = {
   },
 
   'wpt_descr': {
+    type: 'textarea',
+    required: false,
     label: 'Web Platform Tests Description',
     help_text: html`
       Please link to the <a href="https://wpt.fyi/results">results on
@@ -801,12 +877,17 @@ export const ALL_FIELDS = {
   },
 
   'sample_links': {
+    type: 'textarea',
+    attrs: MULTI_URL_FIELD_ATTRS,
+    required: false,
     label: 'Demo and sample links',
     help_text: html`
       Links to demos and samples (one URL per line).`,
   },
 
   'non_oss_deps': {
+    type: 'textarea',
+    required: false,
     label: 'Non-OSS dependencies',
     help_text: html`
       Does the feature depend on any code or APIs outside the Chromium

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -317,7 +317,7 @@ export const ALL_FIELDS = {
 
   'comments': {
     type: 'textarea',
-    attrs: {row: 4},
+    attrs: {rows: 4},
     required: false,
     label: 'Comments',
     help_text: html`
@@ -509,7 +509,7 @@ export const ALL_FIELDS = {
 
   'safari_views_notes': {
     type: 'textarea',
-    attrs: {row: 2, placeholder: 'Notes'},
+    attrs: {rows: 2, placeholder: 'Notes'},
     required: false,
     label: '',
     help_text: '',
@@ -535,7 +535,7 @@ export const ALL_FIELDS = {
 
   'ff_views_notes': {
     type: 'textarea',
-    attrs: {row: 2, placeholder: 'Notes'},
+    attrs: {rows: 2, placeholder: 'Notes'},
     required: false,
     label: '',
     help_text: '',
@@ -562,7 +562,7 @@ export const ALL_FIELDS = {
 
   'web_dev_views_notes': {
     type: 'textarea',
-    attrs: {row: 2, placeholder: 'Notes'},
+    attrs: {rows: 2, placeholder: 'Notes'},
     required: false,
     label: '',
     help_text: html`
@@ -572,7 +572,7 @@ export const ALL_FIELDS = {
 
   'other_views_notes': {
     type: 'textarea',
-    attrs: {row: 4, placeholder: 'Notes'},
+    attrs: {rows: 4, placeholder: 'Notes'},
     required: false,
     label: 'Other views',
     help_text: html`
@@ -656,7 +656,7 @@ export const ALL_FIELDS = {
 
   'experiment_timeline': {
     type: 'textarea',
-    attrs: {row: 2, placeholder: 'This field is deprecated', disabled: 'disabled'},
+    attrs: {rows: 2, placeholder: 'This field is deprecated', disabled: true},
     required: false,
     label: 'Experiment Timeline',
     help_text: html`


### PR DESCRIPTION
This PR migrates all the textarea form fields to JS. The changes include:

1. Added an else if clause to handle form fields with a type of `textarea`.
2. The default attributes (cols, rows, and maxlength) of the textareas are specified in the constructor of chromedash-textarea.js. And these get overwritten upon connectedCallback() if an additional `attrs` property is specified.
3. Updated textarea fields in form-field-specs.js.

This "single type, with attributes that modify its behavior" approach for textarea is different from how we deal with the input field type (using subclass specified by `input_type` for each subtype), and we had discussions on this [here](https://github.com/GoogleChrome/chromium-dashboard/pull/2145#issuecomment-1219787341). But now I think it's more flexible and simpler to just use attributes for input fields as well (also to be consistent with the changes in this PR). I will submit another PR to do some refactoring for the input fields.