### PR TITLE
Remove class="loading" from spa.html.

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -13,13 +13,10 @@ body {
     #spinner {
       display: flex;
     }
-    chromedash-toast {
-      visibility: hidden;
-    }
   }
 }
 
-/* The following ones can be removed once switch to SPA 
+/* The following ones can be removed once switch to SPA
  * because these styles are included in <chromedash-app> */
 
 #spinner {

--- a/templates/spa.html
+++ b/templates/spa.html
@@ -70,7 +70,7 @@ limitations under the License.
   <script type="module" nonce="{{nonce}}" defer src="/static/dist/components.js?v={{app_version}}"></script>
 </head>
 
-<body class="loading">
+<body>
   <chromedash-app
     appTitle="{{APP_TITLE}}"
     googleSignInClientId="{{google_sign_in_client_id}}"


### PR DESCRIPTION
In your recent PR #2237 you removed the JS code that removed the class="loading" from the body element because it was no longer needed.  However, the toast will not display when a page is loading, so that means that the toast can never display on SPA pages.  

In this PR:
* Removed the class="loading" in spa.html 
* Removed the CSS rule that hides chromedash-toast while there is `<body class="loading">`.  This seems like a bad idea because it would prevent any loading related errors from displaying a toast.  


I checked that the toast does not pop up initially when the old feature list page is loaded.  I think that the don't-show-while-loading logic was there because it would have been shown until some JS code executed, but that is no longer the case.

