### PR TITLE
Fix size and alignment of pagination icons.

### DIFF
--- a/client-src/elements/chromedash-feature-table.js
+++ b/client-src/elements/chromedash-feature-table.js
@@ -103,12 +103,20 @@ class ChromedashFeatureTable extends LitElement {
       css`
       .pagination {
         padding: var(--content-padding-half) 0;
-        text-align: right;
         min-height: 50px;
+        display: flex;
+        align-items: center;
+        justify-content: end;
       }
       .pagination span {
         color: var(--unimportant-text-color);
         margin-right: var(--content-padding);
+      }
+      .pagination sl-icon-button {
+        font-size: 1.4rem;
+      }
+      .pagination sl-icon-button::part(base) {
+        padding: 0;
       }
       table {
         width: 100%;

--- a/client-src/elements/chromedash-feature-table.js
+++ b/client-src/elements/chromedash-feature-table.js
@@ -113,7 +113,7 @@ class ChromedashFeatureTable extends LitElement {
         margin-right: var(--content-padding);
       }
       .pagination sl-icon-button {
-        font-size: 1.4rem;
+        font-size: 1.6rem;
       }
       .pagination sl-icon-button::part(base) {
         padding: 0;


### PR DESCRIPTION
This PR makes the pagination `<` and `>` icons bigger and better aligned with the pagination text.

Old screenshot:
![image](https://user-images.githubusercontent.com/17365/199130321-291ede59-ffee-4673-a2b7-19a4e25d6735.png)

New screenshot:
![image](https://user-images.githubusercontent.com/17365/199130628-176b72a6-aeae-4c46-a206-a3ee66d4255b.png)