### PR TITLE
Update and handle deprecated views fields

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -444,7 +444,7 @@ def feature_entry_to_json_verbose(fe: FeatureEntry) -> dict[str, Any]:
     },
     'safari': {
       'view': {
-        'text': VENDOR_VIEWS.get(fe.safari_views,
+        'text': VENDOR_VIEWS.get(safari_views,
             VENDOR_VIEWS_COMMON[NO_PUBLIC_SIGNALS]),
         'val': (safari_views if safari_views in VENDOR_VIEWS
             else NO_PUBLIC_SIGNALS),
@@ -454,7 +454,7 @@ def feature_entry_to_json_verbose(fe: FeatureEntry) -> dict[str, Any]:
     },
     'webdev': {
       'view': {
-        'text': WEB_DEV_VIEWS.get(fe.web_dev_views,
+        'text': WEB_DEV_VIEWS.get(web_dev_views,
             WEB_DEV_VIEWS[DEV_NO_SIGNALS]),
         'val': (web_dev_views if web_dev_views in WEB_DEV_VIEWS
             else DEV_NO_SIGNALS),

--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -1,0 +1,57 @@
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config  # Must be imported before the module under test.
+
+
+from api import converters
+from internals.core_models import FeatureEntry
+
+from google.cloud import ndb  # type: ignore
+
+class ConvertersTest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.fe_1 = FeatureEntry(
+        id=123, name='feature template', summary='sum',
+        owner_emails=['feature_owner@example.com'],
+        editor_emails=['feature_editor@example.com', 'owner_1@example.com'],
+        category=1, creator_email='creator_template@example.com',
+        updater_email='editor_template@example.com',
+        blink_components=['Blink'])
+    self.fe_1.put()
+    self.maxDiff = None
+
+  def tearDown(self) -> None:
+    self.fe_1.key.delete()
+
+  def test_feature_entry_to_json_basic__bad_view_field(self):
+    """Function handles if any views fields have deprecated values."""
+    # Deprecated views enum value.
+    self.fe_1.ff_views = 4
+    self.fe_1.safari_views = 4
+    self.fe_1.put()
+    result = converters.feature_entry_to_json_basic(self.fe_1)
+    self.assertEqual(5, result['browsers']['safari']['view']['val'])
+    self.assertEqual(5, result['browsers']['ff']['view']['val'])
+
+  def test_feature_entry_to_jason_verbose__bad_view_field(self):
+    """Function handles if any views fields have deprecated values."""
+    # Deprecated views enum value.
+    self.fe_1.safari_views = 4
+    self.fe_1.ff_views = 4
+    self.fe_1.put()
+    result = converters.feature_entry_to_json_verbose(self.fe_1)
+    self.assertEqual(5, result['browsers']['safari']['view']['val'])
+    self.assertEqual(5, result['browsers']['ff']['view']['val'])

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -440,3 +440,40 @@ class WriteUpdatedField(FlaskHandler):
         count += 1
     
     return f'{count} FeatureEntry entities given updated field values.'
+
+class UpdateDeprecatedViews(FlaskHandler):
+
+  def get_template_data(self, **kwargs):
+    """Migrates deprecated feature views fields to their new values"""
+    self.require_cron_header()
+
+    for fe in FeatureEntry.query():
+      if fe.ff_views == MIXED_SIGNALS:
+        fe.ff_views = NO_PUBLIC_SIGNALS
+      if fe.ff_views == PUBLIC_SKEPTICISM:
+        fe.ff_views = OPPOSED
+
+      if fe.safari_views == MIXED_SIGNALS:
+        fe.safari_views = NO_PUBLIC_SIGNALS
+      if fe.safari_views == PUBLIC_SKEPTICISM:
+        fe.safari_views = OPPOSED
+      fe.put()
+    
+    for f in Feature.query():
+      if f.ff_views == MIXED_SIGNALS:
+        f.ff_views = NO_PUBLIC_SIGNALS
+      if f.ff_views == PUBLIC_SKEPTICISM:
+        f.ff_views = OPPOSED
+
+      if f.ie_views == MIXED_SIGNALS:
+        f.ie_views = NO_PUBLIC_SIGNALS
+      if f.ie_views == PUBLIC_SKEPTICISM:
+        f.ie_views = OPPOSED
+
+      if f.safari_views == MIXED_SIGNALS:
+        f.safari_views = NO_PUBLIC_SIGNALS
+      if f.safari_views == PUBLIC_SKEPTICISM:
+        f.safari_views = OPPOSED
+      f.put()
+    
+    return 'Feature and FeatureEntry view fields updated.'

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -441,6 +441,7 @@ class WriteUpdatedField(FlaskHandler):
     
     return f'{count} FeatureEntry entities given updated field values.'
 
+
 class UpdateDeprecatedViews(FlaskHandler):
 
   def get_template_data(self, **kwargs):
@@ -448,32 +449,48 @@ class UpdateDeprecatedViews(FlaskHandler):
     self.require_cron_header()
 
     for fe in FeatureEntry.query():
+      fe_changed = False
       if fe.ff_views == MIXED_SIGNALS:
+        fe_changed = True
         fe.ff_views = NO_PUBLIC_SIGNALS
-      if fe.ff_views == PUBLIC_SKEPTICISM:
+      elif fe.ff_views == PUBLIC_SKEPTICISM:
+        fe_changed = True
         fe.ff_views = OPPOSED
 
       if fe.safari_views == MIXED_SIGNALS:
+        fe_changed = True
         fe.safari_views = NO_PUBLIC_SIGNALS
-      if fe.safari_views == PUBLIC_SKEPTICISM:
+      elif fe.safari_views == PUBLIC_SKEPTICISM:
+        fe_changed = True
         fe.safari_views = OPPOSED
-      fe.put()
+      
+      if fe_changed:
+        fe.put()
     
     for f in Feature.query():
+      f_changed = False
       if f.ff_views == MIXED_SIGNALS:
+        f_changed = True
         f.ff_views = NO_PUBLIC_SIGNALS
       if f.ff_views == PUBLIC_SKEPTICISM:
+        f_changed = True
         f.ff_views = OPPOSED
 
       if f.ie_views == MIXED_SIGNALS:
+        f_changed = True
         f.ie_views = NO_PUBLIC_SIGNALS
-      if f.ie_views == PUBLIC_SKEPTICISM:
+      elif f.ie_views == PUBLIC_SKEPTICISM:
+        f_changed = True
         f.ie_views = OPPOSED
 
       if f.safari_views == MIXED_SIGNALS:
+        f_changed = True
         f.safari_views = NO_PUBLIC_SIGNALS
-      if f.safari_views == PUBLIC_SKEPTICISM:
+      elif f.safari_views == PUBLIC_SKEPTICISM:
+        f_changed = True
         f.safari_views = OPPOSED
-      f.put()
+
+      if f_changed:
+        f.put()
     
     return 'Feature and FeatureEntry view fields updated.'

--- a/main.py
+++ b/main.py
@@ -227,6 +227,8 @@ internals_routes: list[Route] = [
       schema_migration.EvaluateGateStatus),
   Route('/admin/schema_migration_updated_field',
       schema_migration.WriteUpdatedField),
+  Route('/admin/schema_migration_update_views',
+      schema_migration.UpdateDeprecatedViews)
 ]
 
 


### PR DESCRIPTION
This PR adds a script to migrate all deprecated views fields to their respective new values, as well as handles cases when the field is an unexpected value.