### PR TITLE
Add JSONIFY = True to NotifyInactiveUsersHandler get requests

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -257,6 +257,7 @@ class FeatureStar(ndb.Model):
 
 
 class NotifyInactiveUsersHandler(basehandlers.FlaskHandler):
+  JSONIFY = True
   DEFAULT_LAST_VISIT = datetime(2022, 8, 1)  # 2022-08-01
   INACTIVE_WARN_DAYS = 180
   EMAIL_TEMPLATE_PATH = 'inactive_user_email.html'


### PR DESCRIPTION
Fixing `No TEMPLATE_PATH` error. `NotifyInactiveUsersHandler` should return a JSON response, rather than a `dict`. 
`get_template_path` shouldn't be called at all. Instead, It should pass the if statement in [`if self.JSONIFY and type(handler_data) in (dict, list)`](https://github.com/GoogleChrome/chromium-dashboard/blob/88014a2844941990213d6fffe3818f770af5fc8b/framework/basehandlers.py#L361)

```
ValueError: No TEMPLATE_PATH was defined in 'NotifyInactiveUsersHandler' or returned in template_data.

at .get_template_path ( /srv/framework/basehandlers.py:299 )
at .get ( /srv/framework/basehandlers.py:370 )
at .wrapped_function ( /layers/google.python.pip/pip/lib/python3.9/site-packages/flask_cors/extension.py:165 )
```