### PR TITLE
Add Redis staginng setup for notifier

### DIFF
--- a/notifier.yaml
+++ b/notifier.yaml
@@ -12,6 +12,13 @@ handlers:
 
 app_engine_apis: true
 
+# Set up VPC Access Connector for Redis.
+vpc_access_connector:
+  name: projects/cr-status-staging/locations/us-central1/connectors/redis-connector
+
 env_variables:
   DJANGO_SETTINGS_MODULE: 'settings'
   DJANGO_SECRET: 'this-is-a-secret'
+  # Redis envs
+  REDISHOST: '10.231.56.251'
+  REDISPORT: '6379'


### PR DESCRIPTION
Fix `ConnectionError: Error 111 connecting to localhost:6379. Connection refused` in notifier.  Redis in production still needs to be set up.