### PR TITLE
Implement top-level or

### DIFF
--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -389,6 +389,38 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     actual, tc = search.process_query('-browsers.webdev.view=1')
     self.assertEqual(0, len(actual))
 
+  def test_process_query__multiple_fields(self):
+    """We can can run multi-field queries."""
+
+    actual, tc = search.process_query('category=1 category=2')
+    self.assertEqual([], actual)
+
+    actual, tc = search.process_query('category=1 OR category=2')
+    self.assertEqual(2, len(actual))
+    self.assertCountEqual(
+        [f['name'] for f in actual],
+        ['feature 1', 'feature 2'])
+
+    actual, tc = search.process_query('category=1 -category=2')
+    self.assertEqual(1, len(actual))
+    self.assertEqual(actual[0]['name'], 'feature 1')
+
+    actual, tc = search.process_query('browsers.webdev.view=1 -category=2')
+    self.assertEqual(1, len(actual))
+    self.assertEqual(actual[0]['name'], 'feature 1')
+
+    actual, tc = search.process_query(
+        'browsers.webdev.view=1 -category=2 OR category=2')
+    self.assertEqual(2, len(actual))
+    self.assertCountEqual(
+        [f['name'] for f in actual],
+        ['feature 1', 'feature 2'])
+
+    actual, tc = search.process_query(
+        'browsers.webdev.view=1 -category=2 OR category=1 -category=2')
+    self.assertEqual(1, len(actual))
+    self.assertEqual(actual[0]['name'], 'feature 1')
+
   @mock.patch('logging.warning')
   def test_process_query__bad(self, mock_warn):
     """Query terms that are not valid, give warnings."""


### PR DESCRIPTION
Fix https://github.com/GoogleChrome/chromium-dashboard/issues/2346. Address the previous [draft comments](https://github.com/GoogleChrome/chromium-dashboard/pull/2434#pullrequestreview-1167827012). The OR logical operator divides the proceeding and trailing operations into separate flat clauses and each clause is being processed from left to right.

E.g. the query category=1 OR category=2 cc:me would have clauses equal to [category=] OR [category=2  AND cc:me] 

In each OR clause, the negation logic is turned into AND by excluding its ids from all possible ids, then perform set intersections.