### PR TITLE
Remove ability to update feature_type field

### DIFF
--- a/pages/guide.py
+++ b/pages/guide.py
@@ -112,11 +112,10 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
 
     # For now, selects are considered "touched", if they are
     # present on the form and are not empty strings.
-    selects = ['category', 'feature_type', 'intent_stage',
-      'standard_maturity', 'security_review_status',
-      'privacy_review_status', 'tag_review_status',
-      'safari_views', 'ff_views', 'web_dev_views',
-      'blink_components', 'impl_status_chrome']
+    selects = ['category', 'intent_stage', 'standard_maturity',
+        'security_review_status', 'privacy_review_status', 'tag_review_status',
+        'safari_views', 'ff_views', 'web_dev_views', 'blink_components',
+        'impl_status_chrome']
     if param_name in selects:
       return self.form.get(param_name)
 
@@ -143,7 +142,6 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
 
     update_items = []
     stage_update_items = []
-    feature_type = feature.feature_type
 
     if self.touched('spec_link'):
       feature.spec_link = self.parse_link('spec_link')
@@ -378,11 +376,6 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       feature.devrel = self.split_emails('devrel')
       update_items.append(('devrel_emails', self.split_emails('devrel')))
 
-    if self.touched('feature_type'):
-      feature.feature_type = int(self.form.get('feature_type'))
-      update_items.append(('feature_type', int(self.form.get('feature_type'))))
-      feature_type = int(self.form.get('feature_type'))
-
     # intent_stage can be be set either by <select> or a checkbox
     if self.touched('intent_stage'):
       feature.intent_stage = int(self.form.get('intent_stage'))
@@ -555,7 +548,8 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     
     # Write changes made to the corresponding stage type.
     if stage_update_items:
-      self.update_stage_fields(feature_id, feature_type, stage_update_items)
+      self.update_stage_fields(feature_id, feature.feature_type,
+          stage_update_items)
 
     # Remove all feature-related cache.
     rediscache.delete_keys_with_prefix(core_models.feature_cache_prefix())

--- a/static/elements/chromedash-form-field.js
+++ b/static/elements/chromedash-form-field.js
@@ -65,6 +65,7 @@ export class ChromedashFormField extends LitElement {
 
   renderWidgets() {
     const type = this.fieldProps.type;
+    const fieldDisabled = this.fieldProps.disabled;
 
     // if no value is provided, use the initial value specified in form-field-spec
     const fieldValue = !this.value && this.fieldProps.initial ?
@@ -86,7 +87,7 @@ export class ChromedashFormField extends LitElement {
           id="id_${this.name}"
           size="small"
           ?checked=${fieldValue === 'true' || fieldValue === 'True'}
-          ?disabled=${this.disabled}>
+          ?disabled=${this.disabled || fieldDisabled}>
           ${this.fieldProps.label}
         </sl-checkbox>
       `;
@@ -98,7 +99,7 @@ export class ChromedashFormField extends LitElement {
           value="${fieldValue}"
           size="small"
           hoist
-          ?disabled=${this.disabled || this.loading}>
+          ?disabled=${fieldDisabled || this.disabled || this.loading}>
           ${Object.values(choices).map(
             ([value, label]) => html`
               <sl-menu-item value="${value}"> ${label} </sl-menu-item>

--- a/static/elements/chromedash-form-field_test.js
+++ b/static/elements/chromedash-form-field_test.js
@@ -22,7 +22,7 @@ describe('chromedash-form-field', () => {
   it('renders a select type of field', async () => {
     const component = await fixture(
       html`
-      <chromedash-form-field name="feature_type" value="0">
+      <chromedash-form-field name="category" value="0">
       </chromedash-form-field>`);
     assert.exists(component);
     assert.instanceOf(component, ChromedashFormField);
@@ -30,7 +30,7 @@ describe('chromedash-form-field', () => {
     assert.exists(fieldRow);
 
     const renderElement = component.renderRoot;
-    assert.include(renderElement.innerHTML, 'Feature type');
+    assert.include(renderElement.innerHTML, 'category');
     assert.include(renderElement.innerHTML, 'sl-select');
     assert.include(renderElement.innerHTML, 'sl-menu-item');
   });

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -209,15 +209,6 @@ export const ALL_FIELDS = {
         Select the most specific category. If unsure, leave as "Miscellaneous".`,
   },
 
-  'feature_type': {
-    type: 'select',
-    choices: FEATURE_TYPES,
-    initial: FEATURE_TYPES.FEATURE_TYPE_INCUBATE_ID[0],
-    label: 'Feature type',
-    help_text: html`
-        Select the feature type.`,
-  },
-
   'feature_type_radio_group': {
     // form field name matches underlying DB field (sets "feature_type" in DB).
     name: 'feature_type',
@@ -225,7 +216,11 @@ export const ALL_FIELDS = {
     choices: FEATURE_TYPES,
     label: 'Feature type',
     help_text: html`
-        Select the feature type.`,
+        Select the feature type.
+        <br/>
+        <p style="color: red"><strong>Note:</strong> The feature type field
+        cannot be changed. If this field needs to be modified, a new feature
+        would need to be created.</p>`,
   },
 
   'set_stage': {
@@ -1127,9 +1122,7 @@ function makeDisplaySpecs(fields) {
 };
 
 export const DISPLAY_FIELDS_IN_STAGES = {
-  'Metadata': makeDisplaySpecs([
-    'category', 'feature_type', 'intent_stage', 'accurate_as_of',
-  ]),
+  'Metadata': makeDisplaySpecs(['category', 'intent_stage', 'accurate_as_of']),
   [INTENT_STAGES.INTENT_INCUBATE[0]]: makeDisplaySpecs([
     'initial_public_proposal_url', 'explainer_links',
     'requires_embedder_support',

--- a/static/elements/form-field-specs.js
+++ b/static/elements/form-field-specs.js
@@ -209,6 +209,19 @@ export const ALL_FIELDS = {
         Select the most specific category. If unsure, leave as "Miscellaneous".`,
   },
 
+  'feature_type': {
+    type: 'select',
+    disabled: true,
+    choices: FEATURE_TYPES,
+    label: 'Feature type',
+    help_text: html`
+    Feature type chosen at time of creation.
+        <br/>
+        <p style="color: red"><strong>Note:</strong> The feature type field
+        cannot be changed. If this field needs to be modified, a new feature
+        would need to be created.</p>`,
+  },
+
   'feature_type_radio_group': {
     // form field name matches underlying DB field (sets "feature_type" in DB).
     name: 'feature_type',
@@ -1122,7 +1135,9 @@ function makeDisplaySpecs(fields) {
 };
 
 export const DISPLAY_FIELDS_IN_STAGES = {
-  'Metadata': makeDisplaySpecs(['category', 'intent_stage', 'accurate_as_of']),
+  'Metadata': makeDisplaySpecs([
+    'category', 'feature_type', 'intent_stage', 'accurate_as_of',
+  ]),
   [INTENT_STAGES.INTENT_INCUBATE[0]]: makeDisplaySpecs([
     'initial_public_proposal_url', 'explainer_links',
     'requires_embedder_support',


### PR DESCRIPTION
Part of the schema migration work.

This change removes the ability to change the `feature_type` field after the feature has been created, as well as adding a warning to users that this feature cannot be updated after creation.