### PR TITLE
Schema migration staging fixes 2022-10-19

### DIFF
--- a/api/approvals_api_test.py
+++ b/api/approvals_api_test.py
@@ -35,6 +35,14 @@ class ApprovalsAPITest(testing_config.CustomTestCase):
         name='feature one', summary='sum', category=1)
     self.feature_1.put()
     self.feature_id = self.feature_1.key.integer_id()
+
+    self.gate_1 = review_models.Gate(feature_id=self.feature_id, stage_id=1,
+        gate_type=1, state=review_models.Approval.NA)
+    self.gate_1.put()
+    self.gate_2 = review_models.Gate(feature_id=self.feature_id, stage_id=2,
+        gate_type=2, state=review_models.Approval.NA)
+    self.gate_2.put()
+
     self.handler = approvals_api.ApprovalsAPI()
     self.request_path = '/api/v0/features/%d/approvals' % self.feature_id
 
@@ -67,6 +75,8 @@ class ApprovalsAPITest(testing_config.CustomTestCase):
     self.feature_1.key.delete()
     for appr in review_models.Approval.query():
       appr.key.delete()
+    for gate in review_models.Gate.query().fetch():
+      gate.key.delete()
 
   def test_get__all_empty(self):
     """We can get all approvals for a given feature, even if there none."""

--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -19,7 +19,7 @@ from typing import Any, Optional
 from framework import basehandlers
 from framework import permissions
 from internals import approval_defs
-from internals.review_models import Activity, Approval
+from internals.review_models import Activity, Approval, Gate, Vote
 from internals import notifier
 
 
@@ -46,9 +46,9 @@ class CommentsAPI(basehandlers.APIHandler):
     return comment.deleted_by is None or email == comment.deleted_by or is_admin
 
   def do_get(self, **kwargs) -> dict[str, list[dict[str, Any]]]:
+    """Return a list of all review comments on the given feature."""
     feature_id = kwargs['feature_id']
     field_id = kwargs.get('field_id', None)
-    """Return a list of all review comments on the given feature."""
     # Note: We assume that anyone may view approval comments.
     comments = Activity.get_activities(
         feature_id, field_id, comments_only=True)
@@ -65,31 +65,37 @@ class CommentsAPI(basehandlers.APIHandler):
   def do_post(self, **kwargs) -> dict[str, str]:
     """Add a review comment and possibly set a approval value."""
     feature_id = kwargs['feature_id']
-    gate_id = kwargs.get('gate_id', None)
+    gate_type = kwargs.get('gate_type', None)
     new_state = self.get_int_param(
         'state', required=False,
-        validator=Approval.is_valid_state)
+        validator=Vote.is_valid_state)
     feature = self.get_specified_feature(feature_id=feature_id)
     user = self.get_current_user(required=True)
     post_to_approval_field_id = self.get_param(
         'postToApprovalFieldId', required=False)
 
-    old_state = None
-    if gate_id is not None and new_state is not None:
+    if gate_type is not None and new_state is not None:
       old_approvals = Approval.get_approvals(
-          feature_id=feature_id, field_id=gate_id,
+          feature_id=feature_id, field_id=gate_type,
           set_by=user.email())
 
-      approvers = approval_defs.get_approvers(gate_id)
+      approvers = approval_defs.get_approvers(gate_type)
       if not permissions.can_approve_feature(user, feature, approvers):
         self.abort(403, msg='User is not an approver')
       Approval.set_approval(
-          feature.key.integer_id(), gate_id, new_state, user.email())
-      approval_defs.set_vote(feature_id, gate_id, new_state, user.email())
+          feature.key.integer_id(), gate_type, new_state, user.email())
+      approval_defs.set_vote(feature_id, gate_type, new_state, user.email())
 
     comment_content = self.get_param('comment', required=False)
 
     if comment_content:
+      # TODO(danielrsmith): After UI changes, gate_id should be passed in
+      # post request and not queried for.
+      gates: list[Gate] = Gate.query(
+          Gate.feature_id == feature_id, Gate.gate_type == gate_type).fetch()
+      gate_id = None
+      if len(gates) > 0:
+        gate_id = gates[0].key.integer_id()
       # Schema migration double-write.
       comment_activity = Activity(feature_id=feature_id, gate_id=gate_id,
           author=user.email(), content=comment_content)

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -166,7 +166,7 @@ def set_vote(
     gate_id: Optional[int]=None) -> None:
   """Add or update an approval value."""
   gate: Optional[Gate] = None
-  if not gate_id:
+  if gate_id is None:
     gate = get_gate_by_type(feature_id, gate_type)
     # If a vote is being set, a corresponding gate should already exist.
     if not gate:

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -285,7 +285,7 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
       review_models.Approval.set_approval(
           feature_id, approval_field.field_id,
           review_models.Approval.APPROVED, from_addr)
-      approval_defs.set_vote(feature_id,approval_field.field_id,
+      approval_defs.set_vote(feature_id, approval_field.field_id,
           review_models.Vote.APPROVED, from_addr)
       self.record_lgtm(feature, approval_field, from_addr)
 
@@ -298,7 +298,7 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
         review_models.Approval.set_approval(
             feature_id, approval_field.field_id,
             review_models.Approval.REVIEW_REQUESTED, from_addr)
-        approval_defs.set_vote(feature_id,approval_field.field_id,
+        approval_defs.set_vote(feature_id, approval_field.field_id,
             review_models.Vote.APPROVED, from_addr)
 
   def record_lgtm(self, feature, approval_field, from_addr):

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -328,6 +328,13 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
     self.feature_1.put()
     self.feature_id = self.feature_1.key.integer_id()
 
+    self.gate_1 = review_models.Gate(feature_id=self.feature_id, stage_id=1,
+        gate_type=1, state=review_models.Approval.NA)
+    self.gate_1.put()
+    self.gate_2 = review_models.Gate(feature_id=self.feature_id, stage_id=2,
+        gate_type=4, state=review_models.Approval.NA)
+    self.gate_2.put()
+
     self.request_path = '/tasks/detect-intent'
 
     self.thread_url = (
@@ -357,6 +364,8 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
     self.feature_1.key.delete()
     for appr in review_models.Approval.query().fetch(None):
       appr.key.delete()
+    for gate in review_models.Gate.query().fetch():
+      gate.key.delete()
 
   def test_process_post_data__new_thread(self):
     """When we detect a new thread, we record it as the intent thread."""

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -108,13 +108,6 @@ class Approval(ndb.Model):
     new_appr.put()
     logging.info('new_appr is %r', new_appr.key.integer_id())
 
-    # Write for new Vote entity.
-    new_vote = Vote(
-        id=new_appr.key.integer_id(), feature_id=feature_id, gate_id=field_id,
-        state=new_state, set_on=now, set_by=set_by_email)
-    new_vote.put()
-    logging.info('new_vote is %r', new_vote.key.integer_id())
-
   @classmethod
   def clear_request(cls, feature_id, field_id):
     """After the review requirement has been satisfied, remove the request."""

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -36,14 +36,6 @@ class ApprovalTest(testing_config.CustomTestCase):
         set_by='one@example.com')
     self.appr_1.put()
 
-    # Approval 1 has already been migrated to a Vote entity.
-    self.vote_1 = Vote(id=self.appr_1.key.integer_id(),
-        feature_id=self.feature_1_id, gate_id=1,
-        state=Vote.REVIEW_REQUESTED,
-        set_on=datetime.datetime.now() - datetime.timedelta(1),
-        set_by='one@example.com')
-    self.vote_1.put()
-
     self.appr_2 = Approval(
         feature_id=self.feature_1_id, field_id=1,
         state=Approval.APPROVED,
@@ -103,9 +95,6 @@ class ApprovalTest(testing_config.CustomTestCase):
     self.assertEqual(
         4,
         len(Approval.query().fetch(None)))
-    
-    # Check that the Vote entity was also created.
-    self.assertEqual(2, len(Vote.query().fetch()))
 
   def test_clear_request(self):
     """We can clear a review request so that it is no longer pending."""

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -305,7 +305,7 @@ class MigrateEntities(FlaskHandler):
     num_gates += totals[0]
     num_votes += totals[1]
     # Return number of Stage entities created.
-    return 6, num_gates, num_votes
+    return 7, num_gates, num_votes
 
   @classmethod
   def write_existing_stages(cls, feature, devtrial_mstones, ot_mstones,
@@ -348,7 +348,7 @@ class MigrateEntities(FlaskHandler):
     num_gates += totals[0]
     num_votes += totals[1]
     # Return number of Stage entities created.
-    return 4, num_gates, num_votes
+    return 5, num_gates, num_votes
 
   @classmethod
   def write_code_change_stages(cls, feature, devtrial_mstones, ship_mstones):
@@ -410,4 +410,4 @@ class MigrateEntities(FlaskHandler):
     stage = Stage(stage_type=STAGE_DEP_REMOVE_CODE, **kwargs)
     stage.put()
     # Return number of Stage entities created.
-    return 5, num_gates, num_votes
+    return 6, num_gates, num_votes


### PR DESCRIPTION
- Fixed approval_defs.set_vote() to write `Vote.gate_id` properly. Previously was erroneously writing `gate_type` to `gate_id`, as well as passing in `gate_type` in a number of places with the name of `gate_id`.
- Created Gate entities in tests to allow Vote entities to be properly written with a corresponding `gate_id`.
- Incremented stage counts in schema migration script properly reflect the amount of stages created.
- Removed Vote double-write call in Approval.set_approval(). This is no longer needed as approval_defs.set_vote() is being called in the places it is necessary.