### PR TITLE
Setup Redis in production

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -13,6 +13,10 @@ automatic_scaling:
 # each deployment, users get new static files to match the new app version.
 default_expiration: "10d"
 
+# Set up VPC Access Connector for Redis.
+vpc_access_connector:
+  name: projects/cr-status/locations/us-central1/connectors/redis-connector
+
 handlers:
 # Static handlers ---------------------------------------------------------------
 - url: /favicon\.ico
@@ -39,6 +43,9 @@ env_variables:
   GAE_USE_SOCKETS_HTTPLIB : ''
   DJANGO_SETTINGS_MODULE: 'settings'
   DJANGO_SECRET: 'this-is-a-secret'
+  # Redis envs
+  REDISHOST: '10.250.3.187'
+  REDISPORT: '6379'
 
 inbound_services:
 - mail


### PR DESCRIPTION
Enable Redis in production. Fix https://github.com/GoogleChrome/chromium-dashboard/issues/2085.