### PR TITLE
Map deprecation_motivaton to motivation both ways.

### DIFF
--- a/client-src/elements/chromedash-guide-stage-page.js
+++ b/client-src/elements/chromedash-guide-stage-page.js
@@ -5,6 +5,7 @@ import './chromedash-form-table';
 import './chromedash-form-field';
 import {formatFeatureForEdit, STAGE_FORMS, IMPL_STATUS_FORMS} from './form-definition';
 import {IMPLEMENTATION_STATUS} from './form-field-enums';
+import {ALL_FIELDS} from './form-field-specs';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 import {FORM_STYLES} from '../sass/forms-css.js';
 
@@ -200,16 +201,22 @@ export class ChromedashGuideStagePage extends LitElement {
     `;
   }
 
+  renderOneField(formattedFeature, field) {
+    const featureJSONKey = ALL_FIELDS[field].name || field;
+    return html`
+      <chromedash-form-field
+        name=${field}
+        value=${formattedFeature[featureJSONKey]}>
+      </chromedash-form-field>
+    `;
+  }
+
   renderFeatureFormSection(formattedFeature) {
     const alreadyOnThisStage = this.stageId === this.feature.intent_stage_int;
     return html`
       <section class="stage_form">
-        ${this.featureFormFields.map((field) => html`
-          <chromedash-form-field
-            name=${field}
-            value=${formattedFeature[field]}>
-          </chromedash-form-field>
-        `)}
+        ${this.featureFormFields.map((field) => this.renderOneField(
+      formattedFeature, field))}
         <chromedash-form-field
           name="set_stage"
           value=${alreadyOnThisStage}

--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -311,7 +311,7 @@ const PAS_PREPARETOSHIP = [
   'launch_bug_url', 'intent_to_ship_url', 'comments',
 ];
 
-const DEPRECATION_IMPLEMENT = ['motivation', 'spec_link', 'comments'];
+const DEPRECATION_IMPLEMENT = ['deprecation_motivation', 'spec_link', 'comments'];
 
 // Note: Even though this is similar to another form, it is likely to change.
 // const DEPRECATION_PREPARETOSHIP = [


### PR DESCRIPTION
The should fix the display of the motivation field on deprecation features.

There is only one motivation field in a feature, however the client-side forms can reference it by the name `motivation` or `deprecation_motivation` to choose one field spec or the other.   The field specs are different in that they provide different on-page help text.   The `deprecation_motivation` field spec says `name: 'motivation'` to allow for a mapping from the form element name `deprecation_motivation` back to the field name `motivation`.

The problem was that that name mapping was being used only when rendering the NAME `<textarea name=NAME>` to be used in the form submission POST.   It was not being used to map the name used to look up the value to be displayed when the page loads.  The net effect was that the text that the user entered was being saved, but then it is shown as blank when the user visits the editing form again.

This PR checks for a mapping of in the form field spec.  If there is one,  it is used when looking up the value to be displayed in the texture.  If there is not a mapping, the original field name is used. 