### PR TITLE
Rename FeatureEntry fields with clear email names

### DIFF
--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -1044,13 +1044,13 @@ class FeatureEntry(ndb.Model):  # Copy from Feature
   created = ndb.DateTimeProperty(auto_now_add=True)
   updated = ndb.DateTimeProperty()
   accurate_as_of = ndb.DateTimeProperty()
-  creator = ndb.StringProperty()
-  updater = ndb.StringProperty()
+  creator_email = ndb.StringProperty()
+  updater_email = ndb.StringProperty()
 
   # Metadata: Access controls
-  owners = ndb.StringProperty(repeated=True)  # copy from owner
-  editors = ndb.StringProperty(repeated=True)
-  cc_recipients = ndb.StringProperty(repeated=True)
+  owner_emails = ndb.StringProperty(repeated=True)  # copy from owner
+  editor_emails = ndb.StringProperty(repeated=True)
+  cc_emails = ndb.StringProperty(repeated=True)
   unlisted = ndb.BooleanProperty(default=False)
   deleted = ndb.BooleanProperty(default=False)
 
@@ -1087,7 +1087,7 @@ class FeatureEntry(ndb.Model):  # Copy from Feature
   standard_maturity = ndb.IntegerProperty(required=True, default=UNSET_STD)
   spec_link = ndb.StringProperty()
   api_spec = ndb.BooleanProperty(default=False)
-  spec_mentors = ndb.StringProperty(repeated=True)
+  spec_mentor_emails = ndb.StringProperty(repeated=True)
   interop_compat_risks = ndb.TextProperty()
   prefixed = ndb.BooleanProperty()
   all_platforms = ndb.BooleanProperty()
@@ -1120,7 +1120,7 @@ class FeatureEntry(ndb.Model):  # Copy from Feature
   webview_risks = ndb.TextProperty()
 
   # Gate: Devrel & Docs
-  devrel = ndb.StringProperty(repeated=True)
+  devrel_emails = ndb.StringProperty(repeated=True)
   debuggability = ndb.TextProperty()
   doc_links = ndb.StringProperty(repeated=True)
   sample_links = ndb.StringProperty(repeated=True)

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -176,6 +176,6 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
 
   @classmethod
   def special_handler(cls, original_entity, kwargs):
-    # udpater_email will use the email from the updated_by field
+    # updater_email will use the email from the updated_by field
     kwargs['updater_email'] = (original_entity.updated_by.email()
         if original_entity.updated_by else None)

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -111,11 +111,11 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
         ('created', 'created'),
         ('updated', 'updated'),
         ('accurate_as_of', 'accurate_as_of'),
-        ('creator', 'creator'),
-        ('owners', 'owner'),
-        ('editors', 'editors'),
+        ('creator_email', 'creator'),
+        ('owner_emails', 'owner'),  # Renamed
+        ('editor_emails', 'editors'),  # Renamed
         ('unlisted', 'unlisted'),
-        ('cc_recipients', 'cc_recipients'),
+        ('cc_emails', 'cc_recipients'),  # Renamed
         ('feature_notes', 'comments'),  # Renamed
         ('deleted', 'deleted'),
         ('name', 'name'),
@@ -141,7 +141,7 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
         ('standard_maturity', 'standard_maturity'),
         ('spec_link', 'spec_link'),
         ('api_spec', 'api_spec'),
-        ('spec_mentors', 'spec_mentors'),
+        ('spec_mentor_emails', 'spec_mentors'),  # Renamed
         ('interop_compat_risks', 'interop_compat_risks'),
         ('prefixed', 'prefixed'),
         ('all_platforms', 'all_platforms'),
@@ -167,7 +167,7 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
         ('wpt', 'wpt'),
         ('wpt_descr', 'wpt_descr'),
         ('webview_risks', 'webview_risks'),
-        ('devrel', 'devrel'),
+        ('devrel_emails', 'devrel'),  # Renamed
         ('debuggability', 'debuggability'),
         ('doc_links', 'doc_links'),
         ('sample_links', 'sample_links')]
@@ -176,6 +176,6 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
 
   @classmethod
   def special_handler(cls, original_entity, kwargs):
-    # updater will use the email from the updated_by field
-    kwargs['updater'] = (original_entity.updated_by.email()
+    # udpater_email will use the email from the updated_by field
+    kwargs['updater_email'] = (original_entity.updated_by.email()
         if original_entity.updated_by else None)

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -111,7 +111,7 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
         ('created', 'created'),
         ('updated', 'updated'),
         ('accurate_as_of', 'accurate_as_of'),
-        ('creator_email', 'creator'),
+        ('creator_email', 'creator'),  # Renamed
         ('owner_emails', 'owner'),  # Renamed
         ('editor_emails', 'editors'),  # Renamed
         ('unlisted', 'unlisted'),

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -34,7 +34,7 @@ class FeatureCreateHandler(basehandlers.FlaskHandler):
   def process_post_data(self):
     owners = self.split_emails('owner')
     editors = self.split_emails('editors')
-    cc_recipients = self.split_emails('cc_recipients')
+    cc_emails = self.split_emails('cc_recipients')
 
     blink_components = (
         self.split_input('blink_components', delim=',') or
@@ -54,7 +54,7 @@ class FeatureCreateHandler(basehandlers.FlaskHandler):
         summary=self.form.get('summary'),
         owner=owners,
         editors=editors,
-        cc_recipients=cc_recipients,
+        cc_recipients=cc_emails,
         creator=signed_in_user.email(),
         accurate_as_of=datetime.now(),
         impl_status_chrome=core_enums.NO_ACTIVE_DEV,
@@ -75,11 +75,11 @@ class FeatureCreateHandler(basehandlers.FlaskHandler):
         feature_type=feature_type,
         intent_stage=core_enums.INTENT_NONE,
         summary=self.form.get('summary'),
-        owners=owners,
-        editors=editors,
-        cc_recipients=cc_recipients,
-        creator=signed_in_user.email(),
-        updater=signed_in_user.email(),
+        owner_emails=owners,
+        editor_emails=editors,
+        cc_emails=cc_emails,
+        creator_email=signed_in_user.email(),
+        updater_email=signed_in_user.email(),
         accurate_as_of=datetime.now(),
         impl_status_chrome=core_enums.NO_ACTIVE_DEV,
         unlisted=self.form.get('unlisted') == 'on',
@@ -164,7 +164,8 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
 
     if self.touched('spec_mentors'):
       feature.spec_mentors = self.split_emails('spec_mentors')
-      update_items.append(('spec_mentors', self.split_emails('spec_mentors')))
+      update_items.append(('spec_mentor_emails',
+          self.split_emails('spec_mentors')))
 
     if self.touched('security_review_status'):
       feature.security_review_status = self.parse_int('security_review_status')
@@ -311,15 +312,15 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
 
     if self.touched('owner'):
       feature.owner = self.split_emails('owner')
-      update_items.append(('owners', self.split_emails('owner')))
+      update_items.append(('owner_emails', self.split_emails('owner')))
 
     if self.touched('editors'):
       feature.editors = self.split_emails('editors')
-      update_items.append(('editors', self.split_emails('editors')))
+      update_items.append(('editor_emails', self.split_emails('editors')))
 
     if self.touched('cc_recipients'):
       feature.cc_recipients = self.split_emails('cc_recipients')
-      update_items.append(('cc_recipients', self.split_emails('cc_recipients')))
+      update_items.append(('cc_emails', self.split_emails('cc_recipients')))
 
     if self.touched('doc_links'):
       feature.doc_links = self.parse_links('doc_links')
@@ -348,7 +349,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
 
     if self.touched('devrel'):
       feature.devrel = self.split_emails('devrel')
-      update_items.append(('devrel', self.split_emails('devrel')))
+      update_items.append(('devrel_emails', self.split_emails('devrel')))
 
     if self.touched('feature_type'):
       feature.feature_type = int(self.form.get('feature_type'))
@@ -508,7 +509,8 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     feature.updated_by = ndb.User(
         email=self.get_current_user().email(),
         _auth_domain='gmail.com')
-    update_items.append(('updater', self.get_current_user().email()))
+    update_items.append(('updater_email', self.get_current_user().email()))
+    update_items.append(('updated', datetime.now()))
     key = feature.put()
 
     # Write for new FeatureEntry entity.

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -86,7 +86,7 @@ class FeatureCreateTest(testing_config.CustomTestCase):
     self.assertEqual(1, feature_entry.category)
     self.assertEqual('Feature name', feature_entry.name)
     self.assertEqual('Feature summary', feature_entry.summary)
-    self.assertEqual('user1@google.com', feature_entry.creator)
+    self.assertEqual('user1@google.com', feature_entry.creator_email)
 
     feature.key.delete()
     feature_entry.key.delete()
@@ -104,7 +104,7 @@ class FeatureEditHandlerTest(testing_config.CustomTestCase):
 
     self.feature_entry_1 = core_models.FeatureEntry(
         id=self.feature_1.key.integer_id(), name='feature one',
-        summary='sum', owners=['user1@google.com'], category=1,
+        summary='sum', owner_emails=['user1@google.com'], category=1,
         standard_maturity=1, web_dev_views=1, impl_status_chrome=1)
     self.feature_entry_1.put()
 


### PR DESCRIPTION
Part of the schema migration work.

This change updates field names in the FeatureEntry kind to clearly denote that they are fields containing emails.

| Old name  |  New name   |
| ------- | ---------- |
| creator | creator_email |
| updater | updater_email |
| owners | owner_emails |
| editors | editor_emails |
| cc_recipients | cc_emails |
| spec_mentors | spec_mentor_emails |
| devrel | devrel_emails |

This change also writes the `updated` field as intended for FeatureEntry entities.