### PR TITLE
Remove old form submit handler

### DIFF
--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -41,33 +41,6 @@ class ChromeStatusClient {
     return tokenExpiresDate < new Date();
   }
 
-  /* Return all hidden form fields for XSRF tokens. */
-  allTokenFields() {
-    return document.querySelectorAll('input[name=token]');
-  }
-
-  /* Add updateFormToken() as a listener on all forms use XSRF. */
-  addFormSubmitListner() {
-    this.allTokenFields().forEach((field) => {
-      field.form.addEventListener('submit', (event) => {
-        this.updateFormToken(event);
-      });
-    });
-  }
-
-  /* If too much time has passed since the page loaded, get a new XSRF
-   * token from the server and stuff it into the XSRF token form field
-   * before submitting. */
-  updateFormToken(event) {
-    event.preventDefault();
-    this.ensureTokenIsValid().then(() => {
-      this.allTokenFields().forEach((field) => {
-        field.value = this.token;
-      });
-      event.target.submit();
-    });
-  }
-
   /* Make a JSON API call to the server, including an XSRF header.
    * Then strip off the defensive prefix from the response. */
   async doFetch(resource, httpMethod, body, includeToken=true) {

--- a/static/js-src/shared.js
+++ b/static/js-src/shared.js
@@ -25,15 +25,3 @@ gtag('js', new Date());
 
 gtag('config', 'UA-179341418-1');
 // End Google Analytics
-
-
-// Make sure that our form handler for XSRF token updates gets
-// registered after all the Shoelace form listeners are registered
-// so that failed form validation cancels the submit event before
-// our listener tries to programatically submit the form.
-// Ten seconds should be enough time, and there is no rush since
-// XSRF tokens don't expire until much more time has passsed.
-// TODO(jrobbins): Make this event-driven rather than a timeout.
-window.setTimeout(
-    window.csClient.addFormSubmitListner.bind(window.csClient),
-    10 * 1000);


### PR DESCRIPTION
The old way of registering form submit handler is no longer used. New forms are all in shadowDOMs and handled via new methods, so these old methods can be removed.