### PR TITLE
Make the debuggability field not required

### DIFF
--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -903,7 +903,7 @@ export const ALL_FIELDS = {
 
   'debuggability': {
     type: 'textarea',
-    required: true,
+    required: false,
     label: 'Debuggability',
     help_text: html`
       Description of the DevTools debugging support for your feature.


### PR DESCRIPTION
This should resolve #2362.

That field was initially marked as required because it was done that way in a PR sent from a user, but the field would be a better fit for our UX if it is not required for form submission.  Requiring values for form submission has the downside of encouraging users to enter "NA" or "TBD" just to get past the form submission.  In the bigger picture, we rely on approvals to make feature owners put in information that is needed to earn those approvals.