### PR TITLE
Refactor <chromedash-activity> out of activity log.

### DIFF
--- a/static/elements/chromedash-activity-log.js
+++ b/static/elements/chromedash-activity-log.js
@@ -4,12 +4,12 @@ import '@polymer/iron-icon';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
 
-export class ChromedashActivityLog extends LitElement {
+export class ChromedashActivity extends LitElement {
   static get properties() {
     return {
       user: {type: Object},
       feature: {type: Object},
-      comments: {type: Array},
+      activity: {type: Object},
     };
   }
 
@@ -17,18 +17,13 @@ export class ChromedashActivityLog extends LitElement {
     super();
     this.user = null;
     this.feature = {};
-    this.comments = [];
+    this.activity = null;
   }
 
   static get styles() {
     return [
       ...SHARED_STYLES,
       css`
-        .comment_section {
-          max-height: 250px;
-          overflow-y: scroll;
-        }
-
         .comment_header {
           height: 24px;
         }
@@ -62,33 +57,33 @@ export class ChromedashActivityLog extends LitElement {
     return dateStr.split('.')[0]; // Ignore microseconds.
   }
 
-  // Returns a boolean representing whether the given comment can be edited.
-  commentIsEditable(comment) {
+  // Returns a boolean representing whether the given activity can be edited.
+  isEditable() {
     if (!this.user) {
       return false;
     }
     // If the comment has been deleted, it should only be editable
     // by site admins or the user who deleted it.
-    if (comment.deleted_by) {
-      return this.user.is_admin || comment.deleted_by === this.user.email;
+    if (this.activity.deleted_by) {
+      return this.user.is_admin || this.activity.deleted_by === this.user.email;
     }
     // If the comment is not deleted, site admins or the author can edit.
-    return this.user.email === comment.author || this.user.is_admin;
+    return this.user.email === this.activity.author || this.user.is_admin;
   }
 
   // Format a message to show on a deleted comment the user can edit.
-  renderCommentDeletedPreface(comment) {
-    if (!this.commentIsEditable(comment) || !comment.deleted_by) {
+  renderDeletedPreface() {
+    if (!this.isEditable() || !this.activity.deleted_by) {
       return nothing;
     }
     return html`<div style="color: darkred">[Deleted] (comment hidden for other users)
     </div>`;
   }
 
-  toggleCommentMenu(commentId) {
-    const menuEl = this.shadowRoot.querySelector(`#comment-menu-${commentId}`);
+  toggleMenu() {
+    const menuEl = this.shadowRoot.querySelector(`#comment-menu`);
     // Change the menu icon to represent open/closing on click.
-    const iconEl = this.shadowRoot.querySelector(`#icon-${commentId}`);
+    const iconEl = this.shadowRoot.querySelector(`iron-icon`);
     const isVisible = menuEl.style.display !== 'none';
     if (isVisible) {
       menuEl.style.display = 'none';
@@ -99,85 +94,125 @@ export class ChromedashActivityLog extends LitElement {
     }
   }
 
-  // Add a dropdown menu to the comment header if the user can edit the comment.
-  formatCommentEditMenu(comment) {
-    // If the comment is not editable, don't show a comment menu.
-    if (!this.commentIsEditable(comment)) {
+  // Add a dropdown menu to the activity header if the user can edit the activity.
+  formatEditMenu() {
+    // If the activity is not editable, don't show a menu.
+    if (!this.isEditable()) {
       return nothing;
     }
     // Show delete option if not deleted, else show undelete.
     let menuItem = html`
-    <sl-menu-item @click="${() => this.handleDeleteToggle(comment, false)}"
+    <sl-menu-item @click="${() => this.handleDeleteToggle(false)}"
     >Delete Comment</sl-menu-item>`;
-    if (comment.deleted_by) {
+    if (this.activity.deleted_by) {
       menuItem = html`
-      <sl-menu-item @click="${() => this.handleDeleteToggle(comment, true)}"
+      <sl-menu-item @click="${() => this.handleDeleteToggle(true)}"
       >Undelete Comment</sl-menu-item>`;
     }
 
     return html`
-      <iron-icon class="comment-menu-icon" id="icon-${comment.comment_id}"
+      <iron-icon class="comment-menu-icon"
       icon="chromestatus:more-vert"
-      @click=${() => this.toggleCommentMenu(comment.comment_id)}></iron-icon>
+      @click=${() => this.toggleMenu()}></iron-icon>
       <div class="edit-menu">
-        <div id="comment-menu-${comment.comment_id}" style="display: none;">
+        <div id="comment-menu" style="display: none;">
           <sl-menu>${menuItem}</sl-menu>
         </div>
       </div>`;
   }
 
   // Display how long ago the comment was created compared to now.
-  formatCommentRelativeDate(comment) {
-    const commentDate = new Date(`${comment.created} UTC`);
-    if (isNaN(commentDate)) {
+  formatRelativeDate() {
+    const activityDate = new Date(`${this.activity.created} UTC`);
+    if (isNaN(activityDate)) {
       return nothing;
     }
     return html`
       <span class="relative_date">
-        (<sl-relative-time date="${commentDate.toISOString()}">
+        (<sl-relative-time date="${activityDate.toISOString()}">
         </sl-relative-time>)
       </span>`;
   }
 
-  renderComment(comment) {
-    const preface = this.renderCommentDeletedPreface(comment);
+  render() {
+    if (!this.activity) {
+      return nothing;
+    }
+    const preface = this.renderDeletedPreface();
     return html`
       <div class="comment">
         <div class="comment_header">
-           <span class="author">${comment.author}</span>
+           <span class="author">${this.activity.author}</span>
            on
-           <span class="date">${this.formatDate(comment.created)}</span>
-           ${this.formatCommentRelativeDate(comment)}
-           ${this.formatCommentEditMenu(comment)}
+           <span class="date">${this.formatDate(this.activity.created)}</span>
+           ${this.formatRelativeDate()}
+           ${this.formatEditMenu()}
         </div>
-        <div class="comment_body">${preface}${comment.content}</div>
+        <div class="comment_body">${preface}${this.activity.content}</div>
       </div>
     `;
   }
 
-  render() {
-    return html`
-        <div class="comment_section">
-          ${this.comments.map(this.renderComment.bind(this))}
-        </div>
-    `;
-  }
-
   // Handle deleting or undeleting a comment.
-  async handleDeleteToggle(comment, isUndelete) {
+  async handleDeleteToggle(isUndelete) {
     let resp;
     if (isUndelete) {
       resp = await window.csClient.undeleteComment(
-        this.feature.id, comment.comment_id);
+        this.feature.id, this.activity.comment_id);
     } else {
       resp = await window.csClient.deleteComment(
-        this.feature.id, comment.comment_id);
+        this.feature.id, this.activity.comment_id);
     }
     if (resp && resp.message === 'Done') {
-      comment.deleted_by = (isUndelete) ? null : this.user.email;
-      this.toggleCommentMenu(comment.comment_id);
+      this.activity.deleted_by = (isUndelete) ? null : this.user.email;
+      this.toggleMenu();
       this.requestUpdate();
     }
+  }
+};
+customElements.define('chromedash-activity', ChromedashActivity);
+
+
+export class ChromedashActivityLog extends LitElement {
+  static get properties() {
+    return {
+      user: {type: Object},
+      feature: {type: Object},
+      comments: {type: Array},
+    };
+  }
+
+  constructor() {
+    super();
+    this.user = null;
+    this.feature = {};
+    this.comments = [];
+  }
+
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      css`
+        .comment_section {
+          max-height: 250px;
+          overflow-y: scroll;
+        }
+      `];
+  }
+
+
+  render() {
+    return html`
+        <div class="comment_section">
+          ${this.comments.map((activity) => html`
+        <chromedash-activity
+        .user=${this.user}
+        .feature=${this.feature}
+        .activity=${activity}>
+        </chromedash-activity>
+          `)}
+        </div>
+    `;
   }
 }
 

--- a/static/elements/chromedash-activity-log_test.js
+++ b/static/elements/chromedash-activity-log_test.js
@@ -1,81 +1,80 @@
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
-import {ChromedashActivityLog} from './chromedash-activity-log';
+import {ChromedashActivity, ChromedashActivityLog} from './chromedash-activity-log';
 import '../js-src/cs-client';
 import sinon from 'sinon';
 
-describe('chromedash-activity-log', () => {
-  const nonAdminUser = {
-    can_approve: false,
-    can_create_feature: true,
-    can_edit_all: true,
-    is_admin: false,
-    email: 'non-admin@google.com',
-  };
-  const featureOne = {
-    id: 123456,
-  };
-  const commentOne = {
-    comment_id: 1,
-    author: 'non-admin@google.com',
-    created: '2022-08-30 12:34:45.567',
-    content: 'hey, nice feature',
-  };
-  const commentTwo = {
-    comment_id: 2,
-    author: 'troll@example.com',
-    created: '2022-08-30 12:34:45.567',
-    content: 'mean stuff',
-  };
+const nonAdminUser = {
+  can_approve: false,
+  can_create_feature: true,
+  can_edit_all: true,
+  is_admin: false,
+  email: 'non-admin@google.com',
+};
 
+const featureOne = {
+  id: 123456,
+};
+
+const actOne = {
+  comment_id: 1,
+  author: 'non-admin@google.com',
+  created: '2022-08-30 12:34:45.567',
+  content: 'hey, nice feature',
+};
+
+const actTwo = {
+  comment_id: 2,
+  author: 'troll@example.com',
+  created: '2022-08-30 12:34:45.567',
+  content: 'mean stuff',
+};
+
+
+describe('chromedash-activity', () => {
   it('renders with no data', async () => {
     const component = await fixture(
-      html`<chromedash-activity-log></chromedash-activity-log>`);
+      html`<chromedash-activity></chromedash-activity>`);
     assert.exists(component);
-    assert.instanceOf(component, ChromedashActivityLog);
+    assert.instanceOf(component, ChromedashActivity);
     assert.notExists(component.shadowRoot.querySelector('sl-relative-time'));
     assert.notExists(component.shadowRoot.querySelector('sl-menu'));
   });
 
-  it('renders a list of comments when signed out', async () => {
+  it('renders an activity when signed out', async () => {
     const anonUser = null;
     const component = await fixture(
-      html`<chromedash-activity-log
+      html`<chromedash-activity
               .user=${anonUser}
               .feature=${featureOne}
-              .comments=${[commentOne, commentTwo]}>
-             </chromedash-activity-log>`);
-    const commentSection = component.shadowRoot.querySelector('.comment_section');
-    assert.include(commentSection.innerHTML, commentOne.author);
-    assert.include(commentSection.innerHTML, '2022-08-30 12:34:45');
-    assert.include(commentSection.innerHTML, 'hey, nice feature');
-    assert.include(commentSection.innerHTML, commentTwo.author);
-    assert.include(commentSection.innerHTML, '2022-08-30 12:34:45');
-    assert.include(commentSection.innerHTML, 'mean stuff');
+              .activity=${actOne}>
+             </chromedash-activity>`);
+    const commentDiv = component.shadowRoot.querySelector('.comment');
+    assert.include(commentDiv.innerHTML, actOne.author);
+    assert.include(commentDiv.innerHTML, '2022-08-30 12:34:45');
+    assert.include(commentDiv.innerHTML, 'hey, nice feature');
     // TODO: Fails on firefox.  See issue #2186.
     // assert.exists(component.shadowRoot.querySelector('sl-relative-time'));
     assert.notExists(component.shadowRoot.querySelector('.edit-menu'));
     assert.notExists(component.shadowRoot.querySelector('sl-menu'));
   });
 
-  it('renders a list of comments when signed in', async () => {
+  it('renders an activity when signed in', async () => {
     const component = await fixture(
-      html`<chromedash-activity-log
+      html`<chromedash-activity
               .user=${nonAdminUser}
               .feature=${featureOne}
-              .comments=${[commentOne, commentTwo]}>
-             </chromedash-activity-log>`);
-    const commentSection = component.shadowRoot.querySelector('.comment_section');
-    assert.include(commentSection.innerHTML, 'hey, nice feature');
-    assert.exists(component.shadowRoot.querySelector('#comment-menu-1'));
-    assert.include(commentSection.innerHTML, 'mean stuff');
-    assert.notExists(component.shadowRoot.querySelector('#comment-menu-2'));
+              .activity=${actOne}>
+             </chromedash-activity>`);
+    const commentDiv = component.shadowRoot.querySelector('.comment');
+    assert.include(commentDiv.innerHTML, 'hey, nice feature');
+    assert.exists(component.shadowRoot.querySelector('#comment-menu'));
   });
 
   // Note: It does not hide or prefix a deleted comment for users who don't
   // have permission to view that comment because that is done by the API.
 
-  it('prefixes a undeleteable comment', async () => {
+  it('prefixes a undeleteable activity', async () => {
     const deletedComment = {
       comment_id: 3,
       author: 'non-admin@google.com',
@@ -84,19 +83,19 @@ describe('chromedash-activity-log', () => {
       deleted_by: 'non-admin@google.com',
     };
     const component = await fixture(
-      html`<chromedash-activity-log
+      html`<chromedash-activity
               .user=${nonAdminUser}
               .feature=${featureOne}
-              .comments=${[deletedComment]}>
-             </chromedash-activity-log>`);
-    const commentSection = component.shadowRoot.querySelector('.comment_section');
-    assert.include(commentSection.innerHTML, '[Deleted]');
-    assert.include(commentSection.innerHTML, 'better left unsaid');
-    assert.exists(component.shadowRoot.querySelector('#comment-menu-3'));
+              .activity=${deletedComment}>
+             </chromedash-activity>`);
+    const commentDiv = component.shadowRoot.querySelector('.comment');
+    assert.include(commentDiv.innerHTML, '[Deleted]');
+    assert.include(commentDiv.innerHTML, 'better left unsaid');
+    assert.exists(component.shadowRoot.querySelector('#comment-menu'));
     assert.exists(component.shadowRoot.querySelector('sl-menu'));
   });
 
-  it('can delete a comment', async () => {
+  it('can delete an activity', async () => {
     window.csClient = new ChromeStatusClient('fake_token', 1);
     sinon.stub(window.csClient, 'deleteComment');
     window.csClient.deleteComment.returns(Promise.resolve({message: 'Done'}));
@@ -108,23 +107,23 @@ describe('chromedash-activity-log', () => {
       content: 'something off the cuff',
     };
     const component = await fixture(
-      html`<chromedash-activity-log
+      html`<chromedash-activity
               .user=${nonAdminUser}
               .feature=${featureOne}
-              .comments=${[doomedComment]}>
-             </chromedash-activity-log>`);
-    const before = component.shadowRoot.querySelector('.comment_section');
+              .activity=${doomedComment}>
+             </chromedash-activity>`);
+    const before = component.shadowRoot.querySelector('.comment');
     assert.notInclude(before.innerHTML, '[Deleted]');
     assert.include(before.innerHTML, 'something off the cuff');
 
-    await component.handleDeleteToggle(doomedComment, false);
+    await component.handleDeleteToggle(false);
     assert.equal(doomedComment.deleted_by, nonAdminUser.email);
-    const after = component.shadowRoot.querySelector('.comment_section');
+    const after = component.shadowRoot.querySelector('.comment');
     assert.include(after.innerHTML, '[Deleted]');
     assert.include(after.innerHTML, 'something off the cuff');
   });
 
-  it('can undelete a comment', async () => {
+  it('can undelete an activity', async () => {
     window.csClient = new ChromeStatusClient('fake_token', 1);
     sinon.stub(window.csClient, 'undeleteComment');
     window.csClient.undeleteComment.returns(Promise.resolve({message: 'Done'}));
@@ -137,19 +136,45 @@ describe('chromedash-activity-log', () => {
       deleted_by: 'non-admin@google.com',
     };
     const component = await fixture(
-      html`<chromedash-activity-log
+      html`<chromedash-activity
               .user=${nonAdminUser}
               .feature=${featureOne}
-              .comments=${[blessedComment]}>
-             </chromedash-activity-log>`);
-    const before = component.shadowRoot.querySelector('.comment_section');
+              .activity=${blessedComment}>
+             </chromedash-activity>`);
+    const before = component.shadowRoot.querySelector('.comment');
     assert.include(before.innerHTML, '[Deleted]');
     assert.include(before.innerHTML, 'lucky guess');
 
-    await component.handleDeleteToggle(blessedComment, true);
+    await component.handleDeleteToggle(true);
     assert.equal(blessedComment.deleted_by, null);
-    const after = component.shadowRoot.querySelector('.comment_section');
+    const after = component.shadowRoot.querySelector('.comment');
     assert.notInclude(after.innerHTML, '[Deleted]');
     assert.include(after.innerHTML, 'lucky guess');
   });
+});
+
+
+describe('chromedash-activity-log', () => {
+  it('renders with no data', async () => {
+    const component = await fixture(
+      html`<chromedash-activity-log></chromedash-activity-log>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashActivityLog);
+    assert.notExists(component.shadowRoot.querySelector('chromedash-activity'));
+  });
+
+  it('renders with some data', async () => {
+    const component = await fixture(
+        html`<chromedash-activity-log
+            .user=${nonAdminUser}
+            .feature=${featureOne}
+            .comments=${[actOne, actTwo]}>
+            </chromedash-activity-log>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashActivityLog);
+    assert.lengthOf(
+        component.shadowRoot.querySelectorAll('chromedash-activity'),
+        2);
+  });
+
 });

--- a/static/elements/chromedash-activity-log_test.js
+++ b/static/elements/chromedash-activity-log_test.js
@@ -165,7 +165,7 @@ describe('chromedash-activity-log', () => {
 
   it('renders with some data', async () => {
     const component = await fixture(
-        html`<chromedash-activity-log
+      html`<chromedash-activity-log
             .user=${nonAdminUser}
             .feature=${featureOne}
             .comments=${[actOne, actTwo]}>
@@ -173,8 +173,7 @@ describe('chromedash-activity-log', () => {
     assert.exists(component);
     assert.instanceOf(component, ChromedashActivityLog);
     assert.lengthOf(
-        component.shadowRoot.querySelectorAll('chromedash-activity'),
-        2);
+      component.shadowRoot.querySelectorAll('chromedash-activity'),
+      2);
   });
-
 });

--- a/static/elements/chromedash-roadmap-milestone-card.js
+++ b/static/elements/chromedash-roadmap-milestone-card.js
@@ -1,6 +1,6 @@
 import {LitElement, html, nothing} from 'lit';
 import {ROADMAP_MILESTONE_CARD_CSS} from
-  '../sass/elements/chromedash-roadmap-milestone-card-css.js';
+'../sass/elements/chromedash-roadmap-milestone-card-css.js';
 
 const REMOVED_STATUS = ['Removed'];
 const DEPRECATED_STATUS = ['Deprecated', 'No longer pursuing'];


### PR DESCRIPTION
We'll be doing more with the display of activities, so I simplified our current code a bit.  Instead of a single element for the entire activity log, there are now separate elements for each activity.  This modularizes the code a bit, and it also avoids the need to have ID numbers in the element ID names, and reduces a bunch of method names and arguments.