### PR TITLE
Clarify where we load features directly from the DB, not cache.

### DIFF
--- a/api/processes_api.py
+++ b/api/processes_api.py
@@ -24,6 +24,7 @@ class ProcessesAPI(basehandlers.APIHandler):
 
   def do_get(self, feature_id):
     """Return the process of the feature."""
+    # Load feature directly from NDB so as to never get a stale cached copy.
     f = core_models.Feature.get_by_id(feature_id)
     if f is None:
       self.abort(404, msg=f'Feature {feature_id} not found')

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -130,6 +130,7 @@ class BaseHandler(flask.views.MethodView):
                   self.get_int_param('featureId', required=required))
     if not required and not feature_id:
       return None
+    # Load feature directly from NDB so as to never get a stale cached copy.
     feature = core_models.Feature.get_by_id(feature_id)
     if required and not feature:
       self.abort(404, msg='Feature not found')
@@ -530,13 +531,13 @@ class SPAHandler(FlaskHandler):
     # Check if the page requires user to sign in
     if defaults.get('require_signin') and not self.get_current_user():
       return flask.redirect(settings.LOGIN_PAGE_URL), self.get_headers()
-    
+
     # Check if the page requires create feature permission
     if defaults.get('require_create_feature'):
       redirect_resp = permissions.validate_feature_create_permission(self)
       if redirect_resp:
         return redirect_resp
-    
+
     # Validate the user has edit permissions and redirect if needed.
     if defaults.get('require_edit_feature'):
       feature_id = defaults.get('feature_id')

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -64,7 +64,7 @@ def can_edit_any_feature(user):
   """Return True if the user is allowed to edit all features."""
   if not user:
     return False
-  app_user = user_models.AppUser.get_app_user(user.email())  
+  app_user = user_models.AppUser.get_app_user(user.email())
   if not app_user:
     return False
 
@@ -98,6 +98,7 @@ def can_edit_feature(user, feature_id):
   if not feature_id or not user:
     return False
 
+  # Load feature directly from NDB so as to never get a stale cached copy.
   feature = core_models.Feature.get_by_id(feature_id)
   if not feature:
     return False
@@ -189,6 +190,7 @@ def validate_feature_edit_permission(handler_obj, feature_id):
     return handler_obj.redirect(settings.LOGIN_PAGE_URL)
 
   # Redirect to 404 if feature is not found.
+  # Load feature directly from NDB so as to never get a stale cached copy.
   if core_models.Feature.get_by_id(int(feature_id)) is None:
     handler_obj.abort(404, msg='Feature not found')
 

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -384,6 +384,13 @@ class Feature(DictModel):
   @classmethod
   def get_all(self, limit=None, order='-updated', filterby=None,
               update_cache=False, version=2, keys_only=False):
+    """Return JSON dicts for entities that fit the filterby criteria.
+
+    Because the cache may rarely have stale data, this should only be
+    used for displaying data read-only, not for populating forms or
+    procesing a POST to edit data.  For editing use case, load the
+    data from NDB directly.
+    """
     KEY = '%s|%s|%s|%s' % (Feature.DEFAULT_CACHE_KEY, order, limit, keys_only)
 
     # TODO(ericbidelman): Support more than one filter.
@@ -421,6 +428,13 @@ class Feature(DictModel):
 
   @classmethod
   def get_all_with_statuses(self, statuses, update_cache=False):
+    """Return JSON dicts for entities with the given statuses.
+
+    Because the cache may rarely have stale data, this should only be
+    used for displaying data read-only, not for populating forms or
+    procesing a POST to edit data.  For editing use case, load the
+    data from NDB directly.
+    """
     if not statuses:
       return []
 
@@ -442,6 +456,13 @@ class Feature(DictModel):
 
   @classmethod
   def get_feature(self, feature_id, update_cache=False):
+    """Return a JSON dict for a feature.
+
+    Because the cache may rarely have stale data, this should only be
+    used for displaying data read-only, not for populating forms or
+    procesing a POST to edit data.  For editing use case, load the
+    data from NDB directly.
+    """
     KEY = '%s|%s' % (Feature.DEFAULT_CACHE_KEY, feature_id)
     feature = ramcache.get(KEY)
 
@@ -478,6 +499,13 @@ class Feature(DictModel):
 
   @classmethod
   def get_by_ids(self, feature_ids, update_cache=False):
+    """Return a list of JSON dicts for the specified features.
+
+    Because the cache may rarely have stale data, this should only be
+    used for displaying data read-only, not for populating forms or
+    procesing a POST to edit data.  For editing use case, load the
+    data from NDB directly.
+    """
     result_dict = {}
     futures = []
 
@@ -509,6 +537,13 @@ class Feature(DictModel):
   @classmethod
   def get_chronological(
       self, limit=None, update_cache=False, version=None, show_unlisted=False):
+    """Return a list of JSON dicts for features, ordered by milestone.
+
+    Because the cache may rarely have stale data, this should only be
+    used for displaying data read-only, not for populating forms or
+    procesing a POST to edit data.  For editing use case, load the
+    data from NDB directly.
+    """
     cache_key = '%s|%s|%s|%s' % (Feature.DEFAULT_CACHE_KEY,
                                  'cronorder', limit, version)
 
@@ -603,6 +638,14 @@ class Feature(DictModel):
   @classmethod
   def get_in_milestone(
       self, show_unlisted=False, milestone=None):
+    """Return {reason: [feaure_dict]} with all the reasons a feature can
+    be part of a milestone.
+
+    Because the cache may rarely have stale data, this should only be
+    used for displaying data read-only, not for populating forms or
+    procesing a POST to edit data.  For editing use case, load the
+    data from NDB directly.
+    """
     if milestone == None:
       return None
 
@@ -1121,6 +1164,13 @@ class FeatureEntry(ndb.Model):  # Copy from Feature
 
   @classmethod
   def get_by_ids(self, entry_ids, update_cache=False):
+    """Return a list of FeatureEntry instances for the specified features.
+
+    Because the cache may rarely have stale data, this should only be
+    used for displaying data read-only, not for populating forms or
+    procesing a POST to edit data.  For editing use case, load the
+    data from NDB directly.
+    """
     result_dict = {}
     futures = []
 

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -220,6 +220,7 @@ class FeatureStar(ndb.Model):
     else:
       return  # No need to update anything in datastore
 
+    # Load feature directly from NDB so as to never get a stale cached copy.
     feature = core_models.Feature.get_by_id(feature_id)
     feature.star_count += 1 if starred else -1
     if feature.star_count < 0:
@@ -360,6 +361,7 @@ class FeatureChangeHandler(basehandlers.FlaskHandler):
 
     # Email feature subscribers if the feature exists and there were
     # actually changes to it.
+    # Load feature directly from NDB so as to never get a stale cached copy.
     feature = core_models.Feature.get_by_id(feature['id'])
     if feature and (is_update and len(changes) or not is_update):
       email_tasks = make_email_tasks(

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -115,6 +115,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       return redirect_resp
 
     if feature_id:
+      # Load feature directly from NDB so as to never get a stale cached copy.
       feature = core_models.Feature.get_by_id(feature_id)
       if feature is None:
         self.abort(404, msg='Feature not found')


### PR DESCRIPTION
Add comments to clarify what we discussed today.

Basically, there can be scenarios in which concurrent reads and writes could result in stale data in our cache.  That is acceptable when displaying a list of features because the speed that the cache gives us is worth it.  However, we do not need the speed or want the risk of stale data when:
* viewing an individual feature, or
* populating an editing form, or
* processing a request to update an issue

 