### PR TITLE
Fix Dart Sass deprecation warnings

### DIFF
--- a/client-src/sass/blink.scss
+++ b/client-src/sass/blink.scss
@@ -72,7 +72,7 @@ body {
   }
 }
 .column_header {
-  margin-bottom: $content-padding / 2;
+  margin-bottom: calc($content-padding / 2);
 }
 .owners_list {
   flex: 1 0 auto;
@@ -81,7 +81,7 @@ body {
   font-weight: 600;
 }
 .owners_list_add_remove {
-  margin-left: $content-padding / 2;
+  margin-left: calc($content-padding / 2);
   opacity: 0;
   transition: 200ms opacity cubic-bezier(0,0,0.2,1);
   pointer-events: none;

--- a/client-src/sass/forms.scss
+++ b/client-src/sass/forms.scss
@@ -65,7 +65,7 @@ li {
 
 form[name="feature_form"] {
   h3 {
-    margin: $content-padding / 2 0;
+    margin: calc($content-padding / 2) 0;
   }
   input[type="submit"] {
     margin-top: $content-padding;


### PR DESCRIPTION
After the Node 18 update, some gulp deprecation warnings appear while building.
```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($content-padding, 2) or calc($content-padding / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
75 │   margin-bottom: $content-padding / 2;
   │                  ^^^^^^^^^^^^^^^^^^^^
   ╵
    client-src/sass/blink.scss 75:18  root stylesheet
```
This change is a simple fix to fix the warnings.