### PR TITLE
Add temporary rank skeletons and remove the show all button

### DIFF
--- a/client-src/elements/chromedash-stack-rank-page.js
+++ b/client-src/elements/chromedash-stack-rank-page.js
@@ -39,7 +39,7 @@ export class ChromedashStackRankPage extends LitElement {
       type: {type: String}, // "css" or "feature"
       view: {type: String}, // "popularity" or "animated"
       viewList: {attribute: false},
-      topList: {attribute: false},
+      tempList: {attribute: false},
     };
   }
 
@@ -48,7 +48,7 @@ export class ChromedashStackRankPage extends LitElement {
     this.type = '';
     this.view = '';
     this.viewList = [];
-    this.topList = [];
+    this.tempList = [];
   }
 
   connectedCallback() {
@@ -68,19 +68,17 @@ export class ChromedashStackRankPage extends LitElement {
       for (let i = 0, item; item = props[i]; ++i) {
         item.percentage = (item.day_percentage * 100).toFixed(6);
       }
-      this.viewList = props.filter((item) => {
+      const viewList = props.filter((item) => {
         return !['ERROR', 'PageVisits', 'PageDestruction'].includes(item.property_name);
       });
-      this.topList = this.viewList.slice(0, 30);
-      this.shadowRoot.querySelector('#show_all').disabled = false;
+      this.tempList = viewList.slice(0, 30);
+      // Set a timeout to avoid batch updates for tempList and viewList.
+      setTimeout(() => {
+        this.viewList = viewList;
+      }, 300);
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });
-  }
-
-  showAll() {
-    this.shadowRoot.querySelector('#show_all').disabled = true;
-    this.topList = this.viewList;
   }
 
   handleSearchBarChange(e) {
@@ -123,9 +121,9 @@ export class ChromedashStackRankPage extends LitElement {
       <chromedash-stack-rank
         .type=${this.type}
         .view=${this.view}
-        .viewList=${this.topList}>
+        .tempList=${this.tempList}
+        .viewList=${this.viewList}>
       </chromedash-stack-rank>
-      <sl-button id="show_all" disabled variant="primary" @click=${this.showAll}>Show All</sl-button>
     `;
   }
 

--- a/client-src/elements/chromedash-stack-rank.js
+++ b/client-src/elements/chromedash-stack-rank.js
@@ -1,4 +1,4 @@
-import {LitElement, css, html} from 'lit';
+import {LitElement, css, html, nothing} from 'lit';
 import '@polymer/iron-icon';
 import './chromedash-x-meter';
 import {SHARED_STYLES} from '../sass/shared-css.js';
@@ -13,6 +13,7 @@ class ChromedashStackRank extends LitElement {
       maxPercentage: {attribute: false},
       sortType: {type: String},
       sortReverse: {type: Boolean},
+      tempList: {attribute: false},
     };
   }
 
@@ -20,6 +21,7 @@ class ChromedashStackRank extends LitElement {
     super();
     this.type = '';
     this.viewList = [];
+    this.tempList = [];
     this.maxPercentage = 100;
     this.sortType = 'percentage';
     this.sortReverse = false;
@@ -210,9 +212,9 @@ class ChromedashStackRank extends LitElement {
     `;
   }
 
-  renderStackRank() {
+  renderStackRank(displayedList) {
     return html`
-      ${this.viewList.map((item) => html`
+      ${displayedList.map((item) => html`
         <li class="stack-rank-item" id="${item.property_name}">
           <div title="${item.property_name}. Click to deep link to this property.">
             <a class="stack-rank-item-name" href="#${item.property_name}" @click=${this.scrollToPosition}>
@@ -248,6 +250,13 @@ class ChromedashStackRank extends LitElement {
     `)}`;
   }
 
+  renderTemporaryRank() {
+    return html`
+      ${this.tempList.length ? this.renderStackRank(this.tempList) : nothing}
+      ${this.renderSkeletons()}
+    `;
+  }
+
   renderStackRankList() {
     return html`
       <ol class="stack-rank-list">
@@ -261,7 +270,7 @@ class ChromedashStackRank extends LitElement {
             </a>
           </div>
         </li>
-        ${this.viewList.length ? this.renderStackRank() : this.renderSkeletons()}
+        ${this.viewList.length ? this.renderStackRank(this.viewList) : this.renderTemporaryRank()}
       </ol>
     `;
   }


### PR DESCRIPTION
Fix https://github.com/GoogleChrome/chromium-dashboard/issues/2267. Add temporary rank skeletons and remove the show all button.

- Add 300ms timeout between the temporary list and the full property list, to avoid LitElement batch view updates