### PR TITLE
Fix editing of unlisted checkbox on metadata form.

### DIFF
--- a/client-src/elements/chromedash-guide-metadata.js
+++ b/client-src/elements/chromedash-guide-metadata.js
@@ -104,7 +104,7 @@ export class ChromedashGuideMetadata extends LitElement {
             <a id="open-metadata" @click=${() => this.editing = true}>Edit</a>
             ${this.isAdmin ? html`
               <div>
-                <a id="delete-feature" class="delete-button" 
+                <a id="delete-feature" class="delete-button"
                   @click=${this.handleDeleteFeature}>Delete</a>
               </div>
             `: nothing}
@@ -215,6 +215,8 @@ export class ChromedashGuideMetadata extends LitElement {
       <div id="metadata-editing">
         <form name="overview_form" method="POST" action="/guide/stage/${this.feature.id}/0">
           <input type="hidden" name="token">
+          <input type="hidden" name="form_fields"
+             value="${METADATA_FORM_FIELDS.join(',')}">
 
           <chromedash-form-table ${ref(this.registerFormSubmitHandler)}>
             ${METADATA_FORM_FIELDS.map((field) => html`

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -146,6 +146,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       ('owner', 'emails'),
       ('editors', 'emails'),
       ('cc_recipients', 'emails'),
+      ('unlisted', 'bool'),
       ('doc_links', 'links'),
       ('measurement', 'str'),
       ('sample_links', 'links'),
@@ -209,7 +210,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
   CHECKBOX_FIELDS: frozenset[str] = frozenset([
       'accurate_as_of', 'unlisted', 'api_spec', 'all_platforms',
       'wpt', 'requires_embedder_support', 'prefixed'])
-  
+
   SELECT_FIELDS: frozenset[str] = frozenset([
       'category', 'intent_stage', 'standard_maturity', 'security_review_status',
       'privacy_review_status', 'tag_review_status', 'safari_views', 'ff_views',
@@ -411,7 +412,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       else:
         old_val = getattr(stage, field)
         setattr(stage, field, new_val)
-      
+
       if old_val != new_val:
         changed_fields.append((field, old_val, new_val))
 


### PR DESCRIPTION
This fixes two problems with editing feature metadata:
* The form did not have a form_fields hidden field, so all checkboxes were considered touched, even if they were not present on the form, which caused other boolean fields in the issue to be cleared whenever a user used the metadata form.
* guide.py's list of fields to parse did not include unlisted, so the user checking or unchecking the box had no effect.