### PR TITLE
Use hoist to make all sl-select elements faster

### DIFF
--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -97,6 +97,7 @@ export class ChromedashFormField extends LitElement {
           id="id_${this.name}"
           value="${fieldValue}"
           size="small"
+          hoist
           ?disabled=${this.disabled || this.loading}>
           ${Object.values(choices).map(
             ([value, label]) => html`
@@ -141,7 +142,7 @@ export class ChromedashFormField extends LitElement {
     } else if (type === 'datalist') {
       fieldHTML = html`
         <div class="datalist-input-wrapper">
-          <input 
+          <input
             ${ref(this.updateAttributes)}
             name="${fieldName}"
             id="id_${this.name}"

--- a/static/elements/chromedash-roadmap-milestone-card.js
+++ b/static/elements/chromedash-roadmap-milestone-card.js
@@ -1,6 +1,6 @@
 import {LitElement, html, nothing} from 'lit';
 import {ROADMAP_MILESTONE_CARD_CSS} from
-  '../sass/elements/chromedash-roadmap-milestone-card-css.js';
+'../sass/elements/chromedash-roadmap-milestone-card-css.js';
 
 const REMOVED_STATUS = ['Removed'];
 const DEPRECATED_STATUS = ['Deprecated', 'No longer pursuing'];


### PR DESCRIPTION
Earlier this week I discovered that the blink component field took a really long time to open, and that adding hoist is a work-around.  Today I realized that all our sl-selects are kind of slow (but not as bad as that one was), so using hoist is an improvement.

See also:
https://github.com/shoelace-style/shoelace/discussions/902