### PR TITLE
Handle Stage data when changing feature_type

### DIFF
--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -208,6 +208,41 @@ STAGE_TYPES_BY_FIELD_MAPPING = {
     'dt_milestone_webview_start': STAGE_TYPES_DEV_TRIAL
   }
 
+# Mapping of original field names to the new stage types the fields live on.
+STAGE_TYPES_BY_FIELD_MAPPING = {
+    'finch_url': STAGE_TYPES_SHIPPING,
+    'experiment_goals': STAGE_TYPES_ORIGIN_TRIAL,
+    'experiment_risks': STAGE_TYPES_ORIGIN_TRIAL,
+    'experiment_extension_reason': STAGE_TYPES_EXTEND_ORIGIN_TRIAL,
+    'origin_trial_feedback_url': STAGE_TYPES_ORIGIN_TRIAL,
+    'intent_to_implement_url': STAGE_TYPES_PROTOTYPE,
+    'intent_to_ship_url': STAGE_TYPES_SHIPPING,
+    'intent_to_experiment_url': STAGE_TYPES_ORIGIN_TRIAL,
+    'intent_to_extend_experiment_url': STAGE_TYPES_EXTEND_ORIGIN_TRIAL,
+  }
+
+MILESTONE_STAGE_TYPES_MAPPING = {
+    'shipped_milestone': STAGE_TYPES_SHIPPING,
+    'shipped_android_milestone': STAGE_TYPES_SHIPPING,
+    'shipped_ios_milestone': STAGE_TYPES_SHIPPING,
+    'shipped_webview_milestone': STAGE_TYPES_SHIPPING,
+    'ot_milestone_desktop_start': STAGE_TYPES_ORIGIN_TRIAL,
+    'ot_milestone_desktop_end': STAGE_TYPES_ORIGIN_TRIAL,
+    'ot_milestone_android_start': STAGE_TYPES_ORIGIN_TRIAL,
+    'ot_milestone_android_end': STAGE_TYPES_ORIGIN_TRIAL,
+    'ot_milestone_ios_start': STAGE_TYPES_ORIGIN_TRIAL,
+    'ot_milestone_ios_end': STAGE_TYPES_ORIGIN_TRIAL,
+    'ot_milestone_webview_start': STAGE_TYPES_ORIGIN_TRIAL,
+    'ot_milestone_webview_end': STAGE_TYPES_ORIGIN_TRIAL,
+    'dt_milestone_desktop_start': STAGE_TYPES_DEV_TRIAL,
+    'dt_milestone_android_start': STAGE_TYPES_DEV_TRIAL,
+    'dt_milestone_ios_start': STAGE_TYPES_DEV_TRIAL,
+    'dt_milestone_webview_start': STAGE_TYPES_DEV_TRIAL
+  }
+
+STAGES_WITH_MILESTONES = [STAGE_TYPES_SHIPPING, STAGE_TYPES_ORIGIN_TRIAL,
+    STAGE_TYPES_DEV_TRIAL]
+
 NO_ACTIVE_DEV = 1
 PROPOSED = 2
 IN_DEVELOPMENT = 3

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -549,6 +549,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
 
     # Write for new FeatureEntry entity.
     if feature_entry:
+      feature_entry.handle_feature_type_change(feature_type)
       for field, value in update_items:
         setattr(feature_entry, field, value)
       feature_entry.put()
@@ -569,7 +570,9 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
 
     for field, value in update_items:
       # Determine the stage type that the field should change on.
-      stage_type = core_enums.STAGE_TYPES_BY_FIELD_MAPPING[field][feature_type]
+      stage_type = (core_enums.STAGE_TYPES_BY_FIELD_MAPPING[field][feature_type]
+          if field in core_enums.STAGE_TYPES_BY_FIELD_MAPPING
+          else core_enums.MILESTONE_STAGE_TYPES_MAPPING[field][feature_type])
       # If this feature type does not have this field, skip it
       # (e.g. developer-facing code changes cannot have origin trial fields).
       if stage_type is None:


### PR DESCRIPTION
NOTE: These changes is built on top of #2311 and will require that PR to be merged prior to merging this.

Part of the schema migration work.

This change adds handling of changing the `feature_type` field on the FeatureEntry kind. Because a FeatureEntry entity will have specific Stage entity types based on its `feature_type`, special procedures are needed to prepare Stages with matching `stage_type` fields that correspond to the given `feature_type`. Now changing `feature_type`, new Stage entities will be created as needed and data from older stage fields will be migrated to the new stage entities.