### PR TITLE
Guard cron handlers.

### DIFF
--- a/internals/data_backup.py
+++ b/internals/data_backup.py
@@ -33,6 +33,7 @@ class BackupExportHandler(basehandlers.FlaskHandler):
   """Triggers a new Datastore export."""
 
   def get_template_data(self):
+    self.require_cron_header()
     bucket = f'gs://{settings.BACKUP_BUCKET}'
     # The default cache (file_cache) is unavailable when using oauth2client >= 4.0.0 or google-auth,
     # and it will log worrisome messages unless given another interface to use.

--- a/internals/deprecate_field.py
+++ b/internals/deprecate_field.py
@@ -8,6 +8,7 @@ class WriteStandardMaturityHandler(FlaskHandler):
 
   def get_template_data(self):
     """Writes standard_maturity field from the old standardization field."""
+    self.require_cron_header()
     q = Feature.query()
     features = q.fetch()
     update_count = 0
@@ -17,7 +18,7 @@ class WriteStandardMaturityHandler(FlaskHandler):
         update_count += 1
         feature.standard_maturity = STANDARD_MATURITY_BACKFILL[feature.standardization]
         feature.put(notify=False)
-    
+
     logging.info(
         f'{update_count} features updated with standard_maturity field.')
     return 'Success'

--- a/internals/fetchmetrics.py
+++ b/internals/fetchmetrics.py
@@ -186,6 +186,7 @@ class YesterdayHandler(basehandlers.FlaskHandler):
       filename: The filename for the data file to be loaded.
       today: date passed in for testing, defaults to today.
     """
+    self.require_cron_header()
     days = []
     date_str = self.request.args.get('date')
     if date_str:
@@ -244,6 +245,7 @@ class HistogramsHandler(basehandlers.FlaskHandler):
     )
 
   def get_template_data(self):
+    self.require_cron_header()
     # Attempt to fetch enums mapping file.
     response = requests.get(HISTOGRAMS_URL, timeout=60)
 
@@ -278,5 +280,6 @@ class HistogramsHandler(basehandlers.FlaskHandler):
 class BlinkComponentHandler(basehandlers.FlaskHandler):
   """Updates the list of Blink components in the db."""
   def get_template_data(self):
+    self.require_cron_header()
     user_models.BlinkComponent.update_db()
     return 'Blink components updated'

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -279,7 +279,7 @@ class FeatureAccuracyHandler(basehandlers.FlaskHandler):
 
   def get_template_data(self):
     """Sends notifications to users requesting feature updates for accuracy."""
-
+    self.require_cron_header()
     features_to_notify = self._determine_features_to_notify()
     email_tasks = self._build_email_tasks(features_to_notify)
     send_emails(email_tasks)

--- a/static/elements/chromedash-roadmap-milestone-card.js
+++ b/static/elements/chromedash-roadmap-milestone-card.js
@@ -1,6 +1,6 @@
 import {LitElement, html, nothing} from 'lit';
 import {ROADMAP_MILESTONE_CARD_CSS} from
-  '../sass/elements/chromedash-roadmap-milestone-card-css.js';
+'../sass/elements/chromedash-roadmap-milestone-card-css.js';
 
 const REMOVED_STATUS = ['Removed'];
 const DEPRECATED_STATUS = ['Deprecated', 'No longer pursuing'];


### PR DESCRIPTION
Check that requests that run cron handlers come from GAE or from a site admin.