### PR TITLE
Partially migrate Ramcache usage to Redis

### DIFF
--- a/api/accounts_api.py
+++ b/api/accounts_api.py
@@ -19,7 +19,6 @@ from google.cloud import ndb
 
 from framework import basehandlers
 from framework import permissions
-from framework import ramcache
 from internals import user_models
 
 
@@ -77,7 +76,6 @@ class AccountsAPI(basehandlers.APIHandler):
     if account_id:
       found_user = user_models.AppUser.get_by_id(int(account_id))
       if found_user:
-        found_user.key.delete()
-        ramcache.flush_all()
+        found_user.delete()
       else:
         self.abort(404, msg='Specified account ID not found')

--- a/api/channels_api.py
+++ b/api/channels_api.py
@@ -18,7 +18,7 @@ import json
 import requests
 
 from framework import basehandlers
-from framework import ramcache
+from framework import rediscache
 from internals import fetchchannels
 import settings
 
@@ -53,7 +53,7 @@ def construct_chrome_channels_details():
 def fetch_chrome_release_info(version):
   key = 'chromerelease|%s' % version
 
-  data = ramcache.get(key)
+  data = rediscache.get(key)
   if data is None:
     url = ('https://chromiumdash.appspot.com/fetch_milestone_schedule?'
            'mstone=%s' % version)
@@ -68,7 +68,7 @@ def fetch_chrome_release_info(version):
           del data['owners']
           del data['feature_freeze']
           del data['ldaps']
-          ramcache.set(key, data, time=SCHEDULE_CACHE_TIME)
+          rediscache.set(key, data, time=SCHEDULE_CACHE_TIME)
       except ValueError:
         pass  # Handled by next statement
 
@@ -80,7 +80,7 @@ def fetch_chrome_release_info(version):
           'mstone': version,
           'version': version,
       }
-      # Note: we don't put placeholder data into ramcache.
+      # Note: we don't put placeholder data into redis.
 
   return data
 

--- a/api/permissions_api_test.py
+++ b/api/permissions_api_test.py
@@ -18,7 +18,6 @@ import testing_config  # Must be imported before the module under test.
 import flask
 
 from api import permissions_api
-from framework import ramcache
 
 test_app = flask.Flask(__name__)
 
@@ -31,8 +30,6 @@ class PermissionsAPITest(testing_config.CustomTestCase):
 
   def tearDown(self):
     testing_config.sign_out()
-    ramcache.flush_all()
-    ramcache.check_for_distributed_invalidation()
 
   def test_get__anon(self):
     """Returns no user object if not signed in"""

--- a/api/processes_api_test.py
+++ b/api/processes_api_test.py
@@ -18,7 +18,6 @@ import testing_config  # Must be imported before the module under test.
 import flask
 
 from api import processes_api
-from framework import ramcache
 from internals import core_models
 from internals import processes
 from internals import core_enums
@@ -40,8 +39,6 @@ class ProcessesAPITest(testing_config.CustomTestCase):
 
   def tearDown(self):
     self.feature_1.key.delete()
-    ramcache.flush_all()
-    ramcache.check_for_distributed_invalidation()
 
   def test_get__default_feature_type(self):
     """We can get process for features with the default feature type (New feature incubation)."""
@@ -103,8 +100,6 @@ class ProgressAPITest(testing_config.CustomTestCase):
 
   def tearDown(self):
     self.feature_1.key.delete()
-    ramcache.flush_all()
-    ramcache.check_for_distributed_invalidation()
 
   def test_get___feature_progress(self):
     """We can get progress of a feature."""

--- a/framework/rediscache.py
+++ b/framework/rediscache.py
@@ -52,6 +52,9 @@ def set(key, value, time=86400):
   if redis_client is None:
     return
 
+  if value is None:
+    return
+
   cache_key = add_gae_prefix(key)
   if time:
     redis_client.set(cache_key, pickle.dumps(value), ex=time)
@@ -101,6 +104,9 @@ def set_multi(entries, time=86400):
 
   data_entries = {}
   for key in entries:
+    if entries[key] is None:
+      continue
+
     # gae prefix is needed for mset.
     cache_key = add_gae_prefix(key)
     data_entries[cache_key] = pickle.dumps(entries[key])

--- a/framework/rediscache.py
+++ b/framework/rediscache.py
@@ -52,9 +52,6 @@ def set(key, value, time=86400):
   if redis_client is None:
     return
 
-  if value is None:
-    return
-
   cache_key = add_gae_prefix(key)
   if time:
     redis_client.set(cache_key, pickle.dumps(value), ex=time)
@@ -104,9 +101,6 @@ def set_multi(entries, time=86400):
 
   data_entries = {}
   for key in entries:
-    if entries[key] is None:
-      continue
-
     # gae prefix is needed for mset.
     cache_key = add_gae_prefix(key)
     data_entries[cache_key] = pickle.dumps(entries[key])

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -19,7 +19,6 @@ import logging
 import requests
 
 from framework import permissions
-from framework import ramcache
 from internals import review_models
 import settings
 

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -48,7 +48,7 @@ class FetchOwnersTest(testing_config.CustomTestCase):
     actual = approval_defs.fetch_owners('https://example.com')
     again = approval_defs.fetch_owners('https://example.com')
 
-    # Only called once because second call will be a ramcache hit.
+    # Only called once because second call will be a redis hit.
     mock_get.assert_called_once_with('https://example.com')
     self.assertEqual(
         actual,

--- a/internals/core_enums_test.py
+++ b/internals/core_enums_test.py
@@ -16,7 +16,6 @@ import testing_config  # Must be imported before the module under test.
 
 import datetime
 from unittest import mock
-from framework import ramcache
 from framework import users
 
 from internals import core_enums

--- a/internals/fetchchannels.py
+++ b/internals/fetchchannels.py
@@ -16,15 +16,15 @@
 import json
 import requests
 
-from framework import ramcache
+from framework import rediscache
 # Note: this file cannot import core_models because it would be circular.
 
 
 def get_omaha_data():
-  omaha_data = ramcache.get('omaha_data')
+  omaha_data = rediscache.get('omaha_data')
   if omaha_data is None:
     result = requests.get('https://omahaproxy.appspot.com/all.json')
     if result.status_code == 200:
-      omaha_data = json.loads(result.content)
-      ramcache.set('omaha_data', omaha_data, time=86400) # cache for 24hrs.
-  return omaha_data
+      omaha_data = result.content
+      rediscache.set('omaha_data', omaha_data, time=86400) # cache for 24hrs.
+  return json.loads(omaha_data)

--- a/internals/fetchmetrics.py
+++ b/internals/fetchmetrics.py
@@ -24,7 +24,6 @@ from google.auth.transport import requests as reqs
 from google.oauth2 import id_token
 
 from framework import basehandlers
-from framework import ramcache
 from framework import utils
 from internals import metrics_models
 from internals import user_models
@@ -212,7 +211,6 @@ class YesterdayHandler(basehandlers.FlaskHandler):
                 'WebStatusAlert-1: Failed to get metrics even after 2 days')
           return error_message, 500
 
-    ramcache.flush_all()
     return 'Success'
 
 

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -23,7 +23,6 @@ import os
 import urllib
 
 from framework import permissions
-from framework import ramcache
 from google.cloud import ndb
 import requests
 

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -16,7 +16,6 @@ import testing_config  # Must be imported before the module under test.
 
 import datetime
 from unittest import mock
-from framework import ramcache
 from framework import users
 
 from internals import core_models
@@ -189,48 +188,3 @@ class OwnersFileTest(testing_config.CustomTestCase):
 
     expired_content = review_models.OwnersFile.get_raw_owner_file('def')
     self.assertEqual(None, expired_content)
-
-
-class ActivityTest(testing_config.CustomTestCase):
-
-  def setUp(self):
-    self.feature_1 = core_models.Feature(
-        name='feature a', summary='sum', owner=['feature_owner@example.com'],
-        category=1, visibility=1, standardization=1, web_dev_views=1,
-        impl_status_chrome=3)
-    self.feature_1.put()
-
-  def tearDown(self):
-    feature_id = self.feature_1.key.integer_id()
-    activities = review_models.Activity.get_activities(feature_id)
-    for activity in activities:
-      activity.key.delete()
-    self.feature_1.key.delete()
-
-  def test_activities_created(self):
-    # stash_values is used to note what the original values of a feature are.
-    self.feature_1.stash_values()
-    self.feature_1.owner = ["other@example.com"]
-    self.feature_1.summary = "new summary"
-    self.feature_1.put()
-
-    self.feature_1.stash_values()
-    self.feature_1.name = 'Changed name'
-    self.feature_1.put()
-
-    feature_id = self.feature_1.key.integer_id()
-    activities = review_models.Activity.get_activities(feature_id)
-    self.assertEqual(len(activities), 2)
-    self.assertEqual(len(activities[0].amendments), 2)
-    self.assertEqual(len(activities[1].amendments), 1)
-
-    expected = [
-        ('owner', '[\'feature_owner@example.com\']', '[\'other@example.com\']'),
-        ('summary', 'sum', 'new summary'),
-        ('name', 'feature a', 'Changed name')]
-    result = activities[0].amendments + activities[1].amendments
-
-    for i, (field, before, expected) in enumerate(expected):
-      self.assertEqual(field, result[i].field_name)
-      self.assertEqual(before, result[i].old_value)
-      self.assertEqual(expected, result[i].new_value)

--- a/internals/search_queries_test.py
+++ b/internals/search_queries_test.py
@@ -16,7 +16,6 @@ import testing_config  # Must be imported before the module under test.
 
 import datetime
 from unittest import mock
-from framework import ramcache
 
 from internals import core_models
 from internals import review_models
@@ -26,8 +25,6 @@ from internals import search_queries
 class SearchFeaturesTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    ramcache.SharedInvalidate.check_for_distributed_invalidation()
-
     self.feature_1 = core_models.Feature(
         name='feature a', summary='sum', owner=['owner@example.com'],
         category=1, visibility=1, standardization=1, web_dev_views=1,
@@ -75,7 +72,6 @@ class SearchFeaturesTest(testing_config.CustomTestCase):
     self.feature_2.key.delete()
     for appr in review_models.Approval.query():
       appr.key.delete()
-    ramcache.flush_all()
 
   def test_single_field_query_async__normal(self):
     """We get a promise to run the DB query, which produces results."""

--- a/internals/user_models_test.py
+++ b/internals/user_models_test.py
@@ -15,7 +15,6 @@
 import testing_config  # Must be imported before the module under test.
 
 from unittest import mock
-from framework import ramcache
 from framework import users
 
 from internals import user_models

--- a/pages/featuredetail_test.py
+++ b/pages/featuredetail_test.py
@@ -22,7 +22,6 @@ import html5lib
 
 from internals import core_enums
 from internals import core_models
-from framework import ramcache
 from pages import featuredetail
 
 test_app = flask.Flask(__name__)
@@ -48,8 +47,6 @@ class TestWithFeature(testing_config.CustomTestCase):
 
   def tearDown(self):
     self.feature_1.key.delete()
-    ramcache.flush_all()
-    ramcache.check_for_distributed_invalidation()
 
 
 class FeatureDetailHandlerTest(TestWithFeature):

--- a/pages/featurelist.py
+++ b/pages/featurelist.py
@@ -22,7 +22,6 @@ from framework import permissions
 from framework import utils
 from internals import core_models
 from internals import core_enums
-from framework import ramcache
 
 # from google.appengine.api import users
 from framework import users

--- a/pages/featurelist_test.py
+++ b/pages/featurelist_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from framework import ramcache
 import testing_config  # Must be imported first
 
 import os
@@ -20,7 +21,6 @@ import flask
 import werkzeug
 import html5lib
 
-from framework import ramcache
 from internals import core_enums
 from internals import core_models
 from internals import user_models
@@ -58,7 +58,6 @@ class TestWithFeature(testing_config.CustomTestCase):
     self.feature_1.key.delete()
     self.app_user.delete()
     self.app_admin.delete()
-
     ramcache.flush_all()
     ramcache.check_for_distributed_invalidation()
 

--- a/pages/featurelist_test.py
+++ b/pages/featurelist_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-from framework import ramcache
 import testing_config  # Must be imported first
 
 import os
@@ -25,6 +23,7 @@ from internals import core_enums
 from internals import core_models
 from internals import user_models
 from pages import featurelist
+from framework import ramcache
 
 test_app = flask.Flask(__name__)
 


### PR DESCRIPTION
Taken from #2146. Migrate partial Ramcache usage to Redis, except feature-related usage.

- Remove instances of `flush_all`, except in testing, and replace it with individual cache delete
- Remove the cache limit and cache validation logic in the code

### Testing
- [Staging testing](https://a166bab-dot-cr-status-staging.appspot.com/features): verified through the Redis monitoring

### Performance improvement
This PR significantly speeds up first-time page load for parts migrated