### PR TITLE
Populate standard_maturity field with deprecated standardization field

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -19,4 +19,4 @@ cron:
   schedule: every monday 09:00
 - description: Copy over deprecated standardization field
   url: /cron/write_standard_maturity
-  schedule: every day 09:00
+  schedule: 1 of jan 00:00

--- a/cron.yaml
+++ b/cron.yaml
@@ -17,3 +17,6 @@ cron:
 - description: Send reminders to verify the accuracy of feature data.
   url: /cron/send_accuracy_notifications
   schedule: every monday 09:00
+- description: Copy over deprecated standardization field
+  url: /cron/write_standard_maturity
+  schedule: every day 09:00

--- a/internals/deprecate_field.py
+++ b/internals/deprecate_field.py
@@ -7,7 +7,7 @@ from internals.core_models import Feature
 class WriteStandardMaturityHandler(FlaskHandler):
 
   def get_template_data(self):
-    """Writes standard_maturity field from standardization user field."""
+    """Writes standard_maturity field from the old standardization field."""
     q = Feature.query()
     features = q.fetch()
     update_count = 0

--- a/internals/deprecate_field.py
+++ b/internals/deprecate_field.py
@@ -1,0 +1,23 @@
+import logging
+
+from internals.core_enums import STANDARD_MATURITY_BACKFILL
+from framework.basehandlers import FlaskHandler
+from internals.core_models import Feature
+
+class WriteStandardMaturityHandler(FlaskHandler):
+
+  def get_template_data(self):
+    """Writes standard_maturity field from standardization user field."""
+    q = Feature.query()
+    features = q.fetch()
+    update_count = 0
+    for feature in features:
+      if ((feature.standardization is not None and feature.standardization > 0)
+           and (feature.standard_maturity is None or feature.standard_maturity == 0)):
+        update_count += 1
+        feature.standard_maturity = STANDARD_MATURITY_BACKFILL[feature.standardization]
+        feature.put(notify=False)
+    
+    logging.info(
+        f'{update_count} features updated with standard_maturity field.')
+    return 'Success'

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ from internals import detect_intent
 from internals import fetchmetrics
 from internals import notifier
 from internals import data_backup
+from internals import deprecate_field
 from pages import blink_handler
 from pages import featuredetail
 from pages import featurelist
@@ -202,6 +203,7 @@ internals_routes = [
   ('/cron/update_blink_components', fetchmetrics.BlinkComponentHandler),
   ('/cron/export_backup', data_backup.BackupExportHandler),
   ('/cron/send_accuracy_notifications', notifier.FeatureAccuracyHandler),
+  ('/cron/write_standard_maturity', deprecate_field.WriteStandardMaturityHandler),
 
   ('/tasks/email-subscribers', notifier.FeatureChangeHandler),
 


### PR DESCRIPTION
Part of #2135 

This is a temporary cron task that will check if any feature has a valid `standardization` field and does not have a valid `standard_maturity` field. If so, the `standard_maturity` field will be inferred based on a mapping of the `standardization` value.