### PR TITLE
s/Web RTC/WebRTC/

### DIFF
--- a/client-src/elements/form-field-enums.js
+++ b/client-src/elements/form-field-enums.js
@@ -22,7 +22,7 @@ export const FEATURE_CATEGORIES = {
   CSS: [15, 'CSS'],
   HOUDINI: [16, 'Houdini'],
   SERVICEWORKER: [17, 'Service Worker'],
-  WEBRTC: [18, 'Web RTC'],
+  WEBRTC: [18, 'WebRTC'],
   LAYERED: [19, 'Layered APIs'],
   WEBASSEMBLY: [20, 'WebAssembly'],
   CAPABILITIES: [21, 'Capabilities (Fugu)'],

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -57,7 +57,7 @@ FEATURE_CATEGORIES = {
   GRAPHICS: 'Graphics',
   HOUDINI: 'Houdini',
   SERVICEWORKER: 'Service Worker',
-  WEBRTC: 'Web RTC',
+  WEBRTC: 'WebRTC',
   LAYERED: 'Layered APIs',
   WEBASSEMBLY: 'WebAssembly',
   CAPABILITIES: 'Capabilities (Fugu)'


### PR DESCRIPTION
which is the canonical spelling established by
  https://w3c.github.io/webrtc-pc/

(please tell me it is possible to change and we don't need this odd whitespace around forever :-))