### PR TITLE
Move approval constants into core_enums.py

### DIFF
--- a/api/permissions_api.py
+++ b/api/permissions_api.py
@@ -17,6 +17,7 @@
 from framework import basehandlers
 from framework import permissions
 from internals import approval_defs
+from internals import core_enums
 
 
 class PermissionsAPI(basehandlers.APIHandler):
@@ -32,7 +33,7 @@ class PermissionsAPI(basehandlers.APIHandler):
     # get user permission data if signed in
     user = self.get_current_user()
     if user:
-      field_id = approval_defs.ShipApproval.field_id
+      field_id = core_enums.SHIP_APPROVAL.field_id
       approvers = approval_defs.get_approvers(field_id)
       user_data = {
         'can_create_feature': permissions.can_create_feature(user),

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -34,6 +34,7 @@ from framework import users
 from framework import utils
 from framework import xsrf
 from internals import approval_defs
+from internals import core_enums
 from internals import core_models
 from internals import user_models
 
@@ -322,7 +323,7 @@ class FlaskHandler(BaseHandler):
 
     user = self.get_current_user()
     if user:
-      field_id = approval_defs.ShipApproval.field_id
+      field_id = core_enums.SHIP_APPROVAL.field_id
       approvers = approval_defs.get_approvers(field_id)
       user_pref = user_models.UserPref.get_signed_in_user_pref()
       common_data['user'] = {

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -14,56 +14,15 @@
 # limitations under the License.
 
 import base64
-import collections
 import logging
 import requests
 
 from framework import permissions
+from internals.core_enums import *
 from internals import review_models
 import settings
 
 CACHE_EXPIRATION = 60 * 60  # One hour
-
-
-ONE_LGTM = 'One LGTM'
-THREE_LGTM = 'Three LGTMs'
-API_OWNERS_URL = (
-    'https://chromium.googlesource.com/chromium/src/+/'
-    'main/third_party/blink/API_OWNERS?format=TEXT')
-
-ApprovalFieldDef = collections.namedtuple(
-    'ApprovalField',
-    'name, description, field_id, rule, approvers')
-
-# Note: This can be requested manually through the UI, but it is not
-# triggered by a blink-dev thread because i2p intents are only FYIs to
-# bilnk-dev and don't actually need approval by the API Owners.
-PrototypeApproval = ApprovalFieldDef(
-    'Intent to Prototype',
-    'Not normally used.  If a review is requested, API Owners can approve.',
-    1, ONE_LGTM, API_OWNERS_URL)
-
-ExperimentApproval = ApprovalFieldDef(
-    'Intent to Experiment',
-    'One API Owner must approve your intent',
-    2, ONE_LGTM, API_OWNERS_URL)
-
-ExtendExperimentApproval = ApprovalFieldDef(
-    'Intent to Extend Experiment',
-    'One API Owner must approve your intent',
-    3, ONE_LGTM, API_OWNERS_URL)
-
-ShipApproval = ApprovalFieldDef(
-    'Intent to Ship',
-    'Three API Owners must approve your intent',
-    4, THREE_LGTM, API_OWNERS_URL)
-
-APPROVAL_FIELDS_BY_ID = {
-    afd.field_id: afd
-    for afd in [
-        PrototypeApproval, ExperimentApproval, ExtendExperimentApproval,
-        ShipApproval]
-    }
 
 
 def fetch_owners(url):

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -142,6 +142,40 @@ STAGE_DEP_REMOVE_CODE = 470
 # Note: This stage can ge added to any feature that is following any process.
 STAGE_ENT_ROLLOUT = 1061
 
+# Gate types
+GATE_PROTOTYPE = 1
+GATE_ORIGIN_TRIAL = 2
+GATE_EXTEND_ORIGIN_TRIAL = 3
+GATE_SHIP = 4
+
+# List of (stage type, gate type) for each feature type.
+STAGES_AND_GATES_BY_FEATURE_TYPE = {
+    FEATURE_TYPE_INCUBATE_ID: [
+        (STAGE_BLINK_INCUBATE, None),
+        (STAGE_BLINK_PROTOTYPE, GATE_PROTOTYPE),
+        (STAGE_BLINK_DEV_TRIAL, None),
+        (STAGE_BLINK_EVAL_READINESS, None),
+        (STAGE_BLINK_ORIGIN_TRIAL, GATE_ORIGIN_TRIAL),
+        (STAGE_BLINK_EXTEND_ORIGIN_TRIAL, GATE_EXTEND_ORIGIN_TRIAL),
+        (STAGE_BLINK_SHIPPING, GATE_SHIP)],
+    FEATURE_TYPE_EXISTING_ID: [
+        (STAGE_FAST_PROTOTYPE, GATE_PROTOTYPE),
+        (STAGE_FAST_DEV_TRIAL, None),
+        (STAGE_FAST_ORIGIN_TRIAL, GATE_ORIGIN_TRIAL),
+        (STAGE_FAST_EXTEND_ORIGIN_TRIAL, GATE_EXTEND_ORIGIN_TRIAL),
+        (STAGE_FAST_SHIPPING, GATE_SHIP)],
+    FEATURE_TYPE_CODE_CHANGE_ID: [
+        (STAGE_PSA_IMPLEMENT, None),
+        (STAGE_PSA_DEV_TRIAL, None),
+        (STAGE_PSA_SHIPPING, GATE_SHIP)],
+    FEATURE_TYPE_DEPRECATION_ID: [
+        (STAGE_DEP_PLAN, None),
+        (STAGE_DEP_DEV_TRIAL, None),
+        (STAGE_DEP_DEPRECATION_TRIAL, GATE_ORIGIN_TRIAL),
+        (STAGE_DEP_EXTEND_DEPRECATION_TRIAL, GATE_EXTEND_ORIGIN_TRIAL),
+        (STAGE_DEP_SHIPPING, GATE_SHIP),
+        (STAGE_DEP_REMOVE_CODE, None)]
+  }
 
 # Prototype stage types for every feature type.
 STAGE_TYPES_PROTOTYPE = {
@@ -414,6 +448,47 @@ PROPERTY_NAMES_TO_ENUM_DICTS = {
     'web_dev_views': WEB_DEV_VIEWS,
   }
 
+
+# Review and approval enums.
+ONE_LGTM = 'One LGTM'
+THREE_LGTM = 'Three LGTMs'
+API_OWNERS_URL = (
+    'https://chromium.googlesource.com/chromium/src/+/'
+    'main/third_party/blink/API_OWNERS?format=TEXT')
+
+ApprovalFieldDef = collections.namedtuple(
+    'ApprovalFieldDef',
+    'name, description, field_id, rule, approvers')
+
+# Note: This can be requested manually through the UI, but it is not
+# triggered by a blink-dev thread because i2p intents are only FYIs to
+# bilnk-dev and don't actually need approval by the API Owners.
+PROTOTYPE_APPROVAL = ApprovalFieldDef(
+    'Intent to Prototype',
+    'Not normally used.  If a review is requested, API Owners can approve.',
+    GATE_PROTOTYPE, ONE_LGTM, API_OWNERS_URL)
+
+EXPERIMENT_APPROVAL = ApprovalFieldDef(
+    'Intent to Experiment',
+    'One API Owner must approve your intent',
+    GATE_ORIGIN_TRIAL, ONE_LGTM, API_OWNERS_URL)
+
+EXTEND_EXPERIMENT_APPROVAL = ApprovalFieldDef(
+    'Intent to Extend Experiment',
+    'One API Owner must approve your intent',
+    GATE_EXTEND_ORIGIN_TRIAL, ONE_LGTM, API_OWNERS_URL)
+
+SHIP_APPROVAL = ApprovalFieldDef(
+    'Intent to Ship',
+    'Three API Owners must approve your intent',
+    GATE_SHIP, THREE_LGTM, API_OWNERS_URL)
+
+APPROVAL_FIELDS_BY_ID = {
+    afd.field_id: afd
+    for afd in [
+        PROTOTYPE_APPROVAL, EXPERIMENT_APPROVAL, EXTEND_EXPERIMENT_APPROVAL,
+        SHIP_APPROVAL]
+    }
 
 def convert_enum_int_to_string(property_name, value):
   """If the property is an enum, return human-readable string, else value."""

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -21,13 +21,14 @@ from framework import basehandlers
 from framework import permissions
 from framework import users
 from internals import approval_defs
+from internals import core_enums
 from internals import core_models
 from internals import review_models
 
 
 FIELDS_REQUIRING_LGTMS = [
-    approval_defs.ShipApproval, approval_defs.ExperimentApproval,
-    approval_defs.ExtendExperimentApproval,
+    core_enums.SHIP_APPROVAL, core_enums.EXPERIMENT_APPROVAL,
+    core_enums.EXTEND_EXPERIMENT_APPROVAL,
     ]
 
 
@@ -61,16 +62,16 @@ def detect_field(subject):
   subject = ' '.join(subject.split())  # collapse multiple spaces
 
   if SHIP_RE.match(subject):
-    return approval_defs.ShipApproval
+    return core_enums.SHIP_APPROVAL
 
   if PROTO_RE.match(subject):
-    return approval_defs.PrototypeApproval
+    return core_enums.PROTOTYPE_APPROVAL
 
   if EXPERIMENT_RE.match(subject):
-    return approval_defs.ExperimentApproval
+    return core_enums.EXPERIMENT_APPROVAL
 
   if EXTEND_RE.match(subject):
-    return approval_defs.ExtendExperimentApproval
+    return core_enums.EXTEND_EXPERIMENT_APPROVAL
 
   return None
 
@@ -212,20 +213,20 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
 
     # Find the feature by querying for the previously saved discussion link.
     matching_features = []
-    if approval_field == approval_defs.PrototypeApproval:
+    if approval_field == core_enums.PROTOTYPE_APPROVAL:
       query = core_models.Feature.query(
           core_models.Feature.intent_to_implement_url == thread_url)
       matching_features = query.fetch()
     # TODO(jrobbins): Ready-for-trial threads
-    elif approval_field == approval_defs.ExperimentApproval:
+    elif approval_field == core_enums.EXPERIMENT_APPROVAL:
       query = core_models.Feature.query(
           core_models.Feature.intent_to_experiment_url == thread_url)
       matching_features = query.fetch()
-    elif approval_field == approval_defs.ExtendExperimentApproval:
+    elif approval_field == core_enums.EXTEND_EXPERIMENT_APPROVAL:
       query = core_models.Feature.query(
           core_models.Feature.intent_to_extend_experiment_url == thread_url)
       matching_features = query.fetch()
-    elif approval_field == approval_defs.ShipApproval:
+    elif approval_field == core_enums.SHIP_APPROVAL:
       query = core_models.Feature.query(
           core_models.Feature.intent_to_ship_url == thread_url)
       matching_features = query.fetch()
@@ -246,7 +247,7 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     if not thread_url:
       return
 
-    if (approval_field == approval_defs.PrototypeApproval and
+    if (approval_field == core_enums.PROTOTYPE_APPROVAL and
         not feature.intent_to_implement_url):
       feature.intent_to_implement_url = thread_url
       feature.intent_to_implement_subject_line = subject
@@ -254,19 +255,19 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
 
     # TODO(jrobbins): Ready-for-trial threads
 
-    if (approval_field == approval_defs.ExperimentApproval and
+    if (approval_field == core_enums.EXPERIMENT_APPROVAL and
         not feature.intent_to_experiment_url):
       feature.intent_to_experiment_url = thread_url
       feature.intent_to_experiment_subject_line = subject
       feature.put()
 
-    if (approval_field == approval_defs.ExtendExperimentApproval and
+    if (approval_field == core_enums.EXTEND_EXPERIMENT_APPROVAL and
         not feature.intent_to_extend_experiment_url):
       feature.intent_to_extend_experiment_url = thread_url
       feature.intent_to_extend_experiment_subject_line = subject
       feature.put()
 
-    if (approval_field == approval_defs.ShipApproval and
+    if (approval_field == core_enums.SHIP_APPROVAL and
         not feature.intent_to_ship_url):
       feature.intent_to_ship_url = thread_url
       feature.intent_to_ship_subject_line = subject
@@ -302,12 +303,12 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     # Note: Intent-to-prototype and Intent-to-extend are not checked
     # here because there are no old fields for them.
 
-    if (approval_field == approval_defs.ExperimentApproval and
+    if (approval_field == core_enums.EXPERIMENT_APPROVAL and
         from_addr not in feature.i2e_lgtms):
       feature.i2e_lgtms += [from_addr]
       feature.put()
 
-    if (approval_field == approval_defs.ShipApproval and
+    if (approval_field == core_enums.SHIP_APPROVAL and
         from_addr not in feature.i2s_lgtms):
       feature.i2s_lgtms += [from_addr]
       feature.put()

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -41,7 +41,7 @@ class FunctionTest(testing_config.CustomTestCase):
   def test_detect_field(self):
     """We can detect intent thread type by subject line."""
     test_data = {
-      approval_defs.PrototypeApproval: [
+      core_enums.PROTOTYPE_APPROVAL: [
           'Intent to Prototype: Something cool',
           'Re: Re:Intent to Prototype: Something cool',
           'intent to prototype: something cool',
@@ -54,7 +54,7 @@ class FunctionTest(testing_config.CustomTestCase):
           'Request for prototyping Something cool',
           'Requesting to prototyping Something cool',
         ],
-      approval_defs.ExperimentApproval: [
+      core_enums.EXPERIMENT_APPROVAL: [
           'Fwd: Intent to Experiment: Something cool',
           'Fwd: Re: Intent to Experiment: Something cool',
           'Fwd: [blink-dev] Intent to Experiment: Something cool',
@@ -66,7 +66,7 @@ class FunctionTest(testing_config.CustomTestCase):
           'intend to  experiment: something cool',
           'intending to  experiment: something cool',
       ],
-      approval_defs.ExtendExperimentApproval: [
+      core_enums.EXTEND_EXPERIMENT_APPROVAL: [
           'Intent to Continue Experiment: Something cool',
           'Intent to Extend Experiment: Something cool',
           'Intent to Continue Experiment: Something cool',
@@ -77,7 +77,7 @@ class FunctionTest(testing_config.CustomTestCase):
           'Request to Continuing Experiment: Something cool',
           'Requesting to Continuing Experiment: Something cool',
       ],
-      approval_defs.ShipApproval: [
+      core_enums.SHIP_APPROVAL: [
           'Intent to Ship: Something cool',
           'intent to ship: something cool',
           'intend to ship: something cool',
@@ -286,9 +286,9 @@ class FunctionTest(testing_config.CustomTestCase):
     """A user who is in the list of approvers can LGTM."""
     mock_get_approvers.return_value = ['owner@example.com']
     self.assertTrue(detect_intent.is_lgtm_allowed(
-        'owner@example.com', self.feature_1, approval_defs.ShipApproval))
+        'owner@example.com', self.feature_1, core_enums.SHIP_APPROVAL))
     mock_get_approvers.assert_called_once_with(
-        approval_defs.ShipApproval.field_id)
+        core_enums.SHIP_APPROVAL.field_id)
 
   @mock.patch('framework.permissions.can_admin_site')
   @mock.patch('internals.approval_defs.get_approvers')
@@ -298,25 +298,25 @@ class FunctionTest(testing_config.CustomTestCase):
     mock_get_approvers.return_value = ['owner@example.com']
     mock_can_admin_site.return_value = True
     self.assertTrue(detect_intent.is_lgtm_allowed(
-        'admin@example.com', self.feature_1, approval_defs.ShipApproval))
+        'admin@example.com', self.feature_1, core_enums.SHIP_APPROVAL))
 
   @mock.patch('internals.approval_defs.get_approvers')
   def test_is_lgtm_allowed__other(self, mock_get_approvers):
     """An average user cannot LGTM."""
     mock_get_approvers.return_value = ['owner@example.com']
     self.assertFalse(detect_intent.is_lgtm_allowed(
-        'other@example.com', self.feature_1, approval_defs.ShipApproval))
+        'other@example.com', self.feature_1, core_enums.SHIP_APPROVAL))
 
   @mock.patch('internals.review_models.Approval.get_approvals')
   def test_detect_new_thread(self, mock_get_approvals):
     """A thread is new if there are no previous approval values."""
     mock_get_approvals.return_value = []
     self.assertTrue(detect_intent.detect_new_thread(
-        self.feature_1.key.integer_id(), approval_defs.ShipApproval))
+        self.feature_1.key.integer_id(), core_enums.SHIP_APPROVAL))
 
     mock_get_approvals.return_value = ['fake approval value']
     self.assertFalse(detect_intent.detect_new_thread(
-        self.feature_1.key.integer_id(), approval_defs.ShipApproval))
+        self.feature_1.key.integer_id(), core_enums.SHIP_APPROVAL))
 
 
 class IntentEmailHandlerTest(testing_config.CustomTestCase):
@@ -370,7 +370,7 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
     self.assertEqual(1, len(created_approvals))
     appr = created_approvals[0]
     self.assertEqual(self.feature_id, appr.feature_id)
-    self.assertEqual(approval_defs.ShipApproval.field_id, appr.field_id)
+    self.assertEqual(core_enums.SHIP_APPROVAL.field_id, appr.field_id)
     self.assertEqual(review_models.Approval.REVIEW_REQUESTED, appr.state)
     self.assertEqual('user@example.com', appr.set_by)
     self.assertEqual(self.feature_1.intent_to_ship_url, self.thread_url)
@@ -410,7 +410,7 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
     self.assertEqual(1, len(created_approvals))
     appr = created_approvals[0]
     self.assertEqual(self.feature_id, appr.feature_id)
-    self.assertEqual(approval_defs.ShipApproval.field_id, appr.field_id)
+    self.assertEqual(core_enums.SHIP_APPROVAL.field_id, appr.field_id)
     self.assertEqual(review_models.Approval.APPROVED, appr.state)
     self.assertEqual('user@example.com', appr.set_by)
     self.assertEqual(self.feature_1.intent_to_ship_url, self.thread_url)

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -360,14 +360,14 @@ def get_existing_thread_subject(feature, approval_field):
   """If we have the subject line of the Google Groups thread, use it."""
   # This improves message threading in gmail.
 
-  if approval_field == approval_defs.PrototypeApproval:
+  if approval_field == core_enums.PROTOTYPE_APPROVAL:
     return feature.intent_to_implement_subject_line
   # TODO(jrobbins): Ready-for-trial threads
-  elif approval_field == approval_defs.ExperimentApproval:
+  elif approval_field == core_enums.EXPERIMENT_APPROVAL:
     return feature.intent_to_experiment_subject_line
-  elif approval_field == approval_defs.ExtendExperimentApproval:
+  elif approval_field == core_enums.EXTEND_EXPERIMENT_APPROVAL:
     return feature.intent_to_extend_experiment_subject_line
-  elif approval_field == approval_defs.ShipApproval:
+  elif approval_field == core_enums.SHIP_APPROVAL:
     return feature.intent_to_ship_subject_line
   else:
     raise ValueError('Unexpected approval type')
@@ -377,11 +377,11 @@ def generate_thread_subject(feature, approval_field):
   """Use the expected subject based on the feature type and approval type."""
   intent_phrase = approval_field.name
   if feature.feature_type == core_enums.FEATURE_TYPE_DEPRECATION_ID:
-    if approval_field == approval_defs.PrototypeApproval:
+    if approval_field == core_enums.PROTOTYPE_APPROVAL:
       intent_phrase = 'Intent to Deprecate and Remove'
-    if approval_field == approval_defs.ExperimentApproval:
+    if approval_field == core_enums.EXPERIMENT_APPROVAL:
       intent_phrase = 'Request for Deprecation Trial'
-    if approval_field == approval_defs.ExtendExperimentApproval:
+    if approval_field == core_enums.EXTEND_EXPERIMENT_APPROVAL:
       intent_phrase = 'Intent to Extend Deprecation Trial'
 
   return '%s: %s' % (intent_phrase, feature.name)
@@ -389,14 +389,14 @@ def generate_thread_subject(feature, approval_field):
 
 def get_thread_id(feature, approval_field):
   """If we have the URL of the Google Groups thread, we can get its ID."""
-  if approval_field == approval_defs.PrototypeApproval:
+  if approval_field == core_enums.PROTOTYPE_APPROVAL:
     thread_url = feature.intent_to_implement_url
   # TODO(jrobbins): Ready-for-trial threads
-  if approval_field == approval_defs.ExperimentApproval:
+  if approval_field == core_enums.EXPERIMENT_APPROVAL:
     thread_url = feature.intent_to_experiment_url
-  if approval_field == approval_defs.ExtendExperimentApproval:
+  if approval_field == core_enums.EXTEND_EXPERIMENT_APPROVAL:
     thread_url = feature.intent_to_extend_experiment_url
-  if approval_field == approval_defs.ShipApproval:
+  if approval_field == core_enums.SHIP_APPROVAL:
     thread_url = feature.intent_to_ship_url
 
   if not thread_url:

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -606,27 +606,27 @@ class FunctionsTest(testing_config.CustomTestCase):
     self.assertEqual(
         '123xxx=yyy@mail.gmail.com',
         notifier.get_thread_id(
-            self.feature_1, approval_defs.PrototypeApproval))
+            self.feature_1, core_enums.PROTOTYPE_APPROVAL))
     self.assertEqual(
         '456xxx=yyy@mail.gmail.com',
         notifier.get_thread_id(
-            self.feature_1, approval_defs.ExperimentApproval))
+            self.feature_1, core_enums.EXPERIMENT_APPROVAL))
     self.assertEqual(
         None,
         notifier.get_thread_id(
-            self.feature_1, approval_defs.ShipApproval))
+            self.feature_1, core_enums.SHIP_APPROVAL))
 
   def test_get_existing_thread_subject__none(self):
     """If a feature does not store an existing thread subject, use None."""
     self.assertIsNone(notifier.get_existing_thread_subject(
-        self.feature_1, approval_defs.PrototypeApproval))
+        self.feature_1, core_enums.PROTOTYPE_APPROVAL))
 
   def test_get_existing_thread_subject__found(self):
     """If a feature does not store an existing thread subject, use it."""
     self.feature_1.intent_to_ship_subject_line = (
         'Intent to really ship: feature one')
     actual = notifier.get_existing_thread_subject(
-        self.feature_1, approval_defs.ShipApproval)
+        self.feature_1, core_enums.SHIP_APPROVAL)
     self.assertEqual('Intent to really ship: feature one', actual)
 
   def test_get_existing_thread_subject__unknown(self):
@@ -644,19 +644,19 @@ class FunctionsTest(testing_config.CustomTestCase):
     self.assertEqual(
         'Intent to Prototype: feature one',
         notifier.generate_thread_subject(
-            self.feature_1, approval_defs.PrototypeApproval))
+            self.feature_1, core_enums.PROTOTYPE_APPROVAL))
     self.assertEqual(
         'Intent to Experiment: feature one',
         notifier.generate_thread_subject(
-            self.feature_1, approval_defs.ExperimentApproval))
+            self.feature_1, core_enums.EXPERIMENT_APPROVAL))
     self.assertEqual(
         'Intent to Extend Experiment: feature one',
         notifier.generate_thread_subject(
-            self.feature_1, approval_defs.ExtendExperimentApproval))
+            self.feature_1, core_enums.EXTEND_EXPERIMENT_APPROVAL))
     self.assertEqual(
         'Intent to Ship: feature one',
         notifier.generate_thread_subject(
-            self.feature_1, approval_defs.ShipApproval))
+            self.feature_1, core_enums.SHIP_APPROVAL))
 
   def test_generate_thread_subject__deprecation(self):
     """Deprecation intents use different subjects for most intents."""
@@ -664,19 +664,19 @@ class FunctionsTest(testing_config.CustomTestCase):
     self.assertEqual(
         'Intent to Deprecate and Remove: feature one',
         notifier.generate_thread_subject(
-            self.feature_1, approval_defs.PrototypeApproval))
+            self.feature_1, core_enums.PROTOTYPE_APPROVAL))
     self.assertEqual(
         'Request for Deprecation Trial: feature one',
         notifier.generate_thread_subject(
-            self.feature_1, approval_defs.ExperimentApproval))
+            self.feature_1, core_enums.EXPERIMENT_APPROVAL))
     self.assertEqual(
         'Intent to Extend Deprecation Trial: feature one',
         notifier.generate_thread_subject(
-            self.feature_1, approval_defs.ExtendExperimentApproval))
+            self.feature_1, core_enums.EXTEND_EXPERIMENT_APPROVAL))
     self.assertEqual(
         'Intent to Ship: feature one',
         notifier.generate_thread_subject(
-            self.feature_1, approval_defs.ShipApproval))
+            self.feature_1, core_enums.SHIP_APPROVAL))
 
 
   def test_get_thread_id__trailing_junk(self):
@@ -685,4 +685,4 @@ class FunctionsTest(testing_config.CustomTestCase):
     self.assertEqual(
         '123xxx=yyy@mail.gmail.com',
         notifier.get_thread_id(
-            self.feature_1, approval_defs.PrototypeApproval))
+            self.feature_1, core_enums.PROTOTYPE_APPROVAL))

--- a/internals/processes.py
+++ b/internals/processes.py
@@ -175,7 +175,7 @@ BLINK_PROCESS_STAGES = [
       [Action('Draft Intent to Prototype email', INTENT_EMAIL_URL,
               [PI_INITIAL_PUBLIC_PROPOSAL.name, PI_MOTIVATION.name,
                PI_EXPLAINER.name])],
-      [approval_defs.PrototypeApproval],
+      [core_enums.PROTOTYPE_APPROVAL],
       core_enums.INTENT_INCUBATE, core_enums.INTENT_IMPLEMENT),
 
   ProcessStage(
@@ -225,7 +225,7 @@ BLINK_PROCESS_STAGES = [
               [PI_INITIAL_PUBLIC_PROPOSAL.name, PI_MOTIVATION.name,
                PI_EXPLAINER.name, PI_SPEC_LINK.name,
                PI_EST_TARGET_MILESTONE.name])],
-      [approval_defs.ExperimentApproval],
+      [core_enums.EXPERIMENT_APPROVAL],
       core_enums.INTENT_IMPLEMENT_SHIP, core_enums.INTENT_EXTEND_TRIAL),
 
   ProcessStage(
@@ -244,7 +244,7 @@ BLINK_PROCESS_STAGES = [
                PI_EXPLAINER.name, PI_SPEC_LINK.name,
                PI_TAG_ADDRESSED.name, PI_UPDATED_VENDOR_SIGNALS.name,
                PI_UPDATED_TARGET_MILESTONE.name])],
-      [approval_defs.ShipApproval],
+      [core_enums.SHIP_APPROVAL],
       core_enums.INTENT_IMPLEMENT_SHIP, core_enums.INTENT_SHIP),
 
   ProcessStage(
@@ -277,7 +277,7 @@ BLINK_FAST_TRACK_STAGES = [
        ],
       [Action('Draft Intent to Prototype email', INTENT_EMAIL_URL,
               [PI_SPEC_LINK.name])],
-      [approval_defs.PrototypeApproval],
+      [core_enums.PROTOTYPE_APPROVAL],
       core_enums.INTENT_NONE, core_enums.INTENT_IMPLEMENT),
 
   ProcessStage(
@@ -308,7 +308,7 @@ BLINK_FAST_TRACK_STAGES = [
       ],
       [Action('Draft Intent to Experiment email', INTENT_EMAIL_URL,
               [PI_SPEC_LINK.name, PI_EST_TARGET_MILESTONE.name])],
-      [approval_defs.ExperimentApproval],
+      [core_enums.EXPERIMENT_APPROVAL],
       core_enums.INTENT_EXPERIMENT, core_enums.INTENT_EXTEND_TRIAL),
 
   ProcessStage(
@@ -322,7 +322,7 @@ BLINK_FAST_TRACK_STAGES = [
       ],
       [Action('Draft Intent to Ship email', INTENT_EMAIL_URL,
               [PI_SPEC_LINK.name, PI_UPDATED_TARGET_MILESTONE.name])],
-      [approval_defs.ShipApproval],
+      [core_enums.SHIP_APPROVAL],
       core_enums.INTENT_EXPERIMENT, core_enums.INTENT_SHIP),
 
   ProcessStage(
@@ -378,7 +378,7 @@ PSA_ONLY_STAGES = [
       ],
       [Action('Draft Intent to Ship email', INTENT_EMAIL_URL,
               [PI_SPEC_LINK.name, PI_UPDATED_TARGET_MILESTONE.name])],
-      [approval_defs.ShipApproval],
+      [core_enums.SHIP_APPROVAL],
       core_enums.INTENT_EXPERIMENT, core_enums.INTENT_SHIP),
 
   ProcessStage(
@@ -412,7 +412,7 @@ DEPRECATION_STAGES = [
       ],
       [Action('Draft Intent to Deprecate and Remove email', INTENT_EMAIL_URL,
               [PI_MOTIVATION.name])],
-      [approval_defs.PrototypeApproval],
+      [core_enums.PROTOTYPE_APPROVAL],
       core_enums.INTENT_NONE, core_enums.INTENT_IMPLEMENT),
 
   # TODO(cwilso): Work out additional steps for flag defaulting to disabled.
@@ -442,7 +442,7 @@ DEPRECATION_STAGES = [
               [PI_MOTIVATION.name, PI_VENDOR_SIGNALS.name,
                PI_EST_TARGET_MILESTONE.name])],
       # TODO(jrobbins): Intent to extend deprecation.
-      [approval_defs.ExperimentApproval],
+      [core_enums.EXPERIMENT_APPROVAL],
       core_enums.INTENT_EXPERIMENT, core_enums.INTENT_EXTEND_TRIAL),
 
   ProcessStage(
@@ -456,7 +456,7 @@ DEPRECATION_STAGES = [
       [Action('Draft Intent to Ship email', INTENT_EMAIL_URL,
               [PI_MOTIVATION.name, PI_VENDOR_SIGNALS.name,
                PI_UPDATED_TARGET_MILESTONE.name])],
-      [approval_defs.ShipApproval],
+      [core_enums.SHIP_APPROVAL],
       core_enums.INTENT_EXPERIMENT, core_enums.INTENT_SHIP),
 
   ProcessStage(


### PR DESCRIPTION
This change is required for additional work on writing and editing Stage, Gate, and Vote entities. Many files were importing `approval_defs.py` to reference a set of constants referencing approvals constants representing the value of the `feature_type` field, or the `field_type` in Approval entities. These constants are needed for methods to be implemented in the Gate and Vote classes, but would require importing `approval_defs.py` into `review_models.py`. This would cause a circular import. Adding these values to `core_enums.py` seemed like the logical conclusion, and made for a fix that is easy to understand.