### PR TITLE
save feature edits as Activity entities

### DIFF
--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -777,7 +777,7 @@ class Feature(DictModel):
       old_val = getattr(self, prop_name, None)
       setattr(self, '_old_' + prop_name, old_val)
 
-  def __get_changes_as_amendments(self):
+  def _get_changes_as_amendments(self):
     """Get all feature changes as Amendment entities."""
     # Diff values to see what properties have changed.
     amendments = []
@@ -819,7 +819,7 @@ class Feature(DictModel):
 
   def put(self, notify=True, **kwargs):
     is_update = self.is_saved()
-    amendments = self.__get_changes_as_amendments()
+    amendments = self._get_changes_as_amendments()
 
     # Document changes as new Activity entity with amendments.
     if is_update:

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -25,6 +25,7 @@ from framework import users
 from framework import cloud_tasks_helpers
 import settings
 from internals.core_enums import *
+from internals import review_models
 from internals import fetchchannels
 
 
@@ -776,12 +777,10 @@ class Feature(DictModel):
       old_val = getattr(self, prop_name, None)
       setattr(self, '_old_' + prop_name, old_val)
 
-  def __notify_feature_subscribers_of_changes(self, is_update):
-    """Async notifies subscribers of new features and property changes to
-       features by posting to a task queue.
-    """
+  def __get_changes_as_amendments(self):
+    """Get all feature changes as Amendment entities."""
     # Diff values to see what properties have changed.
-    changed_props = []
+    amendments = []
     for prop_name, prop in list(self._properties.items()):
       if prop_name in (
           'created_by', 'updated_by', 'updated', 'created'):
@@ -793,13 +792,21 @@ class Feature(DictModel):
           continue
         new_val = convert_enum_int_to_string(prop_name, new_val)
         old_val = convert_enum_int_to_string(prop_name, old_val)
-        # Convert any dateime props to string.
-        if isinstance(new_val, datetime.datetime):
-          new_val = str(new_val)
-          if old_val is not None:
-            old_val = str(old_val)
-        changed_props.append({
-            'prop_name': prop_name, 'old_val': old_val, 'new_val': new_val})
+        amendments.append(
+            review_models.Amendment(field_name=prop_name,
+            old_value=str(old_val), new_value=str(new_val)))
+
+    return amendments
+
+  def __notify_feature_subscribers_of_changes(self, amendments, is_update):
+    """Async notifies subscribers of new features and property changes to
+       features by posting to a task queue.
+    """
+    changed_props = [{
+        'prop_name': a.field_name,
+        'old_val': a.old_value,
+        'new_val': a.new_value
+      } for a in amendments]
 
     params = {
       'changes': changed_props,
@@ -812,9 +819,20 @@ class Feature(DictModel):
 
   def put(self, notify=True, **kwargs):
     is_update = self.is_saved()
+    amendments = self.__get_changes_as_amendments()
+
+    # Document changes as new Activity entity with amendments.
+    if is_update:
+      user = users.get_current_user()
+      email = user.email() if user else None
+      activity = review_models.Activity(feature_id=self.key.integer_id(),
+          author=email, content='')
+      activity.amendments = amendments
+      activity.put()
+
     key = super(Feature, self).put(**kwargs)
     if notify:
-      self.__notify_feature_subscribers_of_changes(is_update)
+      self.__notify_feature_subscribers_of_changes(amendments, is_update)
 
     # Invalidate ramcache for the individual feature view.
     cache_key = '%s|%s' % (Feature.DEFAULT_CACHE_KEY, self.key.integer_id())

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -189,3 +189,48 @@ class OwnersFileTest(testing_config.CustomTestCase):
 
     expired_content = review_models.OwnersFile.get_raw_owner_file('def')
     self.assertEqual(None, expired_content)
+
+
+class ActivityTest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.feature_1 = core_models.Feature(
+        name='feature a', summary='sum', owner=['feature_owner@example.com'],
+        category=1, visibility=1, standardization=1, web_dev_views=1,
+        impl_status_chrome=3)
+    self.feature_1.put()
+
+  def tearDown(self):
+    feature_id = self.feature_1.key.integer_id()
+    activities = review_models.Activity.get_activities(feature_id)
+    for activity in activities:
+      activity.key.delete()
+    self.feature_1.key.delete()
+
+  def test_activities_created(self):
+    # stash_values is used to note what the original values of a feature are.
+    self.feature_1.stash_values()
+    self.feature_1.owner = ["other@example.com"]
+    self.feature_1.summary = "new summary"
+    self.feature_1.put()
+
+    self.feature_1.stash_values()
+    self.feature_1.name = 'Changed name'
+    self.feature_1.put()
+
+    feature_id = self.feature_1.key.integer_id()
+    activities = review_models.Activity.get_activities(feature_id)
+    self.assertEqual(len(activities), 2)
+    self.assertEqual(len(activities[0].amendments), 2)
+    self.assertEqual(len(activities[1].amendments), 1)
+
+    expected = [
+        ('owner', '[\'feature_owner@example.com\']', '[\'other@example.com\']'),
+        ('summary', 'sum', 'new summary'),
+        ('name', 'feature a', 'Changed name')]
+    result = activities[0].amendments + activities[1].amendments
+
+    for i, (field, before, expected) in enumerate(expected):
+      self.assertEqual(field, result[i].field_name)
+      self.assertEqual(before, result[i].old_value)
+      self.assertEqual(expected, result[i].new_value)


### PR DESCRIPTION
#2168

Adds logging of feature edits as Activity entities. These activity entities have a number of Amendment entities associated with them for each edited field, which described the field previous value and its new value.