### PR TITLE
Complete migration of forms to JS

### DIFF
--- a/pages/guide.py
+++ b/pages/guide.py
@@ -44,12 +44,7 @@ class FeatureNew(basehandlers.FlaskHandler):
   @permissions.require_create_feature
   def get_template_data(self):
     user = self.get_current_user()
-
-    new_feature_form = guideforms.NewFeatureForm(
-        initial={'owner': user.email()})
-    template_data = {
-        'overview_form': new_feature_form,
-        }
+    template_data = {'user_email': user.email()}
     return template_data
 
   @permissions.require_create_feature

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -62,19 +62,6 @@ class FeatureNewTest(testing_config.CustomTestCase):
       with self.assertRaises(werkzeug.exceptions.Forbidden):
         actual_response = self.handler.get_template_data()
 
-  def test_get__normal(self):
-    """Allowed users render a page with a django form."""
-    testing_config.sign_in('user1@google.com', 1234567890)
-    with test_app.test_request_context('/guide/new'):
-      template_data = self.handler.get_template_data()
-
-    self.assertTrue('overview_form' in template_data)
-    form = template_data['overview_form']
-    field = form.fields['owner']
-    self.assertEqual(
-        'user1@google.com',
-        form.get_initial_for_field(field, 'owner'))
-
   def test_post__anon(self):
     """Anon cannot create features, gets a 403."""
     testing_config.sign_out()

--- a/pages/guideforms.py
+++ b/pages/guideforms.py
@@ -13,22 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import re
 
 from django import forms
-from django.forms.widgets import Textarea, Input
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
 
-from django.utils.html import conditional_escape, escape
-from django.utils.safestring import mark_safe
-
-from framework import users
 from internals import core_enums
-from internals import processes
 from internals import user_models
-import settings
 
 
 # This is the longest string that a cloud ndb StringProperty seems to accept.
@@ -507,103 +499,6 @@ ALL_FIELDS = {
         widget=ChromedashTextarea(attrs={'rows': 4})),
 
     }
-
-class ChromedashForm(forms.Form):
-    def simple_html_output(self):
-        """
-        Output HTML. Used by override of as_table() to support chromedash uses only.
-        Simplified to drop support for hidden form fields and errors at the top,
-        which we are not using.
-        Added field 'name' property for use in the normal_row template.
-        Added 'value' and 'checked' properties.
-        Added 'field' and 'errors' to avoid use of slots.
-        """
-        output = []
-
-        # Attributes for all fields except checkbox.
-        attrs = 'name="%(name)s" value="%(value)s" field="%(field)s" errors="%(errors)s" %(html_class_attr)s'
-        # Attributes for checkbox fields.
-        checkbox_attrs = 'name="%(name)s" value="%(value)s"  checked="%(checked)s" errors="%(errors)s" %(html_class_attr)s'
-
-        # Create the row template used for every field.
-        normal_row = '<chromedash-form-field ' + attrs + '></chromedash-form-field>'
-        checkbox_row = '<chromedash-form-field ' + checkbox_attrs + '></chromedash-form-field>'
-
-        for name, field in self.fields.items():
-            html_class_attr = ''
-            bf = self[name]
-            bf_errors = self.error_class(bf.errors)
-
-            # Get value and checked for the field
-            value = field.widget.value_from_datadict(self.data, self.files, self.add_prefix(name))
-            if value is None:
-              value = bf.initial
-
-            row_template = normal_row
-            checked = False
-            if hasattr(field.widget, 'check_test'):
-                # Must be a checkbox field.
-                row_template = checkbox_row
-                if field.widget.check_test(value):
-                    checked = True
-
-                # accurate_as_of field should always be checked, regardless of
-                # the current value. This is only necessary if the feature
-                # has been created before this field was added.
-                if name == 'accurate_as_of':
-                    checked = True
-                    value = True
-
-            # Create a 'class="..."' attribute if the row should have any
-            # CSS classes applied.
-            css_classes = bf.css_classes()
-            if css_classes:
-                html_class_attr = ' class="%s"' % css_classes
-
-            if bf.label:
-                label = conditional_escape(bf.label)
-                label = bf.label_tag(label) or ''
-            else:
-                label = ''
-
-            output.append(row_template % {
-                'name': name,
-                'errors': escape(bf_errors),
-                'field': escape(bf),
-                'value': escape(value),
-                'checked': checked,
-                'html_class_attr': html_class_attr,
-                'css_classes': css_classes,
-                'field_name': bf.html_name,
-            })
-
-        return mark_safe('\n'.join(output))
-
-    def as_table(self):
-        "Return this form rendered as HTML <tr>s -- excluding the <table></table>."
-        return self.simple_html_output()
-
-def define_form_class_using_shared_fields(class_name, field_spec_list):
-  """Define a new subsblass of forms.Form with the given fields, in order."""
-  # field_spec_list is normally just a list of simple field names,
-  # but entries can also have syntax "form_field=shared_field".
-  class_dict = {'field_order': []}
-  for field_spec in field_spec_list:
-    form_field_name = field_spec.split('=')[0]  # first or only
-    shared_field_name = field_spec.split('=')[-1] # last or only
-    properties = ALL_FIELDS[shared_field_name]
-    class_dict[form_field_name] = properties
-    class_dict['field_order'].append(form_field_name)
-
-  return type(class_name, (ChromedashForm,), class_dict)
-
-
-NewFeatureForm = define_form_class_using_shared_fields(
-    'NewFeatureForm',
-    ('name', 'summary',
-     'unlisted', 'owner', 'editors',
-     'blink_components', 'category'))
-    # Note: feature_type is done with custom HTML
 
 
 FIELD_NAME_TO_DISPLAY_TYPE = {

--- a/pages/guideforms_test.py
+++ b/pages/guideforms_test.py
@@ -15,71 +15,9 @@
 import testing_config  # Must be imported first
 import unittest
 
-from unittest import mock
-import html5lib
-
 from django.core.exceptions import ValidationError
-from django.template import engines
 
 from pages import guideforms
-from internals import core_models
-
-
-TestForm = guideforms.define_form_class_using_shared_fields(
-    'TestForm', ('name', 'summary', 'category'))
-
-TEST_TEMPLATE = '''
-<!DOCTYPE html>
-
-{{form}}
-'''
-
-class ChromedashFormTest(unittest.TestCase):
-
-  def render_form(self, feature_dict):
-    form = TestForm(feature_dict)
-    django_engine = engines['django']
-    template = django_engine.from_string(TEST_TEMPLATE)
-    rendered_html = template.render({'form': form})
-    return rendered_html
-
-  def validate_html(self, rendered_html):
-    parser = html5lib.HTMLParser(strict=True)
-    document = parser.parse(rendered_html)
-
-  def test__normal(self):
-    """Our forms can render some widgets with values."""
-    feature_dict = {
-        'name': 'this is a feature name',
-        'summary': 'this is a summary',
-        }
-    actual = self.render_form(feature_dict)
-    self.validate_html(actual)
-    self.assertIn('name="name"', actual)
-    self.assertIn('value="this is a feature name"', actual)
-    self.assertIn('name="summary"', actual)
-    self.assertIn('value="this is a summary"', actual)
-    # Initial value MISC (2) is used because feature_dict has no category.
-    self.assertIn('name="category" value="2"', actual)
-
-  def test__escaping(self):
-    """Our forms render properly even with tricky input."""
-    feature_dict = {
-        'name': 'name single\' doulble\" angle> amper& comment<!--',
-        'summary': 'summary single\' doulble\" angle> amper& comment<!--',
-        }
-    actual = self.render_form(feature_dict)
-    self.validate_html(actual)
-    self.assertIn('name="name"', actual)
-    self.assertIn(
-        'value="name single&#x27; doulble&quot; '
-        'angle&gt; amper&amp; comment&lt;!--"',
-        actual)
-    self.assertIn('name="summary"', actual)
-    self.assertIn(
-        'value="summary single&#x27; doulble&quot; '
-        'angle&gt; amper&amp; comment&lt;!--"',
-        actual)
 
 
 class DisplayFieldsTest(unittest.TestCase):

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -66,6 +66,10 @@ export class ChromedashFormField extends LitElement {
   renderWidgets() {
     const type = this.fieldProps.type;
 
+    // if no value is provided, use the initial value specified in form-field-spec
+    const fieldValue = !this.value && this.fieldProps.initial ?
+      this.fieldProps.initial : this.value;
+
     // form field name can be specified in form-field-spec to match DB field name
     const fieldName = this.fieldProps.name || this.name;
 
@@ -75,12 +79,13 @@ export class ChromedashFormField extends LitElement {
     let fieldHTML = '';
     if (type === 'checkbox') {
       // value can be a js or python boolean value converted to a string
+      // or the initial value specified in form-field-spec
       fieldHTML = html`
         <sl-checkbox
           name="${fieldName}"
           id="id_${this.name}"
           size="small"
-          ?checked=${this.value === 'true' || this.value === 'True'}
+          ?checked=${fieldValue === 'true' || fieldValue === 'True'}
           ?disabled=${this.disabled}>
           ${this.fieldProps.label}
         </sl-checkbox>
@@ -90,7 +95,7 @@ export class ChromedashFormField extends LitElement {
         <sl-select
           name="${fieldName}"
           id="id_${this.name}"
-          value="${this.value}"
+          value="${fieldValue}"
           size="small"
           ?disabled=${this.disabled || this.loading}>
           ${Object.values(choices).map(
@@ -108,7 +113,7 @@ export class ChromedashFormField extends LitElement {
           id="id_${this.name}"
           size="small"
           autocomplete="off"
-          .value=${this.value === 'None' ? '' : this.value}
+          .value=${fieldValue}
           ?required=${this.fieldProps.required}>
         </sl-input>
       `;
@@ -119,7 +124,7 @@ export class ChromedashFormField extends LitElement {
           name="${fieldName}"
           id="id_${this.name}"
           size="small"
-          .value=${this.value === 'None' ? '' : this.value}
+          .value=${fieldValue}
           ?required=${this.fieldProps.required}>
         </chromedash-textarea>
       `;
@@ -140,7 +145,7 @@ export class ChromedashFormField extends LitElement {
             ${ref(this.updateAttributes)}
             name="${fieldName}"
             id="id_${this.name}"
-            value="${this.value}"
+            value="${fieldValue}"
             class="datalist-input"
             type="search"
             list="${this.name}_list"

--- a/static/elements/chromedash-guide-new-page_test.js
+++ b/static/elements/chromedash-guide-new-page_test.js
@@ -1,11 +1,26 @@
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashGuideNewPage} from './chromedash-guide-new-page';
+import '../js-src/cs-client';
+import sinon from 'sinon';
 
 describe('chromedash-guide-new-page', () => {
+  beforeEach(async () => {
+    window.csClient = new ChromeStatusClient('fake_token', 1);
+    sinon.stub(window.csClient, 'getBlinkComponents');
+    window.csClient.getBlinkComponents.returns(Promise.resolve({}));
+  });
+
+  afterEach(() => {
+    window.csClient.getBlinkComponents.restore();
+  });
+
   it('renders with fake data', async () => {
+    const userEmail = 'user@gmail.com';
     const component = await fixture(
-      html`<chromedash-guide-new-page></chromedash-guide-new-page>`);
+      html`<chromedash-guide-new-page
+            .userEmail=${userEmail}>
+           </chromedash-guide-new-page>`);
     assert.exists(component);
     assert.instanceOf(component, ChromedashGuideNewPage);
 
@@ -17,6 +32,9 @@ describe('chromedash-guide-new-page', () => {
     // overview form exists and is with action path
     const overviewForm = component.shadowRoot.querySelector('form[name="overview_form"]');
     assert.include(overviewForm.outerHTML, 'action="/guide/new"');
+
+    // owner field filled with the user email
+    assert.include(overviewForm.innerHTML, userEmail);
 
     // feature type chromedash-form-field exists and is with four options
     const featureTypeFormField = component.shadowRoot.querySelector(

--- a/static/elements/form-definition.js
+++ b/static/elements/form-definition.js
@@ -2,7 +2,6 @@ import {
   FEATURE_TYPES,
   INTENT_STAGES,
   IMPLEMENTATION_STATUS,
-  STANDARD_MATURITY_CHOICES,
 } from './form-field-enums';
 
 
@@ -30,7 +29,7 @@ export function formatFeatureForEdit(feature) {
     // from feature.standards
     spec_link: feature.standards.spec,
     standardization: feature.standards.status.val,
-    standard_maturity: feature.standards.maturity.val || STANDARD_MATURITY_CHOICES.UNKNOWN_STD,
+    standard_maturity: feature.standards.maturity.val,
 
     tag_review_status: feature.tag_review_status_int,
     security_review_status: feature.security_review_status_int,
@@ -85,6 +84,12 @@ export function formatFeatureForEdit(feature) {
 }
 
 // The following arrays define the list of fields for each guide form.
+
+export const NEW_FEATURE_FORM_FIELDS = [
+  'name', 'summary', 'unlisted', 'owner',
+  'editors', 'blink_components', 'category',
+];
+// Note: feature_type is done with custom HTML in chromedash-guide-new-page
 
 export const METADATA_FORM_FIELDS = [
   'name', 'summary', 'unlisted', 'owner',

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -164,6 +164,7 @@ export const ALL_FIELDS = {
   'unlisted': {
     type: 'checkbox',
     label: 'Unlisted',
+    initial: false,
     help_text: html`
         Check this box to hide draft emails in list views. Anyone with
         a link will be able to view the feature's detail page.`,
@@ -172,6 +173,7 @@ export const ALL_FIELDS = {
   'accurate_as_of': {
     type: 'checkbox',
     label: 'Confirm accuracy',
+    initial: true,
     help_text: html`
         Check this box to indicate that feature information is accurate
         as of today.
@@ -191,6 +193,7 @@ export const ALL_FIELDS = {
   'category': {
     type: 'select',
     choices: FEATURE_CATEGORIES,
+    initial: FEATURE_CATEGORIES.MISC[0],
     label: 'Category',
     help_text: html`
         Select the most specific category. If unsure, leave as "Miscellaneous".`,
@@ -199,6 +202,7 @@ export const ALL_FIELDS = {
   'feature_type': {
     type: 'select',
     choices: FEATURE_TYPES,
+    initial: FEATURE_TYPES.FEATURE_TYPE_INCUBATE_ID[0],
     label: 'Feature type',
     help_text: html`
         Select the feature type.`,
@@ -226,6 +230,7 @@ export const ALL_FIELDS = {
   'intent_stage': {
     type: 'select',
     choices: INTENT_STAGES,
+    initial: INTENT_STAGES.INTENT_IMPLEMENT[0],
     label: 'Process stage',
     help_text: html`
         Select the appropriate spec process stage. If you select
@@ -369,6 +374,7 @@ export const ALL_FIELDS = {
   'standard_maturity': {
     type: 'select',
     choices: STANDARD_MATURITY_CHOICES,
+    initial: STANDARD_MATURITY_CHOICES.PROPOSAL_STD[0],
     label: 'Standard maturity',
     help_text: html`
         How far along is the standard that this feature implements?`,
@@ -376,6 +382,7 @@ export const ALL_FIELDS = {
 
   'api_spec': {
     type: 'checkbox',
+    initial: false,
     label: 'API spec',
     help_text: html`
         The spec document has details in a specification language
@@ -434,6 +441,7 @@ export const ALL_FIELDS = {
   'security_review_status': {
     type: 'select',
     choices: REVIEW_STATUS_CHOICES,
+    initial: REVIEW_STATUS_CHOICES.REVIEW_PENDING[0],
     label: 'Security review status',
     help_text: html`
         Status of the security review.`,
@@ -442,6 +450,7 @@ export const ALL_FIELDS = {
   'privacy_review_status': {
     type: 'select',
     choices: REVIEW_STATUS_CHOICES,
+    initial: REVIEW_STATUS_CHOICES.REVIEW_PENDING[0],
     label: 'Privacy review status',
     help_text: html`Status of the privacy review.`,
   },
@@ -458,6 +467,7 @@ export const ALL_FIELDS = {
   'tag_review_status': {
     type: 'select',
     choices: REVIEW_STATUS_CHOICES,
+    initial: REVIEW_STATUS_CHOICES.REVIEW_PENDING[0],
     label: 'TAG review status',
     help_text: html`Status of the tag review.`,
   },
@@ -535,7 +545,8 @@ export const ALL_FIELDS = {
 
   'safari_views': {
     type: 'select',
-    choices: VENDOR_VIEWS_GECKO,
+    choices: VENDOR_VIEWS_COMMON,
+    initial: VENDOR_VIEWS_COMMON.NO_PUBLIC_SIGNALS[0],
     label: 'Safari views',
     help_text: html`
       See <a target="_blank" href="https://bit.ly/blink-signals">
@@ -560,7 +571,8 @@ export const ALL_FIELDS = {
 
   'ff_views': {
     type: 'select',
-    choices: VENDOR_VIEWS_COMMON,
+    choices: VENDOR_VIEWS_GECKO,
+    initial: VENDOR_VIEWS_GECKO.NO_PUBLIC_SIGNALS[0],
     label: 'Firefox views',
     help_text: html`
       See <a target="_blank" href="https://bit.ly/blink-signals">
@@ -587,6 +599,7 @@ export const ALL_FIELDS = {
   'web_dev_views': {
     type: 'select',
     choices: WEB_DEV_VIEWS,
+    initial: WEB_DEV_VIEWS.DEV_NO_SIGNALS[0],
     label: 'Web / Framework developer views',
     help_text: html`
       If unsure, default to "No signals".
@@ -880,6 +893,7 @@ export const ALL_FIELDS = {
 
   'all_platforms': {
     type: 'checkbox',
+    inital: false,
     label: 'Supported on all platforms?',
     help_text: html`
       Will this feature be supported on all six Blink platforms
@@ -898,6 +912,7 @@ export const ALL_FIELDS = {
 
   'wpt': {
     type: 'checkbox',
+    initial: false,
     label: 'Web Platform Tests',
     help_text: html`
       Is this feature fully tested in Web Platform Tests?`,
@@ -984,6 +999,7 @@ export const ALL_FIELDS = {
 
   'requires_embedder_support': {
     type: 'checkbox',
+    initial: false,
     label: 'Requires Embedder Support',
     help_text: html`
        Will this feature require support in //chrome?
@@ -1061,6 +1077,7 @@ export const ALL_FIELDS = {
   'prefixed': {
     type: 'checkbox',
     label: 'Prefixed?',
+    initial: false,
     help_text: '',
   },
 

--- a/templates/guide/new.html
+++ b/templates/guide/new.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
-
+{# TODO(kevinshen56714) - Pass in userEmail from SPA app component #}
 {% block content %}
   <chromedash-guide-new-page
-    overviewForm="{% filter force_escape %} {{ overview_form }} {% endfilter %}">
+    userEmail="{{ user_email }}">
   </chromedash-guide-new-page>
 {% endblock %}


### PR DESCRIPTION
This PR completes form refactoring; specifically, the last form (guide-new-page form) is migrated to JS in this PR. Changes include:

1. Removed the code and tests for generating Django form templates because we no longer need them!
2. Added the initial property to some fields in form-field-spec.js (they were left out in previous migration). And in chromedash-form-field.js, if the value is empty and an initial property is provided to the field, it will render the initial value.
3. Removed unsafeHTML in `<chromedash-guide-new-page>` and render the form with the `NEW_FEATURE_FORM_FIELDS` constant defined in form-definition.js.
4. Updated the unit test for `<chromedash-guide-new-page>`