### PR TITLE
Correct permission terms query logic

### DIFF
--- a/internals/search_queries_test.py
+++ b/internals/search_queries_test.py
@@ -99,6 +99,16 @@ class SearchFeaturesTest(testing_config.CustomTestCase):
         [self.feature_1_id, self.feature_2_id],
         [key.integer_id() for key in actual])
 
+    actual_promise = search_queries.single_field_query_async(
+        'unlisted', '=', True)
+    actual = actual_promise.get_result()
+    self.assertCountEqual([], actual)
+
+    actual_promise = search_queries.single_field_query_async(
+        'deleted', '=', True)
+    actual = actual_promise.get_result()
+    self.assertCountEqual([], actual)
+
   def test_single_field_query_async__multiple_vals(self):
     """We get a promise to run the DB query with multiple values."""
     actual_promise = search_queries.single_field_query_async(

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -344,6 +344,11 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
 
   def test_process_query__single_field(self):
     """We can can run single-field queries."""
+    actual, tc = search.process_query('')
+    self.assertEqual(2, len(actual))
+    self.assertCountEqual(
+        [f['name'] for f in actual],
+        ['feature 1', 'feature 2'])
 
     actual, tc = search.process_query('category=1')
     self.assertEqual(1, len(actual))


### PR DESCRIPTION
Correct permission terms query logic. The permission queries should apply to the result of user queries, instead of only the last OR query clause. 

- When the user query is empty, it should return the result of permission queries.