### PR TITLE
Fix passing feature ID to the accuracy email.

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -387,6 +387,7 @@ class FeatureAccuracyHandler(basehandlers.FlaskHandler):
     email_tasks = []
     for feature, mstone in features_to_notify:
       body_data = {
+        'id': feature.key.integer_id(),
         'feature': feature,
         'site_url': settings.SITE_URL,
         'milestone': mstone,

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -540,6 +540,17 @@ class FeatureAccuracyHandlerTest(testing_config.CustomTestCase):
     expected = {'message': '2 email(s) sent or logged.'}
     self.assertEqual(result, expected)
 
+  def test_build_email_tasks(self):
+    accuracy_notifier = notifier.FeatureAccuracyHandler()
+    actual = accuracy_notifier._build_email_tasks([(self.feature_1, 100)])
+    self.assertEqual(1, len(actual))
+    task = actual[0]
+    self.assertEqual('feature_owner@example.com', task['to'])
+    self.assertEqual('[Action requested] Update feature one', task['subject'])
+    self.assertEqual(None, task['reply_to'])
+    self.assertIn('/guide/verify_accuracy/%d' % self.feature_1.key.integer_id(),
+                  task['html'])
+
 
 class NotifyInactiveUsersHandlerTest(testing_config.CustomTestCase):
 

--- a/templates/accuracy_notice_email.html
+++ b/templates/accuracy_notice_email.html
@@ -4,7 +4,7 @@
 </br>
 <p>
   <strong>{{feature.name}}</strong>
-</p> 
+</p>
 </br>
 <p>
   Your feature is slated to launch soon for m{{milestone}}:
@@ -26,6 +26,6 @@
   fields of your feature entry.</strong>
 </p>
 </br>
-<b><a href="{{site_url}}guide/verify_accuracy/{{feature.id}}">
-  {{site_url}}guide/verify_accuracy/{{feature.id}}
+<b><a href="{{site_url}}guide/verify_accuracy/{{id}}">
+  {{site_url}}guide/verify_accuracy/{{id}}
 </a></b>


### PR DESCRIPTION
This is a follow up to my recent PR that changed this from passing a "formatted" feature dictionary to passing a regular Feature model instance.  The problem with that is that the ID of a Feature is not available as a field, it requires a method call.    The result was that the links in these emails were 404.   This PR passes and uses the feature ID correctly.