### PR TITLE
Write and edit Vote entities when creating Approval entities

### DIFF
--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -108,7 +108,7 @@ class Approval(ndb.Model):
         id=new_appr.key.integer_id(), feature_id=feature_id, gate_id=field_id,
         state=new_state, set_on=now, set_by=set_by_email)
     new_vote.put()
-    logging.info('new_appr is %r', new_vote.key.integer_id())
+    logging.info('new_vote is %r', new_vote.key.integer_id())
 
   @classmethod
   def clear_request(cls, feature_id, field_id):

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -36,6 +36,15 @@ class ApprovalTest(testing_config.CustomTestCase):
         set_on=datetime.datetime.now() - datetime.timedelta(1),
         set_by='one@example.com')
     self.appr_1.put()
+
+    # Approval 1 has already been migrated to a Vote entity.
+    self.vote_1 = review_models.Vote(id=self.appr_1.key.integer_id(),
+        feature_id=self.feature_1_id, gate_id=1,
+        state=review_models.Vote.REVIEW_REQUESTED,
+        set_on=datetime.datetime.now() - datetime.timedelta(1),
+        set_by='one@example.com')
+    self.vote_1.put()
+
     self.appr_2 = review_models.Approval(
         feature_id=self.feature_1_id, field_id=1,
         state=review_models.Approval.APPROVED,
@@ -93,6 +102,9 @@ class ApprovalTest(testing_config.CustomTestCase):
     self.assertEqual(
         4,
         len(review_models.Approval.query().fetch(None)))
+    
+    # Check that the Vote entity was also changed.
+    self.assertEqual(review_models.Approval.REVIEW_REQUESTED, self.vote_1.state)
 
   def test_clear_request(self):
     """We can clear a review request so that it is no longer pending."""
@@ -105,6 +117,12 @@ class ApprovalTest(testing_config.CustomTestCase):
         feature_id=self.feature_1_id, field_id=1,
         states=[review_models.Approval.REVIEW_REQUESTED])
     self.assertEqual([], remaining_apprs)
+
+    # Ensure that Vote entities are also deleted.
+    remaining_votes = review_models.Vote.get_votes(
+        feature_id=self.feature_1_id, gate_id=1,
+        states=[review_models.Approval.REVIEW_REQUESTED])
+    self.assertEqual([], remaining_votes)
 
 
 class CommentTest(testing_config.CustomTestCase):

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -62,6 +62,8 @@ class ApprovalTest(testing_config.CustomTestCase):
     self.feature_1.key.delete()
     for appr in review_models.Approval.query().fetch(None):
       appr.key.delete()
+    for vote in review_models.Vote.query().fetch():
+      vote.key.delete()
 
   def test_get_approvals(self):
     """We can retrieve Approval entities."""
@@ -103,8 +105,8 @@ class ApprovalTest(testing_config.CustomTestCase):
         4,
         len(review_models.Approval.query().fetch(None)))
     
-    # Check that the Vote entity was also changed.
-    self.assertEqual(review_models.Approval.REVIEW_REQUESTED, self.vote_1.state)
+    # Check that the Vote entity was also created.
+    self.assertEqual(2, len(review_models.Vote.query().fetch()))
 
   def test_clear_request(self):
     """We can clear a review request so that it is no longer pending."""


### PR DESCRIPTION
Part of the schema migration work.

This change implements creation and editing of Vote entities while creating or editing a corresponding Approval entity. Creating, editing, and deleting is handled in class methods in `review_models.py`.