### PR TITLE
Add health_check_interval to avoid connection reset

### DIFF
--- a/framework/rediscache.py
+++ b/framework/rediscache.py
@@ -31,7 +31,7 @@ elif settings.STAGING or settings.PROD:
   # Create a Redis client.
   redis_host = os.environ.get('REDISHOST', 'localhost')
   redis_port = int(os.environ.get('REDISPORT', 6379))
-  redis_client = redis.Redis(host=redis_host, port=redis_port)
+  redis_client = redis.Redis(host=redis_host, port=redis_port, health_check_interval=30)
 
 gae_version = None
 if settings.UNIT_TEST_MODE:


### PR DESCRIPTION
Alleviate `Connection reset by peer` errors by using `health_check_interval`, which specifies the time in seconds a connection can be idle before its health needs to be checked.

There were 5 `connections reset by peer` errors within the span of 50 minutes for the first time, since September 12, the deployment of Redis on staging `default` service. Given the infrequent nature of the error, it could be a simple TCP connection lost/interruption. Looking at https://github.com/redis/redis-py/issues/1186, people who use GCP experienced similar issues. There are many tricks we could try, [see comment](https://github.com/redis/redis-py/issues/1186#issuecomment-902102559) and [comment](https://github.com/redis/redis-py/issues/1186#issuecomment-1093799467), but I will start with the most simple suggestion by [the author](https://github.com/redis/redis-py/issues/1186#issuecomment-522794165).

Error messages:
```
redis.exceptions.ConnectionError: Error while reading from 10.231.56.251:6379 : (104, 'Connection reset by peer')
```