### PR TITLE
Migrate and write additional fields for FeatureEntry and Stage

### DIFF
--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -1271,6 +1271,7 @@ class Stage(ndb.Model):
   experiment_extension_reason = ndb.TextProperty()
   intent_thread_url = ndb.StringProperty()
   origin_trial_feedback_url = ndb.StringProperty()
+  announcement_url = ndb.StringProperty()
 
   @classmethod
   def get_feature_stages(cls, feature_id: int) -> dict:

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -171,7 +171,8 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
         ('devrel_emails', 'devrel'),  # Renamed
         ('debuggability', 'debuggability'),
         ('doc_links', 'doc_links'),
-        ('sample_links', 'sample_links')]
+        ('sample_links', 'sample_links'),
+        ('experiment_timeline', 'experiment_timeline')]
     return handle_migration(Feature, FeatureEntry,kwarg_mapping,
         self.special_handler)
 
@@ -244,8 +245,8 @@ class MigrateStages(FlaskHandler):
     stage = Stage(stage_type=STAGE_BLINK_PROTOTYPE,
         intent_thread_url=feature.intent_to_implement_url, **kwargs)
     stage.put()
-    stage = Stage(stage_type=STAGE_BLINK_DEV_TRIAL,
-        milestones=devtrial_mstones, **kwargs)
+    stage = Stage(stage_type=STAGE_BLINK_DEV_TRIAL, milestones=devtrial_mstones,
+        announcement_url=feature.ready_for_trial_url, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_BLINK_EVAL_READINESS, **kwargs)
     stage.put()
@@ -269,7 +270,7 @@ class MigrateStages(FlaskHandler):
         intent_thread_url=feature.intent_to_implement_url, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_FAST_DEV_TRIAL, milestones=devtrial_mstones,
-        **kwargs)
+        announcement_url=feature.ready_for_trial_url, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_FAST_ORIGIN_TRIAL, milestones=ot_mstones,
         intent_thread_url=feature.intent_to_experiment_url,
@@ -289,7 +290,7 @@ class MigrateStages(FlaskHandler):
     stage = Stage(stage_type=STAGE_PSA_IMPLEMENT, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_PSA_DEV_TRIAL, milestones=devtrial_mstones,
-        **kwargs)
+        announcement_url=feature.ready_for_trial_url,  **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_PSA_SHIPPING,  milestones=ship_mstones,
         intent_thread_url=feature.intent_to_ship_url,
@@ -304,7 +305,7 @@ class MigrateStages(FlaskHandler):
     stage = Stage(stage_type=STAGE_DEP_PLAN, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_DEP_DEV_TRIAL, milestones=devtrial_mstones,
-        **kwargs)
+        announcement_url=feature.ready_for_trial_url, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_DEP_DEPRECATION_TRIAL, milestones=ot_mstones,
         **kwargs, intent_thread_url=feature.intent_to_experiment_url,

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -133,7 +133,7 @@ class MigrateFeaturesToFeatureEntriesTest(testing_config.CustomTestCase):
       'safari_views_notes', 'web_dev_views_notes', 'other_views_notes',
       'security_risks', 'security_review_status', 'privacy_review_status',
       'ergonomics_risks', 'wpt', 'wpt_descr', 'webview_risks',
-      'debuggability', 'doc_links', 'sample_links']
+      'debuggability', 'doc_links', 'sample_links', 'experiment_timeline']
   
   # (Feature field, FeatureEntry field)
   RENAMED_FIELDS = [('creator', 'creator_email'),

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -206,6 +206,8 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     if self.touched('ready_for_trial_url'):
       feature.ready_for_trial_url = self.parse_link(
           'ready_for_trial_url')
+      update_items.append(('ready_for_trial_url',
+          self.parse_link('ready_for_trial_url')))
 
     if self.touched('intent_to_experiment_url'):
       feature.intent_to_experiment_url = self.parse_link(
@@ -455,14 +457,6 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     if self.touched('ff_views_notes'):
       feature.ff_views_notes = self.form.get('ff_views_notes')
       update_items.append(('ff_views_notes', self.form.get('ff_views_notes')))
-
-    # TODO(jrobbins): Delete after the next deployment
-    if self.touched('ie_views'):
-      feature.ie_views = int(self.form.get('ie_views'))
-    if self.touched('ie_views_link'):
-      feature.ie_views_link = self.parse_link('ie_views_link')
-    if self.touched('ie_views_notes'):
-      feature.ie_views_notes = self.form.get('ie_views_notes')
 
     if self.touched('safari_views'):
       feature.safari_views = int(self.form.get('safari_views'))


### PR DESCRIPTION
Part of the schema migration work.

Add `announcement_url` to the Stage kind, and populate entities in the migration using the `ready_for_trial_url` field. Additionally, migrate the `experiment_timeline` field for FeatureEntry.