### PR TITLE
Use FeatureEntry entities for "All Features" page

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -455,6 +455,18 @@ def feature_entry_to_json_basic(fe: FeatureEntry) -> dict[str, Any]:
     'summary': fe.summary,
     'unlisted': fe.unlisted,
     'blink_components': fe.blink_components or [],
+    'resources': {
+      'samples': fe.sample_links or [],
+      'docs': fe.doc_links or [],
+    },
+    'standards': {
+      'spec': fe.spec_link,
+      'maturity': {
+        'text': STANDARD_MATURITY_CHOICES.get(fe.standard_maturity),
+        'short_text': STANDARD_MATURITY_SHORT.get(fe.standard_maturity),
+        'val': fe.standard_maturity,
+      },
+    },
     'browsers': {
       'chrome': {
         'bug': fe.bug_url,

--- a/client-src/elements/chromedash-featurelist.js
+++ b/client-src/elements/chromedash-featurelist.js
@@ -324,18 +324,6 @@ class ChromedashFeaturelist extends LitElement {
     this._fireEvent('filtered', {count: this.filtered.length});
   }
 
-  _firstOfMilestone(milestone) {
-    for (let i = 0; i < this.filtered.length; i++) {
-      const feature = this.filtered[i];
-      if (feature.first_of_milestone &&
-          (milestone === feature.browsers.chrome.desktop ||
-           milestone === feature.browsers.chrome.status.text)) {
-        return feature.id;
-      }
-    }
-    return null;
-  }
-
   // Directly called from template/features.html
   scrollToId(targetId) {
     if (!targetId) return;
@@ -356,12 +344,8 @@ class ChromedashFeaturelist extends LitElement {
     this._hasInitialized = true;
   }
 
-  _computeMilestoneHidden(feature, features, filtered) {
-    return filtered.length != features.length || !feature.first_of_milestone;
-  }
-
-  _computeMilestoneString(str) {
-    return isNaN(parseInt(str)) ? str : 'Chrome ' + str;
+  _computeSectionHidden(feature, features, filtered) {
+    return filtered.length != features.length || !feature.first_of_section;
   }
 
   render() {
@@ -384,8 +368,8 @@ class ChromedashFeaturelist extends LitElement {
     return html`
       ${filteredWithState.map((item) => html`
           <div class="item">
-            <div ?hidden="${this._computeMilestoneHidden(item.feature, this.features, this.filtered)}"
-                 class="milestone-marker">${this._computeMilestoneString(item.feature.browsers.chrome.status.milestone_str)}</div>
+            <div ?hidden="${this._computeSectionHidden(item.feature, this.features, this.filtered)}"
+                 class="section-marker">${item.feature.browsers.chrome.status.text}</div>
             <chromedash-feature id="id-${item.feature.id}" tabindex="0"
                  ?open="${item.open}"
                  ?starred="${item.starred}"

--- a/client-src/elements/chromedash-metadata.js
+++ b/client-src/elements/chromedash-metadata.js
@@ -80,11 +80,6 @@ class ChromedashMetadata extends LitElement {
     this._fireEvent('query-changed', {version: this.selected});
   }
 
-  // Directly called in chromedash-featurelist
-  selectMilestone(feature) {
-    this.selected = feature.browsers.chrome.status.milestone_str;
-  }
-
   selectInVersionList(index) {
     this.shadowRoot.getElementById('versionlist').selectedIndex = index; ; // log null
   }

--- a/client-src/sass/elements/chromedash-featurelist-css.js
+++ b/client-src/sass/elements/chromedash-featurelist-css.js
@@ -10,7 +10,7 @@ export const FEATURELIST_CSS = [
     #ironlist {
       min-height: 0;
     }
-    .milestone-marker {
+    .section-marker {
       margin: 32px 0 8px 0;
       font-size: 18px;
       -webkit-font-smoothing: initial;
@@ -23,7 +23,7 @@ export const FEATURELIST_CSS = [
       margin: 32px;
     }
     @media only screen and (max-width: 700px) {
-      .milestone-marker {
+      .section-marker {
         font-size: 14px;
         font-weight: 500;
         margin: 8px;

--- a/internals/core_models_test.py
+++ b/internals/core_models_test.py
@@ -258,7 +258,7 @@ class FeatureTest(testing_config.CustomTestCase):
 
   def test_get_chronological__normal(self):
     """We can retrieve a list of features."""
-    actual = feature_helpers.get_chronological()
+    actual = feature_helpers.get_chronological_legacy()
     names = [f['name'] for f in actual]
     self.assertEqual(
         ['feature c', 'feature d', 'feature a', 'feature b'],
@@ -272,7 +272,7 @@ class FeatureTest(testing_config.CustomTestCase):
     """Unlisted features are not included in the list."""
     self.legacy_feature_2.unlisted = True
     self.legacy_feature_2.put()
-    actual = feature_helpers.get_chronological()
+    actual = feature_helpers.get_chronological_legacy()
     names = [f['name'] for f in actual]
     self.assertEqual(
         ['feature c', 'feature d', 'feature a'],
@@ -282,7 +282,7 @@ class FeatureTest(testing_config.CustomTestCase):
     """Unlisted features are included for users with edit access."""
     self.legacy_feature_2.unlisted = True
     self.legacy_feature_2.put()
-    actual = feature_helpers.get_chronological(show_unlisted=True)
+    actual = feature_helpers.get_chronological_legacy(show_unlisted=True)
     names = [f['name'] for f in actual]
     self.assertEqual(
         ['feature c', 'feature d', 'feature a', 'feature b'],

--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -519,7 +519,7 @@ def get_by_ids(feature_ids: list[int],
 
 def get_features_by_impl_status(limit: int | None=None, update_cache: bool=False,
     show_unlisted: bool=False) -> list[dict]:
-  """Return a list of JSON dicts for features, ordered by milestone.
+  """Return a list of JSON dicts for features, ordered by chrome_impl_status.
 
   Because the cache may rarely have stale data, this should only be
   used for displaying data read-only, not for populating forms or
@@ -530,11 +530,11 @@ def get_features_by_impl_status(limit: int | None=None, update_cache: bool=False
                                 'impl_order', limit, show_unlisted)
 
   feature_list = rediscache.get(cache_key)
-  logging.info('getting chronological feature list')
+  logging.info('getting feature list, sorted by chrome_impl_status')
 
   # On cache miss, do a db query.
   if not feature_list or update_cache:
-    logging.info('recomputing chronological feature list')
+    logging.info('recomputing feature list')
     # Get features by implementation status.
     futures: list[Future] = []
     for impl_status in IMPLEMENTATION_STATUS.keys():

--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -539,7 +539,6 @@ def get_chronological(limit: int | None=None, update_cache: bool=False,
         section = [
             converters.feature_entry_to_json_basic(f) for f in section]
         section[0]['first_of_section'] = True
-        section[0]['section_name'] = "TODO"
         feature_list.extend(section)
 
     rediscache.set(cache_key, feature_list)

--- a/pages/blink_handler.py
+++ b/pages/blink_handler.py
@@ -112,7 +112,7 @@ class SubscribersHandler(basehandlers.FlaskHandler):
   def get_template_data(self, **kwargs):
     users = user_models.FeatureOwner.query().order(
         user_models.FeatureOwner.name).fetch(None)
-    feature_list = feature_helpers.get_chronological()
+    feature_list = feature_helpers.get_chronological_legacy()
 
     milestone = self.get_int_arg('milestone')
     if milestone is not None:

--- a/pages/featurelist.py
+++ b/pages/featurelist.py
@@ -34,7 +34,7 @@ class FeaturesJsonHandler(basehandlers.FlaskHandler):
 
   def get_template_data(self, **kwargs):
     user = users.get_current_user()
-    feature_list = feature_helpers.get_chronological(
+    feature_list = feature_helpers.get_features_by_impl_status(
         show_unlisted=permissions.can_edit_any_feature(user))
     return feature_list
 

--- a/pages/featurelist_test.py
+++ b/pages/featurelist_test.py
@@ -53,6 +53,13 @@ class TestWithFeature(testing_config.CustomTestCase):
     self.feature_1.put()
     self.feature_id = self.feature_1.key.integer_id()
 
+    self.fe_1 = core_models.FeatureEntry(
+        name='feature one', summary='detailed sum',
+        owner_emails=['owner@example.com'],
+        category=1, intent_stage=core_enums.INTENT_IMPLEMENT)
+    self.fe_1.put()
+    self.fe_id = self.fe_1.key.integer_id()
+
     self.request_path = (self.REQUEST_PATH_FORMAT %
         {'feature_id': self.feature_id} if self.REQUEST_PATH_FORMAT else '')
     if self.HANDLER_CLASS:
@@ -60,6 +67,7 @@ class TestWithFeature(testing_config.CustomTestCase):
 
   def tearDown(self):
     self.feature_1.key.delete()
+    self.fe_1.key.delete()
     self.app_user.delete()
     self.app_admin.delete()
     rediscache.flushall()
@@ -83,6 +91,8 @@ class FeaturesJsonHandlerTest(TestWithFeature):
     """JSON feed does not include unlisted features for users who can't edit."""
     self.feature_1.unlisted = True
     self.feature_1.put()
+    self.fe_1.unlisted = True
+    self.fe_1.put()
 
     testing_config.sign_out()
     with test_app.test_request_context(self.request_path):


### PR DESCRIPTION
This change removes some unused functions in `feature_helpers.py` as well as updating `feature_helpers.get_chronological()` to be `feature_helpers.get_features_by_impl_status()`, which retrieves all features sorted by `chrome_impl_status` rather than by milestone. Additionally, features are organized in sections by this field rather than by milestone.

![Screen Shot 2022-11-14 at 11 02 42 AM](https://user-images.githubusercontent.com/56164590/201744050-ded30c9b-9f8c-41f0-b9a8-305b79b762c6.png)
