### PR TITLE
Remove "remove spinner" code for SPA pages

### DIFF
--- a/static/elements/chromedash-all-features-page.js
+++ b/static/elements/chromedash-all-features-page.js
@@ -38,10 +38,6 @@ export class ChromedashAllFeaturesPage extends LitElement {
     ]).then(([user, starredFeatures]) => {
       this.user = user;
       this.starredFeatures = new Set(starredFeatures);
-
-      // TODO(kevinshen56714): Remove this once SPA index page is set up.
-      // Has to include this for now to remove the spinner at _base.html.
-      document.body.classList.remove('loading');
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });

--- a/static/elements/chromedash-feature-page.js
+++ b/static/elements/chromedash-feature-page.js
@@ -135,10 +135,6 @@ export class ChromedashFeaturePage extends LitElement {
         document.title = `${this.feature.name} - ${this.appTitle}`;
       }
       this.loading = false;
-
-      // TODO(kevinshen56714): Remove this once SPA index page is set up.
-      // Has to include this for now to remove the spinner at _base.html.
-      document.body.classList.remove('loading');
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });

--- a/static/elements/chromedash-guide-edit-page.js
+++ b/static/elements/chromedash-guide-edit-page.js
@@ -76,10 +76,6 @@ export class ChromedashGuideEditPage extends LitElement {
       if (this.feature.name) {
         document.title = `${this.feature.name} - ${this.appTitle}`;
       }
-
-      // TODO(kevinshen56714): Remove this once SPA index page is set up.
-      // Has to include this for now to remove the spinner at _base.html.
-      document.body.classList.remove('loading');
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });

--- a/static/elements/chromedash-guide-editall-page.js
+++ b/static/elements/chromedash-guide-editall-page.js
@@ -47,10 +47,6 @@ export class ChromedashGuideEditallPage extends LitElement {
         document.title = `${this.feature.name} - ${this.appTitle}`;
       }
       this.loading = false;
-
-      // TODO(kevinshen56714): Remove this once SPA index page is set up.
-      // Has to include this for now to remove the spinner at _base.html.
-      document.body.classList.remove('loading');
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });

--- a/static/elements/chromedash-guide-new-page.js
+++ b/static/elements/chromedash-guide-new-page.js
@@ -43,14 +43,6 @@ export class ChromedashGuideNewPage extends LitElement {
     this.userEmail = '';
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-
-    // TODO(kevinshen56714): Remove this once SPA index page is set up.
-    // Has to include this for now to remove the spinner at _base.html.
-    document.body.classList.remove('loading');
-  }
-
   /* Add the form's event listener after Shoelace event listeners are attached
    * see more at https://github.com/GoogleChrome/chromium-dashboard/issues/2014 */
   async registerFormSubmitHandler(el) {

--- a/static/elements/chromedash-guide-stage-page.js
+++ b/static/elements/chromedash-guide-stage-page.js
@@ -70,10 +70,6 @@ export class ChromedashGuideStagePage extends LitElement {
         IMPL_STATUS_FORMS[this.stageId] || [null, null];
 
       this.loading = false;
-
-      // TODO(kevinshen56714): Remove this once SPA index page is set up.
-      // Has to include this for now to remove the spinner at _base.html.
-      document.body.classList.remove('loading');
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });

--- a/static/elements/chromedash-guide-verify-accuracy-page.js
+++ b/static/elements/chromedash-guide-verify-accuracy-page.js
@@ -47,10 +47,6 @@ export class ChromedashGuideVerifyAccuracyPage extends LitElement {
         document.title = `${this.feature.name} - ${this.appTitle}`;
       }
       this.loading = false;
-
-      // TODO(kevinshen56714): Remove this once SPA index page is set up.
-      // Has to include this for now to remove the spinner at _base.html.
-      document.body.classList.remove('loading');
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });

--- a/static/elements/chromedash-myfeatures-page.js
+++ b/static/elements/chromedash-myfeatures-page.js
@@ -41,10 +41,6 @@ export class ChromedashMyFeaturesPage extends LitElement {
     ]).then(([user, starredFeatures]) => {
       this.user = user;
       this.starredFeatures = new Set(starredFeatures);
-
-      // TODO(kevinshen56714): Remove this once SPA index page is set up.
-      // Has to include this for now to remove the spinner at _base.html.
-      document.body.classList.remove('loading');
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });

--- a/static/elements/chromedash-roadmap-page.js
+++ b/static/elements/chromedash-roadmap-page.js
@@ -63,10 +63,6 @@ export class ChromedashRoadmapPage extends LitElement {
   fetchData() {
     window.csClient.getPermissions().then((user) => {
       this.user = user;
-
-      // TODO(kevinshen56714): Remove this once SPA index page is set up.
-      // Has to include this for now to remove the spinner at _base.html.
-      document.body.classList.remove('loading');
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });

--- a/static/elements/chromedash-settings-page.js
+++ b/static/elements/chromedash-settings-page.js
@@ -60,10 +60,6 @@ export class ChromedashSettingsPage extends LitElement {
     super.connectedCallback();
     window.csClient.getSettings().then((res) => {
       this.notify_as_starrer = res.notify_as_starrer;
-
-      // TODO(kevinshen56714): Remove this once SPA index page is set up.
-      // Has to include this for now to remove the spinner at _base.html.
-      document.body.classList.remove('loading');
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });

--- a/static/elements/chromedash-stack-rank-page.js
+++ b/static/elements/chromedash-stack-rank-page.js
@@ -58,10 +58,6 @@ export class ChromedashStackRankPage extends LitElement {
     const devMode = false;
     if (devMode) endpoint = 'https://cr-status-staging.appspot.com' + endpoint;
 
-    // TODO(kevinshen56714): Remove this once SPA index page is set up.
-    // Has to include this for now to remove the spinner at _base.html.
-    document.body.classList.remove('loading');
-
     fetch(endpoint).then((res) => res.json()).then((props) => {
       for (let i = 0, item; item = props[i]; ++i) {
         item.percentage = (item.day_percentage * 100).toFixed(6);

--- a/static/elements/chromedash-timeline-page.js
+++ b/static/elements/chromedash-timeline-page.js
@@ -39,10 +39,6 @@ export class ChromedashTimelinePage extends LitElement {
 
     fetch(endpoint).then((res) => res.json()).then((props) => {
       this.props = props;
-
-      // TODO(kevinshen56714): Remove this once SPA index page is set up.
-      // Has to include this for now to remove the spinner at _base.html.
-      document.body.classList.remove('loading');
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });


### PR DESCRIPTION
Clearing more of my TODOs that I left. This PR removes all the `document.body.classList.remove('loading')` in connectedCallback for all SPA page components. That line of code was originally to remove the loading spinner placed in _base.html once data is loaded. However, all the SPA pages now have their own loading skeletons, this is no longer needed (I also didn't include the spinner in `spa.html` from the beginning so this line of code basically does nothing).