### PR TITLE
Avoid reload loop due to comparing str to int.

### DIFF
--- a/static/elements/chromedash-app.js
+++ b/static/elements/chromedash-app.js
@@ -129,23 +129,23 @@ class ChromedashApp extends LitElement {
     });
     page('/guide/edit/:featureId', (ctx) => {
       this.pageComponent = document.createElement('chromedash-guide-edit-page');
-      this.pageComponent.featureId = ctx.params.featureId;
+      this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.appTitle = this.appTitle;
     });
     page('/guide/editall/:featureId', (ctx) => {
       this.pageComponent = document.createElement('chromedash-guide-editall-page');
-      this.pageComponent.featureId = ctx.params.featureId;
+      this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.appTitle = this.appTitle;
     });
     page('/guide/verify_accuracy/:featureId', (ctx) => {
       this.pageComponent = document.createElement('chromedash-guide-verify-accuracy-page');
-      this.pageComponent.featureId = ctx.params.featureId;
+      this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.appTitle = this.appTitle;
     });
     page('/guide/stage/:featureId/:stageId', (ctx) => {
       this.pageComponent = document.createElement('chromedash-guide-stage-page');
-      this.pageComponent.featureId = ctx.params.featureId;
-      this.pageComponent.stageId = ctx.params.stageId;
+      this.pageComponent.featureId = parseInt(ctx.params.featureId);
+      this.pageComponent.stageId = parseInt(ctx.params.stageId);
       this.pageComponent.appTitle = this.appTitle;
     });
     page('/settings', (ctx) => {

--- a/static/elements/chromedash-app.js
+++ b/static/elements/chromedash-app.js
@@ -116,7 +116,7 @@ class ChromedashApp extends LitElement {
       this.contextLink = ctx.path;
       this.currentPage = ctx.path;
     });
-    page('/feature/:featureId', (ctx) => {
+    page('/feature/:featureId(\\d+)', (ctx) => {
       this.pageComponent = document.createElement('chromedash-feature-page');
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.user = this.user;
@@ -127,22 +127,22 @@ class ChromedashApp extends LitElement {
       this.pageComponent = document.createElement('chromedash-guide-new-page');
       this.pageComponent.userEmail = this.user.email;
     });
-    page('/guide/edit/:featureId', (ctx) => {
+    page('/guide/edit/:featureId(\\d+)', (ctx) => {
       this.pageComponent = document.createElement('chromedash-guide-edit-page');
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.appTitle = this.appTitle;
     });
-    page('/guide/editall/:featureId', (ctx) => {
+    page('/guide/editall/:featureId(\\d+)', (ctx) => {
       this.pageComponent = document.createElement('chromedash-guide-editall-page');
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.appTitle = this.appTitle;
     });
-    page('/guide/verify_accuracy/:featureId', (ctx) => {
+    page('/guide/verify_accuracy/:featureId(\\d+)', (ctx) => {
       this.pageComponent = document.createElement('chromedash-guide-verify-accuracy-page');
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.appTitle = this.appTitle;
     });
-    page('/guide/stage/:featureId/:stageId', (ctx) => {
+    page('/guide/stage/:featureId(\\d+)/:stageId(\\d+)', (ctx) => {
       this.pageComponent = document.createElement('chromedash-guide-stage-page');
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.stageId = parseInt(ctx.params.stageId);


### PR DESCRIPTION
When visiting the `/guide/edit` page as a feature editor, the page kept reloading in a loop.   The reload logic is meant to check that the current user still has permission to edit a feature.  A feature editor does have permission to edit the feature that lists them, which is why the server does not give a 403 on each reload.   However, the check in JS code fails because it is comparing `this.featureId` (a string) to `this.user.editable_features` (an int).

In this PR:
* Have the app always convert strings of digits from the URL into JS number values.