### PR TITLE
Migrate Approval entities to Vote entities

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -29,6 +29,9 @@ cron:
 - description: Copy over comment entities to new activity entities
   url: /cron/schema_migration_comment_activity
   schedule: 1 of jan 00:00
+- description: Copy over Approval entities to new Vote entities
+  url: /cron/schema_migration_approval_vote
+  schedule: 1 of jan 00:00
 - description: Copy over deprecated standardization field
   url: /cron/write_standard_maturity
   schedule: 1 of jan 00:00

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -92,29 +92,10 @@ class MigrateApprovalsToVotes(FlaskHandler):
     """Writes a Vote entity for each unmigrated Approval entity."""
     self.require_cron_header()
 
-    approvals = Approval.query().fetch()
-    vote_keys = Vote.query().fetch(keys_only=True)
-    vote_ids = set(key.integer_id() for key in vote_keys)
-    migration_count = 0
-    for approval in approvals:
-      # Check if a Vote with the same ID has already been created.
-      # If so, do not create this Vote again.
-      if approval.key.integer_id() in vote_ids:
-        continue
-
-      kwargs = {
-        'id': approval.key.integer_id(),
-        'feature_id': approval.feature_id,
-        'gate_id': approval.field_id,
-        'state': approval.state,
-        'set_on': approval.set_on,
-        'set_by': approval.set_by
-      }
-
-      vote = Vote(**kwargs)
-      vote.put()
-      migration_count += 1
-
-    message = f'{migration_count} approvals migrated to vote entities.'
-    logging.info(message)
-    return message
+    kwarg_mapping = [
+        ('feature_id', 'feature_id'),
+        ('gate_id', 'field_id'),
+        ('state', 'state'),
+        ('set_on', 'set_on'),
+        ('set_by', 'set_by')]
+    return handle_migration(Approval, Vote, kwarg_mapping)

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -101,7 +101,7 @@ class MigrateApprovalsToVotesTest(testing_config.CustomTestCase):
     migration_handler = schema_migration.MigrateApprovalsToVotes()
     result = migration_handler.get_template_data()
     # One approval is already migrated, so only 2 need migration.
-    expected = '2 approvals migrated to vote entities.'
+    expected = '2 Approval entities migrated to Vote entities.'
     self.assertEqual(result, expected)
     approvals = review_models.Approval.query().fetch()
     self.assertEqual(len(approvals), 3)
@@ -109,5 +109,5 @@ class MigrateApprovalsToVotesTest(testing_config.CustomTestCase):
 
     # The migration should be idempotent, so nothing should be migrated twice.
     result_2 = migration_handler.get_template_data()
-    expected = '0 approvals migrated to vote entities.'
+    expected = '0 Approval entities migrated to Vote entities.'
     self.assertEqual(result_2, expected)

--- a/main.py
+++ b/main.py
@@ -195,6 +195,7 @@ internals_routes = [
   ('/cron/warn_inactive_users', notifier.NotifyInactiveUsersHandler),
   ('/cron/remove_inactive_users', inactive_users.RemoveInactiveUsersHandler),
   ('/cron/schema_migration_comment_activity', schema_migration.MigrateCommentsToActivities),
+  ('/cron/schema_migration_approval_vote', schema_migration.MigrateApprovalsToVotes),
   ('/cron/write_standard_maturity', deprecate_field.WriteStandardMaturityHandler),
 
   ('/tasks/email-subscribers', notifier.FeatureChangeHandler),


### PR DESCRIPTION
Part of the schema migration work.

This script writes all existing Approval to new Vote entities.