### PR TITLE
Add assertions for the templates in #2355 (Part 2 of 2)

### DIFF
--- a/api/accounts_api_test.py
+++ b/api/accounts_api_test.py
@@ -88,6 +88,9 @@ class AccountsAPITest(testing_config.CustomTestCase):
     self.assertTrue(new_appuser.is_site_editor)
     self.assertFalse(new_appuser.is_admin)
 
+    # Clean up
+    new_appuser.key.delete()
+
   def test_create__admin_valid(self):
     """Admin wants to register a new admin account."""
     testing_config.sign_in('admin@example.com', 123567890)
@@ -105,6 +108,9 @@ class AccountsAPITest(testing_config.CustomTestCase):
         user_models.AppUser.email == 'new_admin@example.com').get()
     self.assertEqual('new_admin@example.com', new_appuser.email)
     self.assertTrue(new_appuser.is_admin)
+
+    # Clean up
+    new_appuser.key.delete()
 
   def test_create__forbidden(self):
     """Regular user cannot create an account."""

--- a/framework/utils_test.py
+++ b/framework/utils_test.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 import datetime
-import os
 import unittest
 import testing_config  # Must be imported before the module under test.
-from pathlib import Path
 
 from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
@@ -24,9 +22,7 @@ import werkzeug.exceptions  # Flask HTTP stuff.
 from framework import utils
 
 # Load testdata to be used across all of the test cases
-TESTDATA = testing_config.Testdata(
-  os.path.abspath(os.path.dirname(__file__)),
-  Path(__file__).stem)
+TESTDATA = testing_config.Testdata(__file__)
 
 class MockHandler(object):
 

--- a/framework/utils_test.py
+++ b/framework/utils_test.py
@@ -12,14 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+import os
 import unittest
 import testing_config  # Must be imported before the module under test.
+from pathlib import Path
 
 from unittest import mock
 import werkzeug.exceptions  # Flask HTTP stuff.
 
 from framework import utils
 
+# Load testdata to be used across all of the test cases
+TESTDATA = testing_config.Testdata(
+  os.path.abspath(os.path.dirname(__file__)),
+  Path(__file__).stem)
 
 class MockHandler(object):
 
@@ -105,8 +112,11 @@ class UtilsFunctionTests(unittest.TestCase):
     self.assertIsNone(handlerInstance.handler_called_with)
     self.assertEqual('/request/path', handlerInstance.redirected_to)
 
-  def test_render_atom_feed__empty(self):
+  # For empty feeds, django sets the updated date to utcnow().
+  @mock.patch('django.utils.feedgenerator.SyndicationFeed.latest_post_date')
+  def test_render_atom_feed__empty(self, mock_latest_post_date):
     """It can render a feed with zero items."""
+    mock_latest_post_date.return_value = datetime.datetime(2017, 10, 7)
     request = testing_config.Blank(
         scheme='https', host='host',
         path='/samples.xml')
@@ -122,9 +132,9 @@ class UtilsFunctionTests(unittest.TestCase):
                 'max-age=63072000; includeSubDomains; preload',
             'Content-Type': 'application/atom+xml;charset=utf-8',
         })
-    self.assertIn('http://www.w3.org/2005/Atom', actual_text)
-    self.assertIn('<title>Local testing - test feed</title>', actual_text)
-    self.assertIn('<id>https://host/samples</id>', actual_text)
+    self.maxDiff = None
+    # TESTDATA.make_golden(actual_text, 'test_render_atom_feed__empty.html')
+    self.assertMultiLineEqual(TESTDATA['test_render_atom_feed__empty.html'], actual_text)
 
   def test_render_atom_feed__some(self):
     """It can render a feed with some items."""
@@ -148,16 +158,9 @@ class UtilsFunctionTests(unittest.TestCase):
 
     actual_text, actual_headers = utils.render_atom_feed(
         request, 'test feed', data)
-
-    self.assertIn('<title>feature one</title>', actual_text)
-    self.assertIn('one for testing</summary>', actual_text)
-    self.assertIn('/feature/12345678/</id>', actual_text)
-    self.assertIn('<category term="CSS"></category>', actual_text)
-
-    self.assertIn('<title>feature two</title>', actual_text)
-    self.assertIn('two for testing</summary>', actual_text)
-    self.assertIn('/feature/23456789/</id>', actual_text)
-    self.assertIn('<category term="Device"></category>', actual_text)
+    self.maxDiff = None
+    # TESTDATA.make_golden(actual_text, 'test_render_atom_feed__some.html')
+    self.assertMultiLineEqual(TESTDATA['test_render_atom_feed__some.html'], actual_text)
 
   def test_get_banner_time__None(self):
     """If no time specified, it returns None."""

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -14,10 +14,8 @@
 
 import collections
 import json
-import os
 import testing_config  # Must be imported before the module under test.
 from datetime import datetime
-from pathlib import Path
 
 import flask
 from unittest import mock
@@ -37,9 +35,7 @@ test_app = flask.Flask(__name__,
   template_folder=settings.flask_compat_get_template_path())
 
 # Load testdata to be used across all of the CustomTestCases
-TESTDATA = testing_config.Testdata(
-  os.path.abspath(os.path.dirname(__file__)),
-  Path(__file__).stem)
+TESTDATA = testing_config.Testdata(__file__)
 
 class EmailFormattingTest(testing_config.CustomTestCase):
 
@@ -501,10 +497,7 @@ class FeatureStarTest(testing_config.CustomTestCase):
 
     actual = notifier.FeatureStar.get_user_stars(email)
     expected_ids = [feature_1_id, feature_2_id, feature_3_id]
-    self.assertEqual(
-        sorted(expected_ids,
-                      reverse=True),
-        actual)
+    self.assertEqual(sorted(expected_ids, reverse=True), actual)
     # Cleanup
     for feature_id in expected_ids:
       notifier.FeatureStar.get_star(email, feature_id).key.delete()

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -37,15 +37,9 @@ test_app = flask.Flask(__name__,
   template_folder=settings.flask_compat_get_template_path())
 
 # Load testdata to be used across all of the CustomTestCases
-TESTDATA = {}
-testdata_dir = os.path.join(
+TESTDATA = testing_config.Testdata(
   os.path.abspath(os.path.dirname(__file__)),
-  'testdata',
-  Path(__file__).stem
-  )
-for filename in os.listdir(testdata_dir):
-  with open(os.path.join(testdata_dir, filename), 'r') as f:
-    TESTDATA[filename] = f.read()
+  Path(__file__).stem)
 
 class EmailFormattingTest(testing_config.CustomTestCase):
 
@@ -96,7 +90,12 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.template_feature.key = ndb.Key('Feature', 123)
     self.template_feature.put()
 
+    self.maxDiff = None
+
   def tearDown(self):
+    self.watcher_1.key.delete()
+    self.component_owner_1.key.delete()
+    self.component_1.key.delete()
     self.feature_1.key.delete()
     self.feature_2.key.delete()
     self.template_feature.key.delete()
@@ -106,6 +105,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     with test_app.app_context():
       body_html = notifier.format_email_body(
           False, self.template_feature, [])
+    # TESTDATA.make_golden(body_html, 'test_format_email_body__new.html')
     self.assertEqual(body_html,
       TESTDATA['test_format_email_body__new.html'])
 
@@ -114,6 +114,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     with test_app.app_context():
       body_html = notifier.format_email_body(
           True, self.template_feature, [])
+    # TESTDATA.make_golden(body_html, 'test_format_email_body__update_no_changes.html')
     self.assertEqual(body_html,
       TESTDATA['test_format_email_body__update_no_changes.html'])
 
@@ -122,6 +123,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     with test_app.app_context():
       body_html = notifier.format_email_body(
           True, self.template_feature, self.changes)
+    # TESTDATA.make_golden(body_html, 'test_format_email_body__update_with_changes.html')
     self.assertEqual(body_html,
       TESTDATA['test_format_email_body__update_with_changes.html'])
 
@@ -131,6 +133,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     with test_app.app_context():
       body_html = notifier.format_email_body(
           True, self.template_feature, self.changes)
+    # TESTDATA.make_golden(body_html, 'test_format_email_body__mozdev_links_mozilla.html')
     self.assertEqual(body_html,
       TESTDATA['test_format_email_body__mozdev_links_mozilla.html'])
 
@@ -139,6 +142,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     with test_app.app_context():
       body_html = notifier.format_email_body(
           True, self.template_feature, self.changes)
+    # TESTDATA.make_golden(body_html, 'test_format_email_body__mozdev_links_non_mozilla.html')
     self.assertEqual(body_html,
       TESTDATA['test_format_email_body__mozdev_links_non_mozilla.html'])
 
@@ -496,10 +500,14 @@ class FeatureStarTest(testing_config.CustomTestCase):
     notifier.FeatureStar.set_star(email, feature_2_id)
 
     actual = notifier.FeatureStar.get_user_stars(email)
+    expected_ids = [feature_1_id, feature_2_id, feature_3_id]
     self.assertEqual(
-        sorted([feature_1_id, feature_2_id, feature_3_id],
+        sorted(expected_ids,
                       reverse=True),
         actual)
+    # Cleanup
+    for feature_id in expected_ids:
+      notifier.FeatureStar.get_star(email, feature_id).key.delete()
 
   def test_get_feature_starrers__no_stars(self):
     """No user has starred the given feature."""

--- a/internals/reminders_test.py
+++ b/internals/reminders_test.py
@@ -12,13 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import testing_config  # Must be imported before the module under test.
 from datetime import datetime
 from unittest import mock
+from pathlib import Path
 
 from internals import core_models
 from internals import reminders
 
+from google.cloud import ndb
+
+
+# Load testdata to be used across all of the CustomTestCases
+TESTDATA = testing_config.Testdata(
+  os.path.abspath(os.path.dirname(__file__)),
+  Path(__file__).stem)
 
 class MockResponse:
   """Creates a fake response object for testing."""
@@ -46,19 +55,23 @@ def make_test_features():
 class FunctionTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1, self.feature_2, self.feature_3 = make_test_features()
     self.current_milestone_info = {
         'earliest_beta': '2022-09-21T12:34:56',
     }
+    self.feature_template = core_models.Feature(
+      name='feature one', summary='sum', owner=['feature_owner@example.com'],
+      category=1, ot_milestone_desktop_start=100)
+    self.feature_template.key = ndb.Key('Feature', 123)
+    # This test does not require saving to the database.
+
+    self.maxDiff = None
 
   def tearDown(self):
-    self.feature_1.key.delete()
-    self.feature_2.key.delete()
-    self.feature_3.key.delete()
+    pass
 
-  def test_build_email_tasks(self):
+  def test_build_email_tasks_feature_accuracy(self):
     actual = reminders.build_email_tasks(
-        [(self.feature_1, 100)], '[Action requested] Update %s',
+        [(self.feature_template, 100)], '[Action requested] Update %s',
         reminders.FeatureAccuracyHandler.EMAIL_TEMPLATE_PATH,
         self.current_milestone_info)
     self.assertEqual(1, len(actual))
@@ -66,9 +79,23 @@ class FunctionTest(testing_config.CustomTestCase):
     self.assertEqual('feature_owner@example.com', task['to'])
     self.assertEqual('[Action requested] Update feature one', task['subject'])
     self.assertEqual(None, task['reply_to'])
-    self.assertIn('/guide/verify_accuracy/%d' % self.feature_1.key.integer_id(),
-                  task['html'])
+    # TESTDATA.make_golden(task['html'], 'test_build_email_tasks_feature_accuracy.html')
+    self.assertMultiLineEqual(
+      TESTDATA['test_build_email_tasks_feature_accuracy.html'], task['html'])
 
+  def test_build_email_tasks_prepublication(self):
+    actual = reminders.build_email_tasks(
+        [(self.feature_template, 100)], '[Action requested] Update %s',
+        reminders.PrepublicationHandler.EMAIL_TEMPLATE_PATH,
+        self.current_milestone_info)
+    self.assertEqual(1, len(actual))
+    task = actual[0]
+    self.assertEqual('feature_owner@example.com', task['to'])
+    self.assertEqual('[Action requested] Update feature one', task['subject'])
+    self.assertEqual(None, task['reply_to'])
+    # TESTDATA.make_golden(task['html'], 'test_build_email_tasks_prepublication.html')
+    self.assertMultiLineEqual(
+      TESTDATA['test_build_email_tasks_prepublication.html'], task['html'])
 
 class FeatureAccuracyHandlerTest(testing_config.CustomTestCase):
 

--- a/internals/reminders_test.py
+++ b/internals/reminders_test.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import testing_config  # Must be imported before the module under test.
 from datetime import datetime
 from unittest import mock
-from pathlib import Path
 
 from internals import core_models
 from internals import reminders
@@ -25,9 +23,7 @@ from google.cloud import ndb
 
 
 # Load testdata to be used across all of the CustomTestCases
-TESTDATA = testing_config.Testdata(
-  os.path.abspath(os.path.dirname(__file__)),
-  Path(__file__).stem)
+TESTDATA = testing_config.Testdata(__file__)
 
 class MockResponse:
   """Creates a fake response object for testing."""
@@ -65,9 +61,6 @@ class FunctionTest(testing_config.CustomTestCase):
     # This test does not require saving to the database.
 
     self.maxDiff = None
-
-  def tearDown(self):
-    pass
 
   def test_build_email_tasks_feature_accuracy(self):
     actual = reminders.build_email_tasks(

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -217,6 +217,7 @@ class ActivityTest(testing_config.CustomTestCase):
         name='feature a', summary='sum', owner=['feature_owner@example.com'],
         category=1)
     self.feature_1.put()
+    testing_config.sign_in('one@example.com', 123567890)
 
   def tearDown(self):
     feature_id = self.feature_1.key.integer_id()
@@ -224,6 +225,7 @@ class ActivityTest(testing_config.CustomTestCase):
     for activity in activities:
       activity.key.delete()
     self.feature_1.key.delete()
+    testing_config.sign_out()
 
   def test_activities_created(self):
     # stash_values is used to note what the original values of a feature are.

--- a/pages/blink_handler_test.py
+++ b/pages/blink_handler_test.py
@@ -104,7 +104,6 @@ class SubscribersTemplateTest(testing_config.CustomTestCase):
       "canary": {"mstone": 4},
     }
 
-
     self.request_path = self.HANDLER_CLASS.TEMPLATE_PATH
     self.handler = self.HANDLER_CLASS()
 

--- a/pages/blink_handler_test.py
+++ b/pages/blink_handler_test.py
@@ -16,11 +16,9 @@ import testing_config  # Must be imported before the module under test.
 
 from unittest import mock
 
-import os
 import flask
 import werkzeug
 import html5lib
-from pathlib import Path
 
 from google.cloud import ndb
 from pages import blink_handler
@@ -29,9 +27,7 @@ from internals import user_models
 test_app = flask.Flask(__name__)
 
 # Load testdata to be used across all of the CustomTestCases
-TESTDATA = testing_config.Testdata(
-  os.path.abspath(os.path.dirname(__file__)),
-  Path(__file__).stem)
+TESTDATA = testing_config.Testdata(__file__)
 
 class BlinkTemplateTest(testing_config.CustomTestCase):
 

--- a/pages/blink_handler_test.py
+++ b/pages/blink_handler_test.py
@@ -20,12 +20,18 @@ import os
 import flask
 import werkzeug
 import html5lib
+from pathlib import Path
 
+from google.cloud import ndb
 from pages import blink_handler
 from internals import user_models
 
 test_app = flask.Flask(__name__)
 
+# Load testdata to be used across all of the CustomTestCases
+TESTDATA = testing_config.Testdata(
+  os.path.abspath(os.path.dirname(__file__)),
+  Path(__file__).stem)
 
 class BlinkTemplateTest(testing_config.CustomTestCase):
 
@@ -41,9 +47,38 @@ class BlinkTemplateTest(testing_config.CustomTestCase):
     self.app_admin.put()
     testing_config.sign_in('admin@example.com', 123567890)
 
+    self.component_1 = user_models.BlinkComponent(name='Blink')
+    self.component_1.put()
+    self.component_2 = user_models.BlinkComponent(name='Blink>Accessibility')
+    self.component_2.put()
+    self.component_owner_1 = user_models.FeatureOwner(
+        name='owner_1', email='owner_1@example.com',
+        primary_blink_components=[self.component_1.key, self.component_2.key])
+    self.component_owner_1.key = ndb.Key('FeatureOwner', 111)
+    self.component_owner_1.put()
+    self.watcher_1 = user_models.FeatureOwner(
+        name='watcher_1', email='watcher_1@example.com',
+        watching_all_features=True)
+    self.watcher_1.key = ndb.Key('FeatureOwner', 222)
+    self.watcher_1.put()
+
     with test_app.test_request_context(self.request_path):
       self.template_data = self.handler.get_template_data()
+      self.template_data.update(self.handler.get_common_data())
+      self.template_data['nonce'] = 'fake nonce'
+      self.template_data['xsrf_token'] = ''
+      self.template_data['xsrf_token_expires'] = 0
     self.full_template_path = self.handler.get_template_path(self.template_data)
+
+    self.maxDiff = None
+
+  def tearDown(self):
+    self.watcher_1.key.delete()
+    self.component_owner_1.key.delete()
+    self.component_1.key.delete()
+    self.component_2.key.delete()
+    testing_config.sign_out()
+    self.app_admin.key.delete()
 
   def test_html_rendering(self):
     """We can render the template with valid html."""
@@ -51,6 +86,9 @@ class BlinkTemplateTest(testing_config.CustomTestCase):
         self.template_data, self.full_template_path)
     parser = html5lib.HTMLParser(strict=True)
     document = parser.parse(template_text)
+    # TESTDATA.make_golden(template_text, 'BlinkTemplateTest_test_html_rendering.html')
+    self.assertMultiLineEqual(
+      TESTDATA['BlinkTemplateTest_test_html_rendering.html'], template_text)
 
 
 class SubscribersTemplateTest(testing_config.CustomTestCase):
@@ -58,6 +96,18 @@ class SubscribersTemplateTest(testing_config.CustomTestCase):
   HANDLER_CLASS = blink_handler.SubscribersHandler
 
   def setUp(self):
+    # need to patch in setup because the details are retreived here.
+    # unable to use method decorator for setUp.
+    self.mock_chrome_details_patch = mock.patch(
+      'pages.blink_handler.construct_chrome_channels_details')
+    mock_chrome_details = self.mock_chrome_details_patch.start()
+    mock_chrome_details.return_value = {
+      "stable": {"mstone": 1},
+      "beta": {"mstone": 2},
+      "dev": {"mstone": 3},
+      "canary": {"mstone": 4},
+    }
+
 
     self.request_path = self.HANDLER_CLASS.TEMPLATE_PATH
     self.handler = self.HANDLER_CLASS()
@@ -68,9 +118,39 @@ class SubscribersTemplateTest(testing_config.CustomTestCase):
 
     testing_config.sign_in('admin@example.com', 123567890)
 
+    self.component_1 = user_models.BlinkComponent(name='Blink')
+    self.component_1.put()
+    self.component_2 = user_models.BlinkComponent(name='Blink>Accessibility')
+    self.component_2.put()
+    self.component_owner_1 = user_models.FeatureOwner(
+        name='owner_1', email='owner_1@example.com',
+        primary_blink_components=[self.component_1.key, self.component_2.key])
+    self.component_owner_1.key = ndb.Key('FeatureOwner', 111)
+    self.component_owner_1.put()
+    self.watcher_1 = user_models.FeatureOwner(
+        name='watcher_1', email='watcher_1@example.com',
+        watching_all_features=True)
+    self.watcher_1.key = ndb.Key('FeatureOwner', 222)
+    self.watcher_1.put()
+
     with test_app.test_request_context(self.request_path):
       self.template_data = self.handler.get_template_data()
+      self.template_data.update(self.handler.get_common_data())
+      self.template_data['nonce'] = 'fake nonce'
+      self.template_data['xsrf_token'] = ''
+      self.template_data['xsrf_token_expires'] = 0
     self.full_template_path = self.handler.get_template_path(self.template_data)
+
+    self.maxDiff = None
+
+  def tearDown(self):
+    self.mock_chrome_details_patch.stop()
+    self.watcher_1.key.delete()
+    self.component_owner_1.key.delete()
+    self.component_1.key.delete()
+    self.component_2.key.delete()
+    testing_config.sign_out()
+    self.app_admin.key.delete()
 
   def test_html_rendering(self):
     """We can render the template with valid html."""
@@ -78,3 +158,6 @@ class SubscribersTemplateTest(testing_config.CustomTestCase):
         self.template_data, self.full_template_path)
     parser = html5lib.HTMLParser(strict=True)
     document = parser.parse(template_text)
+    # TESTDATA.make_golden(template_text, 'SubscribersTemplateTest_test_html_rendering.html')
+    self.assertMultiLineEqual(
+      TESTDATA['SubscribersTemplateTest_test_html_rendering.html'], template_text)

--- a/pages/featurelist_test.py
+++ b/pages/featurelist_test.py
@@ -14,7 +14,6 @@
 
 import testing_config  # Must be imported first
 
-from pathlib import Path
 
 import os
 import flask
@@ -30,9 +29,7 @@ from framework import rediscache
 test_app = flask.Flask(__name__)
 
 # Load testdata to be used across all of the CustomTestCases
-TESTDATA = testing_config.Testdata(
-  os.path.abspath(os.path.dirname(__file__)),
-  Path(__file__).stem)
+TESTDATA = testing_config.Testdata(__file__)
 
 class TestWithFeature(testing_config.CustomTestCase):
 

--- a/pages/featurelist_test.py
+++ b/pages/featurelist_test.py
@@ -14,7 +14,6 @@
 
 import testing_config  # Must be imported first
 
-
 import os
 import flask
 import werkzeug

--- a/pages/intentpreview_test.py
+++ b/pages/intentpreview_test.py
@@ -15,7 +15,6 @@
 import testing_config  # Must be imported before the module under test.
 
 from unittest import mock
-from pathlib import Path
 
 import os
 import flask
@@ -30,9 +29,7 @@ from internals import core_models
 test_app = flask.Flask(__name__)
 
 # Load testdata to be used across all of the CustomTestCases
-TESTDATA = testing_config.Testdata(
-  os.path.abspath(os.path.dirname(__file__)),
-  Path(__file__).stem)
+TESTDATA = testing_config.Testdata(__file__)
 
 class IntentEmailPreviewHandlerTest(testing_config.CustomTestCase):
 

--- a/pages/intentpreview_test.py
+++ b/pages/intentpreview_test.py
@@ -15,18 +15,24 @@
 import testing_config  # Must be imported before the module under test.
 
 from unittest import mock
+from pathlib import Path
 
 import os
 import flask
 import werkzeug
 import html5lib
 
+from google.cloud import ndb
 from pages import intentpreview
 from internals import core_enums
 from internals import core_models
 
 test_app = flask.Flask(__name__)
 
+# Load testdata to be used across all of the CustomTestCases
+TESTDATA = testing_config.Testdata(
+  os.path.abspath(os.path.dirname(__file__)),
+  Path(__file__).stem)
 
 class IntentEmailPreviewHandlerTest(testing_config.CustomTestCase):
 
@@ -189,6 +195,8 @@ class IntentEmailPreviewTemplateTest(testing_config.CustomTestCase):
     self.feature_1 = core_models.Feature(
         name='feature one', summary='sum', owner=['user1@google.com'],
         category=1, intent_stage=core_enums.INTENT_IMPLEMENT)
+    # Hardcode the key for the template test
+    self.feature_1.key = ndb.Key('Feature', 234)
     self.feature_1.put()
 
     self.request_path = '/admin/features/launch/%d/%d?intent' % (
@@ -196,6 +204,7 @@ class IntentEmailPreviewTemplateTest(testing_config.CustomTestCase):
     self.handler = self.HANDLER_CLASS()
     self.feature_id = self.feature_1.key.integer_id()
 
+    testing_config.sign_in('user1@google.com', 123567890)
     with test_app.test_request_context(self.request_path):
       self.template_data = self.handler.get_template_data(
         feature_id=self.feature_id)
@@ -207,13 +216,26 @@ class IntentEmailPreviewTemplateTest(testing_config.CustomTestCase):
     template_path = self.handler.get_template_path(self.template_data)
     self.full_template_path = os.path.join(template_path)
 
+    self.maxDiff = None
+
+  def tearDown(self):
+    self.feature_1.key.delete()
+    testing_config.sign_out()
+
   def test_html_rendering(self):
     """We can render the template with valid html."""
-    testing_config.sign_in('user1@google.com', 123567890)
     with test_app.test_request_context(self.request_path):
       actual_data = self.handler.get_template_data(feature_id=self.feature_id)
+      actual_data.update(self.handler.get_common_data())
+      actual_data['nonce'] = 'fake nonce'
+      actual_data['xsrf_token'] = ''
+      actual_data['xsrf_token_expires'] = 0
 
     template_text = self.handler.render(
         actual_data, self.full_template_path)
+    testing_config.sign_out()
     parser = html5lib.HTMLParser(strict=True)
     document = parser.parse(template_text)
+    # TESTDATA.make_golden(template_text, 'test_html_rendering.html')
+    self.assertMultiLineEqual(
+      TESTDATA['test_html_rendering.html'], template_text)

--- a/pages/users_test.py
+++ b/pages/users_test.py
@@ -29,9 +29,7 @@ test_app = flask.Flask(__name__)
 
 
 # Load testdata to be used across all of the CustomTestCases
-TESTDATA = testing_config.Testdata(
-  os.path.abspath(os.path.dirname(__file__)),
-  Path(__file__).stem)
+TESTDATA = testing_config.Testdata(__file__)
 
 class UsersListTemplateTest(testing_config.CustomTestCase):
 
@@ -52,6 +50,7 @@ class UsersListTemplateTest(testing_config.CustomTestCase):
       self.template_data['xsrf_token_expires'] = 0
     self.full_template_path = self.handler.get_template_path(self.template_data)
     self.maxDiff = None
+
   def tearDown(self):
     self.app_admin.key.delete()
     testing_config.sign_out()

--- a/pages/users_test.py
+++ b/pages/users_test.py
@@ -16,12 +16,22 @@ import testing_config  # Must be imported first
 
 import flask
 import html5lib
+import os
+
+from google.cloud import ndb
+from pathlib import Path
+from unittest import mock
 
 from internals import user_models
 from pages import users
 
 test_app = flask.Flask(__name__)
 
+
+# Load testdata to be used across all of the CustomTestCases
+TESTDATA = testing_config.Testdata(
+  os.path.abspath(os.path.dirname(__file__)),
+  Path(__file__).stem)
 
 class UsersListTemplateTest(testing_config.CustomTestCase):
 
@@ -30,12 +40,21 @@ class UsersListTemplateTest(testing_config.CustomTestCase):
 
     self.app_admin = user_models.AppUser(email='admin@example.com')
     self.app_admin.is_admin = True
+    self.app_admin.key = ndb.Key('AppUser', 1)
     self.app_admin.put()
     testing_config.sign_in('admin@example.com', 123567890)
 
     with test_app.test_request_context('/request_path'):
       self.template_data = self.handler.get_template_data()
+      self.template_data.update(self.handler.get_common_data())
+      self.template_data['nonce'] = 'fake nonce'
+      self.template_data['xsrf_token'] = ''
+      self.template_data['xsrf_token_expires'] = 0
     self.full_template_path = self.handler.get_template_path(self.template_data)
+    self.maxDiff = None
+  def tearDown(self):
+    self.app_admin.key.delete()
+    testing_config.sign_out()
 
   def test_html_rendering(self):
     """We can render the template with valid html."""
@@ -43,3 +62,6 @@ class UsersListTemplateTest(testing_config.CustomTestCase):
         self.template_data, self.full_template_path)
     parser = html5lib.HTMLParser(strict=True)
     document = parser.parse(template_text)
+    # TESTDATA.make_golden(template_text, 'test_html_rendering.html')
+    self.assertMultiLineEqual(
+      TESTDATA['test_html_rendering.html'], template_text)

--- a/pages/users_test.py
+++ b/pages/users_test.py
@@ -16,10 +16,8 @@ import testing_config  # Must be imported first
 
 import flask
 import html5lib
-import os
 
 from google.cloud import ndb
-from pathlib import Path
 from unittest import mock
 
 from internals import user_models

--- a/testing_config.py
+++ b/testing_config.py
@@ -89,3 +89,31 @@ class CustomTestCase(unittest.TestCase):
     client = ndb.Client()
     with client.context():
       super(CustomTestCase, self).run(result=result)
+
+
+class Testdata(object):
+  def __init__(self, test_file_abs_directory, test_file_name):
+    """Helper class to load testdata
+    Common pattern to place the testdata in the following format:
+
+    Given a test file, atest_test.py, and it is located at
+    /some/module/atest_test.py.
+
+    The testdata should be located at /some/module/testdata/atest_test/
+    """
+    self.testdata = {}
+    self.testdata_dir = os.path.join(
+    test_file_abs_directory, 'testdata', test_file_name)
+    for filename in os.listdir(self.testdata_dir):
+      with open(os.path.join(self.testdata_dir, filename), 'r') as f:
+        self.testdata[filename] = f.read()
+
+  def make_golden(self, raw_data, test_data_file_name):
+    """Helper function to make golden file
+    """
+    test_data_file_path = os.path.join(self.testdata_dir, test_data_file_name)
+    with open(os.path.join(test_data_file_path), 'w') as f:
+      f.write(raw_data)
+
+  def __getitem__(self, key):
+      return self.testdata[key]

--- a/testing_config.py
+++ b/testing_config.py
@@ -17,6 +17,7 @@ import os
 import unittest
 
 from google.cloud import ndb
+from pathlib import Path
 
 os.environ['DJANGO_SECRET'] = 'test secret'
 os.environ['SERVER_SOFTWARE'] = 'test ' + os.environ.get('SERVER_SOFTWARE', '')
@@ -92,7 +93,7 @@ class CustomTestCase(unittest.TestCase):
 
 
 class Testdata(object):
-  def __init__(self, test_file_abs_directory, test_file_name):
+  def __init__(self, test_file_path: str):
     """Helper class to load testdata
     Common pattern to place the testdata in the following format:
 
@@ -102,17 +103,21 @@ class Testdata(object):
     The testdata should be located at /some/module/testdata/atest_test/
     """
     self.testdata = {}
+    test_file_name = Path(test_file_path).stem
     self.testdata_dir = os.path.join(
-    test_file_abs_directory, 'testdata', test_file_name)
+        os.path.abspath(os.path.dirname(test_file_path)),
+        'testdata',
+        test_file_name)
     for filename in os.listdir(self.testdata_dir):
-      with open(os.path.join(self.testdata_dir, filename), 'r') as f:
+      test_data_file_path = os.path.join(self.testdata_dir, filename)
+      with open(test_data_file_path, 'r', encoding='UTF-8') as f:
         self.testdata[filename] = f.read()
 
   def make_golden(self, raw_data, test_data_file_name):
     """Helper function to make golden file
     """
     test_data_file_path = os.path.join(self.testdata_dir, test_data_file_name)
-    with open(os.path.join(test_data_file_path), 'w') as f:
+    with open(test_data_file_path, 'w', encoding='UTF-8') as f:
       f.write(raw_data)
 
   def __getitem__(self, key):


### PR DESCRIPTION
This is a split of https://github.com/GoogleChrome/chromium-dashboard/pull/2323. In order to make that PR readable, I split that up. This commit contains the assertions. Depends on #2355 

- Move the TESTDATA functionality to a testing_config to be a test helper. In this new helper, users can still retreive from it like a dictionary. In addition, there's a helper function to help make goldens that can be used to regenerate the golden templates. Add commented out code to use it.
- Add some clean ups to individual tests or test cases. This was needed because some of the existing rendering tests would pull from the database. But since the tests only asserted the existence of some values, it did not matter. Now that we assert a complete template, everything in the database matters. (In the future, we can add mocks for all of those)
  - These cleanups also help for more than the rendering tests. Before these fixes, there were ~15 non-rendering tests that would fail if a developer ran the full suite with a clean db, then re-ran a test indivdually without resetting the database. There are still 2 non-rendering tests that fail without clearing the database first. But this first iteartion got a lot of them.
- Add a missing test for the PrepublicationHandler to increase coverage

**WHY merge this PR**: Prior to removing Django, it would be nice to have a baseline of exactly how everything renders