### PR TITLE
Launch the SPA

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -35,7 +35,9 @@ from framework import users
 from framework import utils
 from framework import xsrf
 from internals import approval_defs
+from internals import core_enums
 from internals import core_models
+from internals import processes
 from internals import user_models
 
 from django.template.loader import render_to_string
@@ -505,7 +507,36 @@ def ndb_wsgi_middleware(wsgi_app):
   return middleware
 
 
-def FlaskApplication(import_name, routes, pattern_base='', debug=False):
+class SPAHandler(FlaskHandler):
+  """Single-page app handler"""
+
+  TEMPLATE_PATH = 'spa.html'
+
+  def get_template_data(self, **defaults):
+    # Check if the page requires user to sign in
+    if defaults.get('require_signin') and not self.get_current_user():
+      return flask.redirect(settings.LOGIN_PAGE_URL), self.get_headers()
+    
+    # Check if the page requires create feature permission
+    if defaults.get('require_create_feature'):
+      redirect_resp = permissions.validate_feature_create_permission(self)
+      if redirect_resp:
+        return redirect_resp
+    
+    # Validate the user has edit permissions and redirect if needed.
+    if defaults.get('require_edit_feature'):
+      feature_id = defaults.get('feature_id')
+      if not feature_id:
+        self.abort(500, msg='Cannot get feature ID from the URL')
+      redirect_resp = permissions.validate_feature_edit_permission(
+          self, feature_id)
+      if redirect_resp:
+        return redirect_resp
+
+    return {} # no handler_data needed to be returned
+
+
+def FlaskApplication(import_name, routes, post_routes, pattern_base='', debug=False):
   """Make a Flask app and add routes and handlers that work like webapp2."""
 
   app = flask.Flask(import_name)
@@ -518,6 +549,16 @@ def FlaskApplication(import_name, routes, pattern_base='', debug=False):
     app.secret_key = secrets.get_session_secret()  # For flask.session
     app.permanent_session_lifetime = xsrf.REFRESH_TOKEN_TIMEOUT_SEC
 
+  for i, rule in enumerate(post_routes):
+    pattern = rule[0]
+    handler_class = rule[1]
+    classname = handler_class.__name__
+    app.add_url_rule(
+        pattern_base + pattern,
+        endpoint=classname + str(i),  # We don't use it, but it must be unique.
+        view_func=handler_class.as_view(classname),
+        methods=["POST"])
+
   for i, rule in enumerate(routes):
     pattern = rule[0]
     handler_class = rule[1]
@@ -525,7 +566,7 @@ def FlaskApplication(import_name, routes, pattern_base='', debug=False):
     classname = handler_class.__name__
     app.add_url_rule(
         pattern_base + pattern,
-        endpoint=classname + str(i),  # We don't use it, but it must be unique.
+        endpoint=classname + str(i + len(post_routes)),  # We don't use it, but it must be unique.
         view_func=handler_class.as_view(classname),
         defaults=defaults)
 

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -35,9 +35,7 @@ from framework import users
 from framework import utils
 from framework import xsrf
 from internals import approval_defs
-from internals import core_enums
 from internals import core_models
-from internals import processes
 from internals import user_models
 
 from django.template.loader import render_to_string

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -72,6 +72,7 @@ test_app = basehandlers.FlaskApplication(
      ('/ui/density.json', basehandlers.ConstHandler,
       {'UI density': ['default', 'comfortable', 'compact']}),
      ],
+    [], # POST routes
     debug=True)
 
 

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -165,6 +165,20 @@ def require_create_feature(handler):
   return check_login
 
 
+def validate_feature_create_permission(handler_obj):
+  """Check if user has permission to create feature and abort if not."""
+  user = handler_obj.get_current_user()
+  req = handler_obj.request
+
+  # Give the user a chance to sign in
+  if not user and req.method == 'GET':
+    return handler_obj.redirect(settings.LOGIN_PAGE_URL)
+
+  # Redirect to 403 if user does not have create permission for feature.
+  if not can_create_feature(user):
+    handler_obj.abort(403)
+
+
 def validate_feature_edit_permission(handler_obj, feature_id):
   """Check if user has permission to edit feature and abort if not."""
   user = handler_obj.get_current_user()

--- a/framework/permissions_test.py
+++ b/framework/permissions_test.py
@@ -46,6 +46,7 @@ test_app = basehandlers.FlaskApplication(
     __name__,
     [('/path', MockHandler),
      ],
+    [], # POST routes
     debug=True)
 
 

--- a/main.py
+++ b/main.py
@@ -37,7 +37,6 @@ from internals import notifier
 from internals import data_backup
 from internals import deprecate_field
 from pages import blink_handler
-from pages import featuredetail
 from pages import featurelist
 from pages import guide
 from pages import intentpreview

--- a/main.py
+++ b/main.py
@@ -144,7 +144,7 @@ spa_pages = [
 
 spa_page_routes = []
 for route in spa_pages:
-  page_defaults ={}
+  page_defaults = {}
   if isinstance(route, tuple):
     route, additional_defaults = route
     page_defaults.update(additional_defaults)

--- a/main.py
+++ b/main.py
@@ -118,12 +118,56 @@ api_routes = [
     # (API_BASE + '/metrics/<str:kind>/<int:bucket_id>', TODO),
 ]
 
+spa_pages = [
+  '/',
+  '/roadmap',
+  ('/myfeatures', {'require_signin': True}),
+  '/newfeatures',
+  '/feature/<int:feature_id>',
+  ('/guide/new', {'require_create_feature': True}),
+  ('/guide/edit/<int:feature_id>', {'require_edit_feature': True}),
+  ('/guide/stage/<int:feature_id>/<int:stage_id>', {'require_edit_feature': True}),
+  ('/guide/editall/<int:feature_id>', {'require_edit_feature': True}),
+  ('/guide/verify_accuracy/<int:feature_id>', {'require_edit_feature': True}),
+  '/metrics',
+  '/metrics/css',
+  '/metrics/css/popularity',
+  '/metrics/css/animated',
+  '/metrics/css/timeline/popularity',
+  '/metrics/css/timeline/popularity/<int:bucket_id>',
+  '/metrics/css/timeline/animated',
+  '/metrics/css/timeline/animated/<int:bucket_id>',
+  '/metrics/feature/popularity',
+  '/metrics/feature/timeline/popularity',
+  '/metrics/feature/timeline/popularity/<int:bucket_id>',
+  ('/settings', {'require_signin': True}),
+]
 
-page_routes = [
+spa_page_routes = []
+for route in spa_pages:
+  page_defaults ={}
+  if isinstance(route, tuple):
+    route, additional_defaults = route
+    page_defaults.update(additional_defaults)
+  spa_page_routes.append((route, basehandlers.SPAHandler, page_defaults))
+
+spa_page_post_routes = [
+  ('/guide/new', guide.FeatureCreateHandler),
+  ('/guide/edit/<int:feature_id>', guide.FeatureEditHandler),
+  ('/guide/stage/<int:feature_id>/<int:stage_id>', guide.FeatureEditHandler),
+  ('/guide/editall/<int:feature_id>', guide.FeatureEditHandler),
+  ('/guide/verify_accuracy/<int:feature_id>', guide.FeatureEditHandler),
+]
+
+mpa_page_routes = [
     ('/admin/subscribers', blink_handler.SubscribersHandler),
     ('/admin/blink', blink_handler.BlinkHandler),
+    ('/admin/users/new', users.UserListHandler),
 
-    ('/feature/<int:feature_id>', featuredetail.FeatureDetailHandler),
+    ('/admin/features/launch/<int:feature_id>',
+     intentpreview.IntentEmailPreviewHandler),
+    ('/admin/features/launch/<int:feature_id>/<int:stage_id>',
+     intentpreview.IntentEmailPreviewHandler),
 
     # Note: The only requests being made now hit /features.json and
     # /features_v2.json, but both of those cause version == 2.
@@ -131,69 +175,13 @@ page_routes = [
     (r'/features.json', featurelist.FeaturesJsonHandler),
     (r'/features_v2.json', featurelist.FeaturesJsonHandler),
 
-    ('/', basehandlers.Redirector,
-     {'location': '/roadmap'}),
-
-    ('/newfeatures', basehandlers.ConstHandler,
-     {'template_path': 'new-feature-list.html'}),
     ('/features', featurelist.FeatureListHandler),
     ('/features/<int:feature_id>', featurelist.FeatureListHandler),
     ('/features.xml', basehandlers.ConstHandler,
      {'template_path': 'farewell-rss.xml'}),
 
-    ('/guide/new', guide.FeatureNew),
-    ('/guide/edit/<int:feature_id>', guide.ProcessOverview),
-    ('/guide/stage/<int:feature_id>/<int:stage_id>', guide.FeatureEditStage),
-    ('/guide/editall/<int:feature_id>', guide.FeatureEditAllFields),
-    ('/guide/verify_accuracy/<int:feature_id>', guide.FeatureVerifyAccuracy),
-
-    ('/admin/features/launch/<int:feature_id>',
-     intentpreview.IntentEmailPreviewHandler),
-    ('/admin/features/launch/<int:feature_id>/<int:stage_id>',
-     intentpreview.IntentEmailPreviewHandler),
-
-    ('/metrics', basehandlers.Redirector,
-     {'location': '/metrics/css/popularity'}),
-    ('/metrics/css', basehandlers.Redirector,
-     {'location': '/metrics/css/popularity'}),
-
-    # TODO(jrobbins): These seem like they belong in metrics.py.
-    ('/metrics/css/popularity', basehandlers.ConstHandler,
-     {'template_path': 'metrics/css/popularity.html'}),
-    ('/metrics/css/animated', basehandlers.ConstHandler,
-     {'template_path': 'metrics/css/animated.html'}),
-    ('/metrics/css/timeline/popularity', basehandlers.ConstHandler,
-     {'template_path': 'metrics/css/timeline/popularity.html'}),
-    ('/metrics/css/timeline/popularity/<int:bucket_id>',
-     basehandlers.ConstHandler,
-     {'template_path': 'metrics/css/timeline/popularity.html'}),
-    ('/metrics/css/timeline/animated', basehandlers.ConstHandler,
-     {'template_path': 'metrics/css/timeline/animated.html'}),
-    ('/metrics/css/timeline/animated/<int:bucket_id>',
-     basehandlers.ConstHandler,
-     {'template_path': 'metrics/css/timeline/animated.html'}),
-    ('/metrics/feature/popularity', basehandlers.ConstHandler,
-     {'template_path': 'metrics/feature/popularity.html'}),
-    ('/metrics/feature/timeline/popularity', basehandlers.ConstHandler,
-     {'template_path': 'metrics/feature/timeline/popularity.html'}),
-    ('/metrics/feature/timeline/popularity/<int:bucket_id>',
-     basehandlers.ConstHandler,
-     {'template_path': 'metrics/feature/timeline/popularity.html'}),
     ('/omaha_data', metrics.OmahaDataHandler),
-
-    ('/myfeatures', basehandlers.ConstHandler,
-     {'template_path': 'myfeatures.html', 'require_signin': True}),
-
-    ('/roadmap', basehandlers.ConstHandler,
-     {'template_path': 'roadmap.html'}),
-
-    ('/settings', basehandlers.ConstHandler,
-     {'template_path': 'settings.html', 'require_signin': True}),
-    ('/admin/users/new', users.UserListHandler),
-
-    ('/spa', basehandlers.ConstHandler, {'template_path': 'spa.html'}),
 ]
-
 
 internals_routes = [
   ('/cron/metrics', fetchmetrics.YesterdayHandler),
@@ -212,8 +200,8 @@ internals_routes = [
 # All requests to the app-py3 GAE service are handled by this Flask app.
 app = basehandlers.FlaskApplication(
     __name__,
-    (metrics_chart_routes + api_routes + page_routes +
-     internals_routes))
+    (metrics_chart_routes + api_routes + mpa_page_routes + spa_page_routes +
+     internals_routes), spa_page_post_routes)
 
 # TODO(jrobbins): Make the CSP handler be a class like our others.
 app.add_url_rule(

--- a/main_test.py
+++ b/main_test.py
@@ -33,23 +33,6 @@ class MainTest(testing_config.CustomTestCase):
     """Just test that this file parses and creates an app object."""
     self.assertIsNotNone(main.app)
 
-  def test_redirects(self):
-    """Redirect are working."""
-    main.app.wsgi_app = main.app.original_wsgi_app
-    test_client = testing.FlaskClient(main.app)
-
-    response = test_client.get('/')
-    self.assertEqual(302, response.status_code)
-    self.assertEqual('/roadmap', response.location)
-
-    response = test_client.get('/metrics')
-    self.assertEqual(302, response.status_code)
-    self.assertEqual('/metrics/css/popularity', response.location)
-
-    response = test_client.get('/metrics/css')
-    self.assertEqual(302, response.status_code)
-    self.assertEqual('/metrics/css/popularity', response.location)
-
 
 class ConstTemplateTest(testing_config.CustomTestCase):
 
@@ -67,7 +50,7 @@ class ConstTemplateTest(testing_config.CustomTestCase):
 
   def test_const_templates(self):
     """All the ConstHandler instances render valid HTML."""
-    for route in main.page_routes:
+    for route in main.mpa_page_routes:
       if (route[1] == basehandlers.ConstHandler and
           not route[0].endswith('.xml')):
         with self.subTest(path=route[0]):

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -28,15 +28,7 @@ from internals import processes
 import settings
 
 
-class FeatureNew(basehandlers.FlaskHandler):
-
-  TEMPLATE_PATH = 'guide/new.html'
-
-  @permissions.require_create_feature
-  def get_template_data(self):
-    user = self.get_current_user()
-    template_data = {'user_email': user.email()}
-    return template_data
+class FeatureCreateHandler(basehandlers.FlaskHandler):
 
   @permissions.require_create_feature
   def process_post_data(self):
@@ -80,24 +72,7 @@ class FeatureNew(basehandlers.FlaskHandler):
     return self.redirect(redirect_url)
 
 
-class ProcessOverview(basehandlers.FlaskHandler):
-
-  TEMPLATE_PATH = 'guide/edit.html'
-
-  def get_template_data(self, feature_id):
-    # Validate the user has edit permissions and redirect if needed.
-    redirect_resp = permissions.validate_feature_edit_permission(
-        self, feature_id)
-    if redirect_resp:
-      return redirect_resp
-
-    template_data = {'feature_id': feature_id}
-    return template_data
-
-
-class FeatureEditStage(basehandlers.FlaskHandler):
-
-  TEMPLATE_PATH = 'guide/stage.html'
+class FeatureEditHandler(basehandlers.FlaskHandler):
 
   def touched(self, param_name):
     """Return True if the user edited the specified field."""
@@ -131,34 +106,6 @@ class FeatureEditStage(basehandlers.FlaskHandler):
 
     # See TODO at top of this method.
     return param_name in self.form
-
-  def get_blink_component_from_bug(self, blink_components, bug_url):
-    # TODO(jrobbins): Use monorail API instead of scrapping.
-    return []
-
-  def get_feature_and_process(self, feature_id):
-    """Look up the feature that the user wants to edit, and its process."""
-    f = core_models.Feature.get_by_id(feature_id)
-    if f is None:
-      self.abort(404, msg='Feature not found')
-
-    feature_process = processes.ALL_PROCESSES.get(
-        f.feature_type, processes.BLINK_LAUNCH_PROCESS)
-
-    return f, feature_process
-
-  def get_template_data(self, feature_id, stage_id):
-    # Validate the user has edit permissions and redirect if needed.
-    redirect_resp = permissions.validate_feature_edit_permission(
-        self, feature_id)
-    if redirect_resp:
-      return redirect_resp
-
-    template_data = {
-      'stage_id': stage_id,
-      'feature_id': feature_id,
-    }
-    return template_data
 
   def process_post_data(self, feature_id, stage_id=0):
     # Validate the user has edit permissions and redirect if needed.
@@ -453,32 +400,3 @@ class FeatureEditStage(basehandlers.FlaskHandler):
 
     redirect_url = '/guide/edit/' + str(key.integer_id())
     return self.redirect(redirect_url)
-
-
-class FeatureEditAllFields(FeatureEditStage):
-  """Flat form page that lists all fields in seprate sections."""
-
-  TEMPLATE_PATH = 'guide/editall.html'
-
-  def get_template_data(self, feature_id):
-    # Validate the user has edit permissions and redirect if needed.
-    redirect_resp = permissions.validate_feature_edit_permission(
-        self, feature_id)
-    if redirect_resp:
-      return redirect_resp
-
-    template_data = {'feature_id': feature_id}
-    return template_data
-
-class FeatureVerifyAccuracy(FeatureEditStage):
-  TEMPLATE_PATH = 'guide/verify_accuracy.html'
-
-  def get_template_data(self, feature_id):
-    # Validate the user has edit permissions and redirect if needed.
-    redirect_resp = permissions.validate_feature_edit_permission(
-        self, feature_id)
-    if redirect_resp:
-      return redirect_resp
-
-    template_data = {'feature_id': feature_id}
-    return template_data

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -43,24 +43,10 @@ class TestWithFeature(testing_config.CustomTestCase):
     ramcache.check_for_distributed_invalidation()
 
 
-class FeatureNewTest(testing_config.CustomTestCase):
+class FeatureCreateTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.handler = guide.FeatureNew()
-
-  def test_get__anon(self):
-    """Anon cannot create features, gets a redirect to sign in page."""
-    testing_config.sign_out()
-    with test_app.test_request_context('/guide/new'):
-      actual_response = self.handler.get_template_data()
-    self.assertEqual('302 FOUND', actual_response.status)
-
-  def test_get__non_allowed(self):
-    """Non-allowed cannot create features, gets a 403."""
-    testing_config.sign_in('user1@example.com', 1234567890)
-    with test_app.test_request_context('/guide/new'):
-      with self.assertRaises(werkzeug.exceptions.Forbidden):
-        actual_response = self.handler.get_template_data()
+    self.handler = guide.FeatureCreateHandler()
 
   def test_post__anon(self):
     """Anon cannot create features, gets a 403."""
@@ -98,117 +84,7 @@ class FeatureNewTest(testing_config.CustomTestCase):
     feature.key.delete()
 
 
-class FeatureNewTemplateTest(TestWithFeature):
-
-  HANDLER_CLASS = guide.FeatureNew
-
-  def setUp(self):
-    super(FeatureNewTemplateTest, self).setUp()
-    with test_app.test_request_context(self.request_path):
-      self.template_data = self.handler.get_template_data()
-
-      self.template_data.update(self.handler.get_common_data())
-      self.template_data['nonce'] = 'fake nonce'
-      template_path = self.handler.get_template_path(self.template_data)
-      self.full_template_path = os.path.join(template_path)
-
-  def test_html_rendering(self):
-    """We can render the template with valid html."""
-    testing_config.sign_in('user1@google.com', 1234567890)
-    template_text = self.handler.render(
-        self.template_data, self.full_template_path)
-    parser = html5lib.HTMLParser(strict=True)
-    document = parser.parse(template_text)
-
-
-class ProcessOverviewTest(testing_config.CustomTestCase):
-
-  def setUp(self):
-    self.feature_1 = core_models.Feature(
-        name='feature one', summary='sum', owner=['user1@google.com'],
-        category=1, visibility=1, standardization=1,
-        web_dev_views=core_enums.DEV_NO_SIGNALS, impl_status_chrome=1)
-    self.feature_1.put()
-
-    self.request_path = '/guide/edit/%d' % self.feature_1.key.integer_id()
-    self.handler = guide.ProcessOverview()
-
-  def tearDown(self):
-    self.feature_1.key.delete()
-
-  def test_get__anon(self):
-    """Anon cannot edit features, gets a redirect to viewing page."""
-    testing_config.sign_out()
-    with test_app.test_request_context(self.request_path):
-      actual_response = self.handler.get_template_data(
-          self.feature_1.key.integer_id())
-    self.assertEqual('302 FOUND', actual_response.status)
-
-  def test_get__non_allowed(self):
-    """Non-allowed cannot create features, gets a 403."""
-    testing_config.sign_in('user1@example.com', 1234567890)
-    with test_app.test_request_context(self.request_path):
-      with self.assertRaises(werkzeug.exceptions.Forbidden):
-        self.handler.get_template_data(self.feature_1.key.integer_id())
-
-
-  def test_get__not_found(self):
-    """Allowed users get a 404 if there is no such feature."""
-    testing_config.sign_in('user1@google.com', 1234567890)
-    with test_app.test_request_context(self.request_path):
-      with self.assertRaises(werkzeug.exceptions.NotFound):
-        self.handler.get_template_data(999)
-
-  def test_get__normal(self):
-    """Allowed users render a page with a process overview."""
-    testing_config.sign_in('user1@google.com', 1234567890)
-
-    with test_app.test_request_context(self.request_path):
-      template_data = self.handler.get_template_data(
-          self.feature_1.key.integer_id())
-
-    self.assertTrue('feature_id' in template_data)
-
-
-class ProcessOverviewTemplateTest(TestWithFeature):
-
-  HANDLER_CLASS = guide.ProcessOverview
-
-  def setUp(self):
-    super(ProcessOverviewTemplateTest, self).setUp()
-
-    self.feature_1 = core_models.Feature(
-        name='feature one', summary='sum', owner=['user1@google.com'],
-        category=1, visibility=1, standardization=1,
-        web_dev_views=core_enums.DEV_NO_SIGNALS, impl_status_chrome=1)
-    self.feature_1.put()
-    self.request_path = '/guide/edit/%d' % self.feature_1.key.integer_id()
-
-    with test_app.test_request_context(self.request_path):
-      self.template_data = self.handler.get_template_data(
-        self.feature_1.key.integer_id()
-      )
-
-      self.template_data.update(self.handler.get_common_data())
-      self.template_data['nonce'] = 'fake nonce'
-      template_path = self.handler.get_template_path(self.template_data)
-      self.full_template_path = os.path.join(template_path)
-
-  def test_html_rendering(self):
-    """We can render the template with valid html."""
-    testing_config.sign_in('user1@google.com', 1234567890)
-
-    with test_app.test_request_context(self.request_path):
-      template_data = self.handler.get_template_data(
-          self.feature_1.key.integer_id())
-
-    template_text = self.handler.render(
-        template_data, self.full_template_path)
-    parser = html5lib.HTMLParser(strict=True)
-    document = parser.parse(template_text)
-
-
-class FeatureEditStageTest(testing_config.CustomTestCase):
+class FeatureEditHandlerTest(testing_config.CustomTestCase):
 
   def setUp(self):
     self.feature_1 = core_models.Feature(
@@ -220,7 +96,7 @@ class FeatureEditStageTest(testing_config.CustomTestCase):
 
     self.request_path = ('/guide/stage/%d/%d' % (
         self.feature_1.key.integer_id(), self.stage))
-    self.handler = guide.FeatureEditStage()
+    self.handler = guide.FeatureEditHandler()
 
   def tearDown(self):
     self.feature_1.key.delete()
@@ -257,38 +133,6 @@ class FeatureEditStageTest(testing_config.CustomTestCase):
       self.assertTrue(self.handler.touched('feature_type'))
       # intent_state is a select, but it was not present in this POST.
       self.assertFalse(self.handler.touched('select'))
-
-  def test_get__anon(self):
-    """Anon cannot edit features, gets a redirect to viewing page."""
-    testing_config.sign_out()
-    with test_app.test_request_context(self.request_path):
-      actual_response = self.handler.get_template_data(
-          self.feature_1.key.integer_id(), self.stage)
-    self.assertEqual('302 FOUND', actual_response.status)
-
-  def test_get__non_allowed(self):
-    """Non-allowed cannot edit features, gets a 403."""
-    testing_config.sign_in('user1@example.com', 1234567890)
-    with test_app.test_request_context(self.request_path):
-      with self.assertRaises(werkzeug.exceptions.Forbidden):
-        self.handler.get_template_data(
-            self.feature_1.key.integer_id(), self.stage)
-
-  def test_get__not_found(self):
-    """Allowed users get a 404 if there is no such feature."""
-    testing_config.sign_in('user1@google.com', 1234567890)
-    with test_app.test_request_context(self.request_path):
-      with self.assertRaises(werkzeug.exceptions.NotFound):
-        self.handler.get_template_data(999, self.stage)
-
-  def test_get__normal(self):
-    """Allowed users render a page with a django form."""
-    testing_config.sign_in('user1@google.com', 1234567890)
-
-    with test_app.test_request_context(self.request_path):
-      template_data = self.handler.get_template_data(
-          self.feature_1.key.integer_id(), self.stage)
-    self.assertTrue('feature_id' in template_data)
 
   def test_post__anon(self):
     """Anon cannot edit features, gets a 403."""
@@ -330,96 +174,3 @@ class FeatureEditStageTest(testing_config.CustomTestCase):
     self.assertEqual('Revised feature name', revised_feature.name)
     self.assertEqual('Revised feature summary', revised_feature.summary)
     self.assertEqual(84, revised_feature.shipped_milestone)
-
-
-class FeatureEditStageTemplateTest(TestWithFeature):
-
-  HANDLER_CLASS = guide.FeatureEditStage
-
-  def setUp(self):
-    super(FeatureEditStageTemplateTest, self).setUp()
-    self.feature_1 = core_models.Feature(
-        name='feature one', summary='sum', owner=['user1@google.com'],
-        category=1, visibility=1, standardization=1,
-        web_dev_views=core_enums.DEV_NO_SIGNALS, impl_status_chrome=1)
-    self.feature_1.put()
-    self.stage = core_enums.INTENT_INCUBATE  # Shows first form
-    testing_config.sign_in('user1@google.com', 1234567890)
-
-    with test_app.test_request_context(self.request_path):
-      self.template_data = self.handler.get_template_data(
-        self.feature_1.key.integer_id(), self.stage)
-
-      self.template_data.update(self.handler.get_common_data())
-      self.template_data['nonce'] = 'fake nonce'
-      template_path = self.handler.get_template_path(self.template_data)
-      self.full_template_path = os.path.join(template_path)
-
-  def test_html_rendering(self):
-    """We can render the template with valid html."""
-    template_text = self.handler.render(
-        self.template_data, self.full_template_path)
-    parser = html5lib.HTMLParser(strict=True)
-    document = parser.parse(template_text)
-
-
-
-class FeatureEditAllFieldsTemplateTest(TestWithFeature):
-
-  HANDLER_CLASS = guide.FeatureEditAllFields
-
-  def setUp(self):
-    super(FeatureEditAllFieldsTemplateTest, self).setUp()
-    self.feature_1 = core_models.Feature(
-        name='feature one', summary='sum', owner=['user1@google.com'],
-        category=1, visibility=1, standardization=1,
-        web_dev_views=core_enums.DEV_NO_SIGNALS, impl_status_chrome=1)
-    self.feature_1.put()
-    self.stage = core_enums.INTENT_INCUBATE  # Shows first form
-    testing_config.sign_in('user1@google.com', 1234567890)
-
-    with test_app.test_request_context(self.request_path):
-      self.template_data = self.handler.get_template_data(
-        self.feature_1.key.integer_id())
-
-      self.template_data.update(self.handler.get_common_data())
-      self.template_data['nonce'] = 'fake nonce'
-      template_path = self.handler.get_template_path(self.template_data)
-      self.full_template_path = os.path.join(template_path)
-
-  def test_html_rendering(self):
-    """We can render the template with valid html."""
-    template_text = self.handler.render(
-        self.template_data, self.full_template_path)
-    parser = html5lib.HTMLParser(strict=True)
-    document = parser.parse(template_text)
-
-class FeatureVerifyAccuracyTemplateTest(TestWithFeature):
-
-  HANDLER_CLASS = guide.FeatureVerifyAccuracy
-
-  def setUp(self):
-    super(FeatureVerifyAccuracyTemplateTest, self).setUp()
-    self.feature_1 = core_models.Feature(
-        name='feature one', summary='sum', owner=['user1@google.com'],
-        category=1, visibility=1, standardization=1,
-        web_dev_views=core_enums.DEV_NO_SIGNALS, impl_status_chrome=1)
-    self.feature_1.put()
-    self.stage = core_enums.INTENT_INCUBATE  # Shows first form
-    testing_config.sign_in('user1@google.com', 1234567890)
-
-    with test_app.test_request_context(self.request_path):
-      self.template_data = self.handler.get_template_data(
-        self.feature_1.key.integer_id())
-
-      self.template_data.update(self.handler.get_common_data())
-      self.template_data['nonce'] = 'fake nonce'
-      template_path = self.handler.get_template_path(self.template_data)
-      self.full_template_path = os.path.join(template_path)
-
-  def test_html_rendering(self):
-    """We can render the template with valid html."""
-    template_text = self.handler.render(
-        self.template_data, self.full_template_path)
-    parser = html5lib.HTMLParser(strict=True)
-    document = parser.parse(template_text)

--- a/static/elements/chromedash-app.js
+++ b/static/elements/chromedash-app.js
@@ -115,7 +115,7 @@ class ChromedashApp extends LitElement {
     });
     page('/feature/:featureId', (ctx) => {
       this.pageComponent = document.createElement('chromedash-feature-page');
-      this.pageComponent.featureId = ctx.params.featureId;
+      this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.contextLink = this.contextLink;
     });
     page('/guide/new', () => {

--- a/static/elements/chromedash-header.js
+++ b/static/elements/chromedash-header.js
@@ -198,6 +198,7 @@ export class ChromedashHeader extends LitElement {
     };
 
     // user is not passed in from anywhere, i.e. this.user is still {}
+    // this is for MPA pages where this component is initialized in _base.html
     this.loading = true;
     window.csClient.getPermissions().then((user) => {
       this.user = user;

--- a/static/elements/chromedash-header.js
+++ b/static/elements/chromedash-header.js
@@ -182,11 +182,22 @@ export class ChromedashHeader extends LitElement {
     this.googleSignInClientId = '',
     this.currentPage = '';
     this.user = {};
-    this.loading = true;
+    this.loading = false;
   }
 
   connectedCallback() {
     super.connectedCallback();
+
+    // user is passed in from chromedash-app
+    if (this.user && this.user.email) return;
+
+    // user is passed in from chromedash-app, but the user is not logged in
+    if (!this.user) {
+      this.initializeGoogleSignIn();
+      return;
+    };
+
+    // user is not passed in from anywhere, i.e. this.user is still {}
     this.loading = true;
     window.csClient.getPermissions().then((user) => {
       this.user = user;

--- a/static/elements/chromedash-timeline.js
+++ b/static/elements/chromedash-timeline.js
@@ -119,18 +119,6 @@ class ChromedashTimeline extends LitElement {
 
   firstUpdated() {
     window.google.charts.load('current', {'packages': ['corechart']});
-    window.google.charts.setOnLoadCallback(() => {
-      // If there's an id in the URL, load the property it.
-      // TODO (kevinshen56714) - this can be removed once SPA is fully set up
-      // as the bucketId is passed in from the router.
-      const lastSlash = location.pathname.lastIndexOf('/');
-      if (lastSlash > 0) {
-        const id = parseInt(location.pathname.substring(lastSlash + 1));
-        if (String(id) != 'NaN') {
-          this.selectedBucketId = id;
-        }
-      }
-    });
   }
 
   drawVisualization(data, bucketId, showAllHistoricalData) {
@@ -237,10 +225,10 @@ class ChromedashTimeline extends LitElement {
       this.drawVisualization(response, this.selectedBucketId, this.showAllHistoricalData);
     });
 
-    if (history.pushState) {
-      const url = '/metrics/' + this.type + '/timeline/' + this.view + '/' +
-                this.selectedBucketId;
-      history.pushState({id: this.selectedBucketId}, '', url);
+    const currentUrl = '/metrics/' + this.type + '/timeline/' + this.view + '/' +
+              this.selectedBucketId;
+    if (history.pushState && location.pathname != currentUrl) {
+      history.pushState({id: this.selectedBucketId}, '', currentUrl);
     }
   }
 


### PR DESCRIPTION
This PR sets up the SPA routes, permission checks, and launches the single-page app.

## Routes
1. All the page routes (except for /features, /admin, and /omaha_data) are now handled via a new `SPAHandler` whose template_path is spa.html and doesn't require any page-specific data. The `SPAHandler` is slightly different than the `ConstHandler` in that it has more permission checks (more about permissions below), so I think it's better to separate the two.
2. I separated the GET and POST routes for SPA. The GET routes are added to the Flask app as usual, and the POST routes are provided separately as a list to `basehandlers.FlaskApplication`. These POST routes have the methods=['POST'] and are added ahead of the GET routes so they don't get handled by `SPAHandler`.
3. The POST routes are either handled by the `FeatureCreateHandler` or `FeatureEditHandler` in guide.py (they are just renamed from previous `FeatureNew` and `FeatureEditStage` classes).
4. Some routes were redirected by the server (via `Redirector`), for example, `'/' -> '/roadmap'` and `'/metrics' -> '/metrics/css/popularity'`. These redirections are now handled by the client router in chromedash-app element.

## Permissions
1. In `SPAHandler`, there are three levels of permissions checks - `require_signin`, `require_create_feature`, and `require_edit_feature` that can be specified in the "defaults" dict argument.
2. The /myfeatures and /settings pages have `require_signin` set to True
3. The /guide/new page have `require_create_feature` set to True. The create feature permission is checked by a new method `validate_feature_create_permission` in framework/permissions.py. I had to create this new function because although the current `require_create_feature` function does the same thing, it has to be used as a decorator.
4. The /guide/edit, /guide/editall, /guide/verify_accuracy, and guide/stage pages have `require_edit_feature` set to True. Users need the feature-specific permission to view these pages.
5. Users will be redirected if they don't have the required permissions.

## Misc
1. User object is now fetched through API in `<chromedash-app>`. The user object is now only passed down to the header element, but in a follow-up PR, I will pass it down to all the page elements that fetch user data.
2. `guide.ProcessOverview`, `guide.FeatureEditAllFields`, `guide.FeatureVerifyAccuracy` classes and their unit tests are removed because they don't handle GET request anymore and their POST requests can all be handled the same way via the new `FeatureEditHandler`
3. If this PR looks good. In a follow-up PR, I will remove all the unused HTML files!