### PR TITLE
Adjust intent parsing to cope with more variations.

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -76,7 +76,7 @@ def detect_field(subject):
 
 
 CHROMESTATUS_LINK_GENERATED_RE = re.compile(
-    r'entry on the Chrome Platform Status:?\s+'
+    r'Chrome( Platform)? ?Status(.com)?[ \w]*:?\s+'
     r'[> ]*https?://(www\.)?chromestatus\.com/'
     r'(feature|guide/edit)/(?P<id>\d+)', re.I)
 CHROMESTATUS_LINK_ALTERNATE_RE = re.compile(

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -162,6 +162,17 @@ class FunctionTest(testing_config.CustomTestCase):
         5144822362931200,
         detect_intent.detect_feature_id(body))
 
+  def test_detect_feature_id__alternative(self):
+    """We can parse the feature ID from another common link."""
+    body = (
+        'blah blah blah\n'
+        'Entry on the feature dashboard\n'
+        'https://www.chromestatus.com/feature/5144822362931200\n'
+        'blah blah blah')
+    self.assertEqual(
+        5144822362931200,
+        detect_intent.detect_feature_id(body))
+
   def test_detect_feature_id__alternative_edit(self):
     """We can parse the feature ID from another common link."""
     body = (
@@ -190,6 +201,50 @@ class FunctionTest(testing_config.CustomTestCase):
         'blah blah blah\n'
         'Entry on the feature dashboard: <http://www.chromestatus.com/>\n'
         'https://chromestatus.com/feature/5144822362931200\n'
+        'blah blah blah')
+    self.assertEqual(
+        5144822362931200,
+        detect_intent.detect_feature_id(body))
+
+  def test_detect_feature_id__ad_hoc_1(self):
+    """We can parse, even if the user made up their own variation."""
+    body = (
+        'blah blah blah\n'
+        'Chrome Platform Status page:\n'
+        'https://www.chromestatus.com/feature/5144822362931200\n'
+        'blah blah blah')
+    self.assertEqual(
+        5144822362931200,
+        detect_intent.detect_feature_id(body))
+
+  def test_detect_feature_id__ad_hoc_2(self):
+    """We can parse, even if the user made up their own variation."""
+    body = (
+        'blah blah blah\n'
+        'Chrome Status Entry:\n'
+        'https://www.chromestatus.com/feature/5144822362931200\n'
+        'blah blah blah')
+    self.assertEqual(
+        5144822362931200,
+        detect_intent.detect_feature_id(body))
+
+  def test_detect_feature_id__ad_hoc_3(self):
+    """We can parse, even if the user made up their own variation."""
+    body = (
+        'blah blah blah\n'
+        'ChromeStatus.com launch:\n'
+        'https://www.chromestatus.com/feature/5144822362931200\n'
+        'blah blah blah')
+    self.assertEqual(
+        5144822362931200,
+        detect_intent.detect_feature_id(body))
+
+  def test_detect_feature_id__ad_hoc_4(self):
+    """We can parse, even if the user made up their own variation."""
+    body = (
+        'blah blah blah\n'
+        'ChromeStatus detail page:\n'
+        'https://www.chromestatus.com/feature/5144822362931200\n'
         'blah blah blah')
     self.assertEqual(
         5144822362931200,

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -162,17 +162,6 @@ class FunctionTest(testing_config.CustomTestCase):
         5144822362931200,
         detect_intent.detect_feature_id(body))
 
-  def test_detect_feature_id__alternative(self):
-    """We can parse the feature ID from another common link."""
-    body = (
-        'blah blah blah\n'
-        'Entry on the feature dashboard\n'
-        'https://www.chromestatus.com/feature/5144822362931200\n'
-        'blah blah blah')
-    self.assertEqual(
-        5144822362931200,
-        detect_intent.detect_feature_id(body))
-
   def test_detect_feature_id__alternative_edit(self):
     """We can parse the feature ID from another common link."""
     body = (


### PR DESCRIPTION
This intent slipped past our intent-detection logic because the email sender wrote their own section header name:
https://groups.google.com/a/chromium.org/g/blink-dev/c/JNOQvsTxecI

They wrote "Chrome Platform Status page:", which is reasonable, so we might as well try to accept it.