### PR TITLE
Comment IDs now migrate to Activity entities

### DIFF
--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -28,7 +28,7 @@ class MigrateCommentsToActivities(FlaskHandler):
 
     comments = Comment.query().fetch()
     activity_keys = Activity.query().fetch(keys_only=True)
-    activity_ids = set([key.integer_id() for key in activity_keys])
+    activity_ids = set(key.integer_id() for key in activity_keys)
     migration_count = 0
     for comment in comments:
       # Check if an Activity with the same ID has already been created.

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from google.cloud import ndb
 
 from framework.basehandlers import FlaskHandler
 from internals.review_models import Activity, Comment
@@ -22,14 +23,23 @@ class MigrateCommentsToActivities(FlaskHandler):
   def get_template_data(self):
     """Writes an Activity entity for each unmigrated Comment entity."""
     self.require_cron_header()
+
+    logging.info(self._remove_bad_id_activities())
+
     q = Comment.query()
     comments = q.fetch()
     migration_count = 0
     for comment in comments:
-      if comment.migrated:
+      # Check if an Activity with the same ID has already been created.
+      # If so, do not create this activity again.
+      q = Activity.query().filter(
+          Activity.key == ndb.Key(Activity, comment.key.integer_id()))
+      activities = q.fetch()
+      if len(activities) > 0:
         continue
 
       kwargs = {
+        'id': comment.key.integer_id(),
         'feature_id': comment.feature_id,
         'gate_id': comment.field_id,
         'author': comment.author,
@@ -39,10 +49,30 @@ class MigrateCommentsToActivities(FlaskHandler):
       }
       activity = Activity(**kwargs)
       activity.put()
-      comment.migrated = True
-      comment.put()
       migration_count += 1
 
     message = f'{migration_count} comments migrated to activity entities.'
     logging.info(message)
     return message
+  
+  def _remove_bad_id_activities(self):
+    """Deletes old Activity entities that have a matching comment ID."""
+    q = Activity.query()
+    activities = q.fetch()
+
+    old_migrations_deleted = 0
+    for activity in activities:
+      # Non-null content means this is an Activity entity
+      # that represents a comment.
+      if activity.content is not None:
+        # Check if there is a Comment entity with a matching ID.
+        q = Comment.query().filter(
+            Comment.key == ndb.Key(Comment, activity.key.integer_id()))
+        comments_with_same_id = q.fetch()
+        if len(comments_with_same_id) != 1:
+          # If not, it is from the old migration and it can be deleted.
+          activity.key.delete()
+          old_migrations_deleted += 1
+    
+    return (f'{old_migrations_deleted} Activities deleted '
+        'from previous migration.')

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -26,16 +26,14 @@ class MigrateCommentsToActivities(FlaskHandler):
 
     logging.info(self._remove_bad_id_activities())
 
-    q = Comment.query()
-    comments = q.fetch()
+    comments = Comment.query().fetch()
+    activity_keys = Activity.query().fetch(keys_only=True)
+    activity_ids = set([key.integer_id() for key in activity_keys])
     migration_count = 0
     for comment in comments:
       # Check if an Activity with the same ID has already been created.
       # If so, do not create this activity again.
-      q = Activity.query().filter(
-          Activity.key == ndb.Key(Activity, comment.key.integer_id()))
-      activities = q.fetch()
-      if len(activities) > 0:
+      if comment.key.integer_id() in activity_ids:
         continue
 
       kwargs = {

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -56,7 +56,7 @@ class MigrateCommentsToActivities(FlaskHandler):
     return message
   
   def _remove_bad_id_activities(self):
-    """Deletes old Activity entities that have a matching comment ID."""
+    """Deletes old Activity entities that do not have a matching comment ID."""
     q = Activity.query()
     activities = q.fetch()
 

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -62,9 +62,9 @@ class MigrateCommentsToActivities(FlaskHandler):
 
     old_migrations_deleted = 0
     for activity in activities:
-      # Non-null content means this is an Activity entity
+      # Non-empty content field means this is an Activity entity
       # that represents a comment.
-      if activity.content is not None:
+      if activity.content:
         # Check if there is a Comment entity with a matching ID.
         q = Comment.query().filter(
             Comment.key == ndb.Key(Comment, activity.key.integer_id()))


### PR DESCRIPTION
This change updates the cron job to migrate existing Comment entities with the same ID. The script will now delete Activity entities from the old migration that do not have IDs that match Comment entities, and then will migrate Comment entities as needed. The script also no longer uses the `migrated` field to determine if the Comment has already been migrated, and instead checks if there is an Activity entity with a matching ID.