### PR TITLE
Use new Activity entities to display comments

### DIFF
--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -19,7 +19,7 @@ from typing import Any, Optional
 from framework import basehandlers
 from framework import permissions
 from internals import approval_defs
-from internals.review_models import Activity, Approval, Comment
+from internals.review_models import Activity, Approval
 from internals import notifier
 
 
@@ -59,7 +59,7 @@ class CommentsAPI(basehandlers.APIHandler):
       lambda c: self._should_show_comment(c, user.email(), is_admin), comments)
 
     dicts = [comment_to_json_dict(c) for c in comments]
-    return{'comments': dicts}
+    return {'comments': dicts}
 
   def do_post(
       self, feature_id: int, gate_id: Optional[int]=None) -> dict[str, str]:
@@ -101,7 +101,7 @@ class CommentsAPI(basehandlers.APIHandler):
 
   def do_patch(self, feature_id: int) -> dict[str, str]:
     comment_id = self.get_param('commentId', required=True)
-    comment: Optional[Comment] = Activity.get_by_id(comment_id)
+    comment: Optional[Activity] = Activity.get_by_id(comment_id)
 
     user = self.get_current_user(required=True)
     if not permissions.can_admin_site(user) and (

--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -14,26 +14,25 @@
 # limitations under the License.
 
 import logging
+from typing import Any, Optional
 
 from framework import basehandlers
 from framework import permissions
 from internals import approval_defs
-from internals import review_models
+from internals.review_models import Activity, Approval, Comment
 from internals import notifier
 
 
-def comment_to_json_dict(comment):
+def comment_to_json_dict(comment: Activity) -> dict[str, Any]:
 
   return {
       'comment_id': comment.key.id(),
       'feature_id': comment.feature_id,
-      'field_id': comment.field_id,
+      'gate_id': comment.gate_id,
       'created': str(comment.created),  # YYYY-MM-DD HH:MM:SS.SSS
       'author': comment.author,
       'content': comment.content,
-      'deleted_by': comment.deleted_by,
-      'old_approval_state': comment.old_approval_state,
-      'new_approval_state': comment.new_approval_state,
+      'deleted_by': comment.deleted_by
       }
 
 
@@ -41,14 +40,17 @@ class CommentsAPI(basehandlers.APIHandler):
   """Users may see the list of comments on one of the approvals of a feature,
    and add their own, if allowed."""
 
-  def _should_show_comment(self, comment, email, is_admin):
+  def _should_show_comment(
+      self, comment: Activity, email: str, is_admin: bool) -> bool:
     """Check whether a comment should be visible to the user."""
     return comment.deleted_by is None or email == comment.deleted_by or is_admin
 
-  def do_get(self, feature_id, field_id=None):
+  def do_get(self, feature_id: int,
+      field_id: Optional[int]=None) -> dict[str, dict[str, Any]]:
     """Return a list of all review comments on the given feature."""
     # Note: We assume that anyone may view approval comments.
-    comments = review_models.Comment.get_comments(feature_id, field_id)
+    comments = Activity.get_activities(
+        feature_id, field_id, comments_only=True)
     user = self.get_current_user(required=True)
     is_admin = permissions.can_admin_site(user)
     
@@ -57,49 +59,37 @@ class CommentsAPI(basehandlers.APIHandler):
       lambda c: self._should_show_comment(c, user.email(), is_admin), comments)
 
     dicts = [comment_to_json_dict(c) for c in comments]
-    data = {
-        'comments': dicts,
-        }
-    return data
+    return{'comments': dicts}
 
-  def do_post(self, feature_id, field_id=None):
+  def do_post(
+      self, feature_id: int, gate_id: Optional[int]=None) -> dict[str, str]:
     """Add a review comment and possibly set a approval value."""
     new_state = self.get_int_param(
         'state', required=False,
-        validator=review_models.Approval.is_valid_state)
+        validator=Approval.is_valid_state)
     feature = self.get_specified_feature(feature_id=feature_id)
     user = self.get_current_user(required=True)
     post_to_approval_field_id = self.get_param(
         'postToApprovalFieldId', required=False)
 
     old_state = None
-    if field_id is not None and new_state is not None:
-      old_approvals = review_models.Approval.get_approvals(
-          feature_id=feature_id, field_id=field_id,
+    if gate_id is not None and new_state is not None:
+      old_approvals = Approval.get_approvals(
+          feature_id=feature_id, field_id=gate_id,
           set_by=user.email())
-      if old_approvals:
-        old_state = old_approvals[0].state
 
-      approvers = approval_defs.get_approvers(field_id)
+      approvers = approval_defs.get_approvers(gate_id)
       if not permissions.can_approve_feature(user, feature, approvers):
         self.abort(403, msg='User is not an approver')
-      review_models.Approval.set_approval(
-          feature.key.integer_id(), field_id, new_state, user.email())
+      Approval.set_approval(
+          feature.key.integer_id(), gate_id, new_state, user.email())
 
     comment_content = self.get_param('comment', required=False)
 
-    if comment_content or new_state is not None:
-      comment = review_models.Comment(
-          feature_id=feature_id, field_id=field_id,
-          author=user.email(), content=comment_content,
-          old_approval_state=old_state,
-          new_approval_state=new_state)
-      comment.put()
-
+    if comment_content:
       # Schema migration double-write.
-      comment_activity = review_models.Activity(
-        id=comment.key.integer_id(), feature_id=feature_id, gate_id=field_id,
-        author=user.email(), content=comment_content)
+      comment_activity = Activity(feature_id=feature_id, gate_id=gate_id,
+          author=user.email(), content=comment_content)
       comment_activity.put()
 
     if post_to_approval_field_id:
@@ -109,26 +99,20 @@ class CommentsAPI(basehandlers.APIHandler):
     # Callers don't use the JSON response for this API call.
     return {'message': 'Done'}
 
-  def do_patch(self, feature_id):
+  def do_patch(self, feature_id: int) -> dict[str, str]:
     comment_id = self.get_param('commentId', required=True)
-    comment = review_models.Comment.get_by_id(comment_id)
-    comment_activity = review_models.Activity.get_by_id(comment_id)
+    comment: Optional[Comment] = Activity.get_by_id(comment_id)
 
     user = self.get_current_user(required=True)
-    if not permissions.can_admin_site(user) and user.email() != comment.author:
+    if not permissions.can_admin_site(user) and (
+        comment and user.email() != comment.author):
       self.abort(403, msg='User does not have comment edit permissions')
 
     is_undelete = self.get_param('isUndelete', required=True)
     if is_undelete:
       comment.deleted_by = None
-      if comment_activity is not None:
-        comment_activity.deleted_by = None
-        comment_activity.put()
     else:
       comment.deleted_by = user.email()
-      if comment_activity is not None:
-        comment_activity.deleted_by = user.email()
-        comment_activity.put()
     comment.put()
 
     return {'message': 'Done'}

--- a/static/js-src/cs-client.js
+++ b/static/js-src/cs-client.js
@@ -199,18 +199,18 @@ class ChromeStatusClient {
         });
   }
 
-  getComments(featureId, fieldId) {
-    if (fieldId) {
-      return this.doGet(`/features/${featureId}/approvals/${fieldId}/comments`);
+  getComments(featureId, gateId) {
+    if (gateId) {
+      return this.doGet(`/features/${featureId}/approvals/${gateId}/comments`);
     } else {
       return this.doGet(`/features/${featureId}/approvals/comments`);
     }
   }
 
-  postComment(featureId, fieldId, state, comment, postToApprovalFieldId) {
-    if (fieldId) {
+  postComment(featureId, gateId, state, comment, postToApprovalFieldId) {
+    if (gateId) {
       return this.doPost(
-          `/features/${featureId}/approvals/${fieldId}/comments`,
+          `/features/${featureId}/approvals/${gateId}/comments`,
           {state, comment, postToApprovalFieldId});
     } else {
       return this.doPost(


### PR DESCRIPTION
Part of the schema migration work.

This change moves to using the Activity entities for comment viewing and editing instead of the deprecated Comment entities.