### PR TITLE
Script to create new Stage entities based on Feature data

### DIFF
--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -1035,6 +1035,9 @@ class Feature(DictModel):
 
   finch_url = ndb.StringProperty()
 
+  # Flag set to avoid migrating data that has already been migrated.
+  stages_migrated = ndb.BooleanProperty(default=False)
+
 
 # Note: This class is not used yet.
 class FeatureEntry(ndb.Model):  # Copy from Feature

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -256,7 +256,8 @@ class MigrateStages(FlaskHandler):
         origin_trial_feedback_url=feature.origin_trial_feedback_url)
     stage.put()
     stage = Stage(stage_type=STAGE_BLINK_SHIPPING, milestones=ship_mstones,
-        intent_thread_url=feature.intent_to_ship_url, **kwargs)
+        intent_thread_url=feature.intent_to_ship_url,
+        finch_url=feature.finch_url, **kwargs)
     stage.put()
     # Return number of Stage entities created.
     return 6
@@ -277,7 +278,8 @@ class MigrateStages(FlaskHandler):
         origin_trial_feedback_url=feature.origin_trial_feedback_url, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_FAST_SHIPPING,  milestones=ship_mstones,
-        intent_thread_url=feature.intent_to_ship_url, **kwargs)
+        intent_thread_url=feature.intent_to_ship_url,
+        finch_url=feature.finch_url, **kwargs)
     stage.put()
     # Return number of Stage entities created.
     return 4
@@ -290,7 +292,8 @@ class MigrateStages(FlaskHandler):
         **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_PSA_SHIPPING,  milestones=ship_mstones,
-        intent_thread_url=feature.intent_to_ship_url, **kwargs)
+        intent_thread_url=feature.intent_to_ship_url,
+        finch_url=feature.finch_url, **kwargs)
     stage.put()
     # Return number of Stage entities created.
     return 3
@@ -310,7 +313,8 @@ class MigrateStages(FlaskHandler):
         origin_trial_feedback_url=feature.origin_trial_feedback_url)
     stage.put()
     stage = Stage(stage_type=STAGE_DEP_SHIPPING,  milestones=ship_mstones,
-        intent_thread_url=feature.intent_to_ship_url, **kwargs)
+        intent_thread_url=feature.intent_to_ship_url,
+        finch_url=feature.finch_url, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_DEP_REMOVE_CODE, **kwargs)
     stage.put()

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -16,8 +16,9 @@ import logging
 from google.cloud import ndb
 
 from framework.basehandlers import FlaskHandler
-from internals.core_models import Feature, FeatureEntry
+from internals.core_models import Feature, FeatureEntry, MilestoneSet, Stage
 from internals.review_models import Activity, Approval, Comment, Vote
+from internals.core_enums import *
 
 def handle_migration(original_cls, new_cls, kwarg_mapping,
     special_handler=None):
@@ -179,3 +180,139 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
     # updater_email will use the email from the updated_by field
     kwargs['updater_email'] = (original_entity.updated_by.email()
         if original_entity.updated_by else None)
+
+class MigrateStages(FlaskHandler):
+
+  def get_template_data(self):
+    """Creates new Stage entities MilestoneSet entities based on Feature data"""
+    self.require_cron_header()
+
+    features = Feature.query().fetch()
+    num_stages_created = 0
+    num_features_migrated = 0
+    for feature in features:
+      # Do not create more stages if the data in this feature has been migrated.
+      if feature.stages_migrated:
+        continue
+      # Create MilestoneSets for each major paradigm.
+      devtrial_mstones = MilestoneSet(
+          desktop_first=feature.dt_milestone_desktop_start,
+          android_first=feature.dt_milestone_android_start,
+          ios_first=feature.dt_milestone_ios_start,
+          webview_first=feature.dt_milestone_webview_start)
+      ot_mstones = MilestoneSet(
+          desktop_first=feature.ot_milestone_desktop_start,
+          desktop_last=feature.ot_milestone_desktop_end,
+          android_first=feature.ot_milestone_android_start,
+          android_last=feature.ot_milestone_android_end,
+          webview_first=feature.ot_milestone_webview_start,
+          webview_last=feature.ot_milestone_webview_end)
+      ship_mstones = MilestoneSet(
+          desktop_first=feature.shipped_milestone,
+          android_first=feature.shipped_android_milestone,
+          ios_first=feature.shipped_ios_milestone,
+          webview_first=feature.shipped_webview_milestone)
+      # Depending on the feature type,
+      # create a different group of Stage entities.
+      if feature.feature_type == FEATURE_TYPE_INCUBATE_ID:
+        num_stages_created += self.write_incubate_stages(
+            feature, devtrial_mstones, ot_mstones, ship_mstones)
+      if feature.feature_type == FEATURE_TYPE_EXISTING_ID:
+        num_stages_created += self.write_existing_stages(
+            feature, devtrial_mstones, ot_mstones, ship_mstones)
+      if feature.feature_type == FEATURE_TYPE_CODE_CHANGE_ID:
+        num_stages_created += self.write_code_change_stages(
+            feature, devtrial_mstones, ship_mstones)
+      if feature.feature_type == FEATURE_TYPE_DEPRECATION_ID:
+        num_stages_created += self.write_deprecation_stages(
+            feature, devtrial_mstones, ot_mstones, ship_mstones)
+      feature.stages_migrated = True
+      feature.put()
+      num_features_migrated += 1
+    
+    message = (f'{num_stages_created} Stage entities created '
+        f'for {num_features_migrated} Feature entities.')
+    logging.info(message)
+    return message
+    
+  
+  def write_incubate_stages(self, feature, devtrial_mstones, ot_mstones,
+      ship_mstones):
+    kwargs = {'feature_id': feature.key.integer_id(), 'browser': 'Chrome'}
+    stage = Stage(stage_type=STAGE_BLINK_INCUBATE, **kwargs)
+    stage.put()
+    stage = Stage(stage_type=STAGE_BLINK_PROTOTYPE,
+        intent_thread_url=feature.intent_to_implement_url, **kwargs)
+    stage.put()
+    stage = Stage(stage_type=STAGE_BLINK_DEV_TRIAL,
+        milestones=devtrial_mstones, **kwargs)
+    stage.put()
+    stage = Stage(stage_type=STAGE_BLINK_EVAL_READINESS, **kwargs)
+    stage.put()
+    stage = Stage(stage_type=STAGE_BLINK_ORIGIN_TRIAL, milestones=ot_mstones,
+        **kwargs, intent_thread_url=feature.intent_to_experiment_url,
+        experiment_goals=feature.experiment_goals,
+        experiment_extension_reason=feature.experiment_extension_reason,
+        origin_trial_feedback_url=feature.origin_trial_feedback_url)
+    stage.put()
+    stage = Stage(stage_type=STAGE_BLINK_SHIPPING, milestones=ship_mstones,
+        intent_thread_url=feature.intent_to_ship_url, **kwargs)
+    stage.put()
+    # Return number of Stage entities created.
+    return 6
+  
+  def write_existing_stages(self, feature, devtrial_mstones, ot_mstones,
+      ship_mstones):
+    kwargs = {'feature_id': feature.key.integer_id(), 'browser': 'Chrome'}
+    stage = Stage(stage_type=STAGE_FAST_PROTOTYPE,
+        intent_thread_url=feature.intent_to_implement_url, **kwargs)
+    stage.put()
+    stage = Stage(stage_type=STAGE_FAST_DEV_TRIAL, milestones=devtrial_mstones,
+        **kwargs)
+    stage.put()
+    stage = Stage(stage_type=STAGE_FAST_ORIGIN_TRIAL, milestones=ot_mstones,
+        intent_thread_url=feature.intent_to_experiment_url,
+        experiment_goals=feature.experiment_goals,
+        experiment_extension_reason=feature.experiment_extension_reason,
+        origin_trial_feedback_url=feature.origin_trial_feedback_url, **kwargs)
+    stage.put()
+    stage = Stage(stage_type=STAGE_FAST_SHIPPING,  milestones=ship_mstones,
+        intent_thread_url=feature.intent_to_ship_url, **kwargs)
+    stage.put()
+    # Return number of Stage entities created.
+    return 4
+
+  def write_code_change_stages(self, feature, devtrial_mstones, ship_mstones):
+    kwargs = {'feature_id': feature.key.integer_id(), 'browser': 'Chrome'}
+    stage = Stage(stage_type=STAGE_PSA_IMPLEMENT, **kwargs)
+    stage.put()
+    stage = Stage(stage_type=STAGE_PSA_DEV_TRIAL, milestones=devtrial_mstones,
+        **kwargs)
+    stage.put()
+    stage = Stage(stage_type=STAGE_PSA_SHIPPING,  milestones=ship_mstones,
+        intent_thread_url=feature.intent_to_ship_url, **kwargs)
+    stage.put()
+    # Return number of Stage entities created.
+    return 3
+  
+  def write_deprecation_stages(self, feature, devtrial_mstones, ot_mstones,
+      ship_mstones):
+    kwargs = {'feature_id': feature.key.integer_id(), 'browser': 'Chrome'}
+    stage = Stage(stage_type=STAGE_DEP_PLAN, **kwargs)
+    stage.put()
+    stage = Stage(stage_type=STAGE_DEP_DEV_TRIAL, milestones=devtrial_mstones,
+        **kwargs)
+    stage.put()
+    stage = Stage(stage_type=STAGE_DEP_DEPRECATION_TRIAL, milestones=ot_mstones,
+        **kwargs, intent_thread_url=feature.intent_to_experiment_url,
+        experiment_goals=feature.experiment_goals,
+        experiment_extension_reason=feature.experiment_extension_reason,
+        origin_trial_feedback_url=feature.origin_trial_feedback_url)
+    stage.put()
+    stage = Stage(stage_type=STAGE_DEP_SHIPPING,  milestones=ship_mstones,
+        intent_thread_url=feature.intent_to_ship_url, **kwargs)
+    stage.put()
+    stage = Stage(stage_type=STAGE_DEP_REMOVE_CODE, **kwargs)
+    stage.put()
+    # Return number of Stage entities created.
+    return 5

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -357,6 +357,7 @@ class MigrateStagesTest(testing_config.CustomTestCase):
         ot_milestone_android_start = 102,
         ot_milestone_android_end=104,
         intent_to_experiment_url='https://example.com/intentexperiment',
+        finch_url='https://example.com/finch',
         initial_public_proposal_url='proposal.example.com',
         explainer_links=['explainer.example.com'],
         requires_embedder_support=False,
@@ -471,6 +472,8 @@ class MigrateStagesTest(testing_config.CustomTestCase):
     self.assertEqual(shipping_stage_list[0].milestones.desktop_first, 105)
     self.assertEqual(shipping_stage_list[0].intent_thread_url,
         'https://example.com/intentship')
+    self.assertEqual(shipping_stage_list[0].finch_url,
+        'https://example.com/finch')
     self.assertEqual(len(ot_stage_list), 1)
     self.assertEqual(ot_stage_list[0].milestones.desktop_first, 101)
     self.assertEqual(ot_stage_list[0].milestones.desktop_last, 104)

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -313,3 +313,173 @@ class MigrateFeaturesToFeatureEntriesTest(testing_config.CustomTestCase):
     result_2 = migration_handler.get_template_data()
     expected = '0 Feature entities migrated to FeatureEntry entities.'
     self.assertEqual(result_2, expected)
+
+class MigrateStagesTest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.feature_1 = core_models.Feature(
+        id=1,
+        created=datetime(2020, 1, 1),
+        updated=datetime(2020, 7, 1),
+        accurate_as_of=datetime(2020, 3, 1),
+        created_by=ndb.User(
+            _auth_domain='example.com', email='user@example.com'),
+        updated_by=ndb.User(
+            _auth_domain='example.com', email='editor@example.com'),
+        owner=['owner@example.com'],
+        creator='creator@example.com',
+        editors=['editor@example.com'],
+        cc_recipients=['cc_user@example.com'],
+        unlisted=False,
+        deleted=False,
+        name='feature_one',
+        summary='newly migrated summary',
+        comments='Some comments.',
+        category=1,
+        blink_components=['Blink'],
+        star_count=3,
+        search_tags=['tag1', 'tag2'],
+        feature_type=3,
+        intent_stage=1,
+        bug_url='https://bug.example.com',
+        launch_bug_url='https://bug.example.com',
+        impl_status_chrome=1,
+        flag_name='flagname',
+        ongoing_constraints='constraints',
+        motivation='motivation',
+        devtrial_instructions='instructions',
+        activation_risks='risks',
+        measurement=None,
+        shipped_milestone=105,
+        intent_to_ship_url='https://example.com/intentship',
+        ot_milestone_desktop_start=101,
+        ot_milestone_desktop_end=104,
+        ot_milestone_android_start = 102,
+        ot_milestone_android_end=104,
+        intent_to_experiment_url='https://example.com/intentexperiment',
+        initial_public_proposal_url='proposal.example.com',
+        explainer_links=['explainer.example.com'],
+        requires_embedder_support=False,
+        standard_maturity=1,
+        standardization=1,
+        spec_link='spec.example.com',
+        api_spec=False,
+        spec_mentors=['mentor1', 'mentor2'],
+        interop_compat_risks='risks',
+        prefixed=True,
+        all_platforms=True,
+        all_platforms_descr='All platforms',
+        tag_review='tag_review',
+        tag_review_status=1,
+        non_oss_deps='oss_deps',
+        anticipated_spec_changes='spec_changes',
+        ff_views=1,
+        safari_views=1,
+        web_dev_views=1,
+        ff_views_link='view.example.com',
+        safari_views_link='view.example.com',
+        web_dev_views_link='view.example.com',
+        ff_views_notes='notes',
+        safari_views_notes='notes',
+        web_dev_views_notes='notes',
+        other_views_notes='notes',
+        security_risks='risks',
+        security_review_status=1,
+        privacy_review_status=1,
+        ergonomics_risks='risks',
+        wpt=True,
+        wpt_descr='description',
+        webview_risks='risks',
+        devrel=['devrel'],
+        debuggability='debuggability',
+        doc_links=['link1.example.com', 'link2.example.com'],
+        sample_links=[])
+    self.feature_1.put()
+
+    self.feature_2 = core_models.Feature(
+        id=2,
+        created=datetime(2020, 4, 1),
+        updated=datetime(2020, 7, 1),
+        accurate_as_of=datetime(2020, 6, 1),
+        created_by=ndb.User(
+            _auth_domain='example.com', email='user@example.com'),
+        updated_by=ndb.User(
+            _auth_domain='example.com', email='editor@example.com'),
+        feature_type=0,
+        owner=['owner@example.com'],
+        editors=['editor@example.com'],
+        unlisted=False,
+        deleted=False,
+        name='feature_one',
+        summary='newly migrated summary',
+        standardization=1,
+        category=1,
+        impl_status_chrome=1,
+        web_dev_views=1)
+    self.feature_2.put()
+
+    # Feature 3 stages are already migrated.
+    self.feature_3 = core_models.Feature(
+        id=3,
+        created=datetime(2020, 4, 1),
+        updated=datetime(2020, 7, 1),
+        accurate_as_of=datetime(2020, 6, 1),
+        created_by=ndb.User(
+            _auth_domain='example.com', email='user@example.com'),
+        updated_by=ndb.User(
+            _auth_domain='example.com', email='editor@example.com'),
+        owner=['owner@example.com'],
+        editors=['editor@example.com'],
+        unlisted=False,
+        deleted=False,
+        name='feature_three',
+        summary='migrated summary',
+        standardization=1,
+        category=1,
+        impl_status_chrome=1,
+        web_dev_views=1,
+        stages_migrated=True)
+    self.feature_3.put()
+
+  def tearDown(self):
+    for feature in core_models.Feature.query().fetch():
+      feature.key.delete()
+    for stage in core_models.Stage.query().fetch():
+      stage.key.delete()
+
+  def test_migration(self):
+    migration_handler = schema_migration.MigrateStages()
+    result = migration_handler.get_template_data()
+    # One is already migrated, so only 2 others to migrate.
+    expected = '11 Stage entities created for 2 Feature entities.'
+    self.assertEqual(result, expected)
+    feature_entries = core_models.Stage.query().fetch()
+    self.assertEqual(len(feature_entries), 11)
+    
+    # Check if certain fields were copied over correctly.
+    stages = core_models.Stage.query(
+        core_models.Stage.feature_id == self.feature_1.key.integer_id()).fetch()
+    self.assertEqual(len(stages), 5)
+
+    # Filter for STAGE_DEP_SHIPPING enum
+    shipping_stage_list = [
+      stage for stage in stages if stage.stage_type == 460]
+    ot_stage_list = [
+        stage for stage in stages if stage.stage_type == 450]
+    # Check that 1 Stage exists and the milestone value is correct.
+    self.assertEqual(len(shipping_stage_list), 1)
+    self.assertEqual(shipping_stage_list[0].milestones.desktop_first, 105)
+    self.assertEqual(shipping_stage_list[0].intent_thread_url,
+        'https://example.com/intentship')
+    self.assertEqual(len(ot_stage_list), 1)
+    self.assertEqual(ot_stage_list[0].milestones.desktop_first, 101)
+    self.assertEqual(ot_stage_list[0].milestones.desktop_last, 104)
+    self.assertEqual(ot_stage_list[0].milestones.android_first, 102)
+    self.assertEqual(ot_stage_list[0].milestones.android_last, 104)
+    self.assertEqual(ot_stage_list[0].intent_thread_url,
+        'https://example.com/intentexperiment')
+
+    # The migration should be idempotent, so nothing should be migrated twice.
+    result_2 = migration_handler.get_template_data()
+    expected = '0 Stage entities created for 0 Feature entities.'
+    self.assertEqual(result_2, expected)

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -442,6 +442,50 @@ class MigrateStagesTest(testing_config.CustomTestCase):
         stages_migrated=True)
     self.feature_3.put()
 
+    self.feature_4 = core_models.Feature(
+        id=4,
+        created=datetime(2020, 4, 1),
+        updated=datetime(2020, 7, 1),
+        accurate_as_of=datetime(2020, 6, 1),
+        created_by=ndb.User(
+            _auth_domain='example.com', email='user@example.com'),
+        updated_by=ndb.User(
+            _auth_domain='example.com', email='editor@example.com'),
+        owner=['owner@example.com'],
+        editors=['editor@example.com'],
+        feature_type=1,
+        unlisted=False,
+        deleted=False,
+        name='feature_three',
+        summary='migrated summary',
+        standardization=1,
+        category=1,
+        impl_status_chrome=1,
+        web_dev_views=1)
+    self.feature_4.put()
+
+    self.feature_5 = core_models.Feature(
+        id=5,
+        created=datetime(2020, 4, 1),
+        updated=datetime(2020, 7, 1),
+        accurate_as_of=datetime(2020, 6, 1),
+        created_by=ndb.User(
+            _auth_domain='example.com', email='user@example.com'),
+        updated_by=ndb.User(
+            _auth_domain='example.com', email='editor@example.com'),
+        owner=['owner@example.com'],
+        editors=['editor@example.com'],
+        feature_type=2,
+        unlisted=False,
+        deleted=False,
+        name='feature_three',
+        summary='migrated summary',
+        standardization=1,
+        category=1,
+        impl_status_chrome=1,
+        web_dev_views=1)
+    self.feature_5.put()
+
   def tearDown(self):
     for feature in core_models.Feature.query().fetch():
       feature.key.delete()
@@ -452,10 +496,10 @@ class MigrateStagesTest(testing_config.CustomTestCase):
     migration_handler = schema_migration.MigrateStages()
     result = migration_handler.get_template_data()
     # One is already migrated, so only 2 others to migrate.
-    expected = '11 Stage entities created for 2 Feature entities.'
+    expected = '18 Stage entities created for 4 Feature entities.'
     self.assertEqual(result, expected)
     feature_entries = core_models.Stage.query().fetch()
-    self.assertEqual(len(feature_entries), 11)
+    self.assertEqual(len(feature_entries), 18)
     
     # Check if certain fields were copied over correctly.
     stages = core_models.Stage.query(


### PR DESCRIPTION
Part of the schema migration work.

This script creates a number of Stage entities based on the `feature_type` field of each Feature entity.