### PR TITLE
Show motivation value in deprecation features

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -378,7 +378,7 @@ def feature_entry_to_json_verbose(fe: FeatureEntry) -> dict[str, Any]:
   d['editors'] =  d.pop('editor_emails', [])
   d['cc_emails'] = d.pop('cc_emails', [])
   d['creator'] = fe.creator_email
-
+  d['comments'] = d.pop('feature_notes', None)
   d['browsers'] = {
     'chrome': {
       'bug': fe.bug_url,

--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -311,10 +311,7 @@ const PAS_PREPARETOSHIP = [
   'launch_bug_url', 'intent_to_ship_url', 'comments',
 ];
 
-const DEPRECATION_IMPLEMENT = [
-  'deprecation_motivation', // map to name="motivation" field upon form submission
-  'spec_link', 'comments',
-];
+const DEPRECATION_IMPLEMENT = ['motivation', 'spec_link', 'comments'];
 
 // Note: Even though this is similar to another form, it is likely to change.
 // const DEPRECATION_PREPARETOSHIP = [


### PR DESCRIPTION
Addresses #2361

This change fixes a bug that caused the value of the "motivation" and "comments" field to display without their existing values. It appears there were plans to change the motivation field to map to "deprecation_motivation" for deprecation trials at some point, but did not coalesce.