### PR TITLE
Script to migrate Comment entities to Activity entities

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -17,6 +17,9 @@ cron:
 - description: Send reminders to verify the accuracy of feature data.
   url: /cron/send_accuracy_notifications
   schedule: every monday 09:00
+- description: Copy over comment entities to new activity entities
+  url: /cron/schema_migration_comment_activity
+  schedule: 1 of jan 00:00
 - description: Copy over deprecated standardization field
   url: /cron/write_standard_maturity
   schedule: 1 of jan 00:00

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -141,6 +141,7 @@ class Comment(ndb.Model):
   author = ndb.StringProperty()
   content = ndb.StringProperty()
   deleted_by = ndb.StringProperty()
+  migrated = ndb.BooleanProperty()
   # If the user set an approval value, we capture that here so that we can
   # display a change log.  This could be generalized to a list of separate
   # Amendment entities, but that complexity is not needed yet.
@@ -300,7 +301,7 @@ class Activity(ndb.Model):  # copy from Comment
   """An activity log entry (comment + amendments) on a gate or feature."""
   feature_id = ndb.IntegerProperty(required=True)
   gate_id = ndb.IntegerProperty()  # The gate commented on, or general comment.
-  created = ndb.DateTimeProperty(auto_now=True)
+  created = ndb.DateTimeProperty(auto_now_add=True)
   author = ndb.StringProperty()
   content = ndb.TextProperty()
   deleted_by = ndb.StringProperty()

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -1,0 +1,48 @@
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from framework.basehandlers import FlaskHandler
+from internals.review_models import Activity, Comment
+
+class MigrateCommentsToActivities(FlaskHandler):
+
+  def get_template_data(self):
+    """Writes an Activity entity for each unmigrated Comment entity."""
+    self.require_cron_header()
+    q = Comment.query()
+    comments = q.fetch()
+    migration_count = 0
+    for comment in comments:
+      if comment.migrated:
+        continue
+
+      kwargs = {
+        'feature_id': comment.feature_id,
+        'gate_id': comment.field_id,
+        'author': comment.author,
+        'content': comment.content,
+        'deleted_by': comment.deleted_by,
+        'created': comment.created
+      }
+      activity = Activity(**kwargs)
+      activity.put()
+      comment.migrated = True
+      comment.put()
+      migration_count += 1
+
+    message = f'{migration_count} comments migrated to activity entities.'
+    logging.info(message)
+    return message

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -1,0 +1,58 @@
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config  # Must be imported before the module under test.
+from datetime import datetime
+
+from internals import review_models
+from internals import schema_migration
+
+class MigrateCommentsToActivitiesTest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.comment_1 = review_models.Comment(feature_id=1, field_id=1,
+        author='user@example.com', content='some text',
+        created=datetime(2020, 1, 1))
+    self.comment_1.put()
+    self.comment_2 = review_models.Comment(feature_id=1, field_id=2,
+        author='other_user@example.com', content='some other text',
+        created=datetime(2020, 1, 1))
+    self.comment_2.put()
+    self.comment_3 = review_models.Comment(feature_id=2, field_id=1,
+        author='user@example.com', content='migrated text',
+        migrated=True)
+    self.comment_3.put()
+
+  def tearDown(self):
+    for comm in review_models.Comment.query().fetch(None):
+      comm.key.delete()
+
+  def test_migration(self):
+    migration_handler = schema_migration.MigrateCommentsToActivities()
+    result = migration_handler.get_template_data()
+    # One comment is marked as migrated, so only 2 need migration.
+    expected = '2 comments migrated to activity entities.'
+    self.assertEqual(result, expected)
+    # All comments should now be marked as migrated.
+    for comm in review_models.Comment.query().fetch(None):
+        self.assertTrue(comm.migrated)
+
+    activities = review_models.Activity.query().fetch(None)
+    self.assertEqual(len(activities), 2)
+    self.assertEqual(2020, activities[0].created.year)
+
+    # The migration should be idempotent, so nothing should be migrated twice.
+    result_2 = migration_handler.get_template_data()
+    expected = '0 comments migrated to activity entities.'
+    self.assertEqual(result_2, expected)

--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ from internals import detect_intent
 from internals import fetchmetrics
 from internals import notifier
 from internals import data_backup
+from internals import schema_migration
 from internals import deprecate_field
 from pages import blink_handler
 from pages import featurelist
@@ -188,6 +189,7 @@ internals_routes = [
   ('/cron/update_blink_components', fetchmetrics.BlinkComponentHandler),
   ('/cron/export_backup', data_backup.BackupExportHandler),
   ('/cron/send_accuracy_notifications', notifier.FeatureAccuracyHandler),
+  ('/cron/schema_migration_comment_activity', schema_migration.MigrateCommentsToActivities),
   ('/cron/write_standard_maturity', deprecate_field.WriteStandardMaturityHandler),
 
   ('/tasks/email-subscribers', notifier.FeatureChangeHandler),


### PR DESCRIPTION
This introduces a new script to copy over each Comment entity to a new Activity entity. This is made to be idempotent, so no comments can be copied multiple times erroneously.