### PR TITLE
Add pagination parmeters to feature search API.

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -55,8 +55,20 @@ class FeaturesAPI(basehandlers.APIHandler):
 
     user_query = self.request.args.get('q', '')
     sort_spec = self.request.args.get('sort')
+    try:
+      start = int(self.request.args.get('start', 0))
+      num = int(self.request.args.get(
+          'num', search.DEFAULT_RESULTS_PER_PAGE))
+    except ValueError:
+      self.abort(400, msg='Invalid start or num')
+    if start < 0:
+      self.abort(400, msg='Parameter out of range: start')
+    if num < 0:
+      self.abort(400, msg='Parameter out of range: num')
+
     features_on_page, total_count = search.process_query(
-        user_query, sort_spec=sort_spec, show_unlisted=show_unlisted_features)
+        user_query, sort_spec=sort_spec, show_unlisted=show_unlisted_features,
+        start=start, num=num)
 
     return {
         'total_count': total_count,

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -243,10 +243,16 @@ class ChromeStatusClient {
       (resp) => resp['features_by_type']);
   }
 
-  searchFeatures(userQuery, sortSpec) {
+  searchFeatures(userQuery, sortSpec, start, num) {
     let url = `/features?q=${userQuery}`;
     if (sortSpec) {
       url += '&sort=' + sortSpec;
+    }
+    if (start) {
+      url += '&start=' + start;
+    }
+    if (num) {
+      url += '&num=' + num;
     }
     return this.doGet(url);
   }

--- a/internals/search.py
+++ b/internals/search.py
@@ -26,6 +26,7 @@ from internals import review_models
 from internals import search_queries
 
 MAX_TERMS = 6
+DEFAULT_RESULTS_PER_PAGE = 100
 
 
 def _get_referenced_feature_ids(approvals, reverse=False):
@@ -194,7 +195,7 @@ def _sort_by_total_order(result_id_list, total_order_ids):
 
 def process_query(
     user_query, sort_spec=None, show_unlisted=False, show_deleted=False,
-    start=0, num=100):
+    start=0, num=DEFAULT_RESULTS_PER_PAGE):
   """Parse the user's query, run it, and return a list of features."""
   # 1a. Parse the user query into terms.  And, add permission terms.
   feature_id_futures = []


### PR DESCRIPTION
This adds pagination parameters `start=` and `num=` to the search functionality of features_api.
These were already supported in the underlying feature search functionality.