### PR TITLE
Use FeatureEntry entities to display roadmap information

### DIFF
--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -406,8 +406,8 @@ class FeaturesAPITestGet_OldSchema(testing_config.CustomTestCase):
 
   def test_get__in_milestone_unlisted_no_perms(self):
     """JSON feed does not include unlisted features for users who can't edit."""
-    self.legacy_feature_1.unlisted = True
-    self.legacy_feature_1.put()
+    self.feature_1.unlisted = True
+    self.feature_1.put()
 
     # No signed-in user
     with test_app.test_request_context(self.request_path+'?milestone=1'):

--- a/internals/core_models_test.py
+++ b/internals/core_models_test.py
@@ -17,8 +17,9 @@ import testing_config  # Must be imported before the module under test.
 
 from api import converters
 from framework import rediscache
-from internals import feature_helpers
 from internals import core_enums
+from internals import feature_helpers
+from internals import stage_helpers
 from internals.core_models import Feature, FeatureEntry, MilestoneSet, Stage
 
 
@@ -93,13 +94,13 @@ class FeatureTest(testing_config.CustomTestCase):
       stage = Stage(
           feature_id=self.feature_4.key.integer_id(), stage_type=s_type)
       stage.put()
-    self.fe_1_stages_dict = Stage.get_feature_stages(
+    self.fe_1_stages_dict = stage_helpers.get_feature_stages(
         self.feature_1.key.integer_id())
-    self.fe_2_stages_dict = Stage.get_feature_stages(
+    self.fe_2_stages_dict = stage_helpers.get_feature_stages(
         self.feature_2.key.integer_id())
-    self.fe_3_stages_dict = Stage.get_feature_stages(
+    self.fe_3_stages_dict = stage_helpers.get_feature_stages(
         self.feature_3.key.integer_id())
-    self.fe_4_stages_dict = Stage.get_feature_stages(
+    self.fe_4_stages_dict = stage_helpers.get_feature_stages(
         self.feature_4.key.integer_id())
 
     # Legacy entities for testing legacy functions.
@@ -322,27 +323,27 @@ class FeatureTest(testing_config.CustomTestCase):
     """We can retrieve a list of features."""
     self.feature_1.impl_status_chrome = 5
     # Set shipping milestone to 1.
-    self.fe_1_stages_dict[160].milestones = MilestoneSet(desktop_first=1)
+    self.fe_1_stages_dict[160][0].milestones = MilestoneSet(desktop_first=1)
     self.feature_1.put()
-    self.fe_1_stages_dict[160].put()
+    self.fe_1_stages_dict[160][0].put()
 
     self.feature_2.impl_status_chrome = 7
     # Set shipping milestone to 1.
-    self.fe_2_stages_dict[260].milestones = MilestoneSet(desktop_first=1)
+    self.fe_2_stages_dict[260][0].milestones = MilestoneSet(desktop_first=1)
     self.feature_2.put()
-    self.fe_2_stages_dict[260].put()
+    self.fe_2_stages_dict[260][0].put()
 
     self.feature_3.impl_status_chrome = 5
     # Set shipping milestone to 1.
-    self.fe_3_stages_dict[360].milestones = MilestoneSet(desktop_first=1)
+    self.fe_3_stages_dict[360][0].milestones = MilestoneSet(desktop_first=1)
     self.feature_3.put()
-    self.fe_3_stages_dict[360].put()
+    self.fe_3_stages_dict[360][0].put()
 
     self.feature_4.impl_status_chrome = 7
     # Set shipping milestone to 1.
-    self.fe_4_stages_dict[460].milestones = MilestoneSet(desktop_first=2)
+    self.fe_4_stages_dict[460][0].milestones = MilestoneSet(desktop_first=2)
     self.feature_4.put()
-    self.fe_4_stages_dict[460].put()
+    self.fe_4_stages_dict[460][0].put()
 
     actual = feature_helpers.get_in_milestone(milestone=1)
     removed = [f['name'] for f in actual['Removed']]
@@ -364,25 +365,25 @@ class FeatureTest(testing_config.CustomTestCase):
   def test_get_in_milestone__unlisted(self):
     """Unlisted features should not be listed for users who can't edit."""
     self.feature_1.impl_status_chrome = 5
-    self.fe_1_stages_dict[160].milestones = MilestoneSet(desktop_first=1)
+    self.fe_1_stages_dict[160][0].milestones = MilestoneSet(desktop_first=1)
     self.feature_1.put()
-    self.fe_1_stages_dict[160].put()
+    self.fe_1_stages_dict[160][0].put()
 
     self.feature_2.unlisted = True
     self.feature_2.impl_status_chrome = 7
-    self.fe_2_stages_dict[260].milestones = MilestoneSet(desktop_first=1)
+    self.fe_2_stages_dict[260][0].milestones = MilestoneSet(desktop_first=1)
     self.feature_2.put()
-    self.fe_2_stages_dict[260].put()
+    self.fe_2_stages_dict[260][0].put()
 
     self.feature_3.impl_status_chrome = 5
-    self.fe_3_stages_dict[360].milestones = MilestoneSet(desktop_first=1)
+    self.fe_3_stages_dict[360][0].milestones = MilestoneSet(desktop_first=1)
     self.feature_3.put()
-    self.fe_3_stages_dict[360].put()
+    self.fe_3_stages_dict[360][0].put()
 
     self.feature_4.impl_status_chrome = 7
-    self.fe_4_stages_dict[460].milestones = MilestoneSet(desktop_first=2)
+    self.fe_4_stages_dict[460][0].milestones = MilestoneSet(desktop_first=2)
     self.feature_4.put()
-    self.fe_4_stages_dict[460].put()
+    self.fe_4_stages_dict[460][0].put()
 
     actual = feature_helpers.get_in_milestone(milestone=1)
     self.assertEqual(
@@ -392,25 +393,25 @@ class FeatureTest(testing_config.CustomTestCase):
   def test_get_in_milestone__unlisted_shown(self):
     """Unlisted features should be listed for users who can edit."""
     self.feature_1.impl_status_chrome = 5
-    self.fe_1_stages_dict[160].milestones = MilestoneSet(desktop_first=1)
+    self.fe_1_stages_dict[160][0].milestones = MilestoneSet(desktop_first=1)
     self.feature_1.put()
-    self.fe_1_stages_dict[160].put()
+    self.fe_1_stages_dict[160][0].put()
 
     self.feature_2.unlisted = True
     self.feature_2.impl_status_chrome = 7
-    self.fe_2_stages_dict[260].milestones = MilestoneSet(desktop_first=1)
+    self.fe_2_stages_dict[260][0].milestones = MilestoneSet(desktop_first=1)
     self.feature_2.put()
-    self.fe_2_stages_dict[260].put()
+    self.fe_2_stages_dict[260][0].put()
 
     self.feature_3.impl_status_chrome = 5
-    self.fe_3_stages_dict[360].milestones = MilestoneSet(desktop_first=1)
+    self.fe_3_stages_dict[360][0].milestones = MilestoneSet(desktop_first=1)
     self.feature_3.put()
-    self.fe_3_stages_dict[360].put()
+    self.fe_3_stages_dict[360][0].put()
 
     self.feature_4.impl_status_chrome = 7
-    self.fe_4_stages_dict[460].milestones = MilestoneSet(desktop_first=2)
+    self.fe_4_stages_dict[460][0].milestones = MilestoneSet(desktop_first=2)
     self.feature_4.put()
-    self.fe_4_stages_dict[460].put()
+    self.fe_4_stages_dict[460][0].put()
 
     actual = feature_helpers.get_in_milestone(
         milestone=1, show_unlisted=True)
@@ -453,13 +454,13 @@ class StageTest(testing_config.CustomTestCase):
   
   def test_get_feature_stages(self):
     """A dictionary with stages relevant to the feature should be present."""
-    stage_dict = Stage.get_feature_stages(self.feature_id)
+    stage_dict = stage_helpers.get_feature_stages(self.feature_id)
     list_stages = stage_dict.items()
     expected_stage_types = {410, 430, 450, 460, 470}
     # Extension stage type was not created, so it should not appear.
     self.assertIsNone(stage_dict.get(451, None))
     self.assertEqual(len(list_stages), 5)
-    for stage_type, stage in stage_dict.items():
+    for stage_type, stages in stage_dict.items():
       self.assertTrue(stage_type in expected_stage_types)
-      self.assertEqual(stage.stage_type, stage_type)
+      self.assertEqual(stages[0].stage_type, stage_type)
       expected_stage_types.remove(stage_type)

--- a/internals/core_models_test.py
+++ b/internals/core_models_test.py
@@ -19,7 +19,7 @@ from api import converters
 from framework import rediscache
 from internals import feature_helpers
 from internals import core_enums
-from internals import core_models
+from internals.core_models import Feature, FeatureEntry, MilestoneSet, Stage
 
 
 class MockQuery(object):
@@ -48,53 +48,83 @@ class ModelsFunctionsTest(testing_config.CustomTestCase):
 class FeatureTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_2 = core_models.FeatureEntry(
+    self.feature_2 = FeatureEntry(
         name='feature b', summary='sum',
         owner_emails=['feature_owner@example.com'], category=1,
-        updated=datetime(2020, 4, 1))
+        updated=datetime(2020, 4, 1), feature_type=1)
     self.feature_2.put()
 
-    self.feature_1 = core_models.FeatureEntry(
+    self.feature_1 = FeatureEntry(
         name='feature a', summary='sum', impl_status_chrome=3,
         owner_emails=['feature_owner@example.com'], category=1,
-        updated=datetime(2020, 3, 1))
+        updated=datetime(2020, 3, 1), feature_type=0)
     self.feature_1.put()
 
-    self.feature_4 = core_models.FeatureEntry(
-        name='feature d', summary='sum', category=1, impl_status_chrome=2,
-        owner_emails=['feature_owner@example.com'],
-        updated=datetime(2020, 2, 1))
-    self.feature_4.put()
-
-    self.feature_3 = core_models.FeatureEntry(
+    self.feature_3 = FeatureEntry(
         name='feature c', summary='sum', category=1, impl_status_chrome=2,
         owner_emails=['feature_owner@example.com'],
-        updated=datetime(2020, 1, 1))
+        updated=datetime(2020, 1, 1), feature_type=2)
     self.feature_3.put()
 
+    self.feature_4 = FeatureEntry(
+        name='feature d', summary='sum', category=1, impl_status_chrome=2,
+        owner_emails=['feature_owner@example.com'],
+        updated=datetime(2020, 2, 1), feature_type=3)
+    self.feature_4.put()
+
+    fe_1_stage_types = [110, 120, 130, 140, 150, 151, 160]
+    fe_2_stage_types = [220, 230, 250, 251, 260]
+    fe_3_stage_types = [320, 330, 360]
+    fe_4_stage_types = [410, 430, 450, 451, 460, 470]
+    self.stages: list[Stage] = []
+    for s_type in fe_1_stage_types:
+      stage = Stage(
+          feature_id=self.feature_1.key.integer_id(), stage_type=s_type)
+      stage.put()
+    for s_type in fe_2_stage_types:
+      stage = Stage(
+          feature_id=self.feature_2.key.integer_id(), stage_type=s_type)
+      stage.put()
+    for s_type in fe_3_stage_types:
+      stage = Stage(
+          feature_id=self.feature_3.key.integer_id(), stage_type=s_type)
+      stage.put()
+    for s_type in fe_4_stage_types:
+      stage = Stage(
+          feature_id=self.feature_4.key.integer_id(), stage_type=s_type)
+      stage.put()
+    self.fe_1_stages_dict = Stage.get_feature_stages(
+        self.feature_1.key.integer_id())
+    self.fe_2_stages_dict = Stage.get_feature_stages(
+        self.feature_2.key.integer_id())
+    self.fe_3_stages_dict = Stage.get_feature_stages(
+        self.feature_3.key.integer_id())
+    self.fe_4_stages_dict = Stage.get_feature_stages(
+        self.feature_4.key.integer_id())
+
     # Legacy entities for testing legacy functions.
-    self.legacy_feature_2 = core_models.Feature(
+    self.legacy_feature_2 = Feature(
         name='feature b', summary='sum',
         owner=['feature_owner@example.com'], category=1)
     self.legacy_feature_2.put()
 
-    self.legacy_feature_1 = core_models.Feature(
+    self.legacy_feature_1 = Feature(
         name='feature a', summary='sum', impl_status_chrome=3,
         owner=['feature_owner@example.com'], category=1)
     self.legacy_feature_1.put()
 
-    self.legacy_feature_4 = core_models.Feature(
+    self.legacy_feature_4 = Feature(
         name='feature d', summary='sum', category=1, impl_status_chrome=2,
         owner=['feature_owner@example.com'])
     self.legacy_feature_4.put()
 
-    self.legacy_feature_3 = core_models.Feature(
+    self.legacy_feature_3 = Feature(
         name='feature c', summary='sum', category=1, impl_status_chrome=2,
         owner=['feature_owner@example.com'])
     self.legacy_feature_3.put()
 
   def tearDown(self):
-    for kind in [core_models.Feature, core_models.FeatureEntry]:
+    for kind in [Feature, FeatureEntry, Stage]:
       for entity in kind.query():
         entity.key.delete()
 
@@ -191,9 +221,9 @@ class FeatureTest(testing_config.CustomTestCase):
     self.assertEqual('feature a', actual[0]['name'])
     self.assertEqual('feature b', actual[1]['name'])
 
-    lookup_key_1 = '%s|%s' % (core_models.FeatureEntry.DEFAULT_CACHE_KEY,
+    lookup_key_1 = '%s|%s' % (FeatureEntry.DEFAULT_CACHE_KEY,
                               self.feature_1.key.integer_id())
-    lookup_key_2 = '%s|%s' % (core_models.FeatureEntry.DEFAULT_CACHE_KEY,
+    lookup_key_2 = '%s|%s' % (FeatureEntry.DEFAULT_CACHE_KEY,
                               self.feature_2.key.integer_id())
     self.assertEqual('feature a', rediscache.get(lookup_key_1)['name'])
     self.assertEqual('feature b', rediscache.get(lookup_key_2)['name'])
@@ -201,7 +231,7 @@ class FeatureTest(testing_config.CustomTestCase):
   def test_get_by_ids__cache_hit(self):
     """We can load features from rediscache."""
     cache_key = '%s|%s' % (
-        core_models.FeatureEntry.DEFAULT_CACHE_KEY, self.feature_1.key.integer_id())
+        FeatureEntry.DEFAULT_CACHE_KEY, self.feature_1.key.integer_id())
     cached_feature = {
       'name': 'fake cached_feature',
       'id': self.feature_1.key.integer_id(),
@@ -290,21 +320,29 @@ class FeatureTest(testing_config.CustomTestCase):
 
   def test_get_in_milestone__normal(self):
     """We can retrieve a list of features."""
-    self.legacy_feature_2.impl_status_chrome = 7
-    self.legacy_feature_2.shipped_milestone = 1
-    self.legacy_feature_2.put()
+    self.feature_1.impl_status_chrome = 5
+    # Set shipping milestone to 1.
+    self.fe_1_stages_dict[160].milestones = MilestoneSet(desktop_first=1)
+    self.feature_1.put()
+    self.fe_1_stages_dict[160].put()
 
-    self.legacy_feature_1.impl_status_chrome = 5
-    self.legacy_feature_1.shipped_milestone = 1
-    self.legacy_feature_1.put()
+    self.feature_2.impl_status_chrome = 7
+    # Set shipping milestone to 1.
+    self.fe_2_stages_dict[260].milestones = MilestoneSet(desktop_first=1)
+    self.feature_2.put()
+    self.fe_2_stages_dict[260].put()
 
-    self.legacy_feature_3.impl_status_chrome = 5
-    self.legacy_feature_3.shipped_milestone = 1
-    self.legacy_feature_3.put()
+    self.feature_3.impl_status_chrome = 5
+    # Set shipping milestone to 1.
+    self.fe_3_stages_dict[360].milestones = MilestoneSet(desktop_first=1)
+    self.feature_3.put()
+    self.fe_3_stages_dict[360].put()
 
-    self.legacy_feature_4.impl_status_chrome = 7
-    self.legacy_feature_4.shipped_milestone = 2
-    self.legacy_feature_4.put()
+    self.feature_4.impl_status_chrome = 7
+    # Set shipping milestone to 1.
+    self.fe_4_stages_dict[460].milestones = MilestoneSet(desktop_first=2)
+    self.feature_4.put()
+    self.fe_4_stages_dict[460].put()
 
     actual = feature_helpers.get_in_milestone(milestone=1)
     removed = [f['name'] for f in actual['Removed']]
@@ -318,29 +356,33 @@ class FeatureTest(testing_config.CustomTestCase):
     self.assertEqual(6, len(actual))
 
     cache_key = '%s|%s|%s' % (
-        core_models.Feature.DEFAULT_CACHE_KEY, 'milestone', 1)
+        FeatureEntry.DEFAULT_CACHE_KEY, 'milestone', 1)
     cached_result = rediscache.get(cache_key)
     self.assertEqual(cached_result, actual)
 
 
   def test_get_in_milestone__unlisted(self):
     """Unlisted features should not be listed for users who can't edit."""
-    self.legacy_feature_2.unlisted = True
-    self.legacy_feature_2.impl_status_chrome = 7
-    self.legacy_feature_2.shipped_milestone = 1
-    self.legacy_feature_2.put()
+    self.feature_1.impl_status_chrome = 5
+    self.fe_1_stages_dict[160].milestones = MilestoneSet(desktop_first=1)
+    self.feature_1.put()
+    self.fe_1_stages_dict[160].put()
 
-    self.legacy_feature_1.impl_status_chrome = 5
-    self.legacy_feature_1.shipped_milestone = 1
-    self.legacy_feature_1.put()
+    self.feature_2.unlisted = True
+    self.feature_2.impl_status_chrome = 7
+    self.fe_2_stages_dict[260].milestones = MilestoneSet(desktop_first=1)
+    self.feature_2.put()
+    self.fe_2_stages_dict[260].put()
 
-    self.legacy_feature_3.impl_status_chrome = 5
-    self.legacy_feature_3.shipped_milestone = 1
-    self.legacy_feature_3.put()
+    self.feature_3.impl_status_chrome = 5
+    self.fe_3_stages_dict[360].milestones = MilestoneSet(desktop_first=1)
+    self.feature_3.put()
+    self.fe_3_stages_dict[360].put()
 
-    self.legacy_feature_4.impl_status_chrome = 7
-    self.legacy_feature_4.shipped_milestone = 2
-    self.legacy_feature_4.put()
+    self.feature_4.impl_status_chrome = 7
+    self.fe_4_stages_dict[460].milestones = MilestoneSet(desktop_first=2)
+    self.feature_4.put()
+    self.fe_4_stages_dict[460].put()
 
     actual = feature_helpers.get_in_milestone(milestone=1)
     self.assertEqual(
@@ -349,22 +391,26 @@ class FeatureTest(testing_config.CustomTestCase):
 
   def test_get_in_milestone__unlisted_shown(self):
     """Unlisted features should be listed for users who can edit."""
-    self.legacy_feature_2.unlisted = True
-    self.legacy_feature_2.impl_status_chrome = 7
-    self.legacy_feature_2.shipped_milestone = 1
-    self.legacy_feature_2.put()
+    self.feature_1.impl_status_chrome = 5
+    self.fe_1_stages_dict[160].milestones = MilestoneSet(desktop_first=1)
+    self.feature_1.put()
+    self.fe_1_stages_dict[160].put()
 
-    self.legacy_feature_1.impl_status_chrome = 5
-    self.legacy_feature_1.shipped_milestone = 1
-    self.legacy_feature_1.put()
+    self.feature_2.unlisted = True
+    self.feature_2.impl_status_chrome = 7
+    self.fe_2_stages_dict[260].milestones = MilestoneSet(desktop_first=1)
+    self.feature_2.put()
+    self.fe_2_stages_dict[260].put()
 
-    self.legacy_feature_3.impl_status_chrome = 5
-    self.legacy_feature_3.shipped_milestone = 1
-    self.legacy_feature_3.put()
+    self.feature_3.impl_status_chrome = 5
+    self.fe_3_stages_dict[360].milestones = MilestoneSet(desktop_first=1)
+    self.feature_3.put()
+    self.fe_3_stages_dict[360].put()
 
-    self.legacy_feature_4.impl_status_chrome = 7
-    self.legacy_feature_4.shipped_milestone = 2
-    self.legacy_feature_4.put()
+    self.feature_4.impl_status_chrome = 7
+    self.fe_4_stages_dict[460].milestones = MilestoneSet(desktop_first=2)
+    self.feature_4.put()
+    self.fe_4_stages_dict[460].put()
 
     actual = feature_helpers.get_in_milestone(
         milestone=1, show_unlisted=True)
@@ -375,7 +421,7 @@ class FeatureTest(testing_config.CustomTestCase):
   def test_get_in_milestone__cached(self):
     """If there is something in the cache, we use it."""
     cache_key = '%s|%s|%s' % (
-        core_models.Feature.DEFAULT_CACHE_KEY, 'milestone', 1)
+        FeatureEntry.DEFAULT_CACHE_KEY, 'milestone', 1)
     cached_test_feature = {'test': [{'name': 'test_feature', 'unlisted': False}]}
     rediscache.set(cache_key, cached_test_feature)
 
@@ -387,7 +433,7 @@ class FeatureTest(testing_config.CustomTestCase):
 class StageTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_entry_1 = core_models.FeatureEntry(id=1, name='fe one',
+    self.feature_entry_1 = FeatureEntry(id=1, name='fe one',
         summary='summary', category=1, impl_status_chrome=1,
         standard_maturity=1, web_dev_views=1)
     self.feature_entry_1.put()
@@ -396,17 +442,17 @@ class StageTest(testing_config.CustomTestCase):
         core_enums.STAGE_DEP_REMOVE_CODE]
     self.feature_id = self.feature_entry_1.key.integer_id()
     for stage_type in stage_types:
-      stage = core_models.Stage(feature_id=self.feature_id, stage_type=stage_type)
+      stage = Stage(feature_id=self.feature_id, stage_type=stage_type)
       stage.put()
 
   def tearDown(self):
     self.feature_entry_1.key.delete()
-    for stage in core_models.Stage.query().fetch():
+    for stage in Stage.query().fetch():
       stage.key.delete()
   
   def test_get_feature_stages(self):
     """A dictionary with stages relevant to the feature should be present."""
-    stage_dict = core_models.Stage.get_feature_stages(self.feature_id)
+    stage_dict = Stage.get_feature_stages(self.feature_id)
     list_stages = stage_dict.items()
     expected_stage_types = {410, 430, 450, 460, 470}
     # Extension stage type was not created, so it should not appear.

--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -340,58 +340,58 @@ def get_in_milestone(milestone: int,
     # but no desktop milestone.
     q = Stage.query(Stage.milestones.android_first == milestone,
         Stage.milestones.desktop_first == None,
-        Stage.stage_type.IN(STAGE_BLINK_SHIPPING, STAGE_PSA_SHIPPING,
-            STAGE_FAST_SHIPPING, STAGE_DEP_SHIPPING))
+        Stage.stage_type.IN((STAGE_BLINK_SHIPPING, STAGE_PSA_SHIPPING,
+            STAGE_FAST_SHIPPING, STAGE_DEP_SHIPPING)))
     android_only_shipping_future = q.fetch_async()
 
     # Origin trial stages (Desktop) in this milestone.
     q = Stage.query(Stage.milestones.desktop_first == milestone,
-        Stage.stage_type.IN(STAGE_BLINK_ORIGIN_TRIAL, STAGE_FAST_ORIGIN_TRIAL,
-            STAGE_DEP_DEPRECATION_TRIAL))
+        Stage.stage_type.IN((STAGE_BLINK_ORIGIN_TRIAL, STAGE_FAST_ORIGIN_TRIAL,
+            STAGE_DEP_DEPRECATION_TRIAL)))
     desktop_origin_trial_future = q.fetch_async()
 
     # Origin trial stages (Android) in this milestone.
     q = Stage.query(Stage.milestones.android_first == milestone,
         Stage.milestones.desktop_first == None,
-        Stage.stage_type.IN(STAGE_BLINK_ORIGIN_TRIAL, STAGE_FAST_ORIGIN_TRIAL,
-            STAGE_DEP_DEPRECATION_TRIAL))
+        Stage.stage_type.IN((STAGE_BLINK_ORIGIN_TRIAL, STAGE_FAST_ORIGIN_TRIAL,
+            STAGE_DEP_DEPRECATION_TRIAL)))
     android_origin_trial_future = q.fetch_async()
 
     # Origin trial stages (Webview) in this milestone.
     q = Stage.query(Stage.milestones.webview_first == milestone,
         Stage.milestones.desktop_first == None,
-        Stage.stage_type.IN(STAGE_BLINK_ORIGIN_TRIAL, STAGE_FAST_ORIGIN_TRIAL,
-            STAGE_DEP_DEPRECATION_TRIAL))
+        Stage.stage_type.IN((STAGE_BLINK_ORIGIN_TRIAL, STAGE_FAST_ORIGIN_TRIAL,
+            STAGE_DEP_DEPRECATION_TRIAL)))
     webview_origin_trial_future = q.fetch_async()
 
     # Dev trial stages (Desktop) in this milestone.
     q = Stage.query(Stage.milestones.desktop_first == milestone,
-        Stage.stage_type.IN(STAGE_BLINK_DEV_TRIAL, STAGE_PSA_DEV_TRIAL,
-            STAGE_FAST_DEV_TRIAL, STAGE_DEP_DEV_TRIAL))
+        Stage.stage_type.IN((STAGE_BLINK_DEV_TRIAL, STAGE_PSA_DEV_TRIAL,
+            STAGE_FAST_DEV_TRIAL, STAGE_DEP_DEV_TRIAL)))
     desktop_dev_trial_future = q.fetch_async()
 
     # Dev trial stages (Android) in this milestone.
     q = Stage.query(Stage.milestones.android_first == milestone,
         Stage.milestones.desktop_first == None,
-        Stage.stage_type.IN(STAGE_BLINK_DEV_TRIAL, STAGE_PSA_DEV_TRIAL,
-            STAGE_FAST_DEV_TRIAL, STAGE_DEP_DEV_TRIAL))
-    android_dev_trial_future = q.fetch_async(None)
+        Stage.stage_type.IN((STAGE_BLINK_DEV_TRIAL, STAGE_PSA_DEV_TRIAL,
+            STAGE_FAST_DEV_TRIAL, STAGE_DEP_DEV_TRIAL)))
+    android_dev_trial_future = q.fetch_async()
 
     # Wait for all futures to complete and collect unique feature IDs.
     desktop_shipping_ids = list({
-        [s.feature_id for s in desktop_shipping_future.result()]})
+        *[s.feature_id for s in desktop_shipping_future.result()]})
     android_only_shipping_ids = list({
-        [s.feature_id for s in android_only_shipping_future.result()]})
+        *[s.feature_id for s in android_only_shipping_future.result()]})
     desktop_origin_trials_ids = list({
-        [s.feature_id for s in desktop_origin_trial_future.result()]})
+        *[s.feature_id for s in desktop_origin_trial_future.result()]})
     android_origin_trials_ids = list({
-        [s.feature_id for s in android_origin_trial_future.result()]})
+        *[s.feature_id for s in android_origin_trial_future.result()]})
     webview_origin_trials_ids = list({
-        [s.feature_id for s in webview_origin_trial_future.result()]})
+        *[s.feature_id for s in webview_origin_trial_future.result()]})
     desktop_dev_trials_ids = list({
-        [s.feature_id for s in desktop_dev_trial_future.result()]})
+        *[s.feature_id for s in desktop_dev_trial_future.result()]})
     android_dev_trials_ids = list({
-        [s.feature_id for s in android_dev_trial_future.result()]})
+        *[s.feature_id for s in android_dev_trial_future.result()]})
 
     # Query for FeatureEntry entities that match the stage feature IDs.
     # Querying with an empty list will raise an error, so check if each

--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -312,6 +312,8 @@ def get_in_milestone(milestone: int,
     logging.info('Getting chronological feature list in milestone %d',
                 milestone)
     # Start each query asynchronously in parallel.
+
+    # Shipping stages with a matching desktop milestone.
     q = Stage.query(Stage.milestones.desktop_first == milestone,
         ndb.OR(Stage.stage_type == STAGE_BLINK_SHIPPING,
             Stage.stage_type == STAGE_PSA_SHIPPING,
@@ -320,7 +322,8 @@ def get_in_milestone(milestone: int,
     q = q.filter()
     desktop_shipping_future = q.fetch_async()
 
-    # Stages with an android shipping milestone but no desktop milestone.
+    # Shipping stages with a matching android shipping milestone
+    # but no desktop milestone.
     q = Stage.query(Stage.milestones.android_first == milestone,
         Stage.milestones.desktop_first == None,
         ndb.OR(Stage.stage_type == STAGE_BLINK_SHIPPING,
@@ -329,14 +332,14 @@ def get_in_milestone(milestone: int,
             Stage.stage_type == STAGE_DEP_SHIPPING))
     android_only_shipping_future = q.fetch_async()
 
-    # Stages that are in origin trial (Desktop) in this milestone
+    # Origin trial stages (Desktop) in this milestone.
     q = Stage.query(Stage.milestones.desktop_first == milestone,
         ndb.OR(Stage.stage_type == STAGE_BLINK_ORIGIN_TRIAL,
             Stage.stage_type == STAGE_FAST_ORIGIN_TRIAL,
             Stage.stage_type == STAGE_DEP_DEPRECATION_TRIAL))
     desktop_origin_trial_future = q.fetch_async()
 
-    # Stages that are in origin trial (Android) in this milestone
+    # Origin trial stages (Android) in this milestone.
     q = Stage.query(Stage.milestones.android_first == milestone,
         Stage.milestones.desktop_first == None,
         ndb.OR(Stage.stage_type == STAGE_BLINK_ORIGIN_TRIAL,
@@ -344,7 +347,7 @@ def get_in_milestone(milestone: int,
             Stage.stage_type == STAGE_DEP_DEPRECATION_TRIAL))
     android_origin_trial_future = q.fetch_async()
 
-    # Stages that are in origin trial (Webview) in this milestone
+    # Origin trial stages (Webview) in this milestone.
     q = Stage.query(Stage.milestones.webview_first == milestone,
         Stage.milestones.desktop_first == None,
         ndb.OR(Stage.stage_type == STAGE_BLINK_ORIGIN_TRIAL,
@@ -352,7 +355,7 @@ def get_in_milestone(milestone: int,
             Stage.stage_type == STAGE_DEP_DEPRECATION_TRIAL))
     webview_origin_trial_future = q.fetch_async()
 
-    # Features that are in dev trial (Desktop) in this milestone
+    # Dev trial stages (Desktop) in this milestone.
     q = Stage.query(Stage.milestones.desktop_first == milestone,
         ndb.OR(Stage.stage_type == STAGE_BLINK_DEV_TRIAL,
             Stage.stage_type == STAGE_PSA_DEV_TRIAL,
@@ -360,7 +363,7 @@ def get_in_milestone(milestone: int,
             Stage.stage_type == STAGE_DEP_DEV_TRIAL))
     desktop_dev_trial_future = q.fetch_async()
 
-    # Features that are in dev trial (Android) in this milestone
+    # Dev trial stages (Android) in this milestone.
     q = Stage.query(Stage.milestones.android_first == milestone,
         Stage.milestones.desktop_first == None,
         ndb.OR(Stage.stage_type == STAGE_BLINK_DEV_TRIAL,


### PR DESCRIPTION
This change updates the `get_in_milestone()` function to use FeatureEntry entities rather than the old Feature entities. This requires that Stage entities be queried for first to obtain feature IDs relevant to the given milestone, and then query for those features by IDs.