### PR TITLE
Remove unused references to opera milestones

### DIFF
--- a/pages/guide.py
+++ b/pages/guide.py
@@ -250,14 +250,6 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       feature.shipped_webview_milestone = self.parse_int(
           'shipped_webview_milestone')
 
-    if self.touched('shipped_opera_milestone'):
-      feature.shipped_opera_milestone = (
-          self.parse_int('shipped_opera_milestone'))
-
-    if self.touched('shipped_opera_android'):
-      feature.shipped_opera_android_milestone = self.parse_int(
-          'shipped_opera_android_milestone')
-
     if self.touched('ot_milestone_desktop_start'):
       feature.ot_milestone_desktop_start = self.parse_int(
           'ot_milestone_desktop_start')


### PR DESCRIPTION
I think these lines of code may have always been unreachable.  I don't see how they could have been used since at least May 2022.