### PR TITLE
Migrate Feature entities to FeatureEntry entities

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -26,8 +26,11 @@ cron:
 - description: Removes any users that have been inactive for 9 months.
   url: /cron/remove_inactive_users
   schedule: 1st monday of month 9:00
-- description: Copy over comment entities to new activity entities
+- description: Copy over Comment entities to new Activity entities
   url: /cron/schema_migration_comment_activity
+  schedule: 1 of jan 00:00
+- description: Copy over Feature entities to new FeatureEntry entities
+  url: /cron/schema_migration_feature_featureentry
   schedule: 1 of jan 00:00
 - description: Copy over deprecated standardization field
   url: /cron/write_standard_maturity

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -1050,6 +1050,7 @@ class FeatureEntry(ndb.Model):  # Copy from Feature
   # Metadata: Access controls
   owners = ndb.StringProperty(repeated=True)  # copy from owner
   editors = ndb.StringProperty(repeated=True)
+  cc_recipients = ndb.StringProperty(repeated=True)
   unlisted = ndb.BooleanProperty(default=False)
   deleted = ndb.BooleanProperty(default=False)
 

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -94,7 +94,7 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
     self.require_cron_header()
     features = Feature.query().fetch()
     feature_entry_keys = FeatureEntry.query().fetch(keys_only=True)
-    feature_entry_ids = set([key.integer_id() for key in feature_entry_keys])
+    feature_entry_ids = set(key.integer_id() for key in feature_entry_keys)
     migration_count = 0
     for feature in features:
       # If a FeatureEntry exists with the same ID, it has already been migrated.

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -92,89 +92,76 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
   def get_template_data(self):
     """Writes a FeatureEntry entity for each unmigrated Feature entity"""
     self.require_cron_header()
-    features = Feature.query().fetch()
-    feature_entry_keys = FeatureEntry.query().fetch(keys_only=True)
-    feature_entry_ids = set(key.integer_id() for key in feature_entry_keys)
-    migration_count = 0
-    for feature in features:
-      # If a FeatureEntry exists with the same ID, it has already been migrated.
-      if feature.key.integer_id() in feature_entry_ids:
-        continue
 
-      # updater will use the email from the updated_by field
-      updater = feature.updated_by.email() if feature.updated_by else None
+    kwarg_mapping = [
+        ('created', 'created'),
+        ('updated', 'updated'),
+        ('accurate_as_of', 'accurate_as_of'),
+        ('creator', 'creator'),
+        ('owners', 'owner'),
+        ('editors', 'editors'),
+        ('unlisted', 'unlisted'),
+        ('cc_recipients', 'cc_recipients'),
+        ('feature_notes', 'comments'),  # Renamed
+        ('deleted', 'deleted'),
+        ('name', 'name'),
+        ('summary', 'summary'),
+        ('category', 'category'),
+        ('blink_components', 'blink_components'),
+        ('star_count', 'star_count'),
+        ('search_tags', 'search_tags'),
+        ('feature_type', 'feature_type'),
+        ('intent_stage', 'intent_stage'),
+        ('bug_url', 'bug_url'),
+        ('launch_bug_url', 'launch_bug_url'),
+        ('impl_status_chrome', 'impl_status_chrome'),
+        ('flag_name', 'flag_name'),
+        ('ongoing_constraints', 'ongoing_constraints'),
+        ('motivation', 'motivation'),
+        ('devtrial_instructions', 'devtrial_instructions'),
+        ('activation_risks', 'activation_risks'),
+        ('measurement', 'measurement'),
+        ('initial_public_proposal_url', 'initial_public_proposal_url'),
+        ('explainer_links', 'explainer_links'),
+        ('requires_embedder_support', 'requires_embedder_support'),
+        ('standard_maturity', 'standard_maturity'),
+        ('spec_link', 'spec_link'),
+        ('api_spec', 'api_spec'),
+        ('spec_mentors', 'spec_mentors'),
+        ('interop_compat_risks', 'interop_compat_risks'),
+        ('prefixed', 'prefixed'),
+        ('all_platforms', 'all_platforms'),
+        ('all_platforms_descr', 'all_platforms_descr'),
+        ('tag_review', 'tag_review'),
+        ('tag_review_status', 'tag_review_status'),
+        ('non_oss_deps', 'non_oss_deps'),
+        ('anticipated_spec_changes', 'anticipated_spec_changes'),
+        ('ff_views', 'ff_views'),
+        ('safari_views', 'safari_views'),
+        ('web_dev_views', 'web_dev_views'),
+        ('ff_views_link', 'ff_views_link'),
+        ('safari_views_link', 'safari_views_link'),
+        ('web_dev_views_link', 'web_dev_views_link'),
+        ('ff_views_notes', 'ff_views_notes'),
+        ('safari_views_notes', 'safari_views_notes'),
+        ('web_dev_views_notes', 'web_dev_views_notes'),
+        ('other_views_notes', 'other_views_notes'),
+        ('security_risks', 'security_risks'),
+        ('security_review_status', 'security_review_status'),
+        ('privacy_review_status', 'privacy_review_status'),
+        ('ergonomics_risks', 'ergonomics_risks'),
+        ('wpt', 'wpt'),
+        ('wpt_descr', 'wpt_descr'),
+        ('webview_risks', 'webview_risks'),
+        ('devrel', 'devrel'),
+        ('debuggability', 'debuggability'),
+        ('doc_links', 'doc_links'),
+        ('sample_links', 'sample_links')]
+    return handle_migration(Feature, FeatureEntry,kwarg_mapping,
+        self.special_handler)
 
-      kwargs = {
-          'id': feature.key.integer_id(),
-          'created': feature.created,
-          'updated': feature.updated,
-          'accurate_as_of': feature.accurate_as_of,
-          'creator': feature.creator,
-          'updater': updater,
-          'owners': feature.owner,  # Renamed
-          'editors': feature.editors,
-          'unlisted': feature.unlisted,
-          'cc_recipients': feature.cc_recipients,
-          'feature_notes': feature.comments,  # Renamed
-          'deleted': feature.deleted,
-          'name': feature.name,
-          'summary': feature.summary,
-          'category': feature.category,
-          'blink_components': feature.blink_components,
-          'star_count': feature.star_count,
-          'search_tags': feature.search_tags,
-          'feature_type': feature.feature_type,
-          'intent_stage': feature.intent_stage,
-          'bug_url': feature.bug_url,
-          'launch_bug_url': feature.launch_bug_url,
-          'impl_status_chrome': feature.impl_status_chrome,
-          'flag_name': feature.flag_name,
-          'ongoing_constraints': feature.ongoing_constraints,
-          'motivation': feature.motivation,
-          'devtrial_instructions': feature.devtrial_instructions,
-          'activation_risks': feature.activation_risks,
-          'measurement': feature.measurement,
-          'initial_public_proposal_url': feature.initial_public_proposal_url,
-          'explainer_links': feature.explainer_links,
-          'requires_embedder_support': feature.requires_embedder_support,
-          'standard_maturity': feature.standard_maturity,
-          'spec_link': feature.spec_link,
-          'api_spec': feature.api_spec,
-          'spec_mentors': feature.spec_mentors,
-          'interop_compat_risks': feature.interop_compat_risks,
-          'prefixed': feature.prefixed,
-          'all_platforms': feature.all_platforms,
-          'all_platforms_descr': feature.all_platforms_descr,
-          'tag_review': feature.tag_review,
-          'tag_review_status': feature.tag_review_status,
-          'non_oss_deps': feature.non_oss_deps,
-          'anticipated_spec_changes': feature.anticipated_spec_changes,
-          'ff_views': feature.ff_views,
-          'safari_views': feature.safari_views,
-          'web_dev_views': feature.web_dev_views,
-          'ff_views_link': feature.ff_views_link,
-          'safari_views_link': feature.safari_views_link,
-          'web_dev_views_link': feature.web_dev_views_link,
-          'ff_views_notes': feature.ff_views_notes,
-          'safari_views_notes': feature.safari_views_notes,
-          'web_dev_views_notes': feature.web_dev_views_notes,
-          'other_views_notes': feature.other_views_notes,
-          'security_risks': feature.security_risks,
-          'security_review_status': feature.security_review_status,
-          'privacy_review_status': feature.privacy_review_status,
-          'ergonomics_risks': feature.ergonomics_risks,
-          'wpt': feature.wpt,
-          'wpt_descr': feature.wpt_descr,
-          'webview_risks': feature.webview_risks,
-          'devrel': feature.devrel,
-          'debuggability': feature.debuggability,
-          'doc_links': feature.doc_links,
-          'sample_links': feature.sample_links}
-
-      feature_entry = FeatureEntry(**kwargs)
-      feature_entry.put()
-      migration_count += 1
-
-    message = f'{migration_count} features migrated to FeatureEntry entities.'
-    logging.info(message)
-    return message
+  @classmethod
+  def special_handler(cls, original_entity, kwargs):
+    # updater will use the email from the updated_by field
+    kwargs['updater'] = (original_entity.updated_by.email()
+        if original_entity.updated_by else None)

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -168,11 +168,11 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
           'debuggability': feature.debuggability,
           'doc_links': feature.doc_links,
           'sample_links': feature.sample_links}
-      
+
       feature_entry = FeatureEntry(**kwargs)
       feature_entry.put()
       migration_count += 1
-  
+
     message = f'{migration_count} features migrated to FeatureEntry entities.'
     logging.info(message)
     return message

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -101,7 +101,9 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
       if feature.key.integer_id() in feature_entry_ids:
         continue
 
+      # updater will use the email from the updated_by field
       updater = feature.updated_by.email() if feature.updated_by else None
+
       kwargs = {
           'id': feature.key.integer_id(),
           'created': feature.created,
@@ -109,11 +111,11 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
           'accurate_as_of': feature.accurate_as_of,
           'creator': feature.creator,
           'updater': updater,
-          'owners': feature.owner,
+          'owners': feature.owner,  # Renamed
           'editors': feature.editors,
           'unlisted': feature.unlisted,
           'cc_recipients': feature.cc_recipients,
-          'feature_notes': feature.comments,
+          'feature_notes': feature.comments,  # Renamed
           'deleted': feature.deleted,
           'name': feature.name,
           'summary': feature.summary,

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -98,7 +98,7 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
     migration_count = 0
     for feature in features:
       # If a FeatureEntry exists with the same ID, it has already been migrated.
-      if feature.integer_id() in feature_entry_ids:
+      if feature.key.integer_id() in feature_entry_ids:
         continue
 
       updater = feature.updated_by.email() if feature.updated_by else None

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -92,15 +92,13 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
   def get_template_data(self):
     """Writes a FeatureEntry entity for each unmigrated Feature entity"""
     self.require_cron_header()
-    q = Feature.query()
-    features = q.fetch()
+    features = Feature.query().fetch()
+    feature_entry_keys = FeatureEntry.query().fetch(keys_only=True)
+    feature_entry_ids = set([key.integer_id() for key in feature_entry_keys])
     migration_count = 0
     for feature in features:
       # If a FeatureEntry exists with the same ID, it has already been migrated.
-      q = FeatureEntry.query().filter(
-          FeatureEntry.key == ndb.Key(FeatureEntry, feature.key.integer_id()))
-      feature_entries = q.fetch()
-      if len(feature_entries) > 0:
+      if feature.integer_id() in feature_entry_ids:
         continue
 
       updater = feature.updated_by.email() if feature.updated_by else None

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -114,6 +114,8 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
           'owners': feature.owner,
           'editors': feature.editors,
           'unlisted': feature.unlisted,
+          'cc_recipients': feature.cc_recipients,
+          'feature_notes': feature.comments,
           'deleted': feature.deleted,
           'name': feature.name,
           'summary': feature.summary,

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -77,11 +77,12 @@ class MigrateCommentsToActivitiesTest(testing_config.CustomTestCase):
 
 class MigrateFeaturesToFeatureEntriesTest(testing_config.CustomTestCase):
 
+  # Fields that do not require name change or revisions during migration.
   FEATURE_FIELDS = ['created', 'updated', 'accurate_as_of', 'editors', 'creator',
       'unlisted', 'deleted', 'name', 'summary', 'category', 'blink_components',
-      'star_count', 'search_tags', 'feature_type', 'intent_stage',
-      'bug_url', 'launch_bug_url', 'impl_status_chrome', 'flag_name',
-      'ongoing_constraints', 'motivation', 'devtrial_instructions',
+      'cc_recipients', 'star_count', 'search_tags', 'feature_type',
+      'intent_stage', 'bug_url', 'launch_bug_url', 'impl_status_chrome',
+      'flag_name', 'ongoing_constraints', 'motivation', 'devtrial_instructions',
       'activation_risks', 'measurement', 'initial_public_proposal_url',
       'explainer_links', 'requires_embedder_support', 'standard_maturity',
       'spec_link', 'api_spec', 'spec_mentors', 'interop_compat_risks',
@@ -107,10 +108,12 @@ class MigrateFeaturesToFeatureEntriesTest(testing_config.CustomTestCase):
         owner=['owner@example.com'],
         creator='creator@example.com',
         editors=['editor@example.com'],
+        cc_recipients=['cc_user@example.com'],
         unlisted=False,
         deleted=False,
         name='feature_one',
         summary='newly migrated summary',
+        comments='Some comments.',
         category=1,
         blink_components=['Blink'],
         star_count=3,
@@ -250,6 +253,7 @@ class MigrateFeaturesToFeatureEntriesTest(testing_config.CustomTestCase):
     feature_entry_1 = q.fetch()[0]
     self.assertEqual(feature_entry_1.owners, self.feature_1.owner)
     self.assertEqual(feature_entry_1.updater, self.feature_1.updated_by.email())
+    self.assertEqual(feature_entry_1.feature_notes, self.feature_1.comments)
     for field in self.FEATURE_FIELDS:
       self.assertEqual(
           getattr(feature_entry_1, field), getattr(self.feature_1, field))

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -77,7 +77,7 @@ class MigrateCommentsToActivitiesTest(testing_config.CustomTestCase):
 
 class MigrateFeaturesToFeatureEntriesTest(testing_config.CustomTestCase):
 
-  FEATURE_FIELDS = ['created', 'updated', 'accurate_as_of', 'editors',
+  FEATURE_FIELDS = ['created', 'updated', 'accurate_as_of', 'editors', 'creator',
       'unlisted', 'deleted', 'name', 'summary', 'category', 'blink_components',
       'star_count', 'search_tags', 'feature_type', 'intent_stage',
       'bug_url', 'launch_bug_url', 'impl_status_chrome', 'flag_name',
@@ -105,6 +105,7 @@ class MigrateFeaturesToFeatureEntriesTest(testing_config.CustomTestCase):
         updated_by=ndb.User(
             _auth_domain='example.com', email='editor@example.com'),
         owner=['owner@example.com'],
+        creator='creator@example.com',
         editors=['editor@example.com'],
         unlisted=False,
         deleted=False,
@@ -247,11 +248,11 @@ class MigrateFeaturesToFeatureEntriesTest(testing_config.CustomTestCase):
     q = core_models.FeatureEntry.query().filter(
         core_models.FeatureEntry.key == ndb.Key(core_models.FeatureEntry, 1))
     feature_entry_1 = q.fetch()[0]
-    feature_entry_1.owners = self.feature_1.owner
-    feature_entry_1.creator = self.feature_1.created_by.email()
-    feature_entry_1.updater = self.feature_1.updated_by.email()
+    self.assertEqual(feature_entry_1.owners, self.feature_1.owner)
+    self.assertEqual(feature_entry_1.updater, self.feature_1.updated_by.email())
     for field in self.FEATURE_FIELDS:
-      getattr(feature_entry_1, field) == getattr(self.feature_1, field)
+      self.assertEqual(
+          getattr(feature_entry_1, field), getattr(self.feature_1, field))
 
     # The migration should be idempotent, so nothing should be migrated twice.
     result_2 = migration_handler.get_template_data()

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from google.cloud import ndb
+
 import testing_config  # Must be imported before the module under test.
 from datetime import datetime
 
-from internals import review_models
+from internals import core_models, review_models
 from internals import schema_migration
 
 class MigrateCommentsToActivitiesTest(testing_config.CustomTestCase):
@@ -70,4 +72,188 @@ class MigrateCommentsToActivitiesTest(testing_config.CustomTestCase):
     # The migration should be idempotent, so nothing should be migrated twice.
     result_2 = migration_handler.get_template_data()
     expected = '0 Comment entities migrated to Activity entities.'
+    self.assertEqual(result_2, expected)
+
+
+class MigrateFeaturesToFeatureEntriesTest(testing_config.CustomTestCase):
+
+  FEATURE_FIELDS = ['created', 'updated', 'accurate_as_of', 'editors',
+      'unlisted', 'deleted', 'name', 'summary', 'category', 'blink_components',
+      'star_count', 'search_tags', 'feature_type', 'intent_stage',
+      'bug_url', 'launch_bug_url', 'impl_status_chrome', 'flag_name',
+      'ongoing_constraints', 'motivation', 'devtrial_instructions',
+      'activation_risks', 'measurement', 'initial_public_proposal_url',
+      'explainer_links', 'requires_embedder_support', 'standard_maturity',
+      'spec_link', 'api_spec', 'spec_mentors', 'interop_compat_risks',
+      'prefixed', 'all_platforms', 'all_platforms_descr', 'tag_review',
+      'tag_review_status', 'non_oss_deps', 'anticipated_spec_changes',
+      'ff_views', 'safari_views', 'web_dev_views', 'ff_views_link',
+      'safari_views_link', 'web_dev_views_link', 'ff_views_notes',
+      'safari_views_notes', 'web_dev_views_notes', 'other_views_notes',
+      'security_risks', 'security_review_status', 'privacy_review_status',
+      'ergonomics_risks', 'wpt', 'wpt_descr', 'webview_risks', 'devrel',
+      'debuggability', 'doc_links', 'sample_links']
+
+  def setUp(self):
+    self.feature_1 = core_models.Feature(
+        id=1,
+        created=datetime(2020, 1, 1),
+        updated=datetime(2020, 7, 1),
+        accurate_as_of=datetime(2020, 3, 1),
+        created_by=ndb.User(
+            _auth_domain='example.com', email='user@example.com'),
+        updated_by=ndb.User(
+            _auth_domain='example.com', email='editor@example.com'),
+        owner=['owner@example.com'],
+        editors=['editor@example.com'],
+        unlisted=False,
+        deleted=False,
+        name='feature_one',
+        summary='newly migrated summary',
+        category=1,
+        blink_components=['Blink'],
+        star_count=3,
+        search_tags=['tag1', 'tag2'],
+        feature_type=1,
+        intent_stage=1,
+        bug_url='https://bug.example.com',
+        launch_bug_url='https://bug.example.com',
+        impl_status_chrome=1,
+        flag_name='flagname',
+        ongoing_constraints='constraints',
+        motivation='motivation',
+        devtrial_instructions='instructions',
+        activation_risks='risks',
+        measurement=None,
+        initial_public_proposal_url='proposal.example.com',
+        explainer_links=['explainer.example.com'],
+        requires_embedder_support=False,
+        standard_maturity=1,
+        standardization=1,
+        spec_link='spec.example.com',
+        api_spec=False,
+        spec_mentors=['mentor1', 'mentor2'],
+        interop_compat_risks='risks',
+        prefixed=True,
+        all_platforms=True,
+        all_platforms_descr='All platforms',
+        tag_review='tag_review',
+        tag_review_status=1,
+        non_oss_deps='oss_deps',
+        anticipated_spec_changes='spec_changes',
+        ff_views=1,
+        safari_views=1,
+        web_dev_views=1,
+        ff_views_link='view.example.com',
+        safari_views_link='view.example.com',
+        web_dev_views_link='view.example.com',
+        ff_views_notes='notes',
+        safari_views_notes='notes',
+        web_dev_views_notes='notes',
+        other_views_notes='notes',
+        security_risks='risks',
+        security_review_status=1,
+        privacy_review_status=1,
+        ergonomics_risks='risks',
+        wpt=True,
+        wpt_descr='description',
+        webview_risks='risks',
+        devrel=['devrel'],
+        debuggability='debuggability',
+        doc_links=['link1.example.com', 'link2.example.com'],
+        sample_links=[])
+    self.feature_1.put()
+
+    self.feature_2 = core_models.Feature(
+        id=2,
+        created=datetime(2020, 4, 1),
+        updated=datetime(2020, 7, 1),
+        accurate_as_of=datetime(2020, 6, 1),
+        created_by=ndb.User(
+            _auth_domain='example.com', email='user@example.com'),
+        updated_by=ndb.User(
+            _auth_domain='example.com', email='editor@example.com'),
+        owner=['owner@example.com'],
+        editors=['editor@example.com'],
+        unlisted=False,
+        deleted=False,
+        name='feature_one',
+        summary='newly migrated summary',
+        standardization=1,
+        category=1,
+        impl_status_chrome=1,
+        web_dev_views=1)
+    self.feature_2.put()
+
+    self.feature_3 = core_models.Feature(
+        id=3,
+        created=datetime(2020, 4, 1),
+        updated=datetime(2020, 7, 1),
+        accurate_as_of=datetime(2020, 6, 1),
+        created_by=ndb.User(
+            _auth_domain='example.com', email='user@example.com'),
+        updated_by=ndb.User(
+            _auth_domain='example.com', email='editor@example.com'),
+        owner=['owner@example.com'],
+        editors=['editor@example.com'],
+        unlisted=False,
+        deleted=False,
+        name='feature_three',
+        summary='migrated summary',
+        standardization=1,
+        category=1,
+        impl_status_chrome=1,
+        web_dev_views=1)
+    self.feature_3.put()
+
+    # Feature 3 is already migrated.
+    self.feature_entry_3 = core_models.FeatureEntry(
+        id=3,
+        created=datetime(2020, 4, 1),
+        updated=datetime(2020, 7, 1),
+        accurate_as_of=datetime(2020, 6, 1),
+        creator='user@example.com',
+        updater='editor@example.com',
+        owners=['owner@example.com'],
+        editors=['editor@example.com'],
+        unlisted=False,
+        deleted=False,
+        name='feature_three',
+        summary='migrated summary',
+        standard_maturity=1,
+        impl_status_chrome=1,
+        category=1,
+        ff_views=1,
+        safari_views=1,
+        web_dev_views=1)
+    self.feature_entry_3.put()
+
+  def tearDown(self):
+    for feature in core_models.Feature.query().fetch():
+      feature.key.delete()
+    for feature_entry in core_models.FeatureEntry.query().fetch():
+      feature_entry.key.delete()
+
+  def test_migration(self):
+    migration_handler = schema_migration.MigrateFeaturesToFeatureEntries()
+    result = migration_handler.get_template_data()
+    # One feature is already migrated, so only 2 other features to migrate.
+    expected = '2 features migrated to FeatureEntry entities.'
+    self.assertEqual(result, expected)
+    feature_entries = core_models.FeatureEntry.query().fetch()
+    self.assertEqual(len(feature_entries), 3)
+    
+    # Check if all fields have been copied over.
+    q = core_models.FeatureEntry.query().filter(
+        core_models.FeatureEntry.key == ndb.Key(core_models.FeatureEntry, 1))
+    feature_entry_1 = q.fetch()[0]
+    feature_entry_1.owners = self.feature_1.owner
+    feature_entry_1.creator = self.feature_1.created_by.email()
+    feature_entry_1.updater = self.feature_1.updated_by.email()
+    for field in self.FEATURE_FIELDS:
+      getattr(feature_entry_1, field) == getattr(self.feature_1, field)
+
+    # The migration should be idempotent, so nothing should be migrated twice.
+    result_2 = migration_handler.get_template_data()
+    expected = '0 features migrated to FeatureEntry entities.'
     self.assertEqual(result_2, expected)

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -241,16 +241,16 @@ class MigrateFeaturesToFeatureEntriesTest(testing_config.CustomTestCase):
   def test_migration(self):
     migration_handler = schema_migration.MigrateFeaturesToFeatureEntries()
     result = migration_handler.get_template_data()
-    # One feature is already migrated, so only 2 other features to migrate.
-    expected = '2 features migrated to FeatureEntry entities.'
+    # One is already migrated, so only 2 others to migrate.
+    expected = '2 Feature entities migrated to FeatureEntry entities.'
     self.assertEqual(result, expected)
     feature_entries = core_models.FeatureEntry.query().fetch()
     self.assertEqual(len(feature_entries), 3)
     
     # Check if all fields have been copied over.
-    q = core_models.FeatureEntry.query().filter(
-        core_models.FeatureEntry.key == ndb.Key(core_models.FeatureEntry, 1))
-    feature_entry_1 = q.fetch()[0]
+    feature_entry_1 = core_models.FeatureEntry.get_by_id(
+        self.feature_1.key.integer_id())
+    self.assertIsNotNone(feature_entry_1)
     self.assertEqual(feature_entry_1.owners, self.feature_1.owner)
     self.assertEqual(feature_entry_1.updater, self.feature_1.updated_by.email())
     self.assertEqual(feature_entry_1.feature_notes, self.feature_1.comments)
@@ -260,5 +260,5 @@ class MigrateFeaturesToFeatureEntriesTest(testing_config.CustomTestCase):
 
     # The migration should be idempotent, so nothing should be migrated twice.
     result_2 = migration_handler.get_template_data()
-    expected = '0 features migrated to FeatureEntry entities.'
+    expected = '0 Feature entities migrated to FeatureEntry entities.'
     self.assertEqual(result_2, expected)

--- a/main.py
+++ b/main.py
@@ -195,6 +195,7 @@ internals_routes = [
   ('/cron/warn_inactive_users', notifier.NotifyInactiveUsersHandler),
   ('/cron/remove_inactive_users', inactive_users.RemoveInactiveUsersHandler),
   ('/cron/schema_migration_comment_activity', schema_migration.MigrateCommentsToActivities),
+  ('/cron/schema_migration_feature_featureentry', schema_migration.MigrateFeaturesToFeatureEntries),
   ('/cron/write_standard_maturity', deprecate_field.WriteStandardMaturityHandler),
 
   ('/tasks/email-subscribers', notifier.FeatureChangeHandler),


### PR DESCRIPTION
Part of the schema migration work.

This script writes all existing features to new FeatureEntry entities. *Note*: This script only copies over fields on the Feature kind that should exist on any FeatureEntry entities. Additional work will be necessary to move some Feature fields that are not part of the schema of different kinds.