### PR TITLE
Fix unclosed h3 in prepub email.

### DIFF
--- a/internals/testdata/reminders_test/test_build_email_tasks_prepublication.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_prepublication.html
@@ -16,7 +16,7 @@ and then revise your feature summary to prepare it for
 publication.</p>
 
 <p>Here's what we have now for publication:</p>
-<h3>feature one<h3>
+<h3>feature one</h3>
 <p>sum</p>
 
 <p><a href="http://127.0.0.1:8888//guide/edit/123">Edit your feature</a></p>

--- a/templates/prepublication-notice-email.html
+++ b/templates/prepublication-notice-email.html
@@ -16,7 +16,7 @@ and then revise your feature summary to prepare it for
 publication.</p>
 
 <p>Here's what we have now for publication:</p>
-<h3>{{feature.name}}<h3>
+<h3>{{feature.name}}</h3>
 <p>{{feature.summary}}</p>
 
 <p><a href="{{site_url}}/guide/edit/{{id}}">Edit your feature</a></p>


### PR DESCRIPTION
This was making half the emails show up in a big bold font.