### PR TITLE
Convert namedtuples to dataclasses

### DIFF
--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -15,6 +15,7 @@
 
 import base64
 import collections
+from dataclasses import dataclass
 import datetime
 import logging
 from typing import Optional
@@ -34,32 +35,37 @@ API_OWNERS_URL = (
     'https://chromium.googlesource.com/chromium/src/+/'
     'main/third_party/blink/API_OWNERS?format=TEXT')
 
-ApprovalFieldDef = collections.namedtuple(
-    'ApprovalFieldDef',
-    'name, team_name, description, field_id, rule, approvers')
+@dataclass(eq=True, frozen=True)
+class ApprovalFieldDef:
+  name: str
+  description: str
+  field_id: int
+  rule: str
+  approvers: str | list[str] = API_OWNERS_URL
+  team_name: str = 'API Owners'
 
 # Note: This can be requested manually through the UI, but it is not
 # triggered by a blink-dev thread because i2p intents are only FYIs to
 # bilnk-dev and don't actually need approval by the API Owners.
 PrototypeApproval = ApprovalFieldDef(
-    'Intent to Prototype', 'API Owners',
+    'Intent to Prototype',
     'Not normally used.  If a review is requested, API Owners can approve.',
-    core_enums.GATE_PROTOTYPE, ONE_LGTM, API_OWNERS_URL)
+    core_enums.GATE_PROTOTYPE, ONE_LGTM)
 
 ExperimentApproval = ApprovalFieldDef(
-    'Intent to Experiment', 'API Owners',
+    'Intent to Experiment',
     'One API Owner must approve your intent',
-    core_enums.GATE_ORIGIN_TRIAL, ONE_LGTM, API_OWNERS_URL)
+    core_enums.GATE_ORIGIN_TRIAL, ONE_LGTM)
 
 ExtendExperimentApproval = ApprovalFieldDef(
-    'Intent to Extend Experiment', 'API Owners',
+    'Intent to Extend Experiment',
     'One API Owner must approve your intent',
-    core_enums.GATE_EXTEND_ORIGIN_TRIAL, ONE_LGTM, API_OWNERS_URL)
+    core_enums.GATE_EXTEND_ORIGIN_TRIAL, ONE_LGTM)
 
 ShipApproval = ApprovalFieldDef(
-    'Intent to Ship', 'API Owners',
+    'Intent to Ship',
     'Three API Owners must approve your intent',
-    core_enums.GATE_SHIP, THREE_LGTM, API_OWNERS_URL)
+    core_enums.GATE_SHIP, THREE_LGTM)
 
 APPROVAL_FIELDS_BY_ID = {
     afd.field_id: afd

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -71,11 +71,11 @@ class FetchOwnersTest(testing_config.CustomTestCase):
 
 MOCK_APPROVALS_BY_ID = {
     1: approval_defs.ApprovalFieldDef(
-        'Intent to test', 'API Owners',
+        'Intent to test',
         'You need permission to test',
         1, approval_defs.ONE_LGTM, ['approver@example.com']),
     2: approval_defs.ApprovalFieldDef(
-        'Intent to optimize', 'API Owners',
+        'Intent to optimize',
         'You need permission to optimize',
         2, approval_defs.THREE_LGTM, 'https://example.com'),
 }

--- a/internals/processes.py
+++ b/internals/processes.py
@@ -13,44 +13,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
+from dataclasses import asdict, dataclass
 
 from internals import approval_defs
 from internals import core_enums
 
 
-Process = collections.namedtuple(
-    'Process',
-    'name, description, applicability, stages')
+@dataclass
+class Action:
+  name: str
+  url: str
+  prerequisites: list[str]
+
+@dataclass
+class ProgressItem:
+  name: str
+  field: str | None = None
+
 # Note: A new feature always starts with intent_stage == INTENT_NONE
 # regardless of process.  intent_stage is set to the first stage of
 # a specific process when the user clicks a "Start" button and submits
 # a form that sets intent_stage.
+@dataclass
+class ProcessStage:
+  name: str
+  description: str
+  progress_items: list[ProgressItem]
+  actions: list[Action]
+  approvals: list[approval_defs.ApprovalFieldDef]
+  incoming_stage: int
+  outgoing_stage: int
 
-
-ProcessStage = collections.namedtuple(
-    'ProcessStage',
-    'name, description, progress_items, actions, approvals, '
-    'incoming_stage, outgoing_stage')
-
-ProgressItem = collections.namedtuple(
-    'ProgressItem',
-    'name, field')
-
-Action = collections.namedtuple(
-    'Action',
-    'name, url, prerequisites')
+@dataclass
+class Process:
+  name: str
+  description: str
+  applicability: str
+  stages: list[ProcessStage]
 
 
 def process_to_dict(process):
-  """Return nested dicts for the nested namedtuples of a process."""
-  # These lines are sort of like a deep version of _asdict().
-  stages = [stage._asdict() for stage in process.stages]
-  for stage in stages:
-    stage['progress_items'] = [pi._asdict() for pi in stage['progress_items']]
-    stage['actions'] = [act._asdict() for act in stage['actions']]
-    stage['approvals'] = [appr._asdict() for appr in stage['approvals']]
-
+  """Return nested dicts for the nested dataclasses of a process."""
+  # asdict() will recursively convert any dataclass props to dicts.
+  stages = [asdict(stage) for stage in process.stages]
   process_dict = {
       'name': process.name,
       'description': process.description,
@@ -80,17 +85,17 @@ PI_EXPLAINER = ProgressItem('Explainer', 'explainer_links')
 
 PI_SPEC_LINK = ProgressItem('Spec link', 'spec_link')
 PI_SPEC_MENTOR = ProgressItem('Spec mentor', 'spec_mentors')
-PI_DRAFT_API_SPEC = ProgressItem('Draft API spec', None)
+PI_DRAFT_API_SPEC = ProgressItem('Draft API spec')
 PI_I2P_EMAIL = ProgressItem(
     'Intent to Prototype email', 'intent_to_implement_url')
 
 PI_SAMPLES = ProgressItem('Samples', 'sample_links')
-PI_DRAFT_API_OVERVIEW = ProgressItem('Draft API overview (may be on MDN)', None)
+PI_DRAFT_API_OVERVIEW = ProgressItem('Draft API overview (may be on MDN)')
 PI_REQUEST_SIGNALS = ProgressItem('Request signals', 'safari_views')
-PI_SEC_REVIEW = ProgressItem('Security review issues addressed', None)
-PI_PRI_REVIEW = ProgressItem('Privacy review issues addressed', None)
+PI_SEC_REVIEW = ProgressItem('Security review issues addressed')
+PI_PRI_REVIEW = ProgressItem('Privacy review issues addressed')
 # TODO(jrobbins): needs detector.
-PI_EXTERNAL_REVIEWS = ProgressItem('External reviews', None)
+PI_EXTERNAL_REVIEWS = ProgressItem('External reviews')
 PI_R4DT_EMAIL = ProgressItem('Ready for Trial email', 'ready_for_trial_url')
 
 PI_TAG_REQUESTED = ProgressItem('TAG review requested', 'tag_review')
@@ -98,21 +103,21 @@ PI_VENDOR_SIGNALS = ProgressItem('Vendor signals', 'safari_views')
 PI_WEB_DEV_SIGNALS = ProgressItem('Web developer signals', 'web_dev_views')
 PI_DOC_LINKS = ProgressItem('Doc links', 'doc_links')
 # TODO(jrobbins): needs detector.
-PI_DOC_SIGNOFF = ProgressItem('Documentation signoff', None)
+PI_DOC_SIGNOFF = ProgressItem('Documentation signoff')
 PI_EST_TARGET_MILESTONE = ProgressItem(
     'Estimated target milestone', 'shipped_milestone')
 
 # TODO(jrobbins): needs detector.
-PI_OT_REQUEST = ProgressItem('OT request', None)
+PI_OT_REQUEST = ProgressItem('OT request')
 # TODO(jrobbins): needs detector.
-PI_OT_AVAILABLE = ProgressItem('OT available', None)
+PI_OT_AVAILABLE = ProgressItem('OT available')
 # TODO(jrobbins): needs detector.
-PI_OT_RESULTS = ProgressItem('OT results', None)
+PI_OT_RESULTS = ProgressItem('OT results')
 PI_I2E_EMAIL = ProgressItem(
     'Intent to Experiment email', 'intent_to_experiment_url')
 PI_I2E_LGTMS = ProgressItem('One LGTM on Intent to Experiment', 'i2e_lgtms')
 
-PI_MIGRATE_INCUBATION = ProgressItem('Request to migrate incubation', None)
+PI_MIGRATE_INCUBATION = ProgressItem('Request to migrate incubation')
 PI_TAG_ADDRESSED = ProgressItem(
     'TAG review issues addressed', 'tag_review_status')
 PI_UPDATED_VENDOR_SIGNALS = ProgressItem(
@@ -128,25 +133,25 @@ PI_FINAL_VENDOR_SIGNALS = ProgressItem('Finalized vendor signals', 'safari_views
 PI_FINAL_TARGET_MILESTONE = ProgressItem(
     'Finalized target milestone', 'shipped_milestone')
 
-PI_CODE_IN_CHROMIUM = ProgressItem('Code in Chromium', None)
+PI_CODE_IN_CHROMIUM = ProgressItem('Code in Chromium')
 
-PI_PSA_EMAIL = ProgressItem('Web facing PSA email', None)
+PI_PSA_EMAIL = ProgressItem('Web facing PSA email')
 
 # TODO(jrobbins): needs detector.
-PI_DT_REQUEST = ProgressItem('DT request', None)
+PI_DT_REQUEST = ProgressItem('DT request')
 # TODO(jrobbins): needs detector.
-PI_DT_AVAILABLE = ProgressItem('DT available', None)
+PI_DT_AVAILABLE = ProgressItem('DT available')
 # TODO(jrobbins): needs detector.
-PI_REMOVAL_OF_DT = ProgressItem('Removal of DT', None)
+PI_REMOVAL_OF_DT = ProgressItem('Removal of DT')
 PI_DT_EMAIL = ProgressItem(
     'Request for Deprecation Trial email', 'intent_to_experiment_url')
 PI_DT_LGTMS = ProgressItem(
     'One LGTM on Request for Deprecation Trial', 'i2e_lgtms')
 
 # TODO(jrobbins): needs detector.
-PI_EXISTING_FEATURE = ProgressItem('Link to existing feature', None)
+PI_EXISTING_FEATURE = ProgressItem('Link to existing feature')
 
-PI_CODE_REMOVED = ProgressItem('Code removed', None)
+PI_CODE_REMOVED = ProgressItem('Code removed')
 
 
 BLINK_PROCESS_STAGES = [

--- a/internals/processes_test.py
+++ b/internals/processes_test.py
@@ -24,9 +24,9 @@ from internals import processes
 
 
 BakeApproval = approval_defs.ApprovalFieldDef(
-    'Approval for baking', 'Chef',
+    'Approval for baking',
     'The head chef must approve of you using the oven',
-    9, approval_defs.ONE_LGTM, ['chef@example.com'])
+    9, approval_defs.ONE_LGTM, ['chef@example.com'], 'Chef')
 
 BAKE_APPROVAL_DEF_DICT = collections.OrderedDict([
     ('name', 'Approval for baking'),


### PR DESCRIPTION
Use dataclasses for proceses and approval definitions rather than `collections.namedtuple`.