### PR TITLE
Migrate ApprovalConfig entities to Gate entities

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -35,6 +35,9 @@ cron:
 - description: Copy over Feature entities to new FeatureEntry entities
   url: /cron/schema_migration_feature_featureentry
   schedule: 1 of jan 00:00
+- description: Copy over ApprovalConfig entities to new Gate entities
+  url: /cron/schema_migration_approvalconfig_gate
+  schedule: 1 of jan 00:00
 - description: Copy over deprecated standardization field
   url: /cron/write_standard_maturity
   schedule: 1 of jan 00:00

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -113,8 +113,7 @@ class MigrateApprovalConfigsToGates(FlaskHandler):
         ('gate_type', 'field_id'),
         ('owners', 'owners'),
         ('next_action', 'next_action'),
-        ('additional_review', 'additional_review')
-    ]
+        ('additional_review', 'additional_review')]
     return handle_migration(ApprovalConfig, Gate, kwarg_mapping,
         self.special_handler)
   

--- a/main.py
+++ b/main.py
@@ -196,6 +196,7 @@ internals_routes = [
   ('/cron/remove_inactive_users', inactive_users.RemoveInactiveUsersHandler),
   ('/cron/schema_migration_comment_activity', schema_migration.MigrateCommentsToActivities),
   ('/cron/schema_migration_approval_vote', schema_migration.MigrateApprovalsToVotes),
+  ('/cron/schema_migration_approvalconfig_gate', schema_migration.MigrateApprovalConfigsToGates),
   ('/cron/schema_migration_feature_featureentry', schema_migration.MigrateFeaturesToFeatureEntries),
   ('/cron/write_standard_maturity', deprecate_field.WriteStandardMaturityHandler),
 


### PR DESCRIPTION
Part of the schema migration work.

This script writes all existing ApprovalConfig to new Gate entities.