### PR TITLE
Reference feature stages as possibly plural

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -253,10 +253,12 @@ def _prep_stage_gate_info(
 
   # Write a collection of stages and gates associated with the feature,
   # sorted by type.
-  d['stages'] = {}
+  d['stages'] = collections.defaultdict(list)
   d['gates'] = collections.defaultdict(list)
   # Stages and gates are given as a dictionary, with the type as the key,
   # and a list of entity IDs as the value.
+  # TODO(danielrsmith): This approach should be removed or refactored when
+  # functionality for creating multiple stages is added.
   for s in stages:
     # Keep major stages for referencing additional fields.
     if s.stage_type == proto_type:
@@ -269,12 +271,50 @@ def _prep_stage_gate_info(
       major_stages['extend'] = s
     elif s.stage_type == ship_type:
       major_stages['ship'] = s
-    d['stages'][s.stage_type] = s.key.integer_id()
+    d['stages'][s.stage_type].append(stage_to_dict(s))
   for g in gates:
     d['gates'][g.gate_type].append(g.key.integer_id())
 
   return major_stages
 
+MILESTONE_FIELDS = [
+  'desktop_first',
+  'desktop_last',
+  'android_first',
+  'android_last',
+  'ios_first',
+  'ios_last',
+  'webview_first',
+  'webview_last'
+]
+
+def stage_to_dict(stage: Stage) -> dict[int, Any]:
+  d: dict[str, Any] = {}
+  d['id'] = stage.key.integer_id()
+  d['feature_id'] = stage.feature_id
+  d['stage_type'] = stage.stage_type
+
+  # Add milestone fields
+  if stage.milestones is not None:
+    for field in MILESTONE_FIELDS:
+      d[field] = getattr(stage.milestones, field)
+  else:
+    for field in MILESTONE_FIELDS:
+      d[field] = None
+
+  d['pm_emails'] = stage.pm_emails
+  d['tl_emails'] = stage.tl_emails
+  d['ux_emails'] = stage.ux_emails
+  d['te_emails'] = stage.te_emails
+  d['experiment_goals'] = stage.experiment_goals
+  d['experiment_risks'] = stage.experiment_risks
+  d['experiment_extension_reason'] = stage.experiment_extension_reason
+  d['intent_thread_url'] = stage.intent_thread_url
+  d['origin_trial_feedback_url'] = stage.origin_trial_feedback_url
+  d['announcement_url'] = stage.announcement_url
+  d['ot_stage_id'] = stage.ot_stage_id
+
+  return d
 
 def feature_entry_to_json_verbose(fe: FeatureEntry) -> dict[str, Any]:
   """Returns a verbose dictionary with all info about a feature."""

--- a/api/processes_api.py
+++ b/api/processes_api.py
@@ -17,6 +17,7 @@
 from framework import basehandlers
 from internals import core_models
 from internals import processes
+from internals import stage_helpers
 
 
 class ProcessesAPI(basehandlers.APIHandler):
@@ -47,7 +48,7 @@ class ProgressAPI(basehandlers.APIHandler):
     fe = core_models.FeatureEntry.get_by_id(feature_id)
     if fe is None:
       self.abort(404, msg=f'Feature {feature_id} not found')
-    stages = core_models.Stage.get_feature_stages(fe.key.integer_id())
+    stages = stage_helpers.get_feature_stages(fe.key.integer_id())
     progress_so_far = {}
     for progress_item, detector in list(processes.PROGRESS_DETECTORS.items()):
       detected = detector(fe, stages)

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -486,11 +486,3 @@ class Stage(ndb.Model):
   announcement_url = ndb.StringProperty()
   # Origin trial stage id that this stage extends, if trial extension stage.
   ot_stage_id = ndb.IntegerProperty()
-
-  @classmethod
-  def get_feature_stages(cls, feature_id: int) -> dict[int, Stage]:
-    """Return a dictionary of stages associated with a given feature."""
-    stages: list[Stage] = cls.query(cls.feature_id == feature_id).fetch()
-    # TODO(danielrsmith): Refactor to return a list of stages for each type
-    # when multiple stages of the same type can exist.
-    return {stage.stage_type: stage for stage in stages}

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -34,6 +34,7 @@ from framework import users
 import settings
 from internals import approval_defs
 from internals import core_enums
+from internals import stage_helpers
 from internals.core_models import Feature, FeatureEntry, MilestoneSet, Stage
 from internals.user_models import (
     AppUser, BlinkComponent, FeatureOwner, UserPref)
@@ -45,7 +46,7 @@ def format_email_body(
   """Return an HTML string for a notification email body."""
 
   stage_type = core_enums.STAGE_TYPES_SHIPPING[fe.feature_type] or 0
-  ship_milestones: MilestoneSet | None = fe_stages[stage_type].milestones
+  ship_milestones: MilestoneSet | None = fe_stages[stage_type][0].milestones
   milestone_str = 'not yet assigned'
   if ship_milestones is not None:
     if ship_milestones.desktop_first:
@@ -154,7 +155,7 @@ def make_email_tasks(fe: FeatureEntry, is_update: bool=False,
       FeatureOwner.watching_all_features == True).fetch(None)
   watcher_emails: list[str] = [watcher.email for watcher in watchers]
 
-  fe_stages = Stage.get_feature_stages(fe.key.integer_id())
+  fe_stages = stage_helpers.get_feature_stages(fe.key.integer_id())
 
   email_html = format_email_body(is_update, fe, fe_stages, changes)
   if is_update:

--- a/internals/processes.py
+++ b/internals/processes.py
@@ -541,19 +541,19 @@ PROGRESS_DETECTORS = {
     'Intent to Prototype email':
     lambda f, stages: (
         core_enums.STAGE_TYPES_PROTOTYPE[f.feature_type] and
-        stages[core_enums.STAGE_TYPES_PROTOTYPE[f.feature_type]].intent_thread_url),
+        stages[core_enums.STAGE_TYPES_PROTOTYPE[f.feature_type]][0].intent_thread_url),
 
     'Intent to Ship email':
     lambda f, stages: (core_enums.STAGE_TYPES_SHIPPING[f.feature_type] and
-        stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]].intent_thread_url),
+        stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]][0].intent_thread_url),
 
     'Ready for Trial email':
     lambda f, stages: (core_enums.STAGE_TYPES_DEV_TRIAL[f.feature_type] and
-        stages[core_enums.STAGE_TYPES_DEV_TRIAL[f.feature_type]].announcement_url),
+        stages[core_enums.STAGE_TYPES_DEV_TRIAL[f.feature_type]][0].announcement_url),
 
     'Intent to Experiment email':
     lambda f, stages: (core_enums.STAGE_TYPES_ORIGIN_TRIAL[f.feature_type] and
-        stages[core_enums.STAGE_TYPES_ORIGIN_TRIAL[f.feature_type]].intent_thread_url),
+        stages[core_enums.STAGE_TYPES_ORIGIN_TRIAL[f.feature_type]][0].intent_thread_url),
 
     'Samples':
     lambda f, _: f.sample_links and f.sample_links[0],
@@ -600,13 +600,13 @@ PROGRESS_DETECTORS = {
 
     'Estimated target milestone':
     lambda f, stages: bool(core_enums.STAGE_TYPES_SHIPPING[f.feature_type] and
-        stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]].milestones and
-        stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]].milestones.desktop_first),
+        stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]][0].milestones and
+        stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]][0].milestones.desktop_first),
 
     'Final target milestone':
     lambda f, stages: bool(core_enums.STAGE_TYPES_SHIPPING[f.feature_type] and
-        stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]].milestones and
-        stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]].milestones.desktop_first),
+        stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]][0].milestones and
+        stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]][0].milestones.desktop_first),
 
     'Code in Chromium':
     lambda f, _: f.impl_status_chrome in (

--- a/internals/processes_test.py
+++ b/internals/processes_test.py
@@ -21,6 +21,7 @@ from internals import approval_defs
 from internals import core_enums
 from internals import core_models
 from internals import processes
+from internals import stage_helpers
 
 
 BakeApproval = approval_defs.ApprovalFieldDef(
@@ -152,7 +153,7 @@ class ProgressDetectorsTest(testing_config.CustomTestCase):
           stage_type=s_type)
       stage.put()
       self.stages.append(stage)
-    self.stages_dict = core_models.Stage.get_feature_stages(
+    self.stages_dict = stage_helpers.get_feature_stages(
         self.feature_1.key.integer_id())
 
   def tearDown(self):

--- a/internals/stage_helpers.py
+++ b/internals/stage_helpers.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+
+from internals.core_models import Stage
+
+def get_feature_stages(feature_id: int) -> dict[int, Stage]:
+  """Return a dictionary of stages associated with a given feature."""
+  stage_dict = defaultdict(list)
+  for stage in Stage.query(Stage.feature_id == feature_id):
+    stage_dict[stage.stage_type].append(stage)
+  return stage_dict
+
+def get_feature_stage_ids(feature_id: int) -> dict[int, list[int]]:
+  stage_dict = defaultdict(list)
+  for stage in Stage.query(Stage.feature_id == feature_id):
+    stage_dict[stage.stage_type].append(stage.key.integer_id())
+  return stage_dict

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -25,6 +25,7 @@ from framework import rediscache
 from framework import basehandlers
 from framework import permissions
 from internals import core_enums, notifier_helpers
+from internals import stage_helpers
 from internals.core_models import Feature, FeatureEntry, MilestoneSet, Stage
 from internals.review_models import Gate, Vote
 from internals import processes
@@ -371,7 +372,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       update_items: list[tuple[str, Any]],
       changed_fields: list[tuple[str, Any, Any]]) -> None:
     # Get all existing stages associated with the feature.
-    stages = Stage.get_feature_stages(feature_id)
+    stages = stage_helpers.get_feature_stages(feature_id)
 
     for field, new_val in update_items:
       field = self.RENAMED_FIELD_MAPPING.get(field, field)
@@ -381,7 +382,8 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       # (e.g. developer-facing code changes cannot have origin trial fields).
       if stage_type is None:
         continue
-      stage = stages.get(stage_type, None)
+      stages_list: list[Stage | None] = stages.get(stage_type, None)
+      stage: Stage | None = stages_list[0] if stages_list else None
       # If a stage of this type does not exist for this feature, create it.
       if stage is None:
         stage = Stage(feature_id=feature_id, stage_type=stage_type)
@@ -416,5 +418,6 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
         changed_fields.append((field, old_val, new_val))
 
     # Write to all the stages.
-    for stage in stages.values():
-      stage.put()
+    for stages_by_type in stages.values():
+      for stage in stages_by_type:
+        stage.put()


### PR DESCRIPTION
This change adjusts most parts of code that reference stages to assume that it is possible to have multiple instances of the same stage type. Additionally, some Stage class methods have been moved to `internals/stage_helpers.py` to mimic the same structure as the Feature/FeatureEntry kinds.