### PR TITLE
Move most entities to single migration script

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -26,14 +26,11 @@ cron:
 - description: Removes any users that have been inactive for 9 months.
   url: /cron/remove_inactive_users
   schedule: 1st monday of month 9:00
-- description: Copy over Comment entities to new Activity entities
+- description: Copy over Comment entities to new Activity entities.
   url: /cron/schema_migration_comment_activity
   schedule: 1 of jan 00:00
-- description: Copy over Approval entities to new Vote entities
-  url: /cron/schema_migration_approval_vote
-  schedule: 1 of jan 00:00
-- description: Copy over Feature entities to new FeatureEntry entities
-  url: /cron/schema_migration_feature_featureentry
+- description: Migrate over most major entities to new schema.
+  url: /cron/schema_migration_entities
   schedule: 1 of jan 00:00
 - description: Copy over deprecated standardization field
   url: /cron/write_standard_maturity

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -1280,6 +1280,8 @@ class Stage(ndb.Model):
   intent_thread_url = ndb.StringProperty()
   origin_trial_feedback_url = ndb.StringProperty()
   announcement_url = ndb.StringProperty()
+  # Origin trial stage id that this stage extends, if trial extension stage.
+  ot_stage_id = ndb.IntegerProperty()
 
   @classmethod
   def get_feature_stages(cls, feature_id: int) -> dict[int, Stage]:

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -16,9 +16,16 @@ import logging
 from google.cloud import ndb
 
 from framework.basehandlers import FlaskHandler
+from internals import approval_defs
 from internals.core_models import Feature, FeatureEntry, MilestoneSet, Stage
-from internals.review_models import Activity, Approval, Comment, Vote
+from internals.review_models import Activity, Approval, Comment, Gate, Vote
 from internals.core_enums import *
+
+# Gate type enums (declared in approval_defs.py)
+PROTOTYPE_ENUM = 1
+OT_ENUM = 2
+EXTEND_ENUM = 3
+SHIP_ENUM = 4
 
 def handle_migration(original_cls, new_cls, kwarg_mapping,
     special_handler=None):
@@ -39,6 +46,11 @@ def handle_migration(original_cls, new_cls, kwarg_mapping,
     # If any fields need special mapping, handle them in the given method.
     if callable(special_handler):
       special_handler(original, kwargs)
+
+    # If Feature is being migrated, stages, Gates, and Votes will need to
+    # also be migrated.
+    if original_cls == Feature:
+      MigrateEntities.write_stages_for_feature(original)
 
     new_entity = new_cls(**kwargs)
     new_entity.put()
@@ -88,26 +100,13 @@ class MigrateCommentsToActivities(FlaskHandler):
     return (f'{old_migrations_deleted} Activities deleted '
         'from previous migration.')
 
-class MigrateApprovalsToVotes(FlaskHandler):
+class MigrateEntities(FlaskHandler):
 
   def get_template_data(self):
-    """Writes a Vote entity for each unmigrated Approval entity."""
+    """Write FeatureEntry, Stage, Gate, and Vote entities"""
     self.require_cron_header()
 
-    kwarg_mapping = [
-        ('feature_id', 'feature_id'),
-        ('gate_id', 'field_id'),
-        ('state', 'state'),
-        ('set_on', 'set_on'),
-        ('set_by', 'set_by')]
-    return handle_migration(Approval, Vote, kwarg_mapping)
-
-class MigrateFeaturesToFeatureEntries(FlaskHandler):
-
-  def get_template_data(self):
-    """Writes a FeatureEntry entity for each unmigrated Feature entity"""
-    self.require_cron_header()
-
+    # Feature -> FeatureEntry mapping.
     kwarg_mapping = [
         ('created', 'created'),
         ('updated', 'updated'),
@@ -173,7 +172,7 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
         ('doc_links', 'doc_links'),
         ('sample_links', 'sample_links'),
         ('experiment_timeline', 'experiment_timeline')]
-    return handle_migration(Feature, FeatureEntry,kwarg_mapping,
+    return handle_migration(Feature, FeatureEntry, kwarg_mapping,
         self.special_handler)
 
   @classmethod
@@ -182,111 +181,182 @@ class MigrateFeaturesToFeatureEntries(FlaskHandler):
     kwargs['updater_email'] = (original_entity.updated_by.email()
         if original_entity.updated_by else None)
 
-class MigrateStages(FlaskHandler):
-
-  def get_template_data(self):
+  @classmethod
+  def write_stages_for_feature(cls, feature):
     """Creates new Stage entities MilestoneSet entities based on Feature data"""
-    self.require_cron_header()
-
-    features = Feature.query().fetch()
-    num_stages_created = 0
-    num_features_migrated = 0
-    for feature in features:
-      # Do not create more stages if the data in this feature has been migrated.
-      if feature.stages_migrated:
-        continue
-      # Create MilestoneSets for each major paradigm.
-      devtrial_mstones = MilestoneSet(
-          desktop_first=feature.dt_milestone_desktop_start,
-          android_first=feature.dt_milestone_android_start,
-          ios_first=feature.dt_milestone_ios_start,
-          webview_first=feature.dt_milestone_webview_start)
-      ot_mstones = MilestoneSet(
-          desktop_first=feature.ot_milestone_desktop_start,
-          desktop_last=feature.ot_milestone_desktop_end,
-          android_first=feature.ot_milestone_android_start,
-          android_last=feature.ot_milestone_android_end,
-          webview_first=feature.ot_milestone_webview_start,
-          webview_last=feature.ot_milestone_webview_end)
-      ship_mstones = MilestoneSet(
-          desktop_first=feature.shipped_milestone,
-          android_first=feature.shipped_android_milestone,
-          ios_first=feature.shipped_ios_milestone,
-          webview_first=feature.shipped_webview_milestone)
-      # Depending on the feature type,
-      # create a different group of Stage entities.
-      if feature.feature_type == FEATURE_TYPE_INCUBATE_ID:
-        num_stages_created += self.write_incubate_stages(
-            feature, devtrial_mstones, ot_mstones, ship_mstones)
-      if feature.feature_type == FEATURE_TYPE_EXISTING_ID:
-        num_stages_created += self.write_existing_stages(
-            feature, devtrial_mstones, ot_mstones, ship_mstones)
-      if feature.feature_type == FEATURE_TYPE_CODE_CHANGE_ID:
-        num_stages_created += self.write_code_change_stages(
-            feature, devtrial_mstones, ship_mstones)
-      if feature.feature_type == FEATURE_TYPE_DEPRECATION_ID:
-        num_stages_created += self.write_deprecation_stages(
-            feature, devtrial_mstones, ot_mstones, ship_mstones)
-      feature.stages_migrated = True
-      feature.put()
-      num_features_migrated += 1
+    stages, gates, votes = 0, 0, 0
+    # Create MilestoneSets for each major paradigm.
+    devtrial_mstones = MilestoneSet(
+        desktop_first=feature.dt_milestone_desktop_start,
+        android_first=feature.dt_milestone_android_start,
+        ios_first=feature.dt_milestone_ios_start,
+        webview_first=feature.dt_milestone_webview_start)
+    ot_mstones = MilestoneSet(
+        desktop_first=feature.ot_milestone_desktop_start,
+        desktop_last=feature.ot_milestone_desktop_end,
+        android_first=feature.ot_milestone_android_start,
+        android_last=feature.ot_milestone_android_end,
+        webview_first=feature.ot_milestone_webview_start,
+        webview_last=feature.ot_milestone_webview_end)
+    extension_mstones = MilestoneSet(
+        desktop_last=feature.ot_milestone_desktop_end,
+        android_last=feature.ot_milestone_android_end,
+        webview_last=feature.ot_milestone_webview_end)
+    ship_mstones = MilestoneSet(
+        desktop_first=feature.shipped_milestone,
+        android_first=feature.shipped_android_milestone,
+        ios_first=feature.shipped_ios_milestone,
+        webview_first=feature.shipped_webview_milestone)
+    # Depending on the feature type,
+    # create a different group of Stage entities.
+    f_type = feature.feature_type
+    if f_type == FEATURE_TYPE_INCUBATE_ID:
+      stages, gates, votes = cls.write_incubate_stages(
+          feature, devtrial_mstones, ot_mstones, extension_mstones, ship_mstones)
+    elif f_type == FEATURE_TYPE_EXISTING_ID:
+      stages, gates, votes = cls.write_existing_stages(
+          feature, devtrial_mstones, ot_mstones, extension_mstones, ship_mstones)
+    elif f_type == FEATURE_TYPE_CODE_CHANGE_ID:
+      stages, gates, votes = cls.write_code_change_stages(
+          feature, devtrial_mstones, ship_mstones)
+    elif f_type == FEATURE_TYPE_DEPRECATION_ID:
+      stages, gates, votes = cls.write_deprecation_stages(
+          feature, devtrial_mstones, ot_mstones, extension_mstones, ship_mstones)
+    else:
+      logging.error(f'Invalid feature type {f_type} for {feature.name}')
     
-    message = (f'{num_stages_created} Stage entities created '
-        f'for {num_features_migrated} Feature entities.')
+    message = (f'Created {stages} stages, {gates} gates, and {votes} votes '
+               f'for feature {feature.key.integer_id()}')
     logging.info(message)
-    return message
+
+  @classmethod
+  def write_gate(cls, feature_id, stage, gate_type):
+    """Writes a Gate entity to match the stage created."""
+    gate = Gate(feature_id=feature_id, stage_id=stage.key.integer_id(),
+        gate_type=gate_type, state=Vote.NA)
+    # Determine the state the Gate should have.
+    approvals: list = Approval.query().filter(Approval.feature_id == feature_id)
+    if approval_defs.is_approved(approvals, gate_type):
+      gate.state = Vote.APPROVED
+    elif approval_defs.is_resolved(approvals, gate_type):
+      gate.state = Vote.NOT_APPROVED
+    gate.put()
+
+    # Filter Approval entities by the gate type and write Vote entities.
+    approvals = [
+        appr for appr in approvals if appr.field_id == gate_type]
+    num_votes = cls.write_votes(feature_id, gate.key.integer_id(), approvals)
+
+    return 1, num_votes
+
+  @classmethod
+  def write_votes(cls, feature_id, gate_id, approvals):
+    """Migrate Vote entities for given feature and gate IDs."""
+    count = 0
+    for appr in approvals:
+      vote = Vote(feature_id=feature_id, gate_id=gate_id, state=appr.state,
+          set_on=appr.set_on, set_by=appr.set_by)
+      vote.put()
+      count += 1
     
-  
-  def write_incubate_stages(self, feature, devtrial_mstones, ot_mstones,
-      ship_mstones):
-    kwargs = {'feature_id': feature.key.integer_id(), 'browser': 'Chrome'}
+    return count
+
+  @classmethod
+  def write_incubate_stages(cls, feature, devtrial_mstones, ot_mstones,
+      extension_mstones, ship_mstones):
+    feature_id = feature.key.integer_id()
+    kwargs = {'feature_id': feature_id, 'browser': 'Chrome'}
+    num_gates, num_votes = 0, 0
+
     stage = Stage(stage_type=STAGE_BLINK_INCUBATE, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_BLINK_PROTOTYPE,
         intent_thread_url=feature.intent_to_implement_url, **kwargs)
     stage.put()
+    totals = cls.write_gate(feature_id, stage, PROTOTYPE_ENUM)
+    num_gates += totals[0]
+    num_votes += totals[1]
     stage = Stage(stage_type=STAGE_BLINK_DEV_TRIAL, milestones=devtrial_mstones,
         announcement_url=feature.ready_for_trial_url, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_BLINK_EVAL_READINESS, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_BLINK_ORIGIN_TRIAL, milestones=ot_mstones,
-        **kwargs, intent_thread_url=feature.intent_to_experiment_url,
+        intent_thread_url=feature.intent_to_experiment_url,
         experiment_goals=feature.experiment_goals,
-        experiment_extension_reason=feature.experiment_extension_reason,
-        origin_trial_feedback_url=feature.origin_trial_feedback_url)
+        origin_trial_feedback_url=feature.origin_trial_feedback_url, **kwargs)
     stage.put()
+    totals = cls.write_gate(feature_id, stage, OT_ENUM)
+    num_gates += totals[0]
+    num_votes += totals[1]
+    stage = Stage(stage_type=STAGE_BLINK_EXTEND_ORIGIN_TRIAL,
+        milestones=extension_mstones,
+        intent_thread_url=feature.intent_to_extend_experiment_url,
+        experiment_extension_reason=feature.experiment_extension_reason,
+        ot_stage_id=stage.key.integer_id() **kwargs)
+    stage.put()
+    totals = cls.write_gate(feature_id, stage, EXTEND_ENUM)
+    num_gates += totals[0]
+    num_votes += totals[1]
     stage = Stage(stage_type=STAGE_BLINK_SHIPPING, milestones=ship_mstones,
         intent_thread_url=feature.intent_to_ship_url,
         finch_url=feature.finch_url, **kwargs)
     stage.put()
+    totals = cls.write_gate(feature_id, stage, SHIP_ENUM)
+    num_gates += totals[0]
+    num_votes += totals[1]
     # Return number of Stage entities created.
-    return 6
-  
-  def write_existing_stages(self, feature, devtrial_mstones, ot_mstones,
-      ship_mstones):
-    kwargs = {'feature_id': feature.key.integer_id(), 'browser': 'Chrome'}
+    return 6, num_gates, num_votes
+
+  @classmethod
+  def write_existing_stages(cls, feature, devtrial_mstones, ot_mstones,
+      extension_mstones, ship_mstones):
+    feature_id = feature.key.integer_id()
+    kwargs = {'feature_id': feature_id, 'browser': 'Chrome'}
+    num_gates, num_votes = 0, 0
+
     stage = Stage(stage_type=STAGE_FAST_PROTOTYPE,
         intent_thread_url=feature.intent_to_implement_url, **kwargs)
     stage.put()
+    totals = cls.write_gate(feature_id, stage, PROTOTYPE_ENUM)
+    num_gates += totals[0]
+    num_votes += totals[1]
     stage = Stage(stage_type=STAGE_FAST_DEV_TRIAL, milestones=devtrial_mstones,
         announcement_url=feature.ready_for_trial_url, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_FAST_ORIGIN_TRIAL, milestones=ot_mstones,
         intent_thread_url=feature.intent_to_experiment_url,
         experiment_goals=feature.experiment_goals,
-        experiment_extension_reason=feature.experiment_extension_reason,
         origin_trial_feedback_url=feature.origin_trial_feedback_url, **kwargs)
     stage.put()
+    totals = cls.write_gate(feature_id, stage, OT_ENUM)
+    num_gates += totals[0]
+    num_votes += totals[1]
+    stage = Stage(stage_type=STAGE_FAST_EXTEND_ORIGIN_TRIAL,
+        milestones=extension_mstones,
+        intent_thread_url=feature.intent_to_extend_experiment_url,
+        experiment_extension_reason=feature.experiment_extension_reason,
+        ot_stage_id=stage.key.integer_id() **kwargs)
+    stage.put()
+    totals = cls.write_gate(feature_id, stage, EXTEND_ENUM)
+    num_gates += totals[0]
+    num_votes += totals[1]
     stage = Stage(stage_type=STAGE_FAST_SHIPPING,  milestones=ship_mstones,
         intent_thread_url=feature.intent_to_ship_url,
         finch_url=feature.finch_url, **kwargs)
     stage.put()
+    totals = cls.write_gate(feature_id, stage, SHIP_ENUM)
+    num_gates += totals[0]
+    num_votes += totals[1]
     # Return number of Stage entities created.
-    return 4
+    return 4, num_gates, num_votes
 
-  def write_code_change_stages(self, feature, devtrial_mstones, ship_mstones):
-    kwargs = {'feature_id': feature.key.integer_id(), 'browser': 'Chrome'}
+  @classmethod
+  def write_code_change_stages(cls, feature, devtrial_mstones, ship_mstones):
+    feature_id = feature.key.integer_id()
+    kwargs = {'feature_id': feature_id, 'browser': 'Chrome'}
+    num_gates, num_votes = 0, 0
+
     stage = Stage(stage_type=STAGE_PSA_IMPLEMENT, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_PSA_DEV_TRIAL, milestones=devtrial_mstones,
@@ -296,28 +366,49 @@ class MigrateStages(FlaskHandler):
         intent_thread_url=feature.intent_to_ship_url,
         finch_url=feature.finch_url, **kwargs)
     stage.put()
+    totals = cls.write_gate(feature_id, stage, SHIP_ENUM)
+    num_gates += totals[0]
+    num_votes += totals[1]
     # Return number of Stage entities created.
-    return 3
-  
-  def write_deprecation_stages(self, feature, devtrial_mstones, ot_mstones,
-      ship_mstones):
-    kwargs = {'feature_id': feature.key.integer_id(), 'browser': 'Chrome'}
+    return 3, num_gates, num_votes
+
+  @classmethod
+  def write_deprecation_stages(cls, feature, devtrial_mstones, ot_mstones,
+      extension_mstones, ship_mstones):
+    feature_id = feature.key.integer_id()
+    kwargs = {'feature_id': feature_id, 'browser': 'Chrome'}
+    num_gates, num_votes = 0, 0
+
     stage = Stage(stage_type=STAGE_DEP_PLAN, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_DEP_DEV_TRIAL, milestones=devtrial_mstones,
         announcement_url=feature.ready_for_trial_url, **kwargs)
     stage.put()
     stage = Stage(stage_type=STAGE_DEP_DEPRECATION_TRIAL, milestones=ot_mstones,
-        **kwargs, intent_thread_url=feature.intent_to_experiment_url,
+        intent_thread_url=feature.intent_to_experiment_url,
         experiment_goals=feature.experiment_goals,
-        experiment_extension_reason=feature.experiment_extension_reason,
-        origin_trial_feedback_url=feature.origin_trial_feedback_url)
+        origin_trial_feedback_url=feature.origin_trial_feedback_url, **kwargs)
     stage.put()
+    totals = cls.write_gate(feature_id, stage, OT_ENUM)
+    num_gates += totals[0]
+    num_votes += totals[1]
+    stage = Stage(stage_type=STAGE_DEP_EXTEND_DEPRECATION_TRIAL,
+        milestones=extension_mstones,
+        intent_thread_url=feature.intent_to_extend_experiment_url,
+        experiment_extension_reason=feature.experiment_extension_reason,
+        ot_stage_id=stage.key.integer_id() **kwargs)
+    stage.put()
+    totals = cls.write_gate(feature_id, stage, EXTEND_ENUM)
+    num_gates += totals[0]
+    num_votes += totals[1]
     stage = Stage(stage_type=STAGE_DEP_SHIPPING,  milestones=ship_mstones,
         intent_thread_url=feature.intent_to_ship_url,
         finch_url=feature.finch_url, **kwargs)
     stage.put()
+    totals = cls.write_gate(feature_id, stage, SHIP_ENUM)
+    num_gates += totals[0]
+    num_votes += totals[1]
     stage = Stage(stage_type=STAGE_DEP_REMOVE_CODE, **kwargs)
     stage.put()
     # Return number of Stage entities created.
-    return 5
+    return 5, num_gates, num_votes

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -293,7 +293,7 @@ class MigrateEntities(FlaskHandler):
         milestones=extension_mstones,
         intent_thread_url=feature.intent_to_extend_experiment_url,
         experiment_extension_reason=feature.experiment_extension_reason,
-        ot_stage_id=stage.key.integer_id() **kwargs)
+        ot_stage_id=stage.key.integer_id(), **kwargs)
     stage.put()
     totals = cls.write_gate(feature_id, stage, EXTEND_ENUM)
     num_gates += totals[0]
@@ -336,7 +336,7 @@ class MigrateEntities(FlaskHandler):
         milestones=extension_mstones,
         intent_thread_url=feature.intent_to_extend_experiment_url,
         experiment_extension_reason=feature.experiment_extension_reason,
-        ot_stage_id=stage.key.integer_id() **kwargs)
+        ot_stage_id=stage.key.integer_id(), **kwargs)
     stage.put()
     totals = cls.write_gate(feature_id, stage, EXTEND_ENUM)
     num_gates += totals[0]
@@ -396,7 +396,7 @@ class MigrateEntities(FlaskHandler):
         milestones=extension_mstones,
         intent_thread_url=feature.intent_to_extend_experiment_url,
         experiment_extension_reason=feature.experiment_extension_reason,
-        ot_stage_id=stage.key.integer_id() **kwargs)
+        ot_stage_id=stage.key.integer_id(), **kwargs)
     stage.put()
     totals = cls.write_gate(feature_id, stage, EXTEND_ENUM)
     num_gates += totals[0]

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -47,11 +47,6 @@ def handle_migration(original_cls, new_cls, kwarg_mapping,
     if callable(special_handler):
       special_handler(original, kwargs)
 
-    # If Feature is being migrated, stages, Gates, and Votes will need to
-    # also be migrated.
-    if original_cls == Feature:
-      MigrateEntities.write_stages_for_feature(original)
-
     new_entity = new_cls(**kwargs)
     new_entity.put()
     migration_count += 1
@@ -180,6 +175,10 @@ class MigrateEntities(FlaskHandler):
     # updater_email will use the email from the updated_by field
     kwargs['updater_email'] = (original_entity.updated_by.email()
         if original_entity.updated_by else None)
+    
+    # If Feature is being migrated, then Stages, Gates, and Votes will need to
+    # also be migrated.
+    cls.write_stages_for_feature(original_entity)
 
   @classmethod
   def write_stages_for_feature(cls, feature):

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -17,38 +17,39 @@ from google.cloud import ndb
 import testing_config  # Must be imported before the module under test.
 from datetime import datetime
 
-from internals import core_models, review_models
-from internals import schema_migration
+from internals.core_models import Feature, FeatureEntry, Stage
+from internals.review_models import Activity, Approval, Comment, Gate, Vote
+from internals import review_models, schema_migration
 
 class MigrateCommentsToActivitiesTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    comment_1 = review_models.Comment(id=1, feature_id=1, field_id=1,
+    comment_1 = Comment(id=1, feature_id=1, field_id=1,
         author='user@example.com', content='some text',
         created=datetime(2020, 1, 1))
     comment_1.put()
-    comment_2 = review_models.Comment(id=2, feature_id=1, field_id=2,
+    comment_2 = Comment(id=2, feature_id=1, field_id=2,
         author='other_user@example.com', content='some other text',
         created=datetime(2020, 1, 1))
     comment_2.put()
 
     # Comment 3 is already migrated.
-    comment_3 = review_models.Comment(id=3, feature_id=2, field_id=1,
+    comment_3 = Comment(id=3, feature_id=2, field_id=1,
         author='user@example.com', content='migrated text')
     comment_3.put()
-    activity_3 = review_models.Activity(id=3, feature_id=2, gate_id=1,
+    activity_3 = Activity(id=3, feature_id=2, gate_id=1,
         author='user@example.com', content='migrated text')
     activity_3.put()
 
   def tearDown(self):
-    for comm in review_models.Comment.query().fetch():
+    for comm in Comment.query().fetch():
       comm.key.delete()
-    for activity in review_models.Activity.query().fetch():
+    for activity in Activity.query().fetch():
       activity.key.delete()
 
   def test_migration__remove_bad_activities(self):
     migration_handler = schema_migration.MigrateCommentsToActivities()
-    bad_activity = review_models.Activity(id=9, feature_id=1, gate_id=1,
+    bad_activity = Activity(id=9, feature_id=1, gate_id=1,
         author='user@example.com', content='some text')
     bad_activity.put()
     result = migration_handler._remove_bad_id_activities()
@@ -56,7 +57,7 @@ class MigrateCommentsToActivitiesTest(testing_config.CustomTestCase):
     expected = '1 Activities deleted from previous migration.'
     self.assertEqual(result, expected)
     # One other Activity should still exist.
-    activities = review_models.Activity.query().fetch()
+    activities = Activity.query().fetch()
     self.assertTrue(len(activities) == 1)
 
   def test_migration(self):
@@ -65,7 +66,7 @@ class MigrateCommentsToActivitiesTest(testing_config.CustomTestCase):
     # One comment is already migrated, so only 2 need migration.
     expected = '2 Comment entities migrated to Activity entities.'
     self.assertEqual(result, expected)
-    activities = review_models.Activity.query().fetch()
+    activities = Activity.query().fetch()
     self.assertEqual(len(activities), 3)
     self.assertEqual(2020, activities[0].created.year)
 
@@ -74,47 +75,7 @@ class MigrateCommentsToActivitiesTest(testing_config.CustomTestCase):
     expected = '0 Comment entities migrated to Activity entities.'
     self.assertEqual(result_2, expected)
 
-class MigrateApprovalsToVotesTest(testing_config.CustomTestCase):
-
-  def setUp(self):
-    approval_1 = review_models.Approval(id=1, feature_id=1, field_id=1,
-        state=1, set_on=datetime(2020, 1, 1), set_by='user1@example.com')
-    approval_1.put()
-
-    approval_2 = review_models.Approval(id=2, feature_id=1, field_id=2,
-        state=2, set_on=datetime(2020, 3, 1), set_by='user2@example.com')
-    approval_2.put()
-
-    approval_3 = review_models.Approval(id=3, feature_id=2, field_id=2,
-        state=1, set_on=datetime(2022, 7, 1), set_by='user1@example.com')
-    approval_3.put()
-
-    vote_3 = review_models.Vote(id=3, feature_id=2, gate_id=2,
-        state=1, set_on=datetime(2022, 7, 1), set_by='user1@example.com')
-    vote_3.put()
-
-  def tearDown(self):
-    for comm in review_models.Approval.query().fetch():
-      comm.key.delete()
-    for activity in review_models.Vote.query().fetch():
-      activity.key.delete()
-
-  def test_migration(self):
-    migration_handler = schema_migration.MigrateApprovalsToVotes()
-    result = migration_handler.get_template_data()
-    # One approval is already migrated, so only 2 need migration.
-    expected = '2 Approval entities migrated to Vote entities.'
-    self.assertEqual(result, expected)
-    approvals = review_models.Approval.query().fetch()
-    self.assertEqual(len(approvals), 3)
-    self.assertEqual(2020, approvals[0].set_on.year)
-
-    # The migration should be idempotent, so nothing should be migrated twice.
-    result_2 = migration_handler.get_template_data()
-    expected = '0 Approval entities migrated to Vote entities.'
-    self.assertEqual(result_2, expected)
-
-class MigrateFeaturesToFeatureEntriesTest(testing_config.CustomTestCase):
+class MigrateEntitiesTest(testing_config.CustomTestCase):
 
   # Fields that do not require name change or revisions during migration.
   FEATURE_FIELDS = ['created', 'updated', 'accurate_as_of',
@@ -145,168 +106,7 @@ class MigrateFeaturesToFeatureEntriesTest(testing_config.CustomTestCase):
     ('comments', 'feature_notes')]
 
   def setUp(self):
-    self.feature_1 = core_models.Feature(
-        id=1,
-        created=datetime(2020, 1, 1),
-        updated=datetime(2020, 7, 1),
-        accurate_as_of=datetime(2020, 3, 1),
-        created_by=ndb.User(
-            _auth_domain='example.com', email='user@example.com'),
-        updated_by=ndb.User(
-            _auth_domain='example.com', email='editor@example.com'),
-        owner=['owner@example.com'],
-        creator='creator@example.com',
-        editors=['editor@example.com'],
-        cc_recipients=['cc_user@example.com'],
-        unlisted=False,
-        deleted=False,
-        name='feature_one',
-        summary='newly migrated summary',
-        comments='Some comments.',
-        category=1,
-        blink_components=['Blink'],
-        star_count=3,
-        search_tags=['tag1', 'tag2'],
-        feature_type=1,
-        intent_stage=1,
-        bug_url='https://bug.example.com',
-        launch_bug_url='https://bug.example.com',
-        impl_status_chrome=1,
-        flag_name='flagname',
-        ongoing_constraints='constraints',
-        motivation='motivation',
-        devtrial_instructions='instructions',
-        activation_risks='risks',
-        measurement=None,
-        initial_public_proposal_url='proposal.example.com',
-        explainer_links=['explainer.example.com'],
-        requires_embedder_support=False,
-        standard_maturity=1,
-        spec_link='spec.example.com',
-        api_spec=False,
-        spec_mentors=['mentor1', 'mentor2'],
-        interop_compat_risks='risks',
-        prefixed=True,
-        all_platforms=True,
-        all_platforms_descr='All platforms',
-        tag_review='tag_review',
-        tag_review_status=1,
-        non_oss_deps='oss_deps',
-        anticipated_spec_changes='spec_changes',
-        ff_views=1,
-        safari_views=1,
-        web_dev_views=1,
-        ff_views_link='view.example.com',
-        safari_views_link='view.example.com',
-        web_dev_views_link='view.example.com',
-        ff_views_notes='notes',
-        safari_views_notes='notes',
-        web_dev_views_notes='notes',
-        other_views_notes='notes',
-        security_risks='risks',
-        security_review_status=1,
-        privacy_review_status=1,
-        ergonomics_risks='risks',
-        wpt=True,
-        wpt_descr='description',
-        webview_risks='risks',
-        devrel=['devrel'],
-        debuggability='debuggability',
-        doc_links=['link1.example.com', 'link2.example.com'],
-        sample_links=[])
-    self.feature_1.put()
-
-    self.feature_2 = core_models.Feature(
-        id=2,
-        created=datetime(2020, 4, 1),
-        updated=datetime(2020, 7, 1),
-        accurate_as_of=datetime(2020, 6, 1),
-        created_by=ndb.User(
-            _auth_domain='example.com', email='user@example.com'),
-        updated_by=ndb.User(
-            _auth_domain='example.com', email='editor@example.com'),
-        owner=['owner@example.com'],
-        editors=['editor@example.com'],
-        unlisted=False,
-        deleted=False,
-        name='feature_one',
-        summary='newly migrated summary',
-        category=1)
-    self.feature_2.put()
-
-    self.feature_3 = core_models.Feature(
-        id=3,
-        created=datetime(2020, 4, 1),
-        updated=datetime(2020, 7, 1),
-        accurate_as_of=datetime(2020, 6, 1),
-        created_by=ndb.User(
-            _auth_domain='example.com', email='user@example.com'),
-        updated_by=ndb.User(
-            _auth_domain='example.com', email='editor@example.com'),
-        owner=['owner@example.com'],
-        editors=['editor@example.com'],
-        unlisted=False,
-        deleted=False,
-        name='feature_three',
-        summary='migrated summary',
-        category=1)
-    self.feature_3.put()
-
-    # Feature 3 is already migrated.
-    self.feature_entry_3 = core_models.FeatureEntry(
-        id=3,
-        created=datetime(2020, 4, 1),
-        updated=datetime(2020, 7, 1),
-        accurate_as_of=datetime(2020, 6, 1),
-        creator_email='user@example.com',
-        updater_email='editor@example.com',
-        owner_emails=['owner@example.com'],
-        editor_emails=['editor@example.com'],
-        unlisted=False,
-        deleted=False,
-        name='feature_three',
-        summary='migrated summary',
-        standard_maturity=1,
-        category=1)
-    self.feature_entry_3.put()
-
-  def tearDown(self):
-    for feature in core_models.Feature.query().fetch():
-      feature.key.delete()
-    for feature_entry in core_models.FeatureEntry.query().fetch():
-      feature_entry.key.delete()
-
-  def test_migration(self):
-    migration_handler = schema_migration.MigrateFeaturesToFeatureEntries()
-    result = migration_handler.get_template_data()
-    # One is already migrated, so only 2 others to migrate.
-    expected = '2 Feature entities migrated to FeatureEntry entities.'
-    self.assertEqual(result, expected)
-    feature_entries = core_models.FeatureEntry.query().fetch()
-    self.assertEqual(len(feature_entries), 3)
-    
-    # Check if all fields have been copied over.
-    feature_entry_1 = core_models.FeatureEntry.get_by_id(
-        self.feature_1.key.integer_id())
-    self.assertIsNotNone(feature_entry_1)
-    # Check that all fields are copied over as expected.
-    for field in self.FEATURE_FIELDS:
-      self.assertEqual(
-          getattr(feature_entry_1, field), getattr(self.feature_1, field))
-    for old_field, new_field in self.RENAMED_FIELDS:
-      self.assertEqual(
-          getattr(feature_entry_1, new_field), getattr(self.feature_1, old_field))
-    self.assertEqual(feature_entry_1.updater_email, self.feature_1.updated_by.email())
-
-    # The migration should be idempotent, so nothing should be migrated twice.
-    result_2 = migration_handler.get_template_data()
-    expected = '0 Feature entities migrated to FeatureEntry entities.'
-    self.assertEqual(result_2, expected)
-
-class MigrateStagesTest(testing_config.CustomTestCase):
-
-  def setUp(self):
-    self.feature_1 = core_models.Feature(
+    self.feature_1 = Feature(
         id=1,
         created=datetime(2020, 1, 1),
         updated=datetime(2020, 7, 1),
@@ -385,7 +185,7 @@ class MigrateStagesTest(testing_config.CustomTestCase):
         sample_links=[])
     self.feature_1.put()
 
-    self.feature_2 = core_models.Feature(
+    self.feature_2 = Feature(
         id=2,
         created=datetime(2020, 4, 1),
         updated=datetime(2020, 7, 1),
@@ -399,13 +199,13 @@ class MigrateStagesTest(testing_config.CustomTestCase):
         editors=['editor@example.com'],
         unlisted=False,
         deleted=False,
-        name='feature_one',
-        summary='newly migrated summary',
+        name='feature_two',
+        summary='summary',
         category=1,)
     self.feature_2.put()
 
     # Feature 3 stages are already migrated.
-    self.feature_3 = core_models.Feature(
+    self.feature_3 = Feature(
         id=3,
         created=datetime(2020, 4, 1),
         updated=datetime(2020, 7, 1),
@@ -419,12 +219,11 @@ class MigrateStagesTest(testing_config.CustomTestCase):
         unlisted=False,
         deleted=False,
         name='feature_three',
-        summary='migrated summary',
-        category=1,
-        stages_migrated=True)
+        summary='summary',
+        category=1)
     self.feature_3.put()
 
-    self.feature_4 = core_models.Feature(
+    self.feature_4 = Feature(
         id=4,
         created=datetime(2020, 4, 1),
         updated=datetime(2020, 7, 1),
@@ -438,12 +237,12 @@ class MigrateStagesTest(testing_config.CustomTestCase):
         feature_type=1,
         unlisted=False,
         deleted=False,
-        name='feature_three',
+        name='feature_four',
         summary='migrated summary',
-        category=1,)
+        category=1)
     self.feature_4.put()
 
-    self.feature_5 = core_models.Feature(
+    self.feature_5 = Feature(
         id=5,
         created=datetime(2020, 4, 1),
         updated=datetime(2020, 7, 1),
@@ -457,32 +256,51 @@ class MigrateStagesTest(testing_config.CustomTestCase):
         feature_type=2,
         unlisted=False,
         deleted=False,
-        name='feature_three',
-        summary='migrated summary',
+        name='feature_five',
+        summary='summary',
         category=1)
     self.feature_5.put()
 
+    # Create a "random" number of Approval entities.
+    appr_states = [Approval.NA, Approval.NOT_APPROVED, Approval.APPROVED]
+    for i in range(20):
+      id = i % 5 + 1
+      gate_type = i % 4 + 1
+      state = appr_states[i % 3]
+      set_on = datetime(2020, 1, 1)
+      set_by = f'voter{i}@example.com'
+      appr = Approval(feature_id=id, field_id=gate_type, state=state,
+        set_on=set_on, set_by=set_by)
+      appr.put()
+
   def tearDown(self):
-    for feature in core_models.Feature.query().fetch():
-      feature.key.delete()
-    for stage in core_models.Stage.query().fetch():
-      stage.key.delete()
+    kinds = [Feature, FeatureEntry, Stage, Gate, Approval, Vote]
+    for kind in kinds:
+      for entity in kind.query().fetch():
+        entity.key.delete()
 
   def test_migration(self):
-    migration_handler = schema_migration.MigrateStages()
+    migration_handler = schema_migration.MigrateEntities()
     result = migration_handler.get_template_data()
     # One is already migrated, so only 2 others to migrate.
-    expected = '18 Stage entities created for 4 Feature entities.'
+    expected = '5 Feature entities migrated to FeatureEntry entities.'
     self.assertEqual(result, expected)
-    feature_entries = core_models.Stage.query().fetch()
-    self.assertEqual(len(feature_entries), 18)
-    
-    # Check if certain fields were copied over correctly.
-    stages = core_models.Stage.query(
-        core_models.Stage.feature_id == self.feature_1.key.integer_id()).fetch()
-    self.assertEqual(len(stages), 5)
+    feature_entries = FeatureEntry.query().fetch()
+    stages = Stage.query().fetch()
+    gates = Gate.query().fetch()
+    approvals = Vote.query().fetch()
 
-    # Filter for STAGE_DEP_SHIPPING enum
+    self.assertEqual(len(feature_entries), 5)
+    self.assertEqual(len(stages), 28)
+    self.assertEqual(len(gates), 16)
+    self.assertEqual(len(approvals), 16)
+
+    # Check if certain fields were copied over correctly.
+    stages = Stage.query(
+        Stage.feature_id == self.feature_1.key.integer_id()).fetch()
+    self.assertEqual(len(stages), 6)
+
+    # Filter for STAGE_DEP_SHIPPING enum.
     shipping_stage_list = [
       stage for stage in stages if stage.stage_type == 460]
     ot_stage_list = [
@@ -502,7 +320,20 @@ class MigrateStagesTest(testing_config.CustomTestCase):
     self.assertEqual(ot_stage_list[0].intent_thread_url,
         'https://example.com/intentexperiment')
 
+    # Check if all fields have been copied over.
+    feature_entry_1 = FeatureEntry.get_by_id(
+        self.feature_1.key.integer_id())
+    self.assertIsNotNone(feature_entry_1)
+    # Check that all fields are copied over as expected.
+    for field in self.FEATURE_FIELDS:
+      self.assertEqual(
+          getattr(feature_entry_1, field), getattr(self.feature_1, field))
+    for old_field, new_field in self.RENAMED_FIELDS:
+      self.assertEqual(
+          getattr(feature_entry_1, new_field), getattr(self.feature_1, old_field))
+    self.assertEqual(feature_entry_1.updater_email, self.feature_1.updated_by.email())
+
     # The migration should be idempotent, so nothing should be migrated twice.
     result_2 = migration_handler.get_template_data()
-    expected = '0 Stage entities created for 0 Feature entities.'
+    expected = '0 Feature entities migrated to FeatureEntry entities.'
     self.assertEqual(result_2, expected)

--- a/main.py
+++ b/main.py
@@ -195,8 +195,7 @@ internals_routes = [
   ('/cron/warn_inactive_users', notifier.NotifyInactiveUsersHandler),
   ('/cron/remove_inactive_users', inactive_users.RemoveInactiveUsersHandler),
   ('/cron/schema_migration_comment_activity', schema_migration.MigrateCommentsToActivities),
-  ('/cron/schema_migration_approval_vote', schema_migration.MigrateApprovalsToVotes),
-  ('/cron/schema_migration_feature_featureentry', schema_migration.MigrateFeaturesToFeatureEntries),
+  ('/cron/schema_migration_entities', schema_migration.MigrateEntities),
   ('/cron/write_standard_maturity', deprecate_field.WriteStandardMaturityHandler),
 
   ('/tasks/email-subscribers', notifier.FeatureChangeHandler),


### PR DESCRIPTION
Part of the schema migration work.

This change combines the migrations scripts for FeatureEntry, Stage, Gate, and Vote entities into one script. These entities are heavily reliant on information from one-another, with all entities having fields that map to entities of different kinds. It's much easier and more consistent to create all of these new entities in one go.