### PR TITLE
Define an enterprise flat edit-all form.

### DIFF
--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -203,6 +203,12 @@ const FLAT_SHIP_FIELDS = [
   'shipped_ios_milestone', 'shipped_webview_milestone',
 ];
 
+const FLAT_ENTERPRISE_PREPARE_TO_SHIP = [
+  'rollout_milestone', 'rollout_platforms', 'rollout_details',
+  'enterprise_policies',
+];
+
+
 // Forms to be used on the "Edit all" page that shows a flat list of fields.
 // [[sectionName, flatFormFields]].
 export const FLAT_FORMS = [
@@ -232,6 +238,10 @@ export const FLAT_FORMS_BY_FEATURE_TYPE = {
     ['Dev trial', FLAT_DEV_TRAIL_FIELDS],
     ['Origin trial', FLAT_ORIGIN_TRIAL_FIELDS],
     ['Prepare to ship', FLAT_PREPARE_TO_SHIP_FIELDS],
+    ['Ship', FLAT_SHIP_FIELDS],
+  ],
+  [FEATURE_TYPES.FEATURE_TYPE_ENTERPRISE_ID[0]]: [
+    ['Start feature rollout', FLAT_ENTERPRISE_PREPARE_TO_SHIP],
     ['Ship', FLAT_SHIP_FIELDS],
   ],
 };

--- a/client-src/elements/form-field-enums.js
+++ b/client-src/elements/form-field-enums.js
@@ -65,7 +65,7 @@ export const FEATURE_TYPES = {
   FEATURE_TYPE_DEPRECATION_ID: [3, 'Feature deprecation',
     'Deprecate and remove an old feature.'],
   FEATURE_TYPE_ENTERPRISE_ID: [4, 'New Feature or removal affecting enterprises',
-    'For features or changes that need to be communicated to enterprises or schools'],
+    'For features or changes that need to be communicated to enterprises or schools.'],
 };
 
 export const INTENT_STAGES = {

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -1174,9 +1174,9 @@ export const ALL_FIELDS = {
     required: false,
     label: 'Rollout details',
     help_text: html`
-      Explain what specifically is changing in the selected milestone for the 
-      selected platforms. Include any controls admins have to test it 
-      (e.g. flags) and control it (e.g. an enterprise policy). Write in the 
+      Explain what specifically is changing in the selected milestone for the
+      selected platforms. Include any controls admins have to test it
+      (e.g. flags) and control it (e.g. an enterprise policy). Write in the
       present tense.`,
   },
 
@@ -1184,7 +1184,9 @@ export const ALL_FIELDS = {
     type: 'checkbox',
     label: 'Breaking change',
     initial: false,
-    help_text: 'This is a breaking change (customers/developers must take action)',
+    help_text: html`
+      This is a breaking change: customers or developers must take action
+      to continue using some existing functionaity.`,
   },
 };
 


### PR DESCRIPTION
This makes the "edit all fields" link work for enterprise features.

I also revised the help text for the "Breaking change" fields to be slightly more explicit.