### PR TITLE
Upgrade search to use FeatureEntry

### DIFF
--- a/internals/search_queries_test.py
+++ b/internals/search_queries_test.py
@@ -74,7 +74,7 @@ class SearchFeaturesTest(testing_config.CustomTestCase):
   def test_single_field_query_async__normal(self):
     """We get a promise to run the DB query, which produces results."""
     actual_promise = search_queries.single_field_query_async(
-        'summary', '=', 'sum')
+        'owner', '=', 'owner@example.com')
     actual = actual_promise.get_result()
     self.assertCountEqual(
         [self.feature_1_id, self.feature_2_id],
@@ -83,7 +83,7 @@ class SearchFeaturesTest(testing_config.CustomTestCase):
   def test_single_field_query_async__zero_results(self):
     """When there are no matching results, we get back a promise for []."""
     actual_promise = search_queries.single_field_query_async(
-        'summary', '=', 'nope')
+        'owner', '=', 'nope')
     actual = actual_promise.get_result()
     self.assertCountEqual([], actual)
 

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -77,15 +77,25 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     self.feature_1 = core_models.Feature(
         name='feature 1', summary='sum', category=1, web_dev_views=1,
         impl_status_chrome=3)
-    self.feature_1.owner = ['owner@example.com']
-    self.feature_1.editors = ['editor@example.com']
-    self.feature_1.cc_recipients = ['cc@example.com']
     self.feature_1.put()
+    self.featureentry_1 = core_models.FeatureEntry(
+        id=self.feature_1.key.integer_id(),
+        name='feature 1', summary='sum', category=1, web_dev_views=1,
+        impl_status_chrome=3)
+    self.featureentry_1.owner_emails = ['owner@example.com']
+    self.featureentry_1.editor_emails = ['editor@example.com']
+    self.featureentry_1.cc_emailss = ['cc@example.com']
+    self.featureentry_1.put()
     self.feature_2 = core_models.Feature(
         name='feature 2', summary='sum', category=2, web_dev_views=1,
         impl_status_chrome=3)
-    self.feature_2.owner = ['owner@example.com']
     self.feature_2.put()
+    self.featureentry_2 = core_models.FeatureEntry(
+        id=self.feature_2.key.integer_id(),
+        name='feature 2', summary='sum', category=2, web_dev_views=1,
+        impl_status_chrome=3)
+    self.featureentry_2.owner_emails = ['owner@example.com']
+    self.featureentry_2.put()
     notifier.FeatureStar.set_star(
         'starrer@example.com', self.feature_1.key.integer_id())
 
@@ -95,6 +105,8 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
         starred=False)
     self.feature_1.key.delete()
     self.feature_2.key.delete()
+    self.featureentry_1.key.delete()
+    self.featureentry_2.key.delete()
     for appr in review_models.Approval.query():
       appr.key.delete()
 

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -206,46 +206,6 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     self.assertEqual(len(actual), 1)
     self.assertEqual(actual[0], self.feature_1.key.integer_id())
 
-  def test_process_access_me_query__owner_none(self):
-    """We can return a list of features owned by the user."""
-    testing_config.sign_in('visitor@example.com', 111)
-    actual = search.process_access_me_query('owner')
-    self.assertEqual(actual, [])
-
-  def test_process_access_me_query__owner_some(self):
-    """We can return a list of features owned by the user."""
-    testing_config.sign_in('owner@example.com', 111)
-    actual = search.process_access_me_query('owner')
-    self.assertEqual(len(actual), 2)
-    self.assertEqual(actual[0], self.feature_1.key.integer_id())
-    self.assertEqual(actual[1], self.feature_2.key.integer_id())
-
-  def test_process_access_me_query__editors_none(self):
-    """We can return a list of features the user can edit."""
-    testing_config.sign_in('visitor@example.com', 111)
-    actual = search.process_access_me_query('editors')
-    self.assertEqual(actual, [])
-
-  def test_process_access_me_query__editors_some(self):
-    """We can return a list of features the user can edit."""
-    testing_config.sign_in('editor@example.com', 111)
-    actual = search.process_access_me_query('editors')
-    self.assertEqual(len(actual), 1)
-    self.assertEqual(actual[0], self.feature_1.key.integer_id())
-
-  def test_process_access_me_query__cc_recipients_none(self):
-    """We can return a list of features the user is CC'd on."""
-    testing_config.sign_in('visitor@example.com', 111)
-    actual = search.process_access_me_query('cc_recipients')
-    self.assertEqual(actual, [])
-
-  def test_process_access_me_query__cc_recipients_some(self):
-    """We can return a list of features the user is CC'd on."""
-    testing_config.sign_in('cc@example.com', 111)
-    actual = search.process_access_me_query('cc_recipients')
-    self.assertEqual(len(actual), 1)
-    self.assertEqual(actual[0], self.feature_1.key.integer_id())
-
   @mock.patch('internals.review_models.Approval.get_approvals')
   @mock.patch('internals.approval_defs.fields_approvable_by')
   def test_process_recent_reviews_query__none(
@@ -309,7 +269,7 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
 
   @mock.patch('internals.search.process_pending_approval_me_query')
   @mock.patch('internals.search.process_starred_me_query')
-  @mock.patch('internals.search.process_access_me_query')
+  @mock.patch('internals.search_queries.handle_me_query_async')
   @mock.patch('internals.search.process_recent_reviews_query')
   def test_process_query__predefined(
       self, mock_recent, mock_own_me, mock_star_me, mock_pend_me):


### PR DESCRIPTION
In this PR:
* Upgrade search.py and search_queries.py to use FeatureEntry objects rather than Features.  The final objects returned to the APIs are still FeatureObjects.  Search just uses FeatureEntry objects while computing the list of feature IDs.
* Redo how the "me" predefined queries are processed.  This is more efficient because a future is returned rather than blocking on loading actual features early in the process, and it decouples from the get_all() function which still uses Feature objects.

With this PR, we lose the ability to search for fields that are in the Stages objects.   I will add that back in the next PR in this series.  It is OK to lose that functionality for now because it is not used by any part of the site that users can navigate to.  (The roadmap queries features by milestone using different code.)