### PR TITLE
Create Redis staging setup

### DIFF
--- a/api/accounts_api.py
+++ b/api/accounts_api.py
@@ -19,7 +19,6 @@ from google.cloud import ndb
 
 from framework import basehandlers
 from framework import permissions
-from framework import ramcache
 from internals import user_models
 
 
@@ -77,7 +76,6 @@ class AccountsAPI(basehandlers.APIHandler):
     if account_id:
       found_user = user_models.AppUser.get_by_id(int(account_id))
       if found_user:
-        found_user.key.delete()
-        ramcache.flush_all()
+        found_user.delete()
       else:
         self.abort(404, msg='Specified account ID not found')

--- a/api/channels_api.py
+++ b/api/channels_api.py
@@ -18,7 +18,7 @@ import json
 import requests
 
 from framework import basehandlers
-from framework import ramcache
+from framework import rediscache
 from internals import fetchchannels
 import settings
 
@@ -53,7 +53,7 @@ def construct_chrome_channels_details():
 def fetch_chrome_release_info(version):
   key = 'chromerelease|%s' % version
 
-  data = ramcache.get(key)
+  data = rediscache.get(key)
   if data is None:
     url = ('https://chromiumdash.appspot.com/fetch_milestone_schedule?'
            'mstone=%s' % version)
@@ -68,7 +68,7 @@ def fetch_chrome_release_info(version):
           del data['owners']
           del data['feature_freeze']
           del data['ldaps']
-          ramcache.set(key, data, time=SCHEDULE_CACHE_TIME)
+          rediscache.set(key, data, time=SCHEDULE_CACHE_TIME)
       except ValueError:
         pass  # Handled by next statement
 
@@ -80,7 +80,7 @@ def fetch_chrome_release_info(version):
           'mstone': version,
           'version': version,
       }
-      # Note: we don't put placeholder data into ramcache.
+      # Note: we don't put placeholder data into redis.
 
   return data
 

--- a/api/permissions_api_test.py
+++ b/api/permissions_api_test.py
@@ -18,7 +18,6 @@ import testing_config  # Must be imported before the module under test.
 import flask
 
 from api import permissions_api
-from framework import ramcache
 
 test_app = flask.Flask(__name__)
 
@@ -31,8 +30,6 @@ class PermissionsAPITest(testing_config.CustomTestCase):
 
   def tearDown(self):
     testing_config.sign_out()
-    ramcache.flush_all()
-    ramcache.check_for_distributed_invalidation()
 
   def test_get__anon(self):
     """Returns no user object if not signed in"""

--- a/api/processes_api_test.py
+++ b/api/processes_api_test.py
@@ -18,7 +18,6 @@ import testing_config  # Must be imported before the module under test.
 import flask
 
 from api import processes_api
-from framework import ramcache
 from internals import core_models
 from internals import processes
 from internals import core_enums
@@ -40,8 +39,6 @@ class ProcessesAPITest(testing_config.CustomTestCase):
 
   def tearDown(self):
     self.feature_1.key.delete()
-    ramcache.flush_all()
-    ramcache.check_for_distributed_invalidation()
 
   def test_get__default_feature_type(self):
     """We can get process for features with the default feature type (New feature incubation)."""
@@ -103,8 +100,6 @@ class ProgressAPITest(testing_config.CustomTestCase):
 
   def tearDown(self):
     self.feature_1.key.delete()
-    ramcache.flush_all()
-    ramcache.check_for_distributed_invalidation()
 
   def test_get___feature_progress(self):
     """We can get progress of a feature."""

--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -1,0 +1,52 @@
+# This GAE service contains most of the app, including all UI pages.
+
+runtime: python39
+service: default
+instance_class: F4_1G
+
+automatic_scaling:
+  min_idle_instances: 1
+  max_pending_latency: 0.2s
+
+# Use a long HTTP cache expiration time for css and JS, but also
+# include the GAE version number as a query string parameter so that on
+# each deployment, users get new static files to match the new app version.
+default_expiration: "10d"
+
+# Set up VPC Access Connector for Redis.
+vpc_access_connector:
+  name: projects/cr-status-staging/locations/us-central1/connectors/redis-connector
+
+handlers:
+# Static handlers ---------------------------------------------------------------
+- url: /favicon\.ico
+  static_files: static/img/chromium-128.png
+  upload: static/img/chromium-128\.png
+  secure: always
+
+- url: /robots\.txt
+  static_files: static/robots.txt
+  upload: static/robots\.txt
+  secure: always
+
+- url: /static
+  static_dir: static
+  secure: always
+
+- url: /.*
+  script: auto
+  secure: always
+
+app_engine_apis: true
+
+env_variables:
+  GAE_USE_SOCKETS_HTTPLIB : ''
+  DJANGO_SETTINGS_MODULE: 'settings'
+  DJANGO_SECRET: 'this-is-a-secret'
+  # Redis envs 
+  REDISHOST: '10.231.56.251'
+  REDISPORT: '6379'
+
+inbound_services:
+- mail
+- mail_bounce

--- a/framework/rediscache.py
+++ b/framework/rediscache.py
@@ -1,0 +1,133 @@
+
+
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pickle
+import logging
+import settings
+
+from google.cloud import ndb
+import redis
+import fakeredis
+
+redis_client = None
+
+if settings.UNIT_TEST_MODE:
+  redis_client = fakeredis.FakeStrictRedis()
+elif settings.STAGING or settings.PROD:
+  # Create a Redis client.
+  redis_host = os.environ.get('REDISHOST', 'localhost')
+  redis_port = int(os.environ.get('REDISPORT', 6379))
+  redis_client = redis.Redis(host=redis_host, port=redis_port)
+
+gae_version = None
+if settings.UNIT_TEST_MODE:
+  # gae_version prefix for testing.
+  gae_version = 'testing'
+elif settings.STAGING or settings.PROD:
+  gae_version = os.environ.get('GAE_VERSION', 'Undeployed')
+
+
+def set(key, value, time=86400):
+  """
+  Redis SET sets the str/binary key, value pair, https://redis.io/commands/set/; if
+  ``key`` already holds a value, it is overwritten.
+
+  ``time`` sets the expire time for this key, in seconds.
+  """
+  if redis_client is None:
+    return
+
+  cache_key = add_gae_prefix(key)
+  if time:
+    redis_client.set(cache_key, pickle.dumps(value), ex=time)
+  else:
+    redis_client.set(cache_key, pickle.dumps(value))
+
+
+def get(key):
+  """
+  Redis GET gets the value of key. Return None if ``key`` does not
+  exist; return an error if the value returned is not a str/binary.
+  """
+  if redis_client is None:
+    return None
+
+  cache_key = add_gae_prefix(key)
+  raw_value = redis_client.get(cache_key)
+  if raw_value is None:
+    return None
+  return pickle.loads(raw_value)
+
+
+def get_multi(keys):
+  """Return the values of all given keys."""
+  if redis_client is None:
+    return None
+
+  cache_keys = [add_gae_prefix(k) for k in keys]
+  raw_vals = redis_client.mget(cache_keys)
+  vals = [pickle.loads(v) if v is not None else None for v in raw_vals]
+  return dict(zip(keys, vals))
+
+
+def set_multi(entries, time=86400):
+  """
+  Set the given keys to their respective values.
+
+  ``time`` sets the expire time for this key, in seconds.
+  """
+  if redis_client is None:
+    return
+
+  if time:
+    for key in entries:
+      set(key, entries[key], time)
+    return
+
+  data_entries = {}
+  for key in entries:
+    # gae prefix is needed for mset.
+    cache_key = add_gae_prefix(key)
+    data_entries[cache_key] = pickle.dumps(entries[key])
+
+  # https://redis.io/commands/mset/.
+  redis_client.mset(data_entries)
+
+
+def delete(key):
+  """Redis DEL removes the value to the key, https://redis.io/commands/del/."""
+  if redis_client is None:
+    return
+
+  cache_key = add_gae_prefix(key)
+  redis_client.delete(cache_key)
+
+
+def flushall():
+  """Delete all the keys in Redis, https://redis.io/commands/flushall/."""
+  if redis_client is None:
+    return
+
+  redis_client.flushall()
+
+
+def add_gae_prefix(key):
+  if gae_version is None:
+    return key
+
+  return gae_version + '-' + key

--- a/framework/rediscache_test.py
+++ b/framework/rediscache_test.py
@@ -1,0 +1,69 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config  # Must be imported before the module under test.
+
+from framework import rediscache
+
+
+KEY_1 = 'cache_key|1'
+KEY_2 = 'cache_key|2'
+KEY_3 = 'cache_key|3'
+KEY_4 = 'cache_key|4'
+KEY_5 = 'cache_key|5'
+KEY_6 = 'cache_key|6'
+KEY_7 = 'cache_key|7'
+
+
+class RedisCacheFunctionTests(testing_config.CustomTestCase):
+
+  def testSetAndGet(self):
+    """We can cache a value and retrieve it from the cache."""
+    self.assertEqual(None, rediscache.get(KEY_1))
+
+    rediscache.set(KEY_1, '101')
+    self.assertEqual('101', rediscache.get(KEY_1))
+
+    rediscache.set(KEY_4, 123)
+    self.assertEqual(123, rediscache.get(KEY_4))
+
+    rediscache.set(KEY_4, '123', 3600)
+    self.assertEqual('123', rediscache.get(KEY_4))
+
+  def testSetAndGetMulti(self):
+    """We can cache values and retrieve them from the cache."""
+    self.assertEqual({}, rediscache.get_multi([]))
+
+    self.assertEqual({KEY_2: None, KEY_3: None},
+                     rediscache.get_multi([KEY_2, KEY_3]))
+
+    rediscache.set_multi({KEY_2: '202', KEY_3: '303'})
+    self.assertEqual(
+        {KEY_2: '202', KEY_3: '303'},
+        rediscache.get_multi([KEY_2, KEY_3]))
+
+    # Ignore non-str types.
+    rediscache.set_multi({KEY_2: '202', KEY_3: '303', KEY_5: 111})
+    self.assertEqual(
+        {KEY_2: '202', KEY_3: '303', KEY_5: 111},
+        rediscache.get_multi([KEY_2, KEY_3, KEY_5]))
+
+    rediscache.set_multi({KEY_5: '222'}, 3600)
+    self.assertEqual({KEY_5: '222'}, rediscache.get_multi([KEY_5]))
+
+  def testDelete(self):
+    rediscache.set(KEY_6, '606')
+    self.assertEqual('606', rediscache.get(KEY_6))
+    rediscache.delete(KEY_6)
+    self.assertEqual(None, rediscache.get(KEY_6))

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -19,7 +19,6 @@ import logging
 import requests
 
 from framework import permissions
-from framework import ramcache
 from internals import review_models
 import settings
 

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -48,7 +48,7 @@ class FetchOwnersTest(testing_config.CustomTestCase):
     actual = approval_defs.fetch_owners('https://example.com')
     again = approval_defs.fetch_owners('https://example.com')
 
-    # Only called once because second call will be a ramcache hit.
+    # Only called once because second call will be a redis hit.
     mock_get.assert_called_once_with('https://example.com')
     self.assertEqual(
         actual,

--- a/internals/core_enums_test.py
+++ b/internals/core_enums_test.py
@@ -16,7 +16,6 @@ import testing_config  # Must be imported before the module under test.
 
 import datetime
 from unittest import mock
-from framework import ramcache
 from framework import users
 
 from internals import core_enums

--- a/internals/fetchchannels.py
+++ b/internals/fetchchannels.py
@@ -16,15 +16,15 @@
 import json
 import requests
 
-from framework import ramcache
+from framework import rediscache
 # Note: this file cannot import core_models because it would be circular.
 
 
 def get_omaha_data():
-  omaha_data = ramcache.get('omaha_data')
+  omaha_data = rediscache.get('omaha_data')
   if omaha_data is None:
     result = requests.get('https://omahaproxy.appspot.com/all.json')
     if result.status_code == 200:
-      omaha_data = json.loads(result.content)
-      ramcache.set('omaha_data', omaha_data, time=86400) # cache for 24hrs.
-  return omaha_data
+      omaha_data = result.content
+      rediscache.set('omaha_data', omaha_data, time=86400) # cache for 24hrs.
+  return json.loads(omaha_data)

--- a/internals/fetchmetrics.py
+++ b/internals/fetchmetrics.py
@@ -24,7 +24,7 @@ from google.auth.transport import requests as reqs
 from google.oauth2 import id_token
 
 from framework import basehandlers
-from framework import ramcache
+from framework import rediscache
 from framework import utils
 from internals import metrics_models
 from internals import user_models
@@ -212,7 +212,13 @@ class YesterdayHandler(basehandlers.FlaskHandler):
                 'WebStatusAlert-1: Failed to get metrics even after 2 days')
           return error_message, 500
 
-    ramcache.flush_all()
+    # The code above calls FetchAndSaveData() which calls _SaveData(),
+    # which calls put() a bunch of times to add a new entity for each metrics datapoint.
+    # Separately, when a request comes in get get metrics data, the file api/metricsdata.py
+    # does a query on those datapoints and caches the result. If we don't invalidate when
+    # we add datapoints, the cached query result will be lacking the new datapoints.
+    # This is run once every 6 hours.
+    rediscache.flushall()
     return 'Success'
 
 

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -23,7 +23,6 @@ import os
 import urllib
 
 from framework import permissions
-from framework import ramcache
 from google.cloud import ndb
 import requests
 

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -16,7 +16,6 @@ import testing_config  # Must be imported before the module under test.
 
 import datetime
 from unittest import mock
-from framework import ramcache
 from framework import users
 
 from internals import core_models

--- a/internals/search_queries_test.py
+++ b/internals/search_queries_test.py
@@ -16,7 +16,6 @@ import testing_config  # Must be imported before the module under test.
 
 import datetime
 from unittest import mock
-from framework import ramcache
 
 from internals import core_models
 from internals import review_models
@@ -26,8 +25,6 @@ from internals import search_queries
 class SearchFeaturesTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    ramcache.SharedInvalidate.check_for_distributed_invalidation()
-
     self.feature_1 = core_models.Feature(
         name='feature a', summary='sum', owner=['owner@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
@@ -75,7 +72,6 @@ class SearchFeaturesTest(testing_config.CustomTestCase):
     self.feature_2.key.delete()
     for appr in review_models.Approval.query():
       appr.key.delete()
-    ramcache.flush_all()
 
   def test_single_field_query_async__normal(self):
     """We get a promise to run the DB query, which produces results."""

--- a/internals/user_models_test.py
+++ b/internals/user_models_test.py
@@ -15,7 +15,6 @@
 import testing_config  # Must be imported before the module under test.
 
 from unittest import mock
-from framework import ramcache
 from framework import users
 
 from internals import user_models

--- a/pages/featuredetail_test.py
+++ b/pages/featuredetail_test.py
@@ -22,7 +22,6 @@ import html5lib
 
 from internals import core_enums
 from internals import core_models
-from framework import ramcache
 from pages import featuredetail
 
 test_app = flask.Flask(__name__)
@@ -48,8 +47,6 @@ class TestWithFeature(testing_config.CustomTestCase):
 
   def tearDown(self):
     self.feature_1.key.delete()
-    ramcache.flush_all()
-    ramcache.check_for_distributed_invalidation()
 
 
 class FeatureDetailHandlerTest(TestWithFeature):

--- a/pages/featurelist.py
+++ b/pages/featurelist.py
@@ -22,7 +22,6 @@ from framework import permissions
 from framework import utils
 from internals import core_models
 from internals import core_enums
-from framework import ramcache
 
 # from google.appengine.api import users
 from framework import users

--- a/pages/featurelist_test.py
+++ b/pages/featurelist_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import testing_config  # Must be imported first
 
 import os
@@ -20,11 +19,11 @@ import flask
 import werkzeug
 import html5lib
 
-from framework import ramcache
 from internals import core_enums
 from internals import core_models
 from internals import user_models
 from pages import featurelist
+from framework import ramcache
 
 test_app = flask.Flask(__name__)
 
@@ -58,7 +57,6 @@ class TestWithFeature(testing_config.CustomTestCase):
     self.feature_1.key.delete()
     self.app_user.delete()
     self.app_admin.delete()
-
     ramcache.flush_all()
     ramcache.check_for_distributed_invalidation()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ google-cloud-ndb==1.11.1
 google-cloud-logging==3.0.0
 google-auth==1.31.0
 requests==2.27.1
+redis==4.3.4
+fakeredis==1.9.0
 
 Flask==2.1.2
 flask-cors==3.0.10

--- a/scripts/deploy_site.sh
+++ b/scripts/deploy_site.sh
@@ -29,6 +29,6 @@ gcloud beta app deploy \
   --version $deployVersion \
   --no-promote \
   $BASEDIR/../notifier.yaml \
-  $BASEDIR/../app.yaml  \
+  $BASEDIR/../app.staging.yaml  \
   $BASEDIR/../dispatch.yaml \
   $BASEDIR/../cron.yaml

--- a/scripts/deploy_site.sh
+++ b/scripts/deploy_site.sh
@@ -10,6 +10,12 @@
 
 deployVersion=$1
 appName=${2:-cr-status}
+
+deployYaml="app.staging.yaml"
+if [[ "${appName}"  == "cr-status" ]]; then
+  deployYaml="app.yaml"
+fi
+
 usage="Usage: deploy.sh `date +%Y-%m-%d`"
 
 if [ -z "$deployVersion" ]
@@ -29,6 +35,6 @@ gcloud beta app deploy \
   --version $deployVersion \
   --no-promote \
   $BASEDIR/../notifier.yaml \
-  $BASEDIR/../app.staging.yaml  \
+  $BASEDIR/../$deployYaml  \
   $BASEDIR/../dispatch.yaml \
   $BASEDIR/../cron.yaml


### PR DESCRIPTION
Taken from #2146. Create Redis staging setup using the [set-up instructions](https://docs.google.com/document/d/1hV5MTrGjtKy5kyyk2983kJz3POUWSOBbH-t-qBRQ7Ns/edit?usp=sharing&resourcekey=0-hdThpHi-WIM-48sl4EfO6Q).

- Create app.staging.yaml for Redis staging setup. All non-Redis fields remain the same
- Set 4GB cache limit on Redis staging
- Tested in staging in #2146

Note that there are separate staging and production Redis setup