### PR TITLE
Replace django templates for email with jinja2 templates

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -48,3 +48,6 @@ htmlcov
 # Python venv directory
 cs-env
 tutorial-env
+
+# Testdata for Python tests
+testdata

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -551,7 +551,8 @@ class SPAHandler(FlaskHandler):
 def FlaskApplication(import_name, routes, post_routes, pattern_base='', debug=False):
   """Make a Flask app and add routes and handlers that work like webapp2."""
 
-  app = flask.Flask(import_name)
+  app = flask.Flask(import_name,
+    template_folder=settings.flask_compat_get_template_path())
   app.original_wsgi_app = app.wsgi_app  # Only for unit tests.
   app.wsgi_app = ndb_wsgi_middleware(app.wsgi_app) # For Cloud NDB Context
   # For GAE legacy libraries

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -24,8 +24,9 @@ import urllib
 from framework import permissions
 from google.cloud import ndb
 
-from django.template.loader import render_to_string
 from django.utils.html import conditional_escape as escape
+
+from flask import render_template
 
 from framework import basehandlers
 from framework import cloud_tasks_helpers
@@ -74,7 +75,8 @@ def format_email_body(is_update, feature, changes):
   }
   template_path = ('update-feature-email.html' if is_update
                    else 'new-feature-email.html')
-  body = render_to_string(template_path, body_data)
+  # final_full_path = os.path.join(settings.TEMPLATES[0]['DIRS'][0], template_path)
+  body = render_template(template_path, **body_data)
   return body
 
 
@@ -310,7 +312,7 @@ class NotifyInactiveUsersHandler(basehandlers.FlaskHandler):
     email_tasks = []
     for email in users_to_notify:
       body_data = {'site_url': settings.SITE_URL}
-      html = render_to_string(self.EMAIL_TEMPLATE_PATH, body_data)
+      html = render_template(self.EMAIL_TEMPLATE_PATH, **body_data)
       subject = f'Notice of WebStatus user inactivity for {email}'
       email_tasks.append({
         'to': email,
@@ -451,8 +453,8 @@ def post_comment_to_mailing_list(
   references = None
   if thread_id:
     references = '<%s>' % thread_id
-  html = render_to_string(
-      'review-comment-email.html', {'comment_content': comment_content})
+  html = render_template(
+      'review-comment-email.html', comment_content=comment_content)
 
   email_task = {
       'to': to_addr,

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -14,8 +14,10 @@
 
 import collections
 import json
+import os
 import testing_config  # Must be imported before the module under test.
 from datetime import datetime
+from pathlib import Path
 
 import flask
 from unittest import mock
@@ -33,6 +35,17 @@ import settings
 
 test_app = flask.Flask(__name__,
   template_folder=settings.flask_compat_get_template_path())
+
+# Load testdata to be used across all of the CustomTestCases
+TESTDATA = {}
+testdata_dir = os.path.join(
+  os.path.abspath(os.path.dirname(__file__)),
+  'testdata',
+  Path(__file__).stem
+  )
+for filename in os.listdir(testdata_dir):
+  with open(os.path.join(testdata_dir, filename), 'r') as f:
+    TESTDATA[filename] = f.read()
 
 class EmailFormattingTest(testing_config.CustomTestCase):
 
@@ -71,58 +84,66 @@ class EmailFormattingTest(testing_config.CustomTestCase):
             email='editor2@example.com', _auth_domain='gmail.com'),
         blink_components=['Blink'])
     self.feature_2.put()
+    # This feature will only be used for the template tests.
+    # Hardcode the Feature Key ID so that the ID is deterministic in the
+    # template tests.
+    self.template_feature = core_models.Feature(
+        name='feature template', summary='sum', owner=['feature_owner@example.com'],
+        editors=['feature_editor@example.com', 'owner_1@example.com'],
+        category=1, visibility=1, standardization=1, web_dev_views=1,
+        impl_status_chrome=1, created_by=ndb.User(
+            email='creator_template@example.com', _auth_domain='gmail.com'),
+        updated_by=ndb.User(
+            email='editor_template@example.com', _auth_domain='gmail.com'),
+        blink_components=['Blink'])
+    self.template_feature.key = ndb.Key('Feature', 123)
+    self.template_feature.put()
 
   def tearDown(self):
     self.feature_1.key.delete()
     self.feature_2.key.delete()
+    self.template_feature.key.delete()
 
   def test_format_email_body__new(self):
     """We generate an email body for new features."""
     with test_app.app_context():
       body_html = notifier.format_email_body(
-          False, self.feature_1, [])
-    self.assertIn('Blink', body_html)
-    self.assertIn('creator1@gmail.com added', body_html)
-    self.assertIn('chromestatus.com/feature/%d' %
-                  self.feature_1.key.integer_id(),
-                  body_html)
-    self.assertNotIn('watcher_1,', body_html)
+          False, self.template_feature, [])
+    self.assertEqual(body_html,
+      TESTDATA['test_format_email_body__new.html'])
 
   def test_format_email_body__update_no_changes(self):
     """We don't crash if the change list is emtpy."""
     with test_app.app_context():
       body_html = notifier.format_email_body(
-          True, self.feature_1, [])
-    self.assertIn('Blink', body_html)
-    self.assertIn('editor1@gmail.com updated', body_html)
-    self.assertNotIn('watcher_1,', body_html)
+          True, self.template_feature, [])
+    self.assertEqual(body_html,
+      TESTDATA['test_format_email_body__update_no_changes.html'])
 
   def test_format_email_body__update_with_changes(self):
     """We generate an email body for an updated feature."""
     with test_app.app_context():
       body_html = notifier.format_email_body(
-          True, self.feature_1, self.changes)
-    self.assertIn('test_prop', body_html)
-    self.assertIn('chromestatus.com/feature/%d' %
-                  self.feature_1.key.integer_id(),
-                  body_html)
-    self.assertIn('test old value', body_html)
-    self.assertIn('test new value', body_html)
+          True, self.template_feature, self.changes)
+    self.assertEqual(body_html,
+      TESTDATA['test_format_email_body__update_with_changes.html'])
 
   def test_format_email_body__mozdev_links(self):
     """We generate an email body with links to developer.mozilla.org."""
     self.feature_1.doc_links = ['https://developer.mozilla.org/look-here']
     with test_app.app_context():
       body_html = notifier.format_email_body(
-          True, self.feature_1, self.changes)
-    self.assertIn('look-here', body_html)
+          True, self.template_feature, self.changes)
+    self.assertEqual(body_html,
+      TESTDATA['test_format_email_body__mozdev_links_mozilla.html'])
 
     self.feature_1.doc_links = [
         'https://hacker-site.org/developer.mozilla.org/look-here']
     with test_app.app_context():
       body_html = notifier.format_email_body(
-          True, self.feature_1, self.changes)
-    self.assertNotIn('look-here', body_html)
+          True, self.template_feature, self.changes)
+    self.assertEqual(body_html,
+      TESTDATA['test_format_email_body__mozdev_links_non_mozilla.html'])
 
   def test_accumulate_reasons(self):
     """We can accumulate lists of reasons why we sent a message to a user."""

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -31,6 +31,8 @@ from internals import notifier
 from internals import user_models
 import settings
 
+test_app = flask.Flask(__name__,
+  template_folder=settings.flask_compat_get_template_path())
 
 class EmailFormattingTest(testing_config.CustomTestCase):
 
@@ -76,8 +78,9 @@ class EmailFormattingTest(testing_config.CustomTestCase):
 
   def test_format_email_body__new(self):
     """We generate an email body for new features."""
-    body_html = notifier.format_email_body(
-        False, self.feature_1, [])
+    with test_app.app_context():
+      body_html = notifier.format_email_body(
+          False, self.feature_1, [])
     self.assertIn('Blink', body_html)
     self.assertIn('creator1@gmail.com added', body_html)
     self.assertIn('chromestatus.com/feature/%d' %
@@ -87,16 +90,18 @@ class EmailFormattingTest(testing_config.CustomTestCase):
 
   def test_format_email_body__update_no_changes(self):
     """We don't crash if the change list is emtpy."""
-    body_html = notifier.format_email_body(
-        True, self.feature_1, [])
+    with test_app.app_context():
+      body_html = notifier.format_email_body(
+          True, self.feature_1, [])
     self.assertIn('Blink', body_html)
     self.assertIn('editor1@gmail.com updated', body_html)
     self.assertNotIn('watcher_1,', body_html)
 
   def test_format_email_body__update_with_changes(self):
     """We generate an email body for an updated feature."""
-    body_html = notifier.format_email_body(
-        True, self.feature_1, self.changes)
+    with test_app.app_context():
+      body_html = notifier.format_email_body(
+          True, self.feature_1, self.changes)
     self.assertIn('test_prop', body_html)
     self.assertIn('chromestatus.com/feature/%d' %
                   self.feature_1.key.integer_id(),
@@ -107,14 +112,16 @@ class EmailFormattingTest(testing_config.CustomTestCase):
   def test_format_email_body__mozdev_links(self):
     """We generate an email body with links to developer.mozilla.org."""
     self.feature_1.doc_links = ['https://developer.mozilla.org/look-here']
-    body_html = notifier.format_email_body(
-        True, self.feature_1, self.changes)
+    with test_app.app_context():
+      body_html = notifier.format_email_body(
+          True, self.feature_1, self.changes)
     self.assertIn('look-here', body_html)
 
     self.feature_1.doc_links = [
         'https://hacker-site.org/developer.mozilla.org/look-here']
-    body_html = notifier.format_email_body(
-        True, self.feature_1, self.changes)
+    with test_app.app_context():
+      body_html = notifier.format_email_body(
+          True, self.feature_1, self.changes)
     self.assertNotIn('look-here', body_html)
 
   def test_accumulate_reasons(self):
@@ -458,7 +465,8 @@ class FeatureStarTest(testing_config.CustomTestCase):
   def test_get_user_stars__no_stars(self):
     """User has never starred any features."""
     email = 'user4@example.com'
-    actual = notifier.FeatureStar.get_user_stars(email)
+    with test_app.app_context():
+      actual = notifier.FeatureStar.get_user_stars(email)
     self.assertEqual([], actual)
 
   def test_get_user_stars__some_stars(self):
@@ -557,8 +565,9 @@ class NotifyInactiveUsersHandlerTest(testing_config.CustomTestCase):
       user.key.delete()
 
   def test_determine_users_to_notify(self):
-    inactive_notifier = notifier.NotifyInactiveUsersHandler()
-    result = inactive_notifier.get_template_data(now=datetime(2023, 9, 1))
+    with test_app.app_context():
+      inactive_notifier = notifier.NotifyInactiveUsersHandler()
+      result = inactive_notifier.get_template_data(now=datetime(2023, 9, 1))
     expected = ('1 users notified of inactivity.\n'
         'Notified users:\ninactive_user@example.com')
     self.assertEqual(result.get('message', None), expected)

--- a/internals/testdata/notifier_test/test_format_email_body__mozdev_links_mozilla.html
+++ b/internals/testdata/notifier_test/test_format_email_body__mozdev_links_mozilla.html
@@ -1,0 +1,35 @@
+<p>
+  editor_template@example.com updated this feature:
+</p>
+
+<p>
+  <b><a href="https://chromestatus.com/feature/123"
+        >feature template</a></b>
+</p>
+
+<p><b>Components</b>: Blink</p>
+<p><b>Implementation status</b>: No active development</p>
+<p><b>Estimated milestones</b>:
+  
+
+  <p>No milestones specified</p>
+
+
+</p>
+
+<p><b>Changes:</b></p>
+<ul>
+<li><b>test_prop:</b> <br/><b>old:</b> test old value <br/><b>new:</b> test new value<br/></li><br/>
+</ul>
+
+<hr>
+
+<p>Next steps:</p>
+<ul>
+  <li>Check existing
+    <a href="https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-core/audits"
+       >Lighthouse audits</a> for correctness.</li>
+
+
+
+</ul>

--- a/internals/testdata/notifier_test/test_format_email_body__mozdev_links_non_mozilla.html
+++ b/internals/testdata/notifier_test/test_format_email_body__mozdev_links_non_mozilla.html
@@ -1,0 +1,35 @@
+<p>
+  editor_template@example.com updated this feature:
+</p>
+
+<p>
+  <b><a href="https://chromestatus.com/feature/123"
+        >feature template</a></b>
+</p>
+
+<p><b>Components</b>: Blink</p>
+<p><b>Implementation status</b>: No active development</p>
+<p><b>Estimated milestones</b>:
+  
+
+  <p>No milestones specified</p>
+
+
+</p>
+
+<p><b>Changes:</b></p>
+<ul>
+<li><b>test_prop:</b> <br/><b>old:</b> test old value <br/><b>new:</b> test new value<br/></li><br/>
+</ul>
+
+<hr>
+
+<p>Next steps:</p>
+<ul>
+  <li>Check existing
+    <a href="https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-core/audits"
+       >Lighthouse audits</a> for correctness.</li>
+
+
+
+</ul>

--- a/internals/testdata/notifier_test/test_format_email_body__new.html
+++ b/internals/testdata/notifier_test/test_format_email_body__new.html
@@ -1,0 +1,36 @@
+<p>
+  creator_template@example.com added a new feature:
+</p>
+
+<p><b><a href="https://chromestatus.com/feature/123"
+         >feature template</a></b>
+</p>
+<p><b>Components</b>: Blink</p>
+<p><b>Implementation status</b>: No active development</p>
+<p><b>Estimated milestones</b>:
+  
+
+  <p>No milestones specified</p>
+
+
+</p>
+
+<hr>
+<p>Next steps:</p>
+<ul>
+  <li>Try the API, write a sample, provide early feedback to eng.</li>
+  <li>Consider authoring a new article/update for /web.</li>
+  <li>Write a
+    <a href="https://github.com/GoogleChrome/lighthouse/tree/master/docs/recipes/custom-audit"
+       >new Lighthouse audit</a>. This can help drive adoption of an API
+    over time.
+  </li>
+  <li>Add a sample to https://github.com/GoogleChrome/samples (see
+    <a href="https://github.com/GoogleChrome/samples#contributing-samples"
+       >contributing</a>).
+  </li>
+  <li>Add demo links and other details to the
+    <a href="https://chromestatus.com/guide/edit/123"
+       >ChromeStatus feature entry</a>.
+  </li>
+</ul>

--- a/internals/testdata/notifier_test/test_format_email_body__update_no_changes.html
+++ b/internals/testdata/notifier_test/test_format_email_body__update_no_changes.html
@@ -1,0 +1,35 @@
+<p>
+  editor_template@example.com updated this feature:
+</p>
+
+<p>
+  <b><a href="https://chromestatus.com/feature/123"
+        >feature template</a></b>
+</p>
+
+<p><b>Components</b>: Blink</p>
+<p><b>Implementation status</b>: No active development</p>
+<p><b>Estimated milestones</b>:
+  
+
+  <p>No milestones specified</p>
+
+
+</p>
+
+<p><b>Changes:</b></p>
+<ul>
+<li>None</li>
+</ul>
+
+<hr>
+
+<p>Next steps:</p>
+<ul>
+  <li>Check existing
+    <a href="https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-core/audits"
+       >Lighthouse audits</a> for correctness.</li>
+
+
+
+</ul>

--- a/internals/testdata/notifier_test/test_format_email_body__update_with_changes.html
+++ b/internals/testdata/notifier_test/test_format_email_body__update_with_changes.html
@@ -1,0 +1,35 @@
+<p>
+  editor_template@example.com updated this feature:
+</p>
+
+<p>
+  <b><a href="https://chromestatus.com/feature/123"
+        >feature template</a></b>
+</p>
+
+<p><b>Components</b>: Blink</p>
+<p><b>Implementation status</b>: No active development</p>
+<p><b>Estimated milestones</b>:
+  
+
+  <p>No milestones specified</p>
+
+
+</p>
+
+<p><b>Changes:</b></p>
+<ul>
+<li><b>test_prop:</b> <br/><b>old:</b> test old value <br/><b>new:</b> test new value<br/></li><br/>
+</ul>
+
+<hr>
+
+<p>Next steps:</p>
+<ul>
+  <li>Check existing
+    <a href="https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-core/audits"
+       >Lighthouse audits</a> for correctness.</li>
+
+
+
+</ul>

--- a/settings.py
+++ b/settings.py
@@ -19,6 +19,19 @@ TEMPLATES = [
   },
 ]
 
+def flask_compat_get_template_path() -> str:
+  """Returns a path to the templates.
+  Leverages the existing TEMPLATES variable used for Django templates and
+  returns a path usable by Flask/Jinja2.
+
+  This is useful because by default flask.render_template will look for a
+  template folder relative to the module.
+
+  Once all Django templates are completely converted to Jinja2, a simpler
+  variable TEMPLATES could be used to hold information about the templates.
+  """
+  return TEMPLATES[0]['DIRS'][0]
+
 # This is necessary to override django templates.
 FORM_RENDERER = 'django.forms.renderers.TemplatesSetting'
 

--- a/templates/new-feature-email.html
+++ b/templates/new-feature-email.html
@@ -5,7 +5,7 @@
 <p><b><a href="https://chromestatus.com/feature/{{id}}"
          >{{feature.name}}</a></b>
 </p>
-<p><b>Components</b>: {{feature.blink_components|join:", "}}</p>
+<p><b>Components</b>: {{feature.blink_components|join(", ")}}</p>
 <p><b>Implementation status</b>: {{status}}</p>
 <p><b>Estimated milestones</b>:
   {% include "estimated-milestones-table.html" %}

--- a/templates/update-feature-email.html
+++ b/templates/update-feature-email.html
@@ -7,7 +7,7 @@
         >{{feature.name}}</a></b>
 </p>
 
-<p><b>Components</b>: {{feature.blink_components|join:", "}}</p>
+<p><b>Components</b>: {{feature.blink_components|join(", ")}}</p>
 <p><b>Implementation status</b>: {{status}}</p>
 <p><b>Estimated milestones</b>:
   {% include "estimated-milestones-table.html" %}


### PR DESCRIPTION
This commit converts the email templates from django templates to jinja2 templates.

It also creates a new helper function: flask_compat_get_template_path

This function uses the existing configuration for django templates and uses it to return a string used to locate the templates for jinja2.

Fixes #2030