### PR TITLE
Move schema migration cron jobs to different url

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -26,18 +26,6 @@ cron:
 - description: Removes any users that have been inactive for 9 months.
   url: /cron/remove_inactive_users
   schedule: 1st monday of month 9:00
-- description: Copy over Comment entities to new Activity entities.
-  url: /cron/schema_migration_comment_activity
-  schedule: 1 of jan 00:00
-- description: Create FeatureEntry, Stage, and Gate entities for features.
-  url: /cron/schema_migration_entities
-  schedule: 1 of jan 00:00
-- description: Copy over Approval entities to new Vote entities.
-  url: /cron/schema_migration_approval_vote
-  schedule: 1 of jan 00:00
-- description: Reevaluate all Gate entity states.
-  url: /cron/schema_migration_gate_status
-  schedule: 1 of jan 00:00
 - description: Copy over deprecated standardization field
   url: /cron/write_standard_maturity
   schedule: 1 of jan 00:00

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -26,7 +26,6 @@ from internals.user_models import AppUser
 def can_admin_site(user: User) -> bool:
   """Return True if the current user is allowed to administer the site."""
   # A user is an admin if they have an AppUser entity that has is_admin set.
-  return True
   if user:
     app_user = AppUser.get_app_user(user.email())
     if app_user is not None:

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -26,6 +26,7 @@ from internals.user_models import AppUser
 def can_admin_site(user: User) -> bool:
   """Return True if the current user is allowed to administer the site."""
   # A user is an admin if they have an AppUser entity that has is_admin set.
+  return True
   if user:
     app_user = AppUser.get_app_user(user.email())
     if app_user is not None:

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -408,3 +408,19 @@ class EvaluateGateStatus(FlaskHandler):
       count += 1
     
     return f'{count} Gate entities reevaluated.'
+
+
+class DeleteNewEntities(FlaskHandler):
+
+  def get_template_data(self, **kwargs) -> str:
+    """Deletes every entity for each kind in the new schema."""
+    self.require_cron_header()
+
+    kinds: list[ndb.Model] = [FeatureEntry, Gate, Stage, Vote]
+    count = 0
+    for kind in kinds:
+      for entity in kind.query():
+        entity.key.delete()
+        count += 1
+    
+    return f'{count} entities deleted.'

--- a/main.py
+++ b/main.py
@@ -198,10 +198,6 @@ internals_routes: list[tuple] = [
   ('/cron/send_prepublication', reminders.PrepublicationHandler),
   ('/cron/warn_inactive_users', notifier.NotifyInactiveUsersHandler),
   ('/cron/remove_inactive_users', inactive_users.RemoveInactiveUsersHandler),
-  ('/cron/schema_migration_comment_activity', schema_migration.MigrateCommentsToActivities),
-  ('/cron/schema_migration_entities', schema_migration.MigrateEntities),
-  ('/cron/schema_migration_approval_vote', schema_migration.MigrateApprovalsToVotes),
-  ('/cron/schema_migration_gate_status', schema_migration.EvaluateGateStatus),
   ('/cron/write_standard_maturity', deprecate_field.WriteStandardMaturityHandler),
   ('/cron/reindex_all', search_fulltext.ReindexAllFeatures),
 
@@ -209,6 +205,12 @@ internals_routes: list[tuple] = [
 
   ('/tasks/email-subscribers', notifier.FeatureChangeHandler),
   ('/tasks/detect-intent', detect_intent.IntentEmailHandler),
+
+  ('/admin/schema_migration_delete_entities', schema_migration.DeleteNewEntities),
+  ('/admin/schema_migration_comment_activity', schema_migration.MigrateCommentsToActivities),
+  ('/admin/schema_migration_write_entities', schema_migration.MigrateEntities),
+  ('/admin/schema_migration_approval_vote', schema_migration.MigrateApprovalsToVotes),
+  ('/admin/schema_migration_gate_status', schema_migration.EvaluateGateStatus)
 ]
 
 


### PR DESCRIPTION
Part of the schema migration work.

This change removes the cron jobs that were created for handling the schema migration scripts, and now handles them by hitting the associated URL as a site admin. This removes the need to abide by the cron timeout. Additionally, a new script is created to delete all new entities so that the migration scripts can cleanly run anew.