### PR TITLE
Remove the same listener function object that was added.

### DIFF
--- a/static/elements/chromedash-roadmap-page.js
+++ b/static/elements/chromedash-roadmap-page.js
@@ -42,15 +42,16 @@ export class ChromedashRoadmapPage extends LitElement {
     this.cardWidth = 0;
     this.numColumns = 0;
     this.viewOffset = 0;
+    this.boundHandleResize = this.handleResize.bind(this);
   }
 
   connectedCallback() {
     super.connectedCallback();
-    window.addEventListener('resize', () => this.handleResize());
+    window.addEventListener('resize', this.boundHandleResize);
   }
 
   disconnectedCallback() {
-    window.removeEventListener('resize', () => this.handleResize());
+    window.removeEventListener('resize', this.boundHandleResize);
     super.disconnectedCallback();
   }
 


### PR DESCRIPTION
I happened to discover a small defect in the roadmap page when used in the SPA.   If you view the roadmap, then switch to a different page, then resize the window, an error shows up on the console.   There is element lifecycle logic to add and remove the resize listener on that page, however it did not work correctly because the arrow-function notation creates a new function object in each case.  Instead, `removeEventListner()` needs to be passed a function object that is `===` to the one that was added.