### PR TITLE
Move structure to supply date for testing to new method

### DIFF
--- a/internals/inactive_users.py
+++ b/internals/inactive_users.py
@@ -22,9 +22,12 @@ class RemoveInactiveUsersHandler(FlaskHandler):
   DEFAULT_LAST_VISIT = datetime(2022, 8, 1)  # 2022-08-01
   INACTIVE_REMOVE_DAYS = 270
 
-  def get_template_data(self, now=None):
+  def get_template_data(self):
     """Removes any users that have been inactive for 9 months."""
     self.require_cron_header()
+    return self._handle_cron_task()
+  
+  def _handle_cron_task(self, now=None):
     if now is None:
       now = datetime.now()
 

--- a/internals/inactive_users_test.py
+++ b/internals/inactive_users_test.py
@@ -70,6 +70,6 @@ class RemoveInactiveUsersHandlerTest(testing_config.CustomTestCase):
 
   def test_remove_inactive_users(self):
     inactive_remover = RemoveInactiveUsersHandler()
-    result = inactive_remover.get_template_data(now=datetime(2023, 9, 1))
+    result = inactive_remover._handle_cron_task(now=datetime(2023, 9, 1))
     expected = 'Success\nRemoved users:\nreally_inactive_user@example.com'
     self.assertEqual(result, expected)

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -266,9 +266,12 @@ class NotifyInactiveUsersHandler(basehandlers.FlaskHandler):
   INACTIVE_WARN_DAYS = 180
   EMAIL_TEMPLATE_PATH = 'inactive_user_email.html'
 
-  def get_template_data(self, now=None):
+  def get_template_data(self):
     """Notify any users that have been inactive for 6 months."""
     self.require_cron_header()
+    return self._handle_cron_task()
+
+  def _handle_cron_task(self, now=None):
     users_to_notify = self._determine_users_to_notify(now)
     email_tasks = self._build_email_tasks(users_to_notify)
     send_emails(email_tasks)

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -629,7 +629,7 @@ class NotifyInactiveUsersHandlerTest(testing_config.CustomTestCase):
 
   def test_determine_users_to_notify(self):
     inactive_notifier = notifier.NotifyInactiveUsersHandler()
-    result = inactive_notifier.get_template_data(now=datetime(2023, 9, 1))
+    result = inactive_notifier._handle_cron_task(now=datetime(2023, 9, 1))
     expected = ('1 users notified of inactivity.\n'
         'Notified users:\ninactive_user@example.com')
     self.assertEqual(result.get('message', None), expected)


### PR DESCRIPTION
Move the optional date argument for testing to a separate method to avoid template issues.