### PR TITLE
Reusable migration function

### DIFF
--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -26,7 +26,6 @@ def handle_migration(original_cls, new_cls, migration_cls, kwarg_mapping):
   for original in originals:
     # Check if a new entity with the same ID has already been created.
     # If so, do not create the entity again.
-    print(f'id={original.key.integer_id()}')
     if original.key.integer_id() in new_ids:
       continue
 

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -18,6 +18,34 @@ from google.cloud import ndb
 from framework.basehandlers import FlaskHandler
 from internals.review_models import Activity, Comment
 
+def handle_migration(original_cls, new_cls, migration_cls, kwarg_mapping):
+  originals = original_cls.query().fetch()
+  new_keys = new_cls.query().fetch(keys_only=True)
+  new_ids = set(key.integer_id() for key in new_keys)
+  migration_count = 0
+  for original in originals:
+    # Check if a new entity with the same ID has already been created.
+    # If so, do not create the entity again.
+    print(f'id={original.key.integer_id()}')
+    if original.key.integer_id() in new_ids:
+      continue
+
+    kwargs = {k : getattr(original, v) for (k, v) in kwarg_mapping}
+    kwargs['id'] = original.key.integer_id()
+
+    # If any fields need special mapping, handle them in the class method.
+    if hasattr(migration_cls, 'handle_special_fields'):
+      migration_cls.handle_special_fields(original, kwargs)
+
+    new_entity = new_cls(**kwargs)
+    new_entity.put()
+    migration_count += 1
+
+  message = (f'{migration_count} {original_cls.__name__} entities migrated '
+      f'to {new_cls.__name__} entities.')
+  logging.info(message)
+  return message
+
 class MigrateCommentsToActivities(FlaskHandler):
 
   def get_template_data(self):
@@ -26,33 +54,15 @@ class MigrateCommentsToActivities(FlaskHandler):
 
     logging.info(self._remove_bad_id_activities())
 
-    comments = Comment.query().fetch()
-    activity_keys = Activity.query().fetch(keys_only=True)
-    activity_ids = set(key.integer_id() for key in activity_keys)
-    migration_count = 0
-    for comment in comments:
-      # Check if an Activity with the same ID has already been created.
-      # If so, do not create this activity again.
-      if comment.key.integer_id() in activity_ids:
-        continue
+    kwarg_mapping = [
+        ('feature_id', 'feature_id'),
+        ('gate_id', 'field_id'),
+        ('author', 'author'),
+        ('content', 'content'),
+        ('deleted_by', 'deleted_by'),
+        ('created', 'created')]
+    return handle_migration(Comment, Activity, self, kwarg_mapping)
 
-      kwargs = {
-        'id': comment.key.integer_id(),
-        'feature_id': comment.feature_id,
-        'gate_id': comment.field_id,
-        'author': comment.author,
-        'content': comment.content,
-        'deleted_by': comment.deleted_by,
-        'created': comment.created
-      }
-      activity = Activity(**kwargs)
-      activity.put()
-      migration_count += 1
-
-    message = f'{migration_count} comments migrated to activity entities.'
-    logging.info(message)
-    return message
-  
   def _remove_bad_id_activities(self):
     """Deletes old Activity entities that do not have a matching comment ID."""
     q = Activity.query()

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -41,7 +41,7 @@ class MigrateCommentsToActivitiesTest(testing_config.CustomTestCase):
   def tearDown(self):
     for comm in review_models.Comment.query().fetch():
       comm.key.delete()
-    for activity in review_models.Activity.query():
+    for activity in review_models.Activity.query().fetch():
       activity.key.delete()
 
   def test_migration__remove_bad_activities(self):
@@ -61,7 +61,7 @@ class MigrateCommentsToActivitiesTest(testing_config.CustomTestCase):
     migration_handler = schema_migration.MigrateCommentsToActivities()
     result = migration_handler.get_template_data()
     # One comment is already migrated, so only 2 need migration.
-    expected = '2 comments migrated to activity entities.'
+    expected = '2 Comment entities migrated to Activity entities.'
     self.assertEqual(result, expected)
     activities = review_models.Activity.query().fetch()
     self.assertEqual(len(activities), 3)
@@ -69,5 +69,5 @@ class MigrateCommentsToActivitiesTest(testing_config.CustomTestCase):
 
     # The migration should be idempotent, so nothing should be migrated twice.
     result_2 = migration_handler.get_template_data()
-    expected = '0 comments migrated to activity entities.'
+    expected = '0 Comment entities migrated to Activity entities.'
     self.assertEqual(result_2, expected)


### PR DESCRIPTION
Part of the schema migration work.

Much of these migration scripts were mostly similar, so this change writes a generic function that can be reused for most kinds.