### PR TITLE
Fix stack rank page anchor link bug

### DIFF
--- a/static/elements/chromedash-app.js
+++ b/static/elements/chromedash-app.js
@@ -153,6 +153,8 @@ class ChromedashApp extends LitElement {
       this.currentPage = ctx.path;
     });
     page('/metrics/:type/:view', (ctx) => {
+      // if already on this page and only the hash changes, don't create a new element
+      if (this.currentPage == ctx.path && ctx.hash) return;
       this.pageComponent = document.createElement('chromedash-stack-rank-page');
       this.pageComponent.type = ctx.params.type;
       this.pageComponent.view = ctx.params.view;


### PR DESCRIPTION
This PR fixes the stack rank page anchor link bug in SPA. The bug is that, if you click any feature text on the stack rank page, a hash value would be attached to href and trigger the client side router to re-create a `<chromedash-stack-rank-page>` element as well as the metric data re-fetch (but you actually just want to create a hash value in href and scroll to the element without a page reload).

So I added an if statement in `<chromedash-app>` so that if we're already on that stack rank page and only the hash value changes, it wouldn't trigger the creation of a new`<chromedash-stack-rank-page>`. This would make the anchor link work properly like previously in MPA.