### PR TITLE
Update test coverage commands and configs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,8 @@ include =
     ./*.py
 omit =
     ./lib/*
+    ./cs-env/*
+    ./*_test.py
 [report]
 exclude_lines =
     # Have to re-enable the standard pragma

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,8 @@ static/js/
 .coverage
 htmlcov
 
+# Web test runner coverage report
+coverage
+
 # venv directory
 cs-env

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "stop": "killall cs-env/bin/python3.9",
     "test": "(npm run start-emulator > /dev/null 2>&1 &); sleep 6; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-tests; status=$?; npm run stop-emulator; exit $status",
     "webtest": "web-test-runner \"static/**/*_test.js\" --node-resolve --playwright --browsers chromium firefox",
+    "webtest-coverage": "web-test-runner \"static/**/*_test.js\" --node-resolve --playwright --coverage --browsers chromium firefox",
     "do-coverage": "coverage3 erase && coverage3 run -m unittest discover -p '*_test.py' -b && coverage3 html",
     "coverage": "source cs-env/bin/activate; (npm run start-emulator > /dev/null 2>&1 &); sleep 3; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-coverage;  npm run stop-emulator",
     "view-coverage": "pushd htmlcov/; python3 -m http.server 8080; popd",


### PR DESCRIPTION
The existing python test coverage report includes all the python files in /cs-env  and all the test files themselves. This PR modifies the `.coveragerc` so that those files are excluded in the coverage calculation.

Meanwhile, I added a new command `npm run webtest-coverage` to generate the JS coverage report. The report is generated to the ./coverage folder so I add that directory in .gitignore.