### PR TITLE
Omit cookies for metrics data requests because of Vary: Cookie

### DIFF
--- a/api/metricsdata.py
+++ b/api/metricsdata.py
@@ -220,6 +220,7 @@ class FeatureObserverPopularityHandler(FeatureHandler):
 
 
 class FeatureBucketsHandler(basehandlers.FlaskHandler):
+  HTTP_CACHE_TYPE = 'private'
   JSONIFY = True
 
   def get_template_data(self, prop_type):

--- a/settings.py
+++ b/settings.py
@@ -115,7 +115,7 @@ SECRET_KEY = os.environ['DJANGO_SECRET']
 
 RSS_FEED_LIMIT = 15
 
-DEFAULT_CACHE_TIME = 60 # seconds
+DEFAULT_CACHE_TIME = 3600 # seconds
 
 USE_I18N = False
 

--- a/static/elements/chromedash-stack-rank-page.js
+++ b/static/elements/chromedash-stack-rank-page.js
@@ -57,8 +57,9 @@ export class ChromedashStackRankPage extends LitElement {
     // [DEV] Change to true to use the staging server endpoint for development
     const devMode = false;
     if (devMode) endpoint = 'https://cr-status-staging.appspot.com' + endpoint;
+    const options = {credentials: 'omit'};
 
-    fetch(endpoint).then((res) => res.json()).then((props) => {
+    fetch(endpoint, options).then((res) => res.json()).then((props) => {
       for (let i = 0, item; item = props[i]; ++i) {
         item.percentage = (item.day_percentage * 100).toFixed(6);
       }
@@ -87,7 +88,7 @@ export class ChromedashStackRankPage extends LitElement {
   renderSearchBar() {
     return html`
       <input id="datalist-input" type="search" list="features"
-        placeholder=${this.viewList.length ? 'Select or search a property for detailed stats' : 'loading...'} 
+        placeholder=${this.viewList.length ? 'Select or search a property for detailed stats' : 'loading...'}
         @change="${this.handleSearchBarChange}" />
       <datalist id="features">
         ${this.viewList.map((item) => html`
@@ -107,7 +108,7 @@ export class ChromedashStackRankPage extends LitElement {
         <a href="https://cs.chromium.org/chromium/src/tools/metrics/histograms/enums.xml"
         target="_blank" rel="noopener">anonymous usage statistics</a>.
       </p>
-      <chromedash-stack-rank 
+      <chromedash-stack-rank
         .type=${this.type}
         .view=${this.view}
         .viewList=${this.viewList}>

--- a/static/elements/chromedash-timeline-page.js
+++ b/static/elements/chromedash-timeline-page.js
@@ -36,8 +36,9 @@ export class ChromedashTimelinePage extends LitElement {
     // [DEV] Change to true to use the staging server endpoint for development
     const devMode = false;
     if (devMode) endpoint = 'https://cr-status-staging.appspot.com' + endpoint;
+    const options = {credentials: 'omit'};
 
-    fetch(endpoint).then((res) => res.json()).then((props) => {
+    fetch(endpoint, options).then((res) => res.json()).then((props) => {
       this.props = props;
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');

--- a/static/elements/chromedash-timeline.js
+++ b/static/elements/chromedash-timeline.js
@@ -221,7 +221,8 @@ class ChromedashTimeline extends LitElement {
       chartEl.insertAdjacentHTML('afterbegin', '<sl-progress-bar indeterminate></sl-progress-bar>');
     }
 
-    fetch(url).then((res) => res.json()).then((response) => {
+    const options = {credentials: 'omit'};
+    fetch(url, options).then((res) => res.json()).then((response) => {
       this.drawVisualization(response, this.selectedBucketId, this.showAllHistoricalData);
     });
 


### PR DESCRIPTION
In researching the problem as I wrote up issue #2267, I thought that I found an easy solution to the HTTP caching problem.  I think this PR solves the HTTP caching problem, but there is still a need for other kinds of speedups outlined in that issue.

In this PR:
* settings.py: allow cachable HTTP content to be used for one hour instead of one minute
* chromedash-timeline-page.js and chromedash-stack-rank-page.js: omit credentials so that the `vary: cookie` response header does not cause cached responses to be unusable.