### PR TITLE
Use FeatureEntry for most client-side use cases

### DIFF
--- a/api/approvals_api_test.py
+++ b/api/approvals_api_test.py
@@ -32,16 +32,16 @@ NOW = datetime.datetime.now()
 class ApprovalsAPITest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = core_models.Feature(
+    self.feature_1 = core_models.FeatureEntry(
         name='feature one', summary='sum', category=1)
     self.feature_1.put()
     self.feature_id = self.feature_1.key.integer_id()
 
     self.gate_1 = Gate(id=1, feature_id=self.feature_id, stage_id=1,
-        gate_type=1, state=Approval.NA)
+        gate_type=1, state=Vote.NA)
     self.gate_1.put()
     self.gate_2 = Gate(id=2, feature_id=self.feature_id, stage_id=2,
-        gate_type=2, state=Approval.NA)
+        gate_type=2, state=Vote.NA)
     self.gate_2.put()
 
     self.handler = approvals_api.ApprovalsAPI()
@@ -244,7 +244,7 @@ class ApprovalsAPITest(testing_config.CustomTestCase):
 class ApprovalConfigsAPITest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = core_models.Feature(
+    self.feature_1 = core_models.FeatureEntry(
         name='feature one', summary='sum', category=1)
     self.feature_1.put()
     self.feature_1_id = self.feature_1.key.integer_id()
@@ -253,7 +253,7 @@ class ApprovalConfigsAPITest(testing_config.CustomTestCase):
         owners=['one_a@example.com', 'one_b@example.com'])
     self.config_1.put()
 
-    self.feature_2 = core_models.Feature(
+    self.feature_2 = core_models.FeatureEntry(
         name='feature two', summary='sum', category=1)
     self.feature_2.put()
     self.feature_2_id = self.feature_2.key.integer_id()
@@ -262,7 +262,7 @@ class ApprovalConfigsAPITest(testing_config.CustomTestCase):
         owners=['two_a@example.com', 'two_b@example.com'])
     self.config_2.put()
 
-    self.feature_3 = core_models.Feature(
+    self.feature_3 = core_models.FeatureEntry(
         name='feature three', summary='sum', category=1)
     self.feature_3.put()
     self.feature_3_id = self.feature_3.key.integer_id()

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -77,7 +77,7 @@ class CommentsConvertersTest(testing_config.CustomTestCase):
 class CommentsAPITest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = core_models.Feature(
+    self.feature_1 = core_models.FeatureEntry(
         name='feature one', summary='sum', category=1)
     self.feature_1.put()
     self.feature_id = self.feature_1.key.integer_id()

--- a/api/converters.py
+++ b/api/converters.py
@@ -290,6 +290,8 @@ def feature_entry_to_json_verbose(fe: FeatureEntry) -> dict[str, Any]:
       stages['dev_trial'], 'ios_first', True)
   d['dt_milestone_webview_start'] = _stage_attr(
       stages['dev_trial'], 'webview_first', True)
+  d['ready_for_trial_url'] = _stage_attr(
+      stages['dev_trial'], 'announcement_url')
 
   # Origin trial stage fields.
   d['ot_milestone_desktop_start'] = _stage_attr(
@@ -320,6 +322,7 @@ def feature_entry_to_json_verbose(fe: FeatureEntry) -> dict[str, Any]:
 
   # Ship stage fields.
   d['intent_to_ship_url'] = _stage_attr(stages['ship'], 'intent_thread_url')
+  d['finch_url'] = _stage_attr(stages['ship'], 'finch_url')
 
   impl_status_chrome = d.pop('impl_status_chrome', None)
   standard_maturity = d.pop('standard_maturity', None)
@@ -427,3 +430,62 @@ def feature_entry_to_json_verbose(fe: FeatureEntry) -> dict[str, Any]:
 
   del_none(d) # Further prune response by removing null/[] values.
   return d
+
+def feature_entry_to_json_basic(fe: FeatureEntry) -> dict[str, Any]:
+  """Returns a dictionary with basic info about a feature."""
+  # Return an empty dictionary if the entity has not been saved to datastore.
+  if not fe.key:
+    return {}
+
+  return {
+    'id': fe.key.integer_id(),
+    'name': fe.name,
+    'summary': fe.summary,
+    'unlisted': fe.unlisted,
+    'blink_components': fe.blink_components or [],
+    'browsers': {
+      'chrome': {
+        'bug': fe.bug_url,
+        'blink_components': fe.blink_components or [],
+        'devrel': fe.devrel_emails or [],
+        'owners': fe.owner_emails or [],
+        'origintrial': fe.impl_status_chrome == ORIGIN_TRIAL,
+        'intervention': fe.impl_status_chrome == INTERVENTION,
+        'prefixed': fe.prefixed,
+        'flag': fe.impl_status_chrome == BEHIND_A_FLAG,
+        'status': {
+          'text': IMPLEMENTATION_STATUS[fe.impl_status_chrome],
+          'val': fe.impl_status_chrome
+        }
+      },
+      'ff': {
+        'view': {
+          'text': VENDOR_VIEWS[fe.ff_views],
+          'val': fe.ff_views,
+          'url': fe.ff_views_link,
+          'notes': fe.ff_views_notes,
+        }
+      },
+      'safari': {
+        'view': {
+          'text': VENDOR_VIEWS[fe.safari_views],
+          'val': fe.safari_views,
+          'url': fe.safari_views_link,
+          'notes': fe.safari_views_notes,
+        }
+      },
+      'webdev': {
+        'view': {
+          'text': WEB_DEV_VIEWS[fe.web_dev_views],
+          'val': fe.web_dev_views,
+          'url': fe.web_dev_views_link,
+          'notes': fe.web_dev_views_notes,
+        }
+      },
+      'other': {
+        'view': {
+          'notes': fe.other_views_notes,
+        }
+      },
+    }
+  }

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -85,7 +85,7 @@ class FeaturesAPI(basehandlers.APIHandler):
       return {'message': 'ID does not match any feature.'}
     feature.deleted = True
     feature.put()
-    rediscache.delete_keys_with_prefix(Feature.feature_cache_prefix())
+    rediscache.delete_keys_with_prefix(FeatureEntry.feature_cache_prefix())
 
     # Write for new FeatureEntry entity.
     feature_entry: Optional[FeatureEntry] = (

--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -28,7 +28,6 @@ export function formatFeatureForEdit(feature) {
 
     // from feature.standards
     spec_link: feature.standards.spec,
-    standardization: feature.standards.status.val,
     standard_maturity: feature.standards.maturity.val,
 
     tag_review_status: feature.tag_review_status_int,

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -35,7 +35,7 @@ from framework import users
 from framework import utils
 from framework import xsrf
 from internals import approval_defs
-from internals.core_models import Feature
+from internals.core_models import FeatureEntry
 from internals import user_models
 
 from google.auth.transport import requests
@@ -117,12 +117,13 @@ class BaseHandler(flask.views.MethodView):
       self.abort(400, msg='Parameter %r was not a bool' % name)
     return val
 
-  def get_specified_feature(self, feature_id: Optional[int]=None) -> Feature:
+  def get_specified_feature(
+      self, feature_id: Optional[int]=None) -> FeatureEntry:
     """Get the feature specified in the featureId parameter."""
     feature_id = (feature_id or
                   self.get_int_param('featureId', required=True))
     # Load feature directly from NDB so as to never get a stale cached copy.
-    feature = Feature.get_by_id(feature_id)
+    feature = FeatureEntry.get_by_id(feature_id)
     if not feature:
       self.abort(404, msg='Feature not found')
     user = self.get_current_user()

--- a/framework/permissions_test.py
+++ b/framework/permissions_test.py
@@ -77,11 +77,11 @@ class PermissionFunctionTests(testing_config.CustomTestCase):
     self.users.append(self.feature_editor)
 
     # Feature for checking permissions against
-    self.feature_1 = core_models.Feature(
+    self.feature_1 = core_models.FeatureEntry(
         name='feature one', summary='sum',
-        creator="feature_creator@example.com",
-        owner=['feature_owner@example.com'],
-        editors=['feature_editor@example.com'], category=1)
+        creator_email="feature_creator@example.com",
+        owner_emails=['feature_owner@example.com'],
+        editor_emails=['feature_editor@example.com'], category=1)
     self.feature_1.put()
     self.feature_id = self.feature_1.key.integer_id()
 

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -150,6 +150,67 @@ class Feature(DictModel):
     except Exception as e:
       logging.error(e)
 
+  def stash_values(self) -> None:
+
+    # Stash existing values when entity is created so we can diff property
+    # values later in put() to know what's changed.
+    # https://stackoverflow.com/a/41344898
+
+    for prop_name in self._properties.keys():
+      old_val = getattr(self, prop_name, None)
+      setattr(self, '_old_' + prop_name, old_val)
+    setattr(self, '_values_stashed', True)
+
+  def _get_changes_as_amendments(self) -> list[review_models.Amendment]:
+    """Get all feature changes as Amendment entities."""
+    # Diff values to see what properties have changed.
+    amendments = []
+    for prop_name in self._properties.keys():
+      if prop_name in (
+          'created_by', 'updated_by', 'updated', 'created'):
+        continue
+      new_val = getattr(self, prop_name, None)
+      old_val = getattr(self, '_old_' + prop_name, None)
+      if new_val != old_val:
+        if (new_val == '' or new_val == False) and old_val is None:
+          continue
+        amendments.append(
+            review_models.Amendment(field_name=prop_name,
+            old_value=str(old_val), new_value=str(new_val)))
+
+    return amendments
+
+  def put(self, notify: bool=True, **kwargs) -> Any:
+    is_update = self.is_saved()
+    amendments = self._get_changes_as_amendments()
+
+    # Document changes as new Activity entity with amendments only if all true:
+    # 1. This is an update to an existing feature.
+    # 2. We used stash_values() to document what fields changed.
+    # 3. One or more fields were changed.
+    should_write_activity = (is_update and hasattr(self, '_values_stashed')
+        and len(amendments) > 0)
+
+    if should_write_activity:
+      user = users.get_current_user()
+      email = user.email() if user else None
+      activity = review_models.Activity(feature_id=self.key.integer_id(),
+          author=email, content='')
+      activity.amendments = amendments
+      activity.put()
+
+    key = super(Feature, self).put(**kwargs)
+    if notify:
+      notifier_helpers.notify_feature_subscribers_of_changes(
+          self, amendments, is_update)
+
+    # Invalidate rediscache for the individual feature view.
+    cache_key = Feature.feature_cache_key(
+        Feature.DEFAULT_CACHE_KEY, self.key.integer_id())
+    rediscache.delete(cache_key)
+
+    return key
+
   # Metadata.
   created = ndb.DateTimeProperty(auto_now_add=True)
   updated = ndb.DateTimeProperty(auto_now=True)
@@ -402,75 +463,6 @@ class FeatureEntry(ndb.Model):  # Copy from Feature
   def feature_cache_prefix(cls):
     return '%s|*' % (cls.DEFAULT_CACHE_KEY)
 
-  @classmethod
-  def get_feature_entry(self, feature_id: int, update_cache: bool=False
-      ) -> Optional[FeatureEntry]:
-    KEY = self.feature_cache_key(
-        FeatureEntry.DEFAULT_CACHE_KEY, feature_id)
-    feature = rediscache.get(KEY)
-
-    if feature is None or update_cache:
-      entry = FeatureEntry.get_by_id(feature_id)
-      if entry:
-        if entry.deleted:
-          return None
-        rediscache.set(KEY, entry)
-
-    return entry
-
-  @classmethod
-  def filter_unlisted(self, entry_list: list[FeatureEntry]
-      ) -> list[FeatureEntry]:
-    """Filters feature entries to display only features the user should see."""
-    user = users.get_current_user()
-    email = None
-    if user:
-      email = user.email()
-    allowed_entries = []
-    for fe in entry_list:
-      # Owners and editors of a feature can see their unlisted features.
-      if (not fe.unlisted or
-          email in fe.owners or
-          email in fe.editors or
-          (email is not None and fe.creator == email)):
-        allowed_entries.append(fe)
-
-    return allowed_entries
-
-  @classmethod
-  def get_by_ids(self, entry_ids: list[int], update_cache: bool=False
-      ) -> list[int]:
-    """Return a list of FeatureEntry instances for the specified features.
-
-    Because the cache may rarely have stale data, this should only be
-    used for displaying data read-only, not for populating forms or
-    procesing a POST to edit data.  For editing use case, load the
-    data from NDB directly.
-    """
-    result_dict: dict[int, int] = {}
-    futures = []
-
-    for fe_id in entry_ids:
-      lookup_key = self.feature_cache_key(
-          FeatureEntry.DEFAULT_CACHE_KEY, fe_id)
-      entry = rediscache.get(lookup_key)
-      if entry is None or update_cache:
-        futures.append(FeatureEntry.get_by_id_async(fe_id))
-      else:
-        result_dict[fe_id] = entry
-
-    for future in futures:
-      entry = future.get_result()
-      if entry and not entry.deleted:
-        store_key = self.feature_cache_key(
-            FeatureEntry.DEFAULT_CACHE_KEY, entry.key.integer_id())
-        rediscache.set(store_key, entry)
-        result_dict[entry.key.integer_id()] = entry
-
-    result_list = [result_dict[fe_id] for fe_id in entry_ids
-                   if fe_id in result_dict]
-    return result_list
-  
   def stash_values(self) -> None:
     # Stash existing values when entity is created so we can diff property
     # values later in put() to know what's changed.
@@ -481,9 +473,14 @@ class FeatureEntry(ndb.Model):  # Copy from Feature
       setattr(self, '_old_' + prop_name, old_val)
     setattr(self, '_values_stashed', True)
 
-  def put(self, notify: bool=True, **kwargs) -> Any:
+  def put(self, notify: bool=False, **kwargs) -> Any:
     key = super(FeatureEntry, self).put(**kwargs)
-    notifier_helpers.notify_subscribers_and_save_amendments(self, notify)
+    # TODO(danielrsmith): Notifying subscribers will not fully function
+    # until stage fields are also stashed and marked as changed.
+    # Notifying and saving amendments is handled by Feature until then.
+    #
+    # notifier_helpers.notify_subscribers_and_save_amendments(self, notify)
+
     # Invalidate rediscache for the individual feature view.
     cache_key = FeatureEntry.feature_cache_key(
         FeatureEntry.DEFAULT_CACHE_KEY, self.key.integer_id())

--- a/internals/core_models_test.py
+++ b/internals/core_models_test.py
@@ -47,31 +47,52 @@ class ModelsFunctionsTest(testing_config.CustomTestCase):
 class FeatureTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_2 = core_models.Feature(
-        name='feature b', summary='sum', owner=['feature_owner@example.com'],
-        category=1)
+    self.feature_2 = core_models.FeatureEntry(
+        name='feature b', summary='sum',
+        owner_emails=['feature_owner@example.com'], category=1)
     self.feature_2.put()
 
-    self.feature_1 = core_models.Feature(
-        name='feature a', summary='sum', owner=['feature_owner@example.com'],
-        category=1, impl_status_chrome=3)
+    self.feature_1 = core_models.FeatureEntry(
+        name='feature a', summary='sum', impl_status_chrome=3,
+        owner_emails=['feature_owner@example.com'], category=1)
     self.feature_1.put()
 
-    self.feature_4 = core_models.Feature(
-        name='feature d', summary='sum', owner=['feature_owner@example.com'],
-        category=1, impl_status_chrome=2)
+    self.feature_4 = core_models.FeatureEntry(
+        name='feature d', summary='sum', category=1, impl_status_chrome=2,
+        owner_emails=['feature_owner@example.com'])
     self.feature_4.put()
 
-    self.feature_3 = core_models.Feature(
-        name='feature c', summary='sum', owner=['feature_owner@example.com'],
-        category=1, impl_status_chrome=2)
+    self.feature_3 = core_models.FeatureEntry(
+        name='feature c', summary='sum', category=1, impl_status_chrome=2,
+        owner_emails=['feature_owner@example.com'])
     self.feature_3.put()
 
+    # Legacy entities for testing legacy functions.
+    self.legacy_feature_2 = core_models.Feature(
+        name='feature b', summary='sum',
+        owner=['feature_owner@example.com'], category=1)
+    self.legacy_feature_2.put()
+
+    self.legacy_feature_1 = core_models.Feature(
+        name='feature a', summary='sum', impl_status_chrome=3,
+        owner=['feature_owner@example.com'], category=1)
+    self.legacy_feature_1.put()
+
+    self.legacy_feature_4 = core_models.Feature(
+        name='feature d', summary='sum', category=1, impl_status_chrome=2,
+        owner=['feature_owner@example.com'])
+    self.legacy_feature_4.put()
+
+    self.legacy_feature_3 = core_models.Feature(
+        name='feature c', summary='sum', category=1, impl_status_chrome=2,
+        owner=['feature_owner@example.com'])
+    self.legacy_feature_3.put()
+
   def tearDown(self):
-    self.feature_1.key.delete()
-    self.feature_2.key.delete()
-    self.feature_3.key.delete()
-    self.feature_4.key.delete()
+    for kind in [core_models.Feature, core_models.FeatureEntry]:
+      for entity in kind.query():
+        entity.key.delete()
+
     rediscache.flushall()
 
   def test_get_all__normal(self):
@@ -79,7 +100,7 @@ class FeatureTest(testing_config.CustomTestCase):
     actual = feature_helpers.get_all(update_cache=True)
     names = [f['name'] for f in actual]
     self.assertEqual(
-        ['feature c', 'feature d', 'feature a', 'feature b'],
+        ['feature b', 'feature a', 'feature d', 'feature c'],
         names)
 
     self.feature_1.summary = 'revised summary'
@@ -87,7 +108,7 @@ class FeatureTest(testing_config.CustomTestCase):
     actual = feature_helpers.get_all(update_cache=True)
     names = [f['name'] for f in actual]
     self.assertEqual(
-        ['feature a', 'feature c', 'feature d', 'feature b'],
+        ['feature b', 'feature a', 'feature d', 'feature c'],
         names)
 
   def test_get_all__category(self):
@@ -111,16 +132,16 @@ class FeatureTest(testing_config.CustomTestCase):
   def test_get_all__owner(self):
     """We can retrieve a list of all features with a given owner."""
     actual = feature_helpers.get_all(
-        filterby=('owner', 'owner@example.com'), update_cache=True)
+        filterby=('owner_emails', 'owner@example.com'), update_cache=True)
     names = [f['name'] for f in actual]
     self.assertEqual(
         [],
         names)
 
-    self.feature_1.owner = ['owner@example.com']
+    self.feature_1.owner_emails = ['owner@example.com']
     self.feature_1.put()  # Changes updated field.
     actual = feature_helpers.get_all(
-        filterby=('owner', 'owner@example.com'), update_cache=True)
+        filterby=('owner_emails', 'owner@example.com'), update_cache=True)
     names = [f['name'] for f in actual]
     self.assertEqual(
         ['feature a'],
@@ -129,26 +150,26 @@ class FeatureTest(testing_config.CustomTestCase):
   def test_get_all__owner_unlisted(self):
     """Unlisted features should still be visible to their owners."""
     self.feature_2.unlisted = True
-    self.feature_2.owner = ['feature_owner@example.com']
+    self.feature_2.owner_emails = ['feature_owner@example.com']
     self.feature_2.put()
     testing_config.sign_in('feature_owner@example.com', 1234567890)
     actual = feature_helpers.get_all(update_cache=True)
     names = [f['name'] for f in actual]
     testing_config.sign_out()
     self.assertEqual(
-      ['feature b', 'feature c', 'feature d', 'feature a'], names)
+      ['feature b', 'feature a', 'feature d', 'feature c'], names)
 
   def test_get_all__editor_unlisted(self):
     """Unlisted features should still be visible to feature editors."""
     self.feature_2.unlisted = True
-    self.feature_2.editors = ['feature_editor@example.com']
+    self.feature_2.editor_emails = ['feature_editor@example.com']
     self.feature_2.put()
     testing_config.sign_in("feature_editor@example.com", 1234567890)
     actual = feature_helpers.get_all(update_cache=True)
     names = [f['name'] for f in actual]
     testing_config.sign_out()
     self.assertEqual(
-      ['feature b', 'feature c', 'feature d', 'feature a'], names)
+      ['feature b', 'feature a', 'feature d', 'feature c'], names)
 
   def test_get_by_ids__empty(self):
     """A request to load zero features returns zero results."""
@@ -165,9 +186,9 @@ class FeatureTest(testing_config.CustomTestCase):
     self.assertEqual('feature a', actual[0]['name'])
     self.assertEqual('feature b', actual[1]['name'])
 
-    lookup_key_1 = '%s|%s' % (core_models.Feature.DEFAULT_CACHE_KEY,
+    lookup_key_1 = '%s|%s' % (core_models.FeatureEntry.DEFAULT_CACHE_KEY,
                               self.feature_1.key.integer_id())
-    lookup_key_2 = '%s|%s' % (core_models.Feature.DEFAULT_CACHE_KEY,
+    lookup_key_2 = '%s|%s' % (core_models.FeatureEntry.DEFAULT_CACHE_KEY,
                               self.feature_2.key.integer_id())
     self.assertEqual('feature a', rediscache.get(lookup_key_1)['name'])
     self.assertEqual('feature b', rediscache.get(lookup_key_2)['name'])
@@ -175,7 +196,7 @@ class FeatureTest(testing_config.CustomTestCase):
   def test_get_by_ids__cache_hit(self):
     """We can load features from rediscache."""
     cache_key = '%s|%s' % (
-        core_models.Feature.DEFAULT_CACHE_KEY, self.feature_1.key.integer_id())
+        core_models.FeatureEntry.DEFAULT_CACHE_KEY, self.feature_1.key.integer_id())
     cached_feature = {
       'name': 'fake cached_feature',
       'id': self.feature_1.key.integer_id(),
@@ -206,9 +227,7 @@ class FeatureTest(testing_config.CustomTestCase):
   def test_get_by_ids__cached_correctly(self):
     """We should no longer be able to trigger bug #1647."""
     # Cache one to try to trigger the bug.
-    feature_helpers.get_by_ids([
-        self.feature_2.key.integer_id(),
-        ])
+    feature_helpers.get_by_ids([self.feature_2.key.integer_id()])
 
     # Now do the lookup, but it would cache feature_2 at the key for feature_3.
     feature_helpers.get_by_ids([
@@ -246,8 +265,8 @@ class FeatureTest(testing_config.CustomTestCase):
 
   def test_get_chronological__unlisted(self):
     """Unlisted features are not included in the list."""
-    self.feature_2.unlisted = True
-    self.feature_2.put()
+    self.legacy_feature_2.unlisted = True
+    self.legacy_feature_2.put()
     actual = feature_helpers.get_chronological()
     names = [f['name'] for f in actual]
     self.assertEqual(
@@ -256,8 +275,8 @@ class FeatureTest(testing_config.CustomTestCase):
 
   def test_get_chronological__unlisted_shown(self):
     """Unlisted features are included for users with edit access."""
-    self.feature_2.unlisted = True
-    self.feature_2.put()
+    self.legacy_feature_2.unlisted = True
+    self.legacy_feature_2.put()
     actual = feature_helpers.get_chronological(show_unlisted=True)
     names = [f['name'] for f in actual]
     self.assertEqual(
@@ -266,21 +285,21 @@ class FeatureTest(testing_config.CustomTestCase):
 
   def test_get_in_milestone__normal(self):
     """We can retrieve a list of features."""
-    self.feature_2.impl_status_chrome = 7
-    self.feature_2.shipped_milestone = 1
-    self.feature_2.put()
+    self.legacy_feature_2.impl_status_chrome = 7
+    self.legacy_feature_2.shipped_milestone = 1
+    self.legacy_feature_2.put()
 
-    self.feature_1.impl_status_chrome = 5
-    self.feature_1.shipped_milestone = 1
-    self.feature_1.put()
+    self.legacy_feature_1.impl_status_chrome = 5
+    self.legacy_feature_1.shipped_milestone = 1
+    self.legacy_feature_1.put()
 
-    self.feature_3.impl_status_chrome = 5
-    self.feature_3.shipped_milestone = 1
-    self.feature_3.put()
+    self.legacy_feature_3.impl_status_chrome = 5
+    self.legacy_feature_3.shipped_milestone = 1
+    self.legacy_feature_3.put()
 
-    self.feature_4.impl_status_chrome = 7
-    self.feature_4.shipped_milestone = 2
-    self.feature_4.put()
+    self.legacy_feature_4.impl_status_chrome = 7
+    self.legacy_feature_4.shipped_milestone = 2
+    self.legacy_feature_4.put()
 
     actual = feature_helpers.get_in_milestone(milestone=1)
     removed = [f['name'] for f in actual['Removed']]
@@ -301,22 +320,22 @@ class FeatureTest(testing_config.CustomTestCase):
 
   def test_get_in_milestone__unlisted(self):
     """Unlisted features should not be listed for users who can't edit."""
-    self.feature_2.unlisted = True
-    self.feature_2.impl_status_chrome = 7
-    self.feature_2.shipped_milestone = 1
-    self.feature_2.put()
+    self.legacy_feature_2.unlisted = True
+    self.legacy_feature_2.impl_status_chrome = 7
+    self.legacy_feature_2.shipped_milestone = 1
+    self.legacy_feature_2.put()
 
-    self.feature_1.impl_status_chrome = 5
-    self.feature_1.shipped_milestone = 1
-    self.feature_1.put()
+    self.legacy_feature_1.impl_status_chrome = 5
+    self.legacy_feature_1.shipped_milestone = 1
+    self.legacy_feature_1.put()
 
-    self.feature_3.impl_status_chrome = 5
-    self.feature_3.shipped_milestone = 1
-    self.feature_3.put()
+    self.legacy_feature_3.impl_status_chrome = 5
+    self.legacy_feature_3.shipped_milestone = 1
+    self.legacy_feature_3.put()
 
-    self.feature_4.impl_status_chrome = 7
-    self.feature_4.shipped_milestone = 2
-    self.feature_4.put()
+    self.legacy_feature_4.impl_status_chrome = 7
+    self.legacy_feature_4.shipped_milestone = 2
+    self.legacy_feature_4.put()
 
     actual = feature_helpers.get_in_milestone(milestone=1)
     self.assertEqual(
@@ -325,22 +344,22 @@ class FeatureTest(testing_config.CustomTestCase):
 
   def test_get_in_milestone__unlisted_shown(self):
     """Unlisted features should be listed for users who can edit."""
-    self.feature_2.unlisted = True
-    self.feature_2.impl_status_chrome = 7
-    self.feature_2.shipped_milestone = 1
-    self.feature_2.put()
+    self.legacy_feature_2.unlisted = True
+    self.legacy_feature_2.impl_status_chrome = 7
+    self.legacy_feature_2.shipped_milestone = 1
+    self.legacy_feature_2.put()
 
-    self.feature_1.impl_status_chrome = 5
-    self.feature_1.shipped_milestone = 1
-    self.feature_1.put()
+    self.legacy_feature_1.impl_status_chrome = 5
+    self.legacy_feature_1.shipped_milestone = 1
+    self.legacy_feature_1.put()
 
-    self.feature_3.impl_status_chrome = 5
-    self.feature_3.shipped_milestone = 1
-    self.feature_3.put()
+    self.legacy_feature_3.impl_status_chrome = 5
+    self.legacy_feature_3.shipped_milestone = 1
+    self.legacy_feature_3.put()
 
-    self.feature_4.impl_status_chrome = 7
-    self.feature_4.shipped_milestone = 2
-    self.feature_4.put()
+    self.legacy_feature_4.impl_status_chrome = 7
+    self.legacy_feature_4.shipped_milestone = 2
+    self.legacy_feature_4.put()
 
     actual = feature_helpers.get_in_milestone(
         milestone=1, show_unlisted=True)

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -235,14 +235,14 @@ class FeatureStar(ndb.Model):
     if feature.star_count < 0:
       logging.error('count would be < 0: %r', (email, feature_id, starred))
       return
-    feature.put(notify=False)
+    feature.put()  # And, do not call notify.
 
     feature_entry = FeatureEntry.get_by_id(feature_id)
     feature_entry.star_count += 1 if starred else -1
     if feature_entry.star_count < 0:
       logging.error('count would be < 0: %r', (email, feature_id, starred))
       return
-    feature_entry.put()  # And, do not call notifiy.
+    feature_entry.put(notify=False)
 
   @classmethod
   def get_user_stars(self, email):

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -235,14 +235,14 @@ class FeatureStar(ndb.Model):
     if feature.star_count < 0:
       logging.error('count would be < 0: %r', (email, feature_id, starred))
       return
-    feature.put()  # And, do not call notify.
+    feature.put(notify=False)
 
     feature_entry = FeatureEntry.get_by_id(feature_id)
     feature_entry.star_count += 1 if starred else -1
     if feature_entry.star_count < 0:
       logging.error('count would be < 0: %r', (email, feature_id, starred))
       return
-    feature_entry.put(notify=False)
+    feature_entry.put()  # And, do not call notify.
 
   @classmethod
   def get_user_stars(self, email):

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -280,9 +280,9 @@ class OwnersFileTest(testing_config.CustomTestCase):
 class ActivityTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = core_models.Feature(
-        name='feature a', summary='sum', owner=['feature_owner@example.com'],
-        category=1)
+    self.feature_1 = core_models.FeatureEntry(
+        name='feature a', summary='sum', category=1,
+        owner_emails=['feature_owner@example.com'])
     self.feature_1.put()
     testing_config.sign_in('one@example.com', 123567890)
 
@@ -297,7 +297,7 @@ class ActivityTest(testing_config.CustomTestCase):
   def test_activities_created(self):
     # stash_values is used to note what the original values of a feature are.
     self.feature_1.stash_values()
-    self.feature_1.owner = ["other@example.com"]
+    self.feature_1.owner_emails = ["other@example.com"]
     self.feature_1.summary = "new summary"
     self.feature_1.put()
 
@@ -312,7 +312,8 @@ class ActivityTest(testing_config.CustomTestCase):
     self.assertEqual(len(activities[1].amendments), 1)
 
     expected = [
-        ('owner', '[\'feature_owner@example.com\']', '[\'other@example.com\']'),
+        ('owner_emails', '[\'feature_owner@example.com\']',
+            '[\'other@example.com\']'),
         ('summary', 'sum', 'new summary'),
         ('name', 'feature a', 'Changed name')]
     result = activities[0].amendments + activities[1].amendments
@@ -324,7 +325,7 @@ class ActivityTest(testing_config.CustomTestCase):
 
   def test_activities_created__no_stash(self):
     """If stash_values() is not called, no activity should be logged."""
-    self.feature_1.owner = ["other@example.com"]
+    self.feature_1.owner_emails = ["other@example.com"]
     self.feature_1.summary = "new summary"
     self.feature_1.put()
 

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -280,9 +280,9 @@ class OwnersFileTest(testing_config.CustomTestCase):
 class ActivityTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = core_models.FeatureEntry(
+    self.feature_1 = core_models.Feature(
         name='feature a', summary='sum', category=1,
-        owner_emails=['feature_owner@example.com'])
+        owner=['feature_owner@example.com'])
     self.feature_1.put()
     testing_config.sign_in('one@example.com', 123567890)
 
@@ -297,7 +297,7 @@ class ActivityTest(testing_config.CustomTestCase):
   def test_activities_created(self):
     # stash_values is used to note what the original values of a feature are.
     self.feature_1.stash_values()
-    self.feature_1.owner_emails = ["other@example.com"]
+    self.feature_1.owner = ["other@example.com"]
     self.feature_1.summary = "new summary"
     self.feature_1.put()
 
@@ -312,8 +312,7 @@ class ActivityTest(testing_config.CustomTestCase):
     self.assertEqual(len(activities[1].amendments), 1)
 
     expected = [
-        ('owner_emails', '[\'feature_owner@example.com\']',
-            '[\'other@example.com\']'),
+        ('owner', '[\'feature_owner@example.com\']', '[\'other@example.com\']'),
         ('summary', 'sum', 'new summary'),
         ('name', 'feature a', 'Changed name')]
     result = activities[0].amendments + activities[1].amendments
@@ -325,7 +324,7 @@ class ActivityTest(testing_config.CustomTestCase):
 
   def test_activities_created__no_stash(self):
     """If stash_values() is not called, no activity should be logged."""
-    self.feature_1.owner_emails = ["other@example.com"]
+    self.feature_1.owner = ["other@example.com"]
     self.feature_1.summary = "new summary"
     self.feature_1.put()
 

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -91,6 +91,7 @@ class FeatureCreateHandler(basehandlers.FlaskHandler):
 
     # Remove all feature-related cache.
     rediscache.delete_keys_with_prefix(Feature.feature_cache_prefix())
+    rediscache.delete_keys_with_prefix(FeatureEntry.feature_cache_prefix())
 
     redirect_url = '/guide/edit/' + str(key.integer_id())
     return self.redirect(redirect_url)

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -168,12 +168,12 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
 
     if feature_id:
       # Load feature directly from NDB so as to never get a stale cached copy.
-      feature = Feature.get_by_id(feature_id)
-      feature_entry = FeatureEntry.get_by_id(feature_id)
-      if feature is None:
+      feature: Feature = Feature.get_by_id(feature_id)
+      feature_entry: FeatureEntry = FeatureEntry.get_by_id(feature_id)
+      if feature_entry is None:
         self.abort(404, msg='Feature not found')
       else:
-        feature.stash_values()
+        feature_entry.stash_values()
 
     logging.info('POST is %r', self.form)
 
@@ -581,7 +581,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
           stage_update_items)
 
     # Remove all feature-related cache.
-    rediscache.delete_keys_with_prefix(Feature.feature_cache_prefix())
+    rediscache.delete_keys_with_prefix(FeatureEntry.feature_cache_prefix())
 
     # Update full-text index.
     if feature_entry:

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -159,7 +159,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
 
   def process_post_data(self, **kwargs):
     feature_id = kwargs.get('feature_id', None)
-    stage_id = kwargs.get('stage_id', 0)
+    intent_stage_id = kwargs.get('stage_id', 0)
     # Validate the user has edit permissions and redirect if needed.
     redirect_resp = permissions.validate_feature_edit_permission(
         self, feature_id)
@@ -173,7 +173,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       if feature_entry is None:
         self.abort(404, msg='Feature not found')
       else:
-        feature_entry.stash_values()
+        feature.stash_values()
 
     logging.info('POST is %r', self.form)
 
@@ -420,8 +420,8 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       feature.intent_stage = int(self.form.get('intent_stage'))
       update_items.append(('intent_stage', int(self.form.get('intent_stage'))))
     elif self.form.get('set_stage') == 'on':
-      feature.intent_stage = stage_id
-      update_items.append(('intent_stage', stage_id))
+      feature.intent_stage = intent_stage_id
+      update_items.append(('intent_stage', intent_stage_id))
 
     if self.touched('category'):
       feature.category = int(self.form.get('category'))
@@ -581,6 +581,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
           stage_update_items)
 
     # Remove all feature-related cache.
+    rediscache.delete_keys_with_prefix(Feature.feature_cache_prefix())
     rediscache.delete_keys_with_prefix(FeatureEntry.feature_cache_prefix())
 
     # Update full-text index.

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -23,7 +23,7 @@ from google.cloud import ndb  # type: ignore
 
 from framework import rediscache
 from internals import core_enums
-from internals.core_models import Feature, FeatureEntry, Stage
+from internals.core_models import Feature, FeatureEntry, MilestoneSet, Stage
 from internals.review_models import Gate
 from pages import guide
 
@@ -129,7 +129,8 @@ class FeatureEditHandlerTest(testing_config.CustomTestCase):
         core_enums.STAGE_BLINK_ORIGIN_TRIAL,
         core_enums.STAGE_BLINK_EXTEND_ORIGIN_TRIAL]
     for stage_type in stage_types:
-      stage = Stage(feature_id=feature_id, stage_type=stage_type)
+      stage = Stage(feature_id=feature_id, stage_type=stage_type,
+          milestones=MilestoneSet())
       stage.put()
 
     self.request_path = ('/guide/stage/%d/%d' % (

--- a/pages/intentpreview.py
+++ b/pages/intentpreview.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # from google.appengine.api import users
-from api.converters import feature_to_legacy_json
+from api.converters import feature_entry_to_json_verbose
 
 from internals import core_enums
 from framework import basehandlers
@@ -51,7 +51,7 @@ class IntentEmailPreviewHandler(basehandlers.FlaskHandler):
     """Return a dictionary of data used to render the page."""
     page_data = {
         'subject_prefix': self.compute_subject_prefix(f, intent_stage),
-        'feature': feature_to_legacy_json(f),
+        'feature': feature_entry_to_json_verbose(f),
         'sections_to_show': processes.INTENT_EMAIL_SECTIONS.get(
             intent_stage, []),
         'intent_stage': intent_stage,

--- a/pages/intentpreview_test.py
+++ b/pages/intentpreview_test.py
@@ -36,8 +36,8 @@ TESTDATA = testing_config.Testdata(__file__)
 class IntentEmailPreviewHandlerTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = core_models.Feature(
-        name='feature one', summary='sum', owner=['user1@google.com'],
+    self.feature_1 = core_models.FeatureEntry(
+        name='feature one', summary='sum', owner_emails=['user1@google.com'],
         category=1, intent_stage=core_enums.INTENT_IMPLEMENT)
     self.feature_1.put()
 
@@ -191,11 +191,11 @@ class IntentEmailPreviewTemplateTest(testing_config.CustomTestCase):
 
   def setUp(self):
     super(IntentEmailPreviewTemplateTest, self).setUp()
-    self.feature_1 = core_models.Feature(
-        name='feature one', summary='sum', owner=['user1@google.com'],
+    self.feature_1 = core_models.FeatureEntry(
+        name='feature one', summary='sum', owner_emails=['user1@google.com'],
         category=1, intent_stage=core_enums.INTENT_IMPLEMENT)
     # Hardcode the key for the template test
-    self.feature_1.key = ndb.Key('Feature', 234)
+    self.feature_1.key = ndb.Key('FeatureEntry', 234)
     self.feature_1.put()
 
     self.request_path = '/admin/features/launch/%d/%d?intent' % (


### PR DESCRIPTION
This change replaces most uses of the Feature kind with the FeatureEntry kind. Many files are touched, replacing references of `core_models.Feature` with `core_models.FeatureEntry`. FeatureEntry entity use is not yet implemented for the features star, process, and detect intent APIs.

To help navigate, here is an explanation of major changes by file:
- `api/converters.py`: Add a new function `feature_entry_to_json_basic()` which returns a more basic dictionary of feature information for uses as list items, etc.
- `client-src/elements/form-definition.js`: remove deprecated field `standardization` from `formatFeatureForEdit()`
- `framework/basehandlers.py`: refactor `BaseHandler.get_specified_feature()` to return a FeatureEntry object.
- `framework/permissions.py`: refactor functions to use FeatureEntry entities.
- `internals/core_models.py`: Remove some FeatureEntry methods that exist as helper functions in `feature_helpers.py`. Also implement most code for writing amendments and notifications for FeatureEntry in `FeatureEntry.put()` and `notifier_helpers.py`, but continue to use Feature for this functionality for now (see TODO on `FeatureEntry.put()`).
- `internals/feature_helpers.py`: Rewrite helper functions `get_all()`, `get_feature()`, and `get_by_ids()` to use FeatureEntry entities, and add "_legacy" suffix to old functions that use Feature.
- `internals/notifier_helpers.py`: Move more Feature methods out of the Feature class and rework as helper functions with FeatureEntry compatibility.


### Important Note!
This change makes it so that fields that should not be visible based on the feature type are shown as BLANK for the user, and can be edited and submitted, but will never display on the front end.
For example, a feature designated as type "Web developer facing change to existing code", will always display `origin_trial_feedback_url` as blank, as this field should not be shown for the given feature type.
With these changes, front end adjustments to remove the display of these fields that are irrelevant to certain feature types should be prioritized.