### PR TITLE
Check if val is assigned in chromedash-feature-detail

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -208,7 +208,7 @@ class ChromedashFeatureDetail extends LitElement {
         }
       }
     }
-    if (fieldId == 'rollout_platforms') {
+    if (value && fieldId == 'rollout_platforms') {
       value = value.map(platformId => PLATFORMS_DISPLAYNAME[platformId]);
     }
     return value;


### PR DESCRIPTION
Fixed errors when opening a [feature detail page](https://cr-status-staging.appspot.com/feature/5713211376533504):
```
components.js?v=b465758:5570 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'map')
    at ChromedashFeatureDetail.getFieldValue (components.js?v=b465758:5570:1147)
    at ChromedashFeatureDetail.renderField (components.js?v=b465758:5578:116)
    at components.js?v=b465758:5583:125
    at Array.map (<anonymous>)
    at ChromedashFeatureDetail.renderSectionFields (components.js?v=b465758:5583:106)
    at ChromedashFeatureDetail.renderStageSection (components.js?v=b465758:5606:16)
    at components.js?v=b465758:5622:45
    at Array.map (<anonymous>)
    at ChromedashFeatureDetail.render (components.js?v=b465758:5622:29)
    at ChromedashFeatureDetail.update (components.js?v=b465758:3323:17371)
```