### PR TITLE
Add stack rank and timeline page unit tests

### DIFF
--- a/static/elements/chromedash-stack-rank-page.js
+++ b/static/elements/chromedash-stack-rank-page.js
@@ -1,5 +1,6 @@
 import {LitElement, css, html} from 'lit';
 import './chromedash-stack-rank';
+import {showToastMessage} from './utils';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
 

--- a/static/elements/chromedash-stack-rank-page_test.js
+++ b/static/elements/chromedash-stack-rank-page_test.js
@@ -1,0 +1,62 @@
+import {html} from 'lit';
+import {assert, fixture} from '@open-wc/testing';
+import {ChromedashStackRankPage} from './chromedash-stack-rank-page';
+import './chromedash-toast';
+import sinon from 'sinon';
+
+describe('chromedash-stack-rank-page', () => {
+  /* <chromedash-toast> are initialized at _base.html
+   * which are not available here, so we initialize them before each test.
+   * We also stub out the API calls here so that they return test data. */
+  beforeEach(async () => {
+    await fixture(html`<chromedash-toast></chromedash-toast>`);
+    sinon.stub(window, 'fetch');
+  });
+
+  afterEach(() => {
+    window.fetch.restore();
+  });
+
+  it('invalid stack-rank fetch response', async () => {
+    window.fetch.returns(Promise.reject(new Error('No results')));
+    const component = await fixture(
+      html`<chromedash-stack-rank-page></chromedash-stack-rank-page>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashStackRankPage);
+
+    // error response would trigger the toast to show message
+    const toastEl = document.querySelector('chromedash-toast');
+    const toastMsgSpan = toastEl.shadowRoot.querySelector('span#msg');
+    assert.include(toastMsgSpan.innerHTML,
+      'Some errors occurred. Please refresh the page or try again later.');
+  });
+
+  it('valid stack-rank fetch response', async () => {
+    const type = 'feature';
+    const view = 'popularity';
+    window.fetch.returns(Promise.resolve({}));
+    const component = await fixture(
+      html`<chromedash-stack-rank-page
+            .type="${type}"
+            .view="${view}">
+           </chromedash-stack-rank-page>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashStackRankPage);
+
+    // header exists and with the correct link and title
+    const subheaderDiv = component.shadowRoot.querySelector('div#subheader');
+    assert.exists(subheaderDiv);
+    assert.include(subheaderDiv.innerHTML,
+      'HTML &amp; JavaScript usage metrics &gt; all features &gt; stack rank');
+
+    // datalist and its input exist
+    const datalistInputEl = component.shadowRoot.querySelector('input#datalist-input');
+    const datalistEl = component.shadowRoot.querySelector('datalist#features');
+    assert.exists(datalistInputEl);
+    assert.exists(datalistEl);
+
+    // chromedash-stack-rank exists
+    const stackrankEl = component.shadowRoot.querySelector('chromedash-stack-rank');
+    assert.exists(stackrankEl);
+  });
+});

--- a/static/elements/chromedash-timeline-page.js
+++ b/static/elements/chromedash-timeline-page.js
@@ -1,5 +1,6 @@
 import {LitElement, css, html} from 'lit';
 import './chromedash-timeline';
+import {showToastMessage} from './utils';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
 

--- a/static/elements/chromedash-timeline-page_test.js
+++ b/static/elements/chromedash-timeline-page_test.js
@@ -1,0 +1,59 @@
+import {html} from 'lit';
+import {assert, fixture} from '@open-wc/testing';
+import {ChromedashTimelinePage} from './chromedash-timeline-page';
+import './chromedash-toast';
+import sinon from 'sinon';
+
+describe('chromedash-timeline-page', () => {
+  /* <chromedash-toast> are initialized at _base.html
+   * which are not available here, so we initialize them before each test.
+   * We also stub out the API calls here so that they return test data. */
+  beforeEach(async () => {
+    await fixture(html`<chromedash-toast></chromedash-toast>`);
+    sinon.stub(window, 'fetch');
+    // hacky way to stub out google chart methods
+    window.google = {charts: {load: () => {}, setOnLoadCallback: () => {}}};
+  });
+
+  afterEach(() => {
+    window.fetch.restore();
+  });
+
+  it('invalid timeline fetch response', async () => {
+    window.fetch.returns(Promise.reject(new Error('No results')));
+    const component = await fixture(
+      html`<chromedash-timeline-page></chromedash-timeline-page>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashTimelinePage);
+
+    // error response would trigger the toast to show message
+    const toastEl = document.querySelector('chromedash-toast');
+    const toastMsgSpan = toastEl.shadowRoot.querySelector('span#msg');
+    assert.include(toastMsgSpan.innerHTML,
+      'Some errors occurred. Please refresh the page or try again later.');
+  });
+
+  it('valid timeline fetch response', async () => {
+    const type = 'feature';
+    const view = 'popularity';
+    window.fetch.returns(Promise.resolve({}));
+    const component = await fixture(
+      html`<chromedash-timeline-page
+            .type="${type}"
+            .view="${view}">
+           </chromedash-timeline-page>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashTimelinePage);
+
+    // header exists and with the correct link and title
+    const subheaderDiv = component.shadowRoot.querySelector('div#subheader');
+    assert.exists(subheaderDiv);
+    assert.include(subheaderDiv.innerHTML, `href="/metrics/${type}/${view}"`);
+    assert.include(subheaderDiv.innerHTML,
+      'HTML &amp; JavaScript usage metrics &gt; all features &gt; timeline');
+
+    // chromedash-timeline exists
+    const timelineEl = component.shadowRoot.querySelector('chromedash-timeline');
+    assert.exists(timelineEl);
+  });
+});


### PR DESCRIPTION
This PR adds unit tests for `<chromedash-stack-rank-page>` and `<chromedash-timeline-page>` that I forgot to add when creating the page elements. The tests are pretty standard except that in the timeline test, I had to add the following to avoid warnings about undefined load and setOnLoadCallback methods from window.google.charts.
```js
window.google = {charts: {load: () => {}, setOnLoadCallback: () => {}}};
```
