### PR TITLE
Allow the user to clear out a multi-select field.

### DIFF
--- a/pages/guide.py
+++ b/pages/guide.py
@@ -227,6 +227,8 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       'privacy_review_status', 'tag_review_status', 'safari_views', 'ff_views',
       'web_dev_views', 'blink_components', 'impl_status_chrome'])
 
+  MULTI_SELECT_FIELDS: frozenset[str] = frozenset(['rollout_platforms'])
+
   def touched(self, param_name: str) -> bool:
     """Return True if the user edited the specified field."""
     # TODO(jrobbins): for now we just consider everything on the current form
@@ -234,9 +236,10 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     # hidden form field named "touched" that lists the names of all fields
     # actually touched by the user.
 
-    # For now, checkboxes are always considered "touched", if they are
-    # present on the form.
-    if param_name in self.CHECKBOX_FIELDS:
+    # For now, checkboxes and multi-selects are always considered "touched",
+    # if they are present on the form.
+    if (param_name in self.CHECKBOX_FIELDS or
+        param_name in self.MULTI_SELECT_FIELDS):
       form_fields_str = self.form.get('form_fields')
       if form_fields_str:
         form_fields = [field_name.strip()

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -175,6 +175,24 @@ class FeatureEditHandlerTest(testing_config.CustomTestCase):
       # intent_state is a select, but it was not present in this POST.
       self.assertFalse(self.handler.touched('select'))
 
+  def test_touched__multiselects(self):
+    """For now, any multi-select listed in form_fields is considered touched."""
+    # Field is in this form and the user selected a value.
+    with test_app.test_request_context(
+        'path', data={'form_fields': 'rollout_platforms',
+                      'rollout_platforms': 'iOS'}):
+      self.assertTrue(self.handler.touched('rollout_platforms'))
+
+    # Field in is this form and no value was selected
+    with test_app.test_request_context(
+        'path', data={'form_fields': 'rollout_platforms'}):
+      self.assertTrue(self.handler.touched('rollout_platforms'))
+
+    # rollout_platforms is not part of this form
+    with test_app.test_request_context(
+        'path', data={'form_fields': 'other,fields'}):
+      self.assertFalse(self.handler.touched('rollout_platforms'))
+
   def test_post__anon(self):
     """Anon cannot edit features, gets a 403."""
     testing_config.sign_out()


### PR DESCRIPTION
HTML form submission is a little tricky for checkboxes and multi-selects.   For checkboxes, if the user unchecks the box, the field is not included in the POST data.  Likewise, for multi-selects, if the user unchecks all items, the field is not in the POST data.  So, the server side needs to anticipate which fields are in which forms and treat the absence of a value as an empty value.