### PR TITLE
Avoid roadmap cards with the same version

### DIFF
--- a/api/channels_api.py
+++ b/api/channels_api.py
@@ -43,6 +43,7 @@ def construct_chrome_channels_details():
     new_beta_version = channels['stable']['version'] + 1
     channels['beta'] = fetch_chrome_release_info(new_beta_version)
     channels['beta']['version'] = new_beta_version
+  if channels['beta']['version'] == channels['dev']['version']:
     new_dev_version = channels['beta']['version'] + 1
     channels['dev'] = fetch_chrome_release_info(new_dev_version)
     channels['dev']['version'] = new_dev_version


### PR DESCRIPTION
This fixes #2215. The bug occurs because the dev and beta channels have the same version.

In channels_api.py, the stable and beta versions are already ensured to be different. However, the situation where the dev and beta channels share the same version is not checked. So I added a line to check if the dev and beta versions are the same. If so, adjust the versions accordingly.