### PR TITLE
Rename NOT_APPROVED to DENIED.

### DIFF
--- a/client-src/elements/chromedash-approvals-dialog.js
+++ b/client-src/elements/chromedash-approvals-dialog.js
@@ -11,7 +11,7 @@ export const STATE_NAMES = [
   [3, 'Review started'],
   [4, 'Needs work'],
   [5, 'Approved'],
-  [6, 'Not approved'],
+  [6, 'Denied'],
 ];
 const PENDING_STATES = [2, 3, 4];
 

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -131,12 +131,12 @@ def is_valid_field_id(field_id):
 
 
 def is_approved(approval_values, field_id):
-  """Return true if we have all needed APPROVED values and no NOT_APPROVED."""
+  """Return true if we have all needed APPROVED values and no DENIED."""
   count = 0
   for av in approval_values:
     if av.state in (Approval.APPROVED, Approval.NA):
       count += 1
-    elif av.state == Approval.NOT_APPROVED:
+    elif av.state == Approval.DENIED:
       return False
   afd = APPROVAL_FIELDS_BY_ID[field_id]
 
@@ -154,9 +154,9 @@ def is_resolved(approval_values, field_id):
   if is_approved(approval_values, field_id):
     return True
 
-  # Any NOT_APPROVED value means that the review is no longer pending.
+  # Any DENIED value means that the review is no longer pending.
   for av in approval_values:
-    if av.state == Approval.NOT_APPROVED:
+    if av.state == Approval.DENIED:
       return True
 
   return False
@@ -214,8 +214,8 @@ def _calc_gate_status(gate: Gate) -> int:
   for vote in votes:
     if vote.state in (Vote.APPROVED, Vote.NA):
       approvals += 1
-    elif vote.state == Vote.NOT_APPROVED:
-      return Vote.NOT_APPROVED
+    elif vote.state == Vote.DENIED:
+      return Vote.DENIED
   afd = APPROVAL_FIELDS_BY_ID[gate.gate_type]
 
   if ((afd.rule == ONE_LGTM and approvals >= 1) or

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -130,7 +130,7 @@ class IsApprovedTest(testing_config.CustomTestCase):
         set_by='one@example.com')
     self.appr_no = review_models.Approval(
         feature_id=feature_1_id, field_id=1,
-        state=review_models.Approval.NOT_APPROVED,
+        state=review_models.Approval.DENIED,
         set_on=datetime.datetime.now(),
         set_by='two@example.com')
     self.appr_yes = review_models.Approval(

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -31,7 +31,7 @@ class Approval(ndb.Model):
   REVIEW_STARTED = 3
   NEEDS_WORK = 4
   APPROVED = 5
-  NOT_APPROVED = 6
+  DENIED = 6
   APPROVAL_VALUES = {
       # Not used: NEEDS_REVIEW: 'needs_review',
       NA: 'na',
@@ -39,10 +39,10 @@ class Approval(ndb.Model):
       REVIEW_STARTED: 'review_started',
       NEEDS_WORK: 'needs_work',
       APPROVED: 'approved',
-      NOT_APPROVED: 'not_approved',
+      DENIED: 'denied',
   }
 
-  FINAL_STATES = [NA, APPROVED, NOT_APPROVED]
+  FINAL_STATES = [NA, APPROVED, DENIED]
 
   feature_id = ndb.IntegerProperty(required=True)
   field_id = ndb.IntegerProperty(required=True)
@@ -105,7 +105,7 @@ class Approval(ndb.Model):
         feature_id=feature_id, field_id=field_id, states=[cls.REVIEW_REQUESTED])
     for rr in review_requests:
       rr.key.delete()
-    
+
     # Delete associated Vote entities as well.
     requested_votes = Vote.get_votes(feature_id=feature_id,
         gate_id=field_id, states=[Vote.REVIEW_REQUESTED])
@@ -227,7 +227,7 @@ class Gate(ndb.Model):  # copy from ApprovalConfig
 
   def is_resolved(self) -> bool:
     """Return if the Gate's outcome has been decided."""
-    return self.state == Vote.APPROVED or self.state == Vote.NOT_APPROVED
+    return self.state == Vote.APPROVED or self.state == Vote.DENIED
 
   def is_approved(self) -> bool:
     """Return if the Gate approval requirements have been met."""
@@ -244,7 +244,7 @@ class Vote(ndb.Model):  # copy from Approval
   REVIEW_STARTED = 3
   NEEDS_WORK = 4
   APPROVED = 5
-  NOT_APPROVED = 6
+  DENIED = 6
   VOTE_VALUES = {
       # Not used: NEEDS_REVIEW: 'needs_review',
       NA: 'na',
@@ -252,10 +252,10 @@ class Vote(ndb.Model):  # copy from Approval
       REVIEW_STARTED: 'review_started',
       NEEDS_WORK: 'needs_work',
       APPROVED: 'approved',
-      NOT_APPROVED: 'not_approved',
+      DENIED: 'denied',
   }
 
-  FINAL_STATES = [NA, APPROVED, NOT_APPROVED]
+  FINAL_STATES = [NA, APPROVED, DENIED]
 
   feature_id = ndb.IntegerProperty(required=True)
   gate_id = ndb.IntegerProperty(required=True)

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -182,7 +182,7 @@ class GateTest(testing_config.CustomTestCase):
     self.votes.append(Vote(feature_id=1, gate_id=gate_id, state=Vote.APPROVED,
         set_on=datetime.datetime(2020, 1, 1), set_by='user1@example.com'))
     self.votes.append(Vote(feature_id=1, gate_id=gate_id,
-        state=Vote.NOT_APPROVED, set_on=datetime.datetime(2020, 1, 1),
+        state=Vote.DENIED, set_on=datetime.datetime(2020, 1, 1),
         set_by='use21@example.com'))
     self.votes.append(Vote(feature_id=1, gate_id=gate_id,
         state=Vote.REVIEW_REQUESTED, set_on=datetime.datetime(2020, 2, 1),
@@ -214,7 +214,7 @@ class GateTest(testing_config.CustomTestCase):
         set_on=datetime.datetime(2021, 1, 1), set_by='user11@example.com'))
 
     # Some additional votes that should have no bearing on the gates.
-    self.votes.append(Vote(feature_id=2, gate_id=5, state=Vote.NOT_APPROVED,
+    self.votes.append(Vote(feature_id=2, gate_id=5, state=Vote.DENIED,
         set_on=datetime.datetime(2021, 1, 1), set_by='user11@example.com'))
     self.votes.append(Vote(feature_id=3, gate_id=3, state=Vote.REVIEW_REQUESTED,
         set_on=datetime.datetime(2021, 1, 1), set_by='user11@example.com'))
@@ -224,7 +224,7 @@ class GateTest(testing_config.CustomTestCase):
         set_on=datetime.datetime(2021, 1, 1), set_by='user11@example.com'))
     self.votes.append(Vote(feature_id=1, gate_id=2, state=Vote.APPROVED,
         set_on=datetime.datetime(2021, 1, 1), set_by='user11@example.com'))
-    
+
     for vote in self.votes:
       vote.put()
 
@@ -321,7 +321,7 @@ class ActivityTest(testing_config.CustomTestCase):
       self.assertEqual(field, result[i].field_name)
       self.assertEqual(before, result[i].old_value)
       self.assertEqual(expected, result[i].new_value)
-  
+
   def test_activities_created__no_stash(self):
     """If stash_values() is not called, no activity should be logged."""
     self.feature_1.owner = ["other@example.com"]

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -95,7 +95,7 @@ class MigrateEntitiesTest(testing_config.CustomTestCase):
       'security_risks', 'security_review_status', 'privacy_review_status',
       'ergonomics_risks', 'wpt', 'wpt_descr', 'webview_risks',
       'debuggability', 'doc_links', 'sample_links', 'experiment_timeline']
-  
+
   # (Feature field, FeatureEntry field)
   RENAMED_FIELDS = [('creator', 'creator_email'),
     ('owner', 'owner_emails'),
@@ -262,7 +262,7 @@ class MigrateEntitiesTest(testing_config.CustomTestCase):
     self.feature_5.put()
 
     # Create a "random" number of Approval entities.
-    appr_states = [Approval.NA, Approval.NOT_APPROVED, Approval.APPROVED]
+    appr_states = [Approval.NA, Approval.DENIED, Approval.APPROVED]
     for i in range(20):
       id = i % 5 + 1
       gate_type = i % 4 + 1


### PR DESCRIPTION
Monorail FLT used to offer an approval value "Not approved", but the internal launch tool uses "Denied".
Our users will have most recently used the launch tool, and they will continue to do use it in some cases, so we want to align our terminology with that tool.

This is not a schema change because the integer value store is the same as it has been, it is just a code and UI strings change.