### PR TITLE
Write and edit FeatureEntry entities when creating Features

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -83,4 +83,10 @@ class FeaturesAPI(basehandlers.APIHandler):
     feature.put()
     rediscache.delete_keys_with_prefix(core_models.feature_cache_prefix())
 
+    # Write for new FeatureEntry entity.
+    feature_entry = core_models.FeatureEntry.get_by_id(feature_id)
+    if feature_entry:
+      feature_entry.deleted = True
+      feature_entry.put()
+
     return {'message': 'Done'}

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -1050,6 +1050,7 @@ class FeatureEntry(ndb.Model):  # Copy from Feature
   # Metadata: Access controls
   owners = ndb.StringProperty(repeated=True)  # copy from owner
   editors = ndb.StringProperty(repeated=True)
+  cc_recipients = ndb.StringProperty(repeated=True)
   unlisted = ndb.BooleanProperty(default=False)
   deleted = ndb.BooleanProperty(default=False)
 

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -68,7 +68,7 @@ class FeatureCreateHandler(basehandlers.FlaskHandler):
     key = feature.put()
 
     # Write for new FeatureEntry entity.
-    feature_entry = core_models.Feature(
+    feature_entry = core_models.FeatureEntry(
         id=feature.key.integer_id(),
         category=int(self.form.get('category')),
         name=self.form.get('name'),
@@ -82,7 +82,6 @@ class FeatureCreateHandler(basehandlers.FlaskHandler):
         updater=signed_in_user.email(),
         accurate_as_of=datetime.now(),
         impl_status_chrome=core_enums.NO_ACTIVE_DEV,
-        standardization=core_enums.EDITORS_DRAFT,
         unlisted=self.form.get('unlisted') == 'on',
         web_dev_views=core_enums.DEV_NO_SIGNALS,
         blink_components=blink_components,
@@ -509,7 +508,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     feature.updated_by = ndb.User(
         email=self.get_current_user().email(),
         _auth_domain='gmail.com')
-    update_items.append('updater', self.get_current_user().email())
+    update_items.append(('updater', self.get_current_user().email()))
     key = feature.put()
 
     # Write for new FeatureEntry entity.

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -168,8 +168,8 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
 
     if self.touched('security_review_status'):
       feature.security_review_status = self.parse_int('security_review_status')
-      update_items.append('security_review_status',
-          self.split_emails('security_review_status'))
+      update_items.append(('security_review_status',
+          self.parse_int('security_review_status')))
 
     if self.touched('privacy_review_status'):
       feature.privacy_review_status = self.parse_int('privacy_review_status')
@@ -342,9 +342,9 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       feature.blink_components = (
           self.split_input('blink_components', delim=',') or
           [settings.DEFAULT_COMPONENT])
-      update_items.append('blink_components', (
+      update_items.append(('blink_components', (
           self.split_input('blink_components', delim=',') or
-          [settings.DEFAULT_COMPONENT]))
+          [settings.DEFAULT_COMPONENT])))
 
     if self.touched('devrel'):
       feature.devrel = self.split_emails('devrel')

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -80,7 +80,16 @@ class FeatureCreateTest(testing_config.CustomTestCase):
     self.assertEqual(1, feature.category)
     self.assertEqual('Feature name', feature.name)
     self.assertEqual('Feature summary', feature.summary)
+    
+    # Ensure FeatureEntry entity was also created.
+    feature_entry = core_models.FeatureEntry.get_by_id(new_feature_id)
+    self.assertEqual(1, feature_entry.category)
+    self.assertEqual('Feature name', feature_entry.name)
+    self.assertEqual('Feature summary', feature_entry.summary)
+    self.assertEqual('user1@google.com', feature_entry.creator)
+
     feature.key.delete()
+    feature_entry.key.delete()
 
 
 class FeatureEditHandlerTest(testing_config.CustomTestCase):
@@ -92,6 +101,12 @@ class FeatureEditHandlerTest(testing_config.CustomTestCase):
         impl_status_chrome=1)
     self.feature_1.put()
     self.stage = core_enums.INTENT_INCUBATE  # Shows first form
+
+    self.feature_entry_1 = core_models.FeatureEntry(
+        id=self.feature_1.key.integer_id(), name='feature one',
+        summary='sum', owners=['user1@google.com'], category=1,
+        standard_maturity=1, web_dev_views=1, impl_status_chrome=1)
+    self.feature_entry_1.put()
 
     self.request_path = ('/guide/stage/%d/%d' % (
         self.feature_1.key.integer_id(), self.stage))
@@ -173,3 +188,10 @@ class FeatureEditHandlerTest(testing_config.CustomTestCase):
     self.assertEqual('Revised feature name', revised_feature.name)
     self.assertEqual('Revised feature summary', revised_feature.summary)
     self.assertEqual(84, revised_feature.shipped_milestone)
+
+    # Ensure changes were also made to FeatureEntry entity
+    revised_entry = core_models.FeatureEntry.get_by_id(
+        self.feature_1.key.integer_id())
+    self.assertEqual(2, revised_entry.category)
+    self.assertEqual('Revised feature name', revised_entry.name)
+    self.assertEqual('Revised feature summary', revised_entry.summary)


### PR DESCRIPTION
Part of the schema migration work.

This change implements creation and editing of FeatureEntry entities while creating or editing a corresponding Feature entity. Creating and editing is handled in `guide.py`, while deletion is handled in `features_api.py`.