### PR TITLE
Fix extra slash in prepub emails.

### DIFF
--- a/internals/testdata/reminders_test/test_build_email_tasks_prepublication.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_prepublication.html
@@ -19,7 +19,7 @@ publication.</p>
 <h3>feature one</h3>
 <p>sum</p>
 
-<p><a href="http://127.0.0.1:8888//guide/edit/123">Edit your feature</a></p>
+<p><a href="http://127.0.0.1:8888/guide/edit/123">Edit your feature</a></p>
 
 
 

--- a/templates/prepublication-notice-email.html
+++ b/templates/prepublication-notice-email.html
@@ -19,7 +19,7 @@ publication.</p>
 <h3>{{feature.name}}</h3>
 <p>{{feature.summary}}</p>
 
-<p><a href="{{site_url}}/guide/edit/{{id}}">Edit your feature</a></p>
+<p><a href="{{site_url}}guide/edit/{{id}}">Edit your feature</a></p>
 
 
 


### PR DESCRIPTION
This should resolve issue #2492.
The value for settings.site_url already has a trailing slash, so we don't need to add another one.