### PR TITLE
Run the mypy executable that is in cs-env/bin.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "do-coverage": "coverage3 erase && coverage3 run -m unittest discover -p '*_test.py' -b && coverage3 html",
     "coverage": "source cs-env/bin/activate; (npm run start-emulator > /dev/null 2>&1 &); sleep 3; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-coverage;  npm run stop-emulator",
     "view-coverage": "pushd htmlcov/; python3 -m http.server 8080; popd",
-    "mypy": "mypy --ignore-missing-imports --exclude cs-env/ --exclude appengine_config.py .",
+    "mypy": "source cs-env/bin/activate; mypy --ignore-missing-imports --exclude cs-env/ --exclude appengine_config.py .",
     "lint": "gulp lint-fix && lit-analyzer \"client-src/elements/chromedash-!(featurelist)*.js\"",
     "presubmit": "npm test && npm run webtest && npm run lint && npm run mypy",
     "pylint": "pylint --output-format=parseable *py api/*py framework/*py internals/*py pages/*py",


### PR DESCRIPTION
I think that without the 'activate', it would be running the version of mypy the the user has installed in their OS.  It's better to run the version that is in cs-env because the version of that is controlled by requirements.dev.txt.