### PR TITLE
Fix changing filter field.

### DIFF
--- a/client-src/elements/chromedash-feature-filter.js
+++ b/client-src/elements/chromedash-feature-filter.js
@@ -293,15 +293,6 @@ class ChromedashFeatureFilter extends LitElement {
     `;
   }
 
-  handleChangeField(fieldName, index) {
-    // Reset values and operator
-    const newCond = {
-      fieldName: fieldName,
-      op: this.findAvailableOps(fieldName)[0],
-    };
-    this.replaceCond(newCond, index);
-  }
-
   renderFilterFieldMenu(fieldName, index) {
     return html`
       <select class="cond-field-menu"
@@ -339,6 +330,17 @@ class ChromedashFeatureFilter extends LitElement {
         `)}
       </select>
     `;
+  }
+
+  handleChangeField(fieldName, index) {
+    // Reset field and operator, but keep value, low, and high.
+    const oldCond = this.filterConditions[index];
+    const newCond = {
+      ...oldCond,
+      fieldName: fieldName,
+      op: this.findAvailableOps(fieldName)[0],
+    };
+    this.replaceCond(newCond, index);
   }
 
   handleChangeValue(value, index) {


### PR DESCRIPTION
This fixes a bug that I found in the new feature list page query builder.

The failure occurred if the user:
1. selected one field to search on (e.g., created) and set a value to search for,
2. changed the field to search on
3. submitted

The UI shows the value entered in step 1, however step 2 actually lost that value.
In this PR:
* keep all value details when changing the search field 