### PR TITLE
Show relative timestamp on Safari and Firefox

### DIFF
--- a/static/elements/chromedash-approvals-dialog.js
+++ b/static/elements/chromedash-approvals-dialog.js
@@ -455,7 +455,7 @@ class ChromedashApprovalsDialog extends LitElement {
 
   // Display how long ago the comment was created compared to now.
   formatCommentRelativeDate(comment) {
-    const commentDate = new Date(`${comment.created} UTC`);
+    const commentDate = new Date(`${comment.created}Z`);
     if (isNaN(commentDate)) {
       return nothing;
     }


### PR DESCRIPTION
fixes #2185