### PR TITLE
Fix milestone table in accurate-as-of email.

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -328,7 +328,7 @@ class FeatureAccuracyHandler(basehandlers.FlaskHandler):
     email_tasks = []
     for feature, mstone in features_to_notify:
       body_data = {
-        'feature': feature.format_for_template(),
+        'feature': feature,
         'site_url': settings.SITE_URL,
         'milestone': mstone,
       }


### PR DESCRIPTION
This is a fix for the issue that was reported via an email thread.  Basically, the milestone table was not showing up in the accurate-as-of email message body.  Instead, it was saying that there were no milestones defined, even though there was clearly some milestone that triggered the email to be sent.

The problem was that this method was passing feature.format_for_template() to the template, when actually just passing feature is better.  The format_for_template() method is not used as much as it once was, and a lot of the templates expect just a plain feature model instance.