### PR TITLE
Show a message to anyone that visits /samples.

### DIFF
--- a/main.py
+++ b/main.py
@@ -181,6 +181,8 @@ mpa_page_routes = [
     ('/features/<int:feature_id>', featurelist.FeatureListHandler),
     ('/features.xml', basehandlers.ConstHandler,
      {'template_path': 'farewell-rss.xml'}),
+    ('/samples', basehandlers.ConstHandler,
+     {'template_path': 'farewell-samples.html'}),
 
     ('/omaha_data', metrics.OmahaDataHandler),
 ]

--- a/main_test.py
+++ b/main_test.py
@@ -42,9 +42,9 @@ class ConstTemplateTest(testing_config.CustomTestCase):
 
     with test_app.test_request_context(request_path):
       template_data = handler.get_template_data(**defaults)
-    full_template_path = handler.get_template_path(template_data)
+      full_template_path = handler.get_template_path(template_data)
+      template_text = handler.render(template_data, full_template_path)
 
-    template_text = handler.render(template_data, full_template_path)
     parser = html5lib.HTMLParser(strict=True)
     document = parser.parse(template_text)
 

--- a/templates/farewell-samples.html
+++ b/templates/farewell-samples.html
@@ -1,0 +1,29 @@
+{% extends "_base.html" %}
+
+{% block css %}
+<style>
+  p {
+      padding: 1rem;
+      font-size: 1.2rem;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+  <p>This site no long offers a list of all features that have
+    samples.</p>
+
+  <p>If a feature entry has samples, a "Demos and samples" section
+    is shown on the feature detail page.</p>
+
+  <p>To view a collection of samples for a variety of features, visit
+    the <a href="https://github.com/GoogleChrome/samples"
+    >GoogleChrome/samples</a> repo on GitHub.</p>
+{% endblock %}
+
+
+{% block js %}
+  <script nonce="{{nonce}}">
+    document.body.classList.remove('loading');
+  </script>
+{% endblock %}


### PR DESCRIPTION
This should resolve #2309.

ChromeStatus used to have a /samples page that was basically a special feature list page that only listed features that had links to sample code.  It didn't get a lot of usage, so we phased out that page in 2021.

In this PR:
* Add a template that displays text directing the user to how to find samples.
* Add a server-side route to display that template at URL /samples.