### PR TITLE
Migrate votes and set Gate state separately

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -29,8 +29,14 @@ cron:
 - description: Copy over Comment entities to new Activity entities.
   url: /cron/schema_migration_comment_activity
   schedule: 1 of jan 00:00
-- description: Migrate over most major entities to new schema.
+- description: Create FeatureEntry, Stage, and Gate entities for features.
   url: /cron/schema_migration_entities
+  schedule: 1 of jan 00:00
+- description: Copy over Approval entities to new Vote entities.
+  url: /cron/schema_migration_approval_vote
+  schedule: 1 of jan 00:00
+- description: Reevaluate all Gate entity states.
+  url: /cron/schema_migration_gate_status
   schedule: 1 of jan 00:00
 - description: Copy over deprecated standardization field
   url: /cron/write_standard_maturity

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -95,6 +95,7 @@ class MigrateCommentsToActivities(FlaskHandler):
     return (f'{old_migrations_deleted} Activities deleted '
         'from previous migration.')
 
+
 class MigrateEntities(FlaskHandler):
 
   def get_template_data(self, **kwargs):
@@ -183,7 +184,6 @@ class MigrateEntities(FlaskHandler):
   @classmethod
   def write_stages_for_feature(cls, feature):
     """Creates new Stage entities MilestoneSet entities based on Feature data"""
-    stages, gates, votes = 0, 0, 0
     # Create MilestoneSets for each major paradigm.
     devtrial_mstones = MilestoneSet(
         desktop_first=feature.dt_milestone_desktop_start,
@@ -210,204 +210,201 @@ class MigrateEntities(FlaskHandler):
     # create a different group of Stage entities.
     f_type = feature.feature_type
     if f_type == FEATURE_TYPE_INCUBATE_ID:
-      stages, gates, votes = cls.write_incubate_stages(
+      cls.write_incubate_stages(
           feature, devtrial_mstones, ot_mstones, extension_mstones, ship_mstones)
     elif f_type == FEATURE_TYPE_EXISTING_ID:
-      stages, gates, votes = cls.write_existing_stages(
+      cls.write_existing_stages(
           feature, devtrial_mstones, ot_mstones, extension_mstones, ship_mstones)
     elif f_type == FEATURE_TYPE_CODE_CHANGE_ID:
-      stages, gates, votes = cls.write_code_change_stages(
+      cls.write_code_change_stages(
           feature, devtrial_mstones, ship_mstones)
     elif f_type == FEATURE_TYPE_DEPRECATION_ID:
-      stages, gates, votes = cls.write_deprecation_stages(
+      cls.write_deprecation_stages(
           feature, devtrial_mstones, ot_mstones, extension_mstones, ship_mstones)
     else:
       logging.error(f'Invalid feature type {f_type} for {feature.name}')
-    
-    message = (f'Created {stages} stages, {gates} gates, and {votes} votes '
-               f'for feature {feature.key.integer_id()}')
-    logging.info(message)
 
   @classmethod
-  def write_gate(cls, feature_id, stage, gate_type):
+  def write_gate(cls, feature_id, stage_id, gate_type):
     """Writes a Gate entity to match the stage created."""
-    gate = Gate(feature_id=feature_id, stage_id=stage.key.integer_id(),
+    gate = Gate(feature_id=feature_id, stage_id=stage_id,
         gate_type=gate_type, state=Vote.NA)
-    # Determine the state the Gate should have.
-    approvals: list = Approval.query().filter(Approval.feature_id == feature_id)
-    if approval_defs.is_approved(approvals, gate_type):
-      gate.state = Vote.APPROVED
-    elif approval_defs.is_resolved(approvals, gate_type):
-      gate.state = Vote.NOT_APPROVED
     gate.put()
-
-    # Filter Approval entities by the gate type and write Vote entities.
-    approvals = [
-        appr for appr in approvals if appr.field_id == gate_type]
-    num_votes = cls.write_votes(feature_id, gate.key.integer_id(), approvals)
-
-    return 1, num_votes
-
-  @classmethod
-  def write_votes(cls, feature_id, gate_id, approvals):
-    """Migrate Vote entities for given feature and gate IDs."""
-    count = 0
-    for appr in approvals:
-      vote = Vote(feature_id=feature_id, gate_id=gate_id, state=appr.state,
-          set_on=appr.set_on, set_by=appr.set_by)
-      vote.put()
-      count += 1
-    
-    return count
 
   @classmethod
   def write_incubate_stages(cls, feature, devtrial_mstones, ot_mstones,
       extension_mstones, ship_mstones):
     feature_id = feature.key.integer_id()
     kwargs = {'feature_id': feature_id, 'browser': 'Chrome'}
-    num_gates, num_votes = 0, 0
 
     stage = Stage(stage_type=STAGE_BLINK_INCUBATE, **kwargs)
     stage.put()
+
     stage = Stage(stage_type=STAGE_BLINK_PROTOTYPE,
         intent_thread_url=feature.intent_to_implement_url, **kwargs)
     stage.put()
-    totals = cls.write_gate(feature_id, stage, PROTOTYPE_ENUM)
-    num_gates += totals[0]
-    num_votes += totals[1]
+    cls.write_gate(feature_id, stage.key.integer_id(), PROTOTYPE_ENUM)
+
     stage = Stage(stage_type=STAGE_BLINK_DEV_TRIAL, milestones=devtrial_mstones,
         announcement_url=feature.ready_for_trial_url, **kwargs)
     stage.put()
+
     stage = Stage(stage_type=STAGE_BLINK_EVAL_READINESS, **kwargs)
     stage.put()
+
     stage = Stage(stage_type=STAGE_BLINK_ORIGIN_TRIAL, milestones=ot_mstones,
         intent_thread_url=feature.intent_to_experiment_url,
         experiment_goals=feature.experiment_goals,
         origin_trial_feedback_url=feature.origin_trial_feedback_url, **kwargs)
     stage.put()
-    totals = cls.write_gate(feature_id, stage, OT_ENUM)
-    num_gates += totals[0]
-    num_votes += totals[1]
+    cls.write_gate(feature_id, stage.key.integer_id(), OT_ENUM)
+
     stage = Stage(stage_type=STAGE_BLINK_EXTEND_ORIGIN_TRIAL,
         milestones=extension_mstones,
         intent_thread_url=feature.intent_to_extend_experiment_url,
         experiment_extension_reason=feature.experiment_extension_reason,
         ot_stage_id=stage.key.integer_id(), **kwargs)
     stage.put()
-    totals = cls.write_gate(feature_id, stage, EXTEND_ENUM)
-    num_gates += totals[0]
-    num_votes += totals[1]
+    cls.write_gate(feature_id, stage.key.integer_id(), EXTEND_ENUM)
     stage = Stage(stage_type=STAGE_BLINK_SHIPPING, milestones=ship_mstones,
         intent_thread_url=feature.intent_to_ship_url,
         finch_url=feature.finch_url, **kwargs)
+
     stage.put()
-    totals = cls.write_gate(feature_id, stage, SHIP_ENUM)
-    num_gates += totals[0]
-    num_votes += totals[1]
-    # Return number of Stage entities created.
-    return 7, num_gates, num_votes
+    cls.write_gate(feature_id, stage.key.integer_id(), SHIP_ENUM)
 
   @classmethod
   def write_existing_stages(cls, feature, devtrial_mstones, ot_mstones,
       extension_mstones, ship_mstones):
     feature_id = feature.key.integer_id()
     kwargs = {'feature_id': feature_id, 'browser': 'Chrome'}
-    num_gates, num_votes = 0, 0
 
     stage = Stage(stage_type=STAGE_FAST_PROTOTYPE,
         intent_thread_url=feature.intent_to_implement_url, **kwargs)
     stage.put()
-    totals = cls.write_gate(feature_id, stage, PROTOTYPE_ENUM)
-    num_gates += totals[0]
-    num_votes += totals[1]
+    cls.write_gate(feature_id, stage.key.integer_id(), PROTOTYPE_ENUM)
+
     stage = Stage(stage_type=STAGE_FAST_DEV_TRIAL, milestones=devtrial_mstones,
         announcement_url=feature.ready_for_trial_url, **kwargs)
     stage.put()
+
     stage = Stage(stage_type=STAGE_FAST_ORIGIN_TRIAL, milestones=ot_mstones,
         intent_thread_url=feature.intent_to_experiment_url,
         experiment_goals=feature.experiment_goals,
         origin_trial_feedback_url=feature.origin_trial_feedback_url, **kwargs)
     stage.put()
-    totals = cls.write_gate(feature_id, stage, OT_ENUM)
-    num_gates += totals[0]
-    num_votes += totals[1]
+    cls.write_gate(feature_id, stage.key.integer_id(), OT_ENUM)
+
     stage = Stage(stage_type=STAGE_FAST_EXTEND_ORIGIN_TRIAL,
         milestones=extension_mstones,
         intent_thread_url=feature.intent_to_extend_experiment_url,
         experiment_extension_reason=feature.experiment_extension_reason,
         ot_stage_id=stage.key.integer_id(), **kwargs)
     stage.put()
-    totals = cls.write_gate(feature_id, stage, EXTEND_ENUM)
-    num_gates += totals[0]
-    num_votes += totals[1]
+    cls.write_gate(feature_id, stage.key.integer_id(), EXTEND_ENUM)
+
     stage = Stage(stage_type=STAGE_FAST_SHIPPING,  milestones=ship_mstones,
         intent_thread_url=feature.intent_to_ship_url,
         finch_url=feature.finch_url, **kwargs)
     stage.put()
-    totals = cls.write_gate(feature_id, stage, SHIP_ENUM)
-    num_gates += totals[0]
-    num_votes += totals[1]
-    # Return number of Stage entities created.
-    return 5, num_gates, num_votes
+    cls.write_gate(feature_id, stage.key.integer_id(), SHIP_ENUM)
 
   @classmethod
   def write_code_change_stages(cls, feature, devtrial_mstones, ship_mstones):
     feature_id = feature.key.integer_id()
     kwargs = {'feature_id': feature_id, 'browser': 'Chrome'}
-    num_gates, num_votes = 0, 0
 
     stage = Stage(stage_type=STAGE_PSA_IMPLEMENT, **kwargs)
     stage.put()
+
     stage = Stage(stage_type=STAGE_PSA_DEV_TRIAL, milestones=devtrial_mstones,
         announcement_url=feature.ready_for_trial_url,  **kwargs)
     stage.put()
+
     stage = Stage(stage_type=STAGE_PSA_SHIPPING,  milestones=ship_mstones,
         intent_thread_url=feature.intent_to_ship_url,
         finch_url=feature.finch_url, **kwargs)
     stage.put()
-    totals = cls.write_gate(feature_id, stage, SHIP_ENUM)
-    num_gates += totals[0]
-    num_votes += totals[1]
-    # Return number of Stage entities created.
-    return 3, num_gates, num_votes
+    cls.write_gate(feature_id, stage.key.integer_id(), SHIP_ENUM)
 
   @classmethod
   def write_deprecation_stages(cls, feature, devtrial_mstones, ot_mstones,
       extension_mstones, ship_mstones):
     feature_id = feature.key.integer_id()
     kwargs = {'feature_id': feature_id, 'browser': 'Chrome'}
-    num_gates, num_votes = 0, 0
 
     stage = Stage(stage_type=STAGE_DEP_PLAN, **kwargs)
     stage.put()
+
     stage = Stage(stage_type=STAGE_DEP_DEV_TRIAL, milestones=devtrial_mstones,
         announcement_url=feature.ready_for_trial_url, **kwargs)
     stage.put()
+
     stage = Stage(stage_type=STAGE_DEP_DEPRECATION_TRIAL, milestones=ot_mstones,
         intent_thread_url=feature.intent_to_experiment_url,
         experiment_goals=feature.experiment_goals,
         origin_trial_feedback_url=feature.origin_trial_feedback_url, **kwargs)
     stage.put()
-    totals = cls.write_gate(feature_id, stage, OT_ENUM)
-    num_gates += totals[0]
-    num_votes += totals[1]
+
+    cls.write_gate(feature_id, stage.key.integer_id(), OT_ENUM)
+
     stage = Stage(stage_type=STAGE_DEP_EXTEND_DEPRECATION_TRIAL,
         milestones=extension_mstones,
         intent_thread_url=feature.intent_to_extend_experiment_url,
         experiment_extension_reason=feature.experiment_extension_reason,
         ot_stage_id=stage.key.integer_id(), **kwargs)
     stage.put()
-    totals = cls.write_gate(feature_id, stage, EXTEND_ENUM)
-    num_gates += totals[0]
-    num_votes += totals[1]
+    cls.write_gate(feature_id, stage.key.integer_id(), EXTEND_ENUM)
+
     stage = Stage(stage_type=STAGE_DEP_SHIPPING,  milestones=ship_mstones,
         intent_thread_url=feature.intent_to_ship_url,
         finch_url=feature.finch_url, **kwargs)
     stage.put()
-    totals = cls.write_gate(feature_id, stage, SHIP_ENUM)
-    num_gates += totals[0]
-    num_votes += totals[1]
+    cls.write_gate(feature_id, stage.key.integer_id(), SHIP_ENUM)
+
     stage = Stage(stage_type=STAGE_DEP_REMOVE_CODE, **kwargs)
     stage.put()
-    # Return number of Stage entities created.
-    return 6, num_gates, num_votes
+
+
+class MigrateApprovalsToVotes(FlaskHandler):
+
+  def get_template_data(self, **kwargs):
+    """Migrate all Approval entities to Vote entities."""
+    self.require_cron_header()
+
+    approvals: ndb.Query = Approval.query()
+    count = 0
+    for approval in approvals:
+      vote = Vote.get_by_id(approval.key.integer_id())
+      if vote:
+        continue
+
+      gates = Gate.query(
+          Gate.feature_id == approval.feature_id,
+          Gate.gate_type == approval.field_id).fetch()
+      # Skip if no gate is found for the given approval.
+      if len(gates) == 0:
+        continue
+      gate_id = gates[0].key.integer_id()
+      vote = Vote(id=approval.key.integer_id(), feature_id=approval.feature_id,
+          gate_id=gate_id, state=approval.state, set_on=approval.set_on,
+          set_by=approval.set_by)
+      vote.put()
+      count += 1
+    
+    return f'{count} Approval entities migrated to Vote entities.'
+
+
+class EvaluateGateStatus(FlaskHandler):
+
+  def get_template_data(self, **kwargs):
+    """Evaluate all existing Gate entities and set correct state."""
+    self.require_cron_header()
+
+    gates: ndb.Query = Gate.query()
+    count = 0
+    for gate in gates:
+      approval_defs.update_gate_approval_state(gate)
+      count += 1
+    
+    return f'{count} Gate entities reevaluated.'

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -19,7 +19,7 @@ from datetime import datetime
 
 from internals.core_models import Feature, FeatureEntry, Stage
 from internals.review_models import Activity, Approval, Comment, Gate, Vote
-from internals import review_models, schema_migration
+from internals import schema_migration
 
 class MigrateCommentsToActivitiesTest(testing_config.CustomTestCase):
 
@@ -279,22 +279,42 @@ class MigrateEntitiesTest(testing_config.CustomTestCase):
       for entity in kind.query().fetch():
         entity.key.delete()
 
-  def test_migration(self):
-    migration_handler = schema_migration.MigrateEntities()
-    result = migration_handler.get_template_data()
-    # One is already migrated, so only 2 others to migrate.
+  def run_handler(self, handler):
+    return handler.get_template_data()
+
+  def test_migrations(self):
+    ## Test FeatureEntry migration. ##
+    handler_message = self.run_handler(
+        schema_migration.MigrateEntities())
     expected = '5 Feature entities migrated to FeatureEntry entities.'
-    self.assertEqual(result, expected)
+    self.assertEqual(handler_message, expected)
     feature_entries = FeatureEntry.query().fetch()
+    self.assertEqual(len(feature_entries), 5)
+
+    # Check if all fields have been copied over.
+    feature_entry_1 = FeatureEntry.get_by_id(
+        self.feature_1.key.integer_id())
+    self.assertIsNotNone(feature_entry_1)
+    # Check that all fields are copied over as expected.
+    for field in self.FEATURE_FIELDS:
+      self.assertEqual(
+          getattr(feature_entry_1, field), getattr(self.feature_1, field))
+    for old_field, new_field in self.RENAMED_FIELDS:
+      self.assertEqual(
+          getattr(feature_entry_1, new_field), getattr(self.feature_1, old_field))
+    self.assertEqual(feature_entry_1.updater_email, self.feature_1.updated_by.email())
+
+    # The migration should be idempotent, so nothing should be migrated twice.
+    handler_message = self.run_handler(
+        schema_migration.MigrateEntities())
+    expected = '0 Feature entities migrated to FeatureEntry entities.'
+    self.assertEqual(handler_message, expected)
+
+    self.assertEqual(handler_message, expected)
     stages = Stage.query().fetch()
     gates = Gate.query().fetch()
-    approvals = Vote.query().fetch()
-
-    self.assertEqual(len(feature_entries), 5)
     self.assertEqual(len(stages), 28)
     self.assertEqual(len(gates), 16)
-    self.assertEqual(len(approvals), 16)
-
     # Check if certain fields were copied over correctly.
     stages = Stage.query(
         Stage.feature_id == self.feature_1.key.integer_id()).fetch()
@@ -320,20 +340,16 @@ class MigrateEntitiesTest(testing_config.CustomTestCase):
     self.assertEqual(ot_stage_list[0].intent_thread_url,
         'https://example.com/intentexperiment')
 
-    # Check if all fields have been copied over.
-    feature_entry_1 = FeatureEntry.get_by_id(
-        self.feature_1.key.integer_id())
-    self.assertIsNotNone(feature_entry_1)
-    # Check that all fields are copied over as expected.
-    for field in self.FEATURE_FIELDS:
-      self.assertEqual(
-          getattr(feature_entry_1, field), getattr(self.feature_1, field))
-    for old_field, new_field in self.RENAMED_FIELDS:
-      self.assertEqual(
-          getattr(feature_entry_1, new_field), getattr(self.feature_1, old_field))
-    self.assertEqual(feature_entry_1.updater_email, self.feature_1.updated_by.email())
+    ## Test Vote migration. ##
+    handler_message = self.run_handler(
+        schema_migration.MigrateApprovalsToVotes())
+    expected = "16 Approval entities migrated to Vote entities."
+    self.assertEqual(handler_message, expected)
+    votes = Vote.query().fetch()
+    self.assertEqual(len(votes), 16)
 
     # The migration should be idempotent, so nothing should be migrated twice.
-    result_2 = migration_handler.get_template_data()
-    expected = '0 Feature entities migrated to FeatureEntry entities.'
-    self.assertEqual(result_2, expected)
+    handler_message = self.run_handler(
+        schema_migration.MigrateApprovalsToVotes())
+    expected = "0 Approval entities migrated to Vote entities."
+    self.assertEqual(handler_message, expected)

--- a/main.py
+++ b/main.py
@@ -197,6 +197,8 @@ internals_routes: list[tuple] = [
   ('/cron/remove_inactive_users', inactive_users.RemoveInactiveUsersHandler),
   ('/cron/schema_migration_comment_activity', schema_migration.MigrateCommentsToActivities),
   ('/cron/schema_migration_entities', schema_migration.MigrateEntities),
+  ('/cron/schema_migration_approval_vote', schema_migration.MigrateApprovalsToVotes),
+  ('/cron/schema_migration_gate_status', schema_migration.EvaluateGateStatus),
   ('/cron/write_standard_maturity', deprecate_field.WriteStandardMaturityHandler),
 
   ('/tasks/email-subscribers', notifier.FeatureChangeHandler),


### PR DESCRIPTION
This change is to handle the timeout issues for the schema migration script. The original implementation took too long to migrate all the entities in the production database. However, the process was completed after a rerun due to the migration being idempotent.

It includes:
- Moving Vote migration into a separate script.
- Evaluating Gate state in a separate script.
- Removing convoluted entity count tracking from main script.