### PR TITLE
Fix spelling error in help text.

### DIFF
--- a/static/elements/chromedash-roadmap-milestone-card.js
+++ b/static/elements/chromedash-roadmap-milestone-card.js
@@ -1,6 +1,6 @@
 import {LitElement, html, nothing} from 'lit';
 import {ROADMAP_MILESTONE_CARD_CSS} from
-  '../sass/elements/chromedash-roadmap-milestone-card-css.js';
+'../sass/elements/chromedash-roadmap-milestone-card-css.js';
 
 const REMOVED_STATUS = ['Removed'];
 const DEPRECATED_STATUS = ['Deprecated', 'No longer pursuing'];

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -120,7 +120,7 @@ export const ALL_FIELDS = {
     </p>
 
     <p>
-    Note: This text communicates with more than just the rest of Chromium development. It's the part most visible to external readers and is used in the beta release announcement, enterprise release notes, and other commuinications.
+    Note: This text communicates with more than just the rest of Chromium development. It's the part most visible to external readers and is used in the beta release announcement, enterprise release notes, and other communications.
     </p>
 
     <ul>


### PR DESCRIPTION
I noticed this typo while reusing some of this text for an email.