### PR TITLE
Remove field and error unsafeHTMLs and add radios field type in `<chromedash-form-field>`

### DIFF
--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -117,12 +117,13 @@ export class ChromedashFormField extends LitElement {
         </chromedash-textarea>
       `;
     } else if (type === 'radios') {
+      const fieldName = this.fieldProps.name || this.name;
       fieldHTML = html`
         ${Object.values(choices).map(
           ([value, label, description]) => html`
-            <input id="id_feature_type_${value}" name="feature_type"
+            <input id="id_${fieldName}_${value}" name="${fieldName}"
               value="${value}" type="radio" required>
-            <label for="id_feature_type_${value}">${label}</label>
+            <label for="id_${fieldName}_${value}">${label}</label>
             <p>${description}</p>
           `)}
       `;

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -62,7 +62,7 @@ export class ChromedashFormField extends LitElement {
     return this;
   }
 
-  renderField() {
+  renderWidgets() {
     const type = this.fieldProps.type;
     const choices = this.fieldProps.choices || this.componentChoices;
 
@@ -146,7 +146,7 @@ export class ChromedashFormField extends LitElement {
         </tr>
       `:nothing}
       <tr>
-        <td>${this.renderField()}</td>
+        <td>${this.renderWidgets()}</td>
         <td>
           ${helpText ? html`<span class="helptext"> ${helpText} </span>`: nothing}
           ${extraHelpText ? html`

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -1,6 +1,5 @@
-import {LitElement, html} from 'lit';
+import {LitElement, html, nothing} from 'lit';
 import {ALL_FIELDS} from './form-field-specs';
-import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import {ref} from 'lit/directives/ref.js';
 
 
@@ -68,14 +67,10 @@ export class ChromedashFormField extends LitElement {
     return this;
   }
 
-  render() {
-    const label = this.fieldProps.label;
-    const helpText = this.fieldProps.help_text || '';
-    const extraHelpText = this.fieldProps.extra_help || '';
+  renderField() {
     const type = this.fieldProps.type;
     const choices = this.fieldProps.choices || this.componentChoices;
 
-    // If type is checkbox, select, or input, then generate locally.
     let fieldHTML = '';
     if (type === 'checkbox') {
       // value can be a js or python boolean value converted to a string
@@ -85,12 +80,10 @@ export class ChromedashFormField extends LitElement {
           id="id_${this.name}"
           size="small"
           ?checked=${this.value === 'true' || this.value === 'True'}
-          ?disabled=${this.disabled}
-        >
-          ${label}
+          ?disabled=${this.disabled}>
+          ${this.fieldProps.label}
         </sl-checkbox>
       `;
-      this.generateFieldLocally = true;
     } else if (type === 'select') {
       fieldHTML = html`
         <sl-select
@@ -98,8 +91,7 @@ export class ChromedashFormField extends LitElement {
           id="id_${this.name}"
           value="${this.value}"
           size="small"
-          ?disabled=${this.disabled || this.loading}
-        >
+          ?disabled=${this.disabled || this.loading}>
           ${Object.values(choices).map(
             ([value, label]) => html`
               <sl-menu-item value="${value}"> ${label} </sl-menu-item>
@@ -129,54 +121,61 @@ export class ChromedashFormField extends LitElement {
           ?required=${this.fieldProps.required}>
         </chromedash-textarea>
       `;
+    } else if (type === 'radios') {
+      fieldHTML = html`
+        ${Object.values(choices).map(
+          ([value, label, description]) => html`
+            <input id="id_feature_type_${value}" name="feature_type"
+              value="${value}" type="radio" required>
+            <label for="id_feature_type_${value}">${label}</label>
+            <p>${description}</p>
+          `)}
+      `;
     } else {
-      // Temporary workaround until we migrate the generation of
-      // all the form fields to be done here.
-      // We pass the escaped html for the low-level form field
-      // through the field attribute, so it must be unescaped,
-      // and then we use unsafeHTML so it isn't re-escaped.
-      fieldHTML = unsafeHTML(unescape(this.field || ''));
+      console.error(`unknown form field type: ${type}`);
     }
+    return fieldHTML;
+  }
 
-    // Similar to above, but maybe we can guarantee that the errors
-    // will never contain HTML.
-    const errorsHTML = unsafeHTML(unescape(this.errors || ''));
+  render() {
+    const helpText = this.fieldProps.help_text;
+    const extraHelpText = this.fieldProps.extra_help;
 
     return html`
+      ${this.fieldProps.label ? html`
+        <tr>
+          <th colspan="2">
+            <b>${this.fieldProps.label}:</b>
+          </th>
+        </tr>
+      `:nothing}
       <tr>
-        <th colspan="2">
-          <b> ${label ? label + ':' : ''} </b>
-        </th>
-      </tr>
-      <tr>
-        <td>${fieldHTML} ${errorsHTML}</td>
+        <td>${this.renderField()}</td>
         <td>
-          <span class="helptext"> ${helpText} </span>
-          ${extraHelpText ?
-            html`
-                <sl-icon-button
-                  name="plus-square"
-                  label="Toggle extra help"
-                  style="position:absolute"
-                  @click="${this.toggleExtraHelp}"
-                  >+</sl-icon-button
-                >
-              ` :
-            ''}
+          ${helpText ? html`<span class="helptext"> ${helpText} </span>`: nothing}
+          ${extraHelpText ? html`
+            <sl-icon-button
+              name="plus-square"
+              label="Toggle extra help"
+              style="position:absolute"
+              @click="${this.toggleExtraHelp}">
+              +
+            </sl-icon-button>
+          `: nothing}
         </td>
       </tr>
 
-      ${extraHelpText ?
-        html` <tr>
-            <td colspan="2" class="extrahelp">
-              <sl-details summary="">
-                <span class="helptext">
-                  ${extraHelpText}
-                </span>
-              </sl-details>
-            </td>
-          </tr>` :
-        ''}
+      ${extraHelpText ? html`
+        <tr>
+          <td colspan="2" class="extrahelp">
+            <sl-details summary="">
+              <span class="helptext">
+                ${extraHelpText}
+              </span>
+            </sl-details>
+          </td>
+        </tr>`:
+      nothing}
     `;
   }
 }

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -1,6 +1,7 @@
 import {LitElement, html, nothing} from 'lit';
 import {ALL_FIELDS} from './form-field-specs';
 import {ref} from 'lit/directives/ref.js';
+import './chromedash-textarea';
 
 
 export class ChromedashFormField extends LitElement {
@@ -8,9 +9,6 @@ export class ChromedashFormField extends LitElement {
     return {
       name: {type: String},
       value: {type: String},
-      field: {type: String},
-      errors: {type: String},
-      stage: {type: String},
       disabled: {type: Boolean},
       loading: {type: Boolean},
       fieldProps: {type: Object},
@@ -22,9 +20,6 @@ export class ChromedashFormField extends LitElement {
     super();
     this.name = '';
     this.value = '';
-    this.field = '';
-    this.errors = '';
-    this.stage = '';
     this.disabled = false;
     this.loading = false;
     this.componentChoices = {};

--- a/static/elements/chromedash-form-field_test.js
+++ b/static/elements/chromedash-form-field_test.js
@@ -3,39 +3,85 @@ import {assert, fixture} from '@open-wc/testing';
 import {ChromedashFormField} from './chromedash-form-field';
 
 describe('chromedash-form-field', () => {
-  it('renders with no data', async () => {
-    const component = await fixture(
-      html`<chromedash-form-field></chromedash-form-field>`);
-    assert.exists(component);
-    assert.instanceOf(component, ChromedashFormField);
-    const fieldRow = component.renderRoot.querySelector('tr');
-    assert.exists(fieldRow);
-  });
-
-  it('renders with attributes for field and error', async () => {
-    const component = await fixture(
-      html`
-      <chromedash-form-field field="Field" errors="Error">
-      </chromedash-form-field>`);
-    assert.exists(component);
-    await component.updateComplete;
-
-    const renderElement = component.renderRoot;
-
-    assert.include(renderElement.innerHTML, 'Field');
-    assert.include(renderElement.innerHTML, 'Error');
-  });
-
   it('renders a checkbox type of field', async () => {
     const component = await fixture(
       html`
       <chromedash-form-field name="unlisted" value="True" checked="True">
       </chromedash-form-field>`);
-    await component.updateComplete;
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashFormField);
+    const fieldRow = component.renderRoot.querySelector('tr');
+    assert.exists(fieldRow);
 
     const renderElement = component.renderRoot;
     assert.include(renderElement.innerHTML, 'Unlisted');
     assert.include(renderElement.innerHTML, 'sl-checkbox');
     assert.include(renderElement.innerHTML, 'checked');
+  });
+
+  it('renders a select type of field', async () => {
+    const component = await fixture(
+      html`
+      <chromedash-form-field name="feature_type" value="0">
+      </chromedash-form-field>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashFormField);
+    const fieldRow = component.renderRoot.querySelector('tr');
+    assert.exists(fieldRow);
+
+    const renderElement = component.renderRoot;
+    assert.include(renderElement.innerHTML, 'Feature type');
+    assert.include(renderElement.innerHTML, 'sl-select');
+    assert.include(renderElement.innerHTML, 'sl-menu-item');
+  });
+
+  it('renders a input type of field (with extraHelp)', async () => {
+    const component = await fixture(
+      html`
+      <chromedash-form-field name="name" value="">
+      </chromedash-form-field>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashFormField);
+    const fieldRow = component.renderRoot.querySelector('tr');
+    assert.exists(fieldRow);
+
+    const renderElement = component.renderRoot;
+    assert.include(renderElement.innerHTML, 'Feature name');
+    assert.include(renderElement.innerHTML, 'sl-input');
+    assert.include(renderElement.innerHTML, 'required');
+    assert.include(renderElement.innerHTML, 'sl-icon-button');
+    assert.include(renderElement.innerHTML, 'class="extrahelp"');
+  });
+
+  it('renders a textarea type of field', async () => {
+    const component = await fixture(
+      html`
+      <chromedash-form-field name="summary" value="">
+      </chromedash-form-field>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashFormField);
+    const fieldRow = component.renderRoot.querySelector('tr');
+    assert.exists(fieldRow);
+
+    const renderElement = component.renderRoot;
+    assert.include(renderElement.innerHTML, 'Summary');
+    assert.include(renderElement.innerHTML, 'chromedash-textarea');
+    assert.include(renderElement.innerHTML, 'required');
+  });
+
+  it('renders a radios type of field', async () => {
+    const component = await fixture(
+      html`
+      <chromedash-form-field name="feature_type_radio_group" value="0">
+      </chromedash-form-field>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashFormField);
+    const fieldRow = component.renderRoot.querySelector('tr');
+    assert.exists(fieldRow);
+
+    const renderElement = component.renderRoot;
+    assert.include(renderElement.innerHTML, 'Feature type');
+    assert.include(renderElement.innerHTML, 'type="radio"');
+    assert.include(renderElement.innerHTML, 'required');
   });
 });

--- a/static/elements/chromedash-guide-editall-page.js
+++ b/static/elements/chromedash-guide-editall-page.js
@@ -2,7 +2,6 @@ import {LitElement, css, html} from 'lit';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import {showToastMessage} from './utils.js';
 import './chromedash-form-table';
-import './chromedash-form-field';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 import {FORM_STYLES} from '../sass/forms-css.js';
 
@@ -142,15 +141,9 @@ export class ChromedashGuideEditallPage extends LitElement {
         `)}
 
         <section class="final_buttons">
-          <chromedash-form-table>
-            <chromedash-form-field>
-              <span slot="field">
-                <input class="button" type="submit" value="Submit">
-                <button id="cancel-button" type="reset"
-                  @click=${this.handleCancelClick}>Cancel</button>
-              </span>
-            </chromedash-form-field>
-          </chromedash-form-table>
+          <input class="button" type="submit" value="Submit">
+          <button id="cancel-button" type="reset"
+            @click=${this.handleCancelClick}>Cancel</button>
         </section>
       </form>
     `;

--- a/static/elements/chromedash-guide-metadata.js
+++ b/static/elements/chromedash-guide-metadata.js
@@ -2,7 +2,6 @@ import {LitElement, css, html, nothing} from 'lit';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import {autolink} from './utils.js';
 import './chromedash-form-table';
-import './chromedash-form-field';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 import {FORM_STYLES} from '../sass/forms-css.js';
 
@@ -209,14 +208,13 @@ export class ChromedashGuideMetadata extends LitElement {
 
           <chromedash-form-table>
             ${unsafeHTML(this.overviewForm)}
-
-            <chromedash-form-field>
-              <span slot="field">
-                <input class="button" type="submit" value="Submit">
-                <button id="close-metadata" @click=${() => this.editing = false} type="reset">Cancel</button>
-              </span>
-            </chromedash-form-field>
           </chromedash-form-table>
+
+          <section class="final_buttons">
+            <input class="button" type="submit" value="Submit">
+            <button id="close-metadata" type="reset"
+              @click=${() => this.editing = false}>Cancel</button>
+          </section>
         </form>
       </div>
     `;

--- a/static/elements/chromedash-guide-new-page.js
+++ b/static/elements/chromedash-guide-new-page.js
@@ -103,53 +103,10 @@ export class ChromedashGuideNewPage extends LitElement {
 
             <chromedash-form-field
               name="feature_type_radio_group"
-              class="choices"
-              field=${`
-                <label for="id_feature_type_0">
-                  <input id="id_feature_type_0" name="feature_type" type="radio"
-                        value="0" required>
-                  New feature incubation
-                </label>
-
-                <p>When building new features, we follow a
-                  process that emphasizes engagement with the WICG and other
-                  stakeholders early.</p>
-
-                <label for="id_feature_type_1">
-                  <input id="id_feature_type_1" name="feature_type" type="radio"
-                        value="1" required>
-                  Existing feature implementation
-                </label>
-
-                <p>If there is already an agreed specification, work may
-                  quickly start on implementation and origin trials.</p>
-
-                <label for="id_feature_type_2">
-                  <input id="id_feature_type_2" name="feature_type" type="radio"
-                        value="2" required>
-                  Web developer-facing change to existing code
-                </label>
-
-                <p>Sometimes a change to a shipped feature requires an additional
-                  feature entry.  This type of feature entry can be referenced
-                  from a PSA immediately.</p>
-
-                <label for="id_feature_type_3">
-                  <input id="id_feature_type_3" name="feature_type" type="radio"
-                        value="3" required>
-                  Feature deprecation
-                </label>
-
-                <p>Deprecate and remove an old feature.</p>`}>
+              class="choices">
             </chromedash-form-field>
-
-            <chromedash-form-field>
-              <span slot="field">
-                <input type="submit" class="primary" value="Submit">
-              </span>
-            </chromedash-form-field>
-
           </chromedash-form-table>
+          <input type="submit" class="primary" value="Submit">
         </form>
       </section>
     `;

--- a/static/elements/chromedash-guide-stage-page.js
+++ b/static/elements/chromedash-guide-stage-page.js
@@ -205,7 +205,6 @@ export class ChromedashGuideStagePage extends LitElement {
 
           <chromedash-form-field
             name="set_stage"
-            stage=${this.stageName}
             value=${alreadyOnThisStage}
             ?disabled=${alreadyOnThisStage}>
           </chromedash-form-field>

--- a/static/elements/chromedash-guide-verify-accuracy-page.js
+++ b/static/elements/chromedash-guide-verify-accuracy-page.js
@@ -2,7 +2,6 @@ import {LitElement, css, html} from 'lit';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import {showToastMessage} from './utils.js';
 import './chromedash-form-table';
-import './chromedash-form-field';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 import {FORM_STYLES} from '../sass/forms-css.js';
 
@@ -137,15 +136,9 @@ export class ChromedashGuideVerifyAccuracyPage extends LitElement {
         `)}
 
         <section class="final_buttons">
-          <chromedash-form-table>
-            <chromedash-form-field>
-              <span slot="field">
-                  <input class="button" type="submit" value="Submit">
-                  <button id="cancel-button" type="reset"
-                    @click=${this.handleCancelClick}>Cancel</button>
-              </span>
-            </chromedash-form-field>
-          </chromedash-form-table>
+          <input class="button" type="submit" value="Submit">
+          <button id="cancel-button" type="reset"
+            @click=${this.handleCancelClick}>Cancel</button>
         </section>
       </form>
     `;

--- a/static/elements/chromedash-textarea.js
+++ b/static/elements/chromedash-textarea.js
@@ -5,7 +5,6 @@ export class ChromedashTextarea extends SlTextarea {
   static get properties() {
     return {
       ...super.properties,
-      attrs: {type: Object},
       multiple: {type: Boolean},
       pattern: {type: String},
       chromedash_single_pattern: {type: String},
@@ -15,7 +14,6 @@ export class ChromedashTextarea extends SlTextarea {
 
   constructor() {
     super();
-    this.attrs = {};
     this.cols = 50;
     this.rows = 10;
 
@@ -23,15 +21,6 @@ export class ChromedashTextarea extends SlTextarea {
     // Fields that accept a URL list can be longer, provided that each individual
     // URL is no more than this length.
     this.maxlength = 1400;
-  }
-
-  connectedCallback() {
-    super.connectedCallback();
-
-    // Update attributes if provided
-    Object.keys(this.attrs).map((attr) => {
-      this.setAttribute(attr, this.attrs[attr]);
-    });
   }
 
   /**

--- a/static/elements/form-field-enums.js
+++ b/static/elements/form-field-enums.js
@@ -28,11 +28,20 @@ export const FEATURE_CATEGORIES = {
   CAPABILITIES: [21, 'Capabilities (Fugu)'],
 };
 
+// FEATURE_TYPES object is organized as [intValue, stringLabel, description],
+// the descriptions are used only for the descriptions of feature_type_radio_group
 export const FEATURE_TYPES = {
-  FEATURE_TYPE_INCUBATE_ID: [0, 'New feature incubation'],
-  FEATURE_TYPE_EXISTING_ID: [1, 'Existing feature implementation'],
-  FEATURE_TYPE_CODE_CHANGE_ID: [2, 'Web developer facing change to existing code'],
-  FEATURE_TYPE_DEPRECATION_ID: [3, 'Feature deprecation'],
+  FEATURE_TYPE_INCUBATE_ID: [0, 'New feature incubation',
+    'When building new features, we follow a process that emphasizes engagement ' +
+    'with the WICG and other stakeholders early.'],
+  FEATURE_TYPE_EXISTING_ID: [1, 'Existing feature implementation',
+    'If there is already an agreed specification, work may quickly start on ' +
+    'implementation and origin trials.'],
+  FEATURE_TYPE_CODE_CHANGE_ID: [2, 'Web developer-facing change to existing code',
+    'Sometimes a change to a shipped feature requires an additional feature entry. ' +
+    'This type of feature entry can be referenced from a PSA immediately.'],
+  FEATURE_TYPE_DEPRECATION_ID: [3, 'Feature deprecation',
+    'Deprecate and remove an old feature.'],
 };
 
 export const INTENT_STAGES = {

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -12,9 +12,45 @@ import {
 } from './form-field-enums';
 
 
+/* Patterns from https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s01.html
+ * Removing single quote ('), backtick (`), and pipe (|) since they are risky unless properly escaped everywhere.
+ * Also removing ! and % because they have special meaning for some older email routing systems. */
+const USER_REGEX = '[A-Za-z0-9_#$&*+/=?{}~^.-]+';
 const DOMAIN_REGEX = String.raw`(([A-Za-z0-9-]+\.)+[A-Za-z]{2,6})`;
+
+const EMAIL_ADDRESS_REGEX = USER_REGEX + '@' + DOMAIN_REGEX;
+const EMAIL_ADDRESSES_REGEX = EMAIL_ADDRESS_REGEX + '([ ]*,[ ]*' + EMAIL_ADDRESS_REGEX + ')*';
+
+// Simple http URLs
 const PORTNUM_REGEX = '(:[0-9]+)?';
 const URL_REGEX = '(https?)://' + DOMAIN_REGEX + PORTNUM_REGEX + String.raw`(/[^\s]*)?`;
+const URL_PADDED_REGEX = String.raw`\s*` + URL_REGEX + String.raw`\s*`;
+
+const URL_FIELD_ATTRS = {
+  title: 'Enter a full URL https://...',
+  type: 'url',
+  placeholder: 'https://...',
+  pattern: URL_PADDED_REGEX,
+};
+
+const MULTI_EMAIL_FIELD_ATTRS = {
+  title: 'Enter one or more comma-separated complete email addresses.',
+  // Don't specify type="email" because browsers consider multiple emails
+  // invalid, regardles of the multiple attribute.
+  type: 'text',
+  multiple: true,
+  placeholder: 'user1@domain.com, user2@chromium.org',
+  pattern: EMAIL_ADDRESSES_REGEX,
+};
+
+const TEXT_FIELD_ATTRS = {
+  type: 'text',
+};
+
+const MILESTONE_NUMBER_FILED_ATTRS = {
+  type: 'number',
+  placeholder: 'Milestone number',
+};
 
 const MULTI_URL_FIELD_ATTRS = {
   title: 'Enter one or more full URLs, one per line:\nhttps://...\nhttps://...',
@@ -41,7 +77,7 @@ export const ALL_FIELDS = {
 
   'name': {
     type: 'input',
-    input_type: 'text',
+    attrs: TEXT_FIELD_ATTRS,
     required: true,
     label: 'Feature name',
     help_text: html`
@@ -108,7 +144,7 @@ export const ALL_FIELDS = {
 
   'owner': {
     type: 'input',
-    input_type: 'multi-email',
+    attrs: MULTI_EMAIL_FIELD_ATTRS,
     required: true,
     label: 'Feature owners',
     help_text: html`
@@ -118,7 +154,7 @@ export const ALL_FIELDS = {
 
   'editors': {
     type: 'input',
-    input_type: 'multi-email',
+    attrs: MULTI_EMAIL_FIELD_ATTRS,
     required: false,
     label: 'Feature editors',
     help_text: html`
@@ -195,7 +231,7 @@ export const ALL_FIELDS = {
 
   'search_tags': {
     type: 'input',
-    input_type: 'text',
+    attrs: TEXT_FIELD_ATTRS,
     required: false,
     label: 'Search tags',
     help_text: html`
@@ -214,7 +250,7 @@ export const ALL_FIELDS = {
 
   'bug_url': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: 'Tracking bug URL',
     help_text: html`
@@ -230,7 +266,7 @@ export const ALL_FIELDS = {
 
   'launch_bug_url': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: 'Launch bug URL',
     help_text: html`
@@ -283,7 +319,7 @@ export const ALL_FIELDS = {
 
   'initial_public_proposal_url': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: 'Initial public proposal URL',
     help_text: html`
@@ -306,7 +342,7 @@ export const ALL_FIELDS = {
 
   'spec_link': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: 'Spec link',
     help_text: html`
@@ -342,7 +378,7 @@ export const ALL_FIELDS = {
 
   'spec_mentors': {
     type: 'input',
-    input_type: 'multi-email',
+    attrs: MULTI_EMAIL_FIELD_ATTRS,
     required: false,
     label: 'Spec mentor',
     help_text: html`
@@ -355,7 +391,7 @@ export const ALL_FIELDS = {
 
   'intent_to_implement_url': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: 'Intent to Prototype link',
     help_text: html`
@@ -422,7 +458,7 @@ export const ALL_FIELDS = {
 
   'intent_to_ship_url': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: 'Intent to Ship link',
     help_text: html`After you have started the "Intent to Ship" discussion
@@ -431,7 +467,7 @@ export const ALL_FIELDS = {
 
   'ready_for_trial_url': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: 'Ready for Trial link',
     help_text: html`After you have started the "Ready for Trial" discussion
@@ -440,7 +476,7 @@ export const ALL_FIELDS = {
 
   'intent_to_experiment_url': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: 'Intent to Experiment link',
     help_text: html`After you have started the "Intent to Experiment"
@@ -449,7 +485,7 @@ export const ALL_FIELDS = {
 
   'intent_to_extend_experiment_url': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: 'Intent to Extend Experiment link',
     help_text: html`If this feature has an "Intent to Extend Experiment"
@@ -459,7 +495,7 @@ export const ALL_FIELDS = {
   'r4dt_url': {
     // Sets intent_to_experiment_url in DB
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: 'Request for Deprecation Trial link',
     help_text: html`After you have started the "Request for Deprecation Trial"
@@ -501,7 +537,7 @@ export const ALL_FIELDS = {
 
   'safari_views_link': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: '',
     help_text: html`Citation link.`,
@@ -526,7 +562,7 @@ export const ALL_FIELDS = {
 
   'ff_views_link': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: '',
     help_text: html`
@@ -553,7 +589,7 @@ export const ALL_FIELDS = {
 
   'web_dev_views_link': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: '',
     help_text: html`
@@ -667,7 +703,7 @@ export const ALL_FIELDS = {
 
   'ot_milestone_desktop_start': {
     type: 'input',
-    input_type: 'milestone-number',
+    attrs: MILESTONE_NUMBER_FILED_ATTRS,
     required: false,
     label: 'OT desktop start',
     help_text: html`
@@ -677,7 +713,7 @@ export const ALL_FIELDS = {
 
   'ot_milestone_desktop_end': {
     type: 'input',
-    input_type: 'milestone-number',
+    attrs: MILESTONE_NUMBER_FILED_ATTRS,
     required: false,
     label: 'OT desktop end',
     help_text: html`
@@ -687,7 +723,7 @@ export const ALL_FIELDS = {
 
   'ot_milestone_android_start': {
     type: 'input',
-    input_type: 'milestone-number',
+    attrs: MILESTONE_NUMBER_FILED_ATTRS,
     required: false,
     label: 'OT Android start',
     help_text: html`
@@ -697,7 +733,7 @@ export const ALL_FIELDS = {
 
   'ot_milestone_android_end': {
     type: 'input',
-    input_type: 'milestone-number',
+    attrs: MILESTONE_NUMBER_FILED_ATTRS,
     required: false,
     label: 'OT Android end',
     help_text: html`
@@ -707,7 +743,7 @@ export const ALL_FIELDS = {
 
   'ot_milestone_webview_start': {
     type: 'input',
-    input_type: 'milestone-number',
+    attrs: MILESTONE_NUMBER_FILED_ATTRS,
     required: false,
     label: 'OT WebView start',
     help_text: html`
@@ -717,7 +753,7 @@ export const ALL_FIELDS = {
 
   'ot_milestone_webview_end': {
     type: 'input',
-    input_type: 'milestone-number',
+    attrs: MILESTONE_NUMBER_FILED_ATTRS,
     required: false,
     label: 'OT WebView end',
     help_text: html`
@@ -757,7 +793,7 @@ export const ALL_FIELDS = {
 
   'origin_trial_feedback_url': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: 'Origin trial feedback summary',
     help_text: html`
@@ -781,7 +817,7 @@ export const ALL_FIELDS = {
 
   'finch_url': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: 'Finch experiment',
     help_text: html`
@@ -792,7 +828,7 @@ export const ALL_FIELDS = {
 
   'i2e_lgtms': {
     type: 'input',
-    input_type: 'multi-email',
+    attrs: MULTI_EMAIL_FIELD_ATTRS,
     required: false,
     label: 'Intent to Experiment LGTM by',
     help_text: html`
@@ -802,7 +838,7 @@ export const ALL_FIELDS = {
 
   'i2s_lgtms': {
     type: 'input',
-    input_type: 'multi-email',
+    attrs: MULTI_EMAIL_FIELD_ATTRS,
     required: false,
     label: 'Intent to Ship LGTMs by',
     help_text: html`
@@ -814,7 +850,7 @@ export const ALL_FIELDS = {
   'r4dt_lgtms': {
     // Sets i2e_lgtms field.
     type: 'input',
-    input_type: 'multi-email',
+    attrs: MULTI_EMAIL_FIELD_ATTRS,
     required: false,
     label: 'Request for Deprecation Trial LGTM by',
     help_text: html`
@@ -899,7 +935,7 @@ export const ALL_FIELDS = {
 
   'devrel': {
     type: 'input',
-    input_type: 'multi-email',
+    attrs: MULTI_EMAIL_FIELD_ATTRS,
     required: false,
     label: 'Developer relations emails',
     help_text: html`
@@ -908,7 +944,7 @@ export const ALL_FIELDS = {
 
   'shipped_milestone': {
     type: 'input',
-    input_type: 'milestone-number',
+    attrs: MILESTONE_NUMBER_FILED_ATTRS,
     required: false,
     label: 'Chrome for desktop',
     help_text: SHIPPED_HELP_TXT,
@@ -916,7 +952,7 @@ export const ALL_FIELDS = {
 
   'shipped_android_milestone': {
     type: 'input',
-    input_type: 'milestone-number',
+    attrs: MILESTONE_NUMBER_FILED_ATTRS,
     required: false,
     label: 'Chrome for Android',
     help_text: SHIPPED_HELP_TXT,
@@ -924,7 +960,7 @@ export const ALL_FIELDS = {
 
   'shipped_ios_milestone': {
     type: 'input',
-    input_type: 'milestone-number',
+    attrs: MILESTONE_NUMBER_FILED_ATTRS,
     required: false,
     label: 'Chrome for iOS (RARE)',
     help_text: SHIPPED_HELP_TXT,
@@ -932,7 +968,7 @@ export const ALL_FIELDS = {
 
   'shipped_webview_milestone': {
     type: 'input',
-    input_type: 'milestone-number',
+    attrs: MILESTONE_NUMBER_FILED_ATTRS,
     required: false,
     label: 'Android Webview',
     help_text: SHIPPED_WEBVIEW_HELP_TXT,
@@ -954,7 +990,7 @@ export const ALL_FIELDS = {
 
   'devtrial_instructions': {
     type: 'input',
-    input_type: 'url',
+    attrs: URL_FIELD_ATTRS,
     required: false,
     label: 'DevTrial instructions',
     help_text: html`
@@ -971,7 +1007,7 @@ export const ALL_FIELDS = {
 
   'dt_milestone_desktop_start': {
     type: 'input',
-    input_type: 'milestone-number',
+    attrs: MILESTONE_NUMBER_FILED_ATTRS,
     required: false,
     label: 'DevTrial on desktop',
     help_text: html`
@@ -983,7 +1019,7 @@ export const ALL_FIELDS = {
 
   'dt_milestone_android_start': {
     type: 'input',
-    input_type: 'milestone-number',
+    attrs: MILESTONE_NUMBER_FILED_ATTRS,
     required: false,
     label: 'DevTrial on Android',
     help_text: html`
@@ -995,7 +1031,7 @@ export const ALL_FIELDS = {
 
   'dt_milestone_ios_start': {
     type: 'input',
-    input_type: 'milestone-number',
+    attrs: MILESTONE_NUMBER_FILED_ATTRS,
     required: false,
     label: 'DevTrial on iOS (RARE)',
     help_text: html`
@@ -1007,7 +1043,7 @@ export const ALL_FIELDS = {
 
   'flag_name': {
     type: 'input',
-    input_type: 'text',
+    attrs: TEXT_FIELD_ATTRS,
     required: false,
     label: 'Flag name',
     help_text: html`

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -203,6 +203,7 @@ export const ALL_FIELDS = {
   },
 
   'feature_type_radio_group': {
+    name: 'feature_type', // actual field name
     type: 'radios',
     choices: FEATURE_TYPES,
     label: 'Feature type',


### PR DESCRIPTION
This PR finishes form field migration to the frontend and refines `<chromedash-form-field>`.  The changes include:
1. Added a `radios` field type and removed the hard coded fieldHTML for feature type radio group in chromedash-guide-new-page. Feature type descriptions are added to the form-field-enums.js.
2. Removed all the unsafeHTMLs in chromedash-form-field as we have migrated all fields to JS and no longer need Django-created htmls. This also includes removing the error messages (see the before and after snapshots below).
3. Not render `<tr>` for empty field labels. This makes the margin smaller for fields with no label (see the before and after snapshots below).
4. Moved all the submit buttons out of the slots of chromedash-form-table.
5. Removed unused properties (field, error, stage) in chromedash-form-field.
6. Updated the chromedash-form-field unit tests to practice html generation of all 5 field types.


Before | After
--- | --- 
<img src="https://user-images.githubusercontent.com/11501902/188000899-849cb197-17bd-4d50-a0ff-c33b4c9de0f4.png"/> | <img src="https://user-images.githubusercontent.com/11501902/188000912-787335b6-48ac-42e0-b52f-90f5461a7c12.png"/>


Before | After
--- | --- 
<img src="https://user-images.githubusercontent.com/11501902/188001016-c9bf55ed-caaa-4a9d-aff7-489a36235745.png"/> | <img src="https://user-images.githubusercontent.com/11501902/188001015-e77e916c-fb79-474c-a632-9b885da20749.png"/>
