### PR TITLE
Feature activity is no longer documented if submitted with no changes

### DIFF
--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -236,7 +236,7 @@ class ActivityTest(testing_config.CustomTestCase):
       self.assertEqual(expected, result[i].new_value)
   
   def test_activities_created__no_stash(self):
-    """stash_values() is not called, so no activity should be logged."""
+    """If stash_values() is not called, no activity should be logged."""
     self.feature_1.owner = ["other@example.com"]
     self.feature_1.summary = "new summary"
     self.feature_1.put()

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -234,3 +234,25 @@ class ActivityTest(testing_config.CustomTestCase):
       self.assertEqual(field, result[i].field_name)
       self.assertEqual(before, result[i].old_value)
       self.assertEqual(expected, result[i].new_value)
+  
+  def test_activities_created__no_stash(self):
+    """stash_values() is not called, so no activity should be logged."""
+    self.feature_1.owner = ["other@example.com"]
+    self.feature_1.summary = "new summary"
+    self.feature_1.put()
+
+    self.feature_1.name = 'Changed name'
+    self.feature_1.put()
+
+    feature_id = self.feature_1.key.integer_id()
+    activities = review_models.Activity.get_activities(feature_id)
+    self.assertEqual(len(activities), 0)
+
+  def test_activities_created__no_changes(self):
+    """No Activity should be logged if submitted with no changes."""
+    self.feature_1.stash_values()
+    self.feature_1.put()
+
+    feature_id = self.feature_1.key.integer_id()
+    activities = review_models.Activity.get_activities(feature_id)
+    self.assertEqual(len(activities), 0)


### PR DESCRIPTION
This fixes an issue where Activity entities were being created with no amendments made. The edit form can be submitted without making changes, and previously we did not check if any amendments existed, so an Activity entity would be logged with no changes.

Additionally, calling the `Feature.put()` method directly would make an assumption that all fields had changed, which logged large amounts of invalid amendments when making changes via cron task. This change also addresses this issue.