### PR TITLE
Simplify our list of stopwords.

### DIFF
--- a/internals/search_fulltext.py
+++ b/internals/search_fulltext.py
@@ -29,11 +29,10 @@ WORD_RE = re.compile(r'\w\w\w+')
 
 # We ignore stop words because they return too many results to be useful.
 STOP_WORDS = frozenset((
-    'the and has was but was will are were with can this that have than then '
-    'for not now some '
-    'new add adds '
-    'http https www monorail com net org web bug bugs blink '
-    'gmail google chromium chrome github ').split())
+    'the and has have was will are were with but can this that than then '
+    'for not now '
+    'http https www com net org web bugs blink '
+    'gmail google chromium github ').split())
 
 
 class FeatureWords(ndb.Model):


### PR DESCRIPTION
The purpose of stop words is to avoid bogging down the system with indexing words that have very low value for searching, e.g., "the" and "and".   Any word that occurs in a high percentage of all feature entries is a candidate for being a stop word.

When I ran /admin/find_stop_words on prod, I found that our top words only occur in about 1/2 of our entries.  So, I dialed back our stop words a bit.  The ones that are now searchable are: "some", "new", "add", "adds".  And, "was" was listed twice.  These didn't crack the top 10, and are therefore in less than half of all entries, so I don't think the they need to be stop words.  Our full-text search performance seems good, so I feel that we can afford index these words, even if they are probably pretty common.