### PR TITLE
Show useful error on feature not found

### DIFF
--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -144,7 +144,6 @@ export class ChromedashFeaturePage extends LitElement {
     }).catch((error) => {
       if (error instanceof FeatureNotFoundError) {
         this.loading = false;
-        showToastMessage('Feature not found.');
       } else {
         showToastMessage('Some errors occurred. Please refresh the page or try again later.');
       }
@@ -464,7 +463,7 @@ export class ChromedashFeaturePage extends LitElement {
     }
     // If after loading, the feature did not load, render nothing.
     if (!this.isFeatureLoaded()) {
-      return html ``;
+      return html `Feature not found.`;
     }
     // At this point, the feature has loaded successfully, render the components.
     return html`

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -465,19 +465,22 @@ export class ChromedashFeaturePage extends LitElement {
   render() {
     // TODO: create another element - chromedash-feature-highlights
     // for all the content of the <div id="feature"> part of the page
+    // If loading, only render the skeletons.
+    if (this.loading) {
+      return this.renderSkeletons();
+    }
+    // If after loading, the feature did not load, render nothing.
+    if (!this.isFeatureLoaded()) {
+      return html ``;
+    }
+    // At this point, the feature has loaded successfully, render the components.
     return html`
-      ${this.loading ?
-        this.renderSkeletons() :
-        this.isFeatureLoaded() ?
-          html`
-            ${this.renderSubHeader()}
-            <div id="feature">
-              ${this.renderFeatureContent()}
-              ${this.renderFeatureStatus()}
-            </div>
-            ${this.renderFeatureDetails()}
-            ` :
-          html``}
+      ${this.renderSubHeader()}
+      <div id="feature">
+        ${this.renderFeatureContent()}
+        ${this.renderFeatureStatus()}
+      </div>
+      ${this.renderFeatureDetails()}
     `;
   }
 }

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -142,14 +142,7 @@ export class ChromedashFeaturePage extends LitElement {
       }
       this.loading = false;
     }).catch((error) => {
-      // Cannot import the type currently with rollup when doing:
-      // import {FeatureNotFoundError} from '../js-src/cs-client';
-      // Will get:
-      //    RollupError: "FeatureNotFoundError" is not exported by
-      //    "client-src/js-src/cs-client.js", imported by
-      //    "client-src/elements/chromedash-feature-page.js"
-      // For now, compare the name.
-      if (error.name && error.name === 'FeatureNotFoundError') {
+      if (error instanceof FeatureNotFoundError) {
         this.loading = false;
         showToastMessage('Feature not found.');
       } else {

--- a/client-src/elements/chromedash-feature-page_test.js
+++ b/client-src/elements/chromedash-feature-page_test.js
@@ -95,6 +95,21 @@ describe('chromedash-feature-page', () => {
     tags: ['tag_one'],
   });
 
+  // Holds the global toast element.
+  // If `document.querySelector('chromedash-toast');` is used in each test, it
+  // returns a new toast element. However, the toast element that actually used
+  // is the one from the first test.
+  // To fix that, manage a single instance and reset it after every test.
+  // More details: https://github.com/GoogleChrome/chromium-dashboard/pull/2503#issuecomment-1329665602
+  let toastEl;
+  function getToastElement() {
+    if (toastEl) {
+      return toastEl;
+    }
+    toastEl = document.querySelector('chromedash-toast');
+    return toastEl;
+  }
+
   /* window.csClient and <chromedash-toast> are initialized at spa.html
    * which are not available here, so we initialize them before each test.
    * We also stub out the API calls here so that they return test data. */
@@ -122,9 +137,14 @@ describe('chromedash-feature-page', () => {
     window.csClient.getDismissedCues.restore();
     window.csClient.getStars.restore();
     window.csClient.getChannels.restore();
+    getToastElement().reset();
   });
 
   it('renders with no data', async () => {
+    const toastEl = getToastElement();
+    assert.isEmpty(toastEl.msg);
+    assert.isFalse(toastEl.open);
+
     const invalidFeaturePromise = Promise.reject(new Error('Got error response from server'));
     window.csClient.getFeature.withArgs(0).returns(invalidFeaturePromise);
 
@@ -134,10 +154,33 @@ describe('chromedash-feature-page', () => {
     assert.instanceOf(component, ChromedashFeaturePage);
 
     // invalid feature requests would trigger the toast to show message
-    const toastEl = document.querySelector('chromedash-toast');
     const toastMsgSpan = toastEl.shadowRoot.querySelector('span#msg');
-    assert.include(toastMsgSpan.innerHTML,
-      'Some errors occurred. Please refresh the page or try again later.');
+    const expectedToastMsg = 'Some errors occurred. Please refresh the page or try again later.';
+    assert.isTrue(toastEl.open);
+    assert.equal(toastEl.msg, expectedToastMsg);
+    assert.include(toastMsgSpan.innerHTML, expectedToastMsg);
+  });
+
+  it('renders with "No Feature Found" when feature not found', async () => {
+    const toastEl = getToastElement();
+    assert.isEmpty(toastEl.msg);
+    assert.isFalse(toastEl.open);
+
+    const featureNotFoundPromise = Promise.reject(new FeatureNotFoundError(12345));
+    window.csClient.getFeature.withArgs(0).returns(featureNotFoundPromise);
+
+    const component = await fixture(
+      html`<chromedash-feature-page></chromedash-feature-page>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashFeaturePage);
+
+    // If a request for a feature returns stating that it is not found, it
+    // would trigger the toast to show message.
+    const toastMsgSpan = toastEl.shadowRoot.querySelector('span#msg');
+    const expectedToastMsg = 'Feature not found.';
+    assert.isTrue(toastEl.open);
+    assert.equal(toastEl.msg, expectedToastMsg);
+    assert.include(toastMsgSpan.innerHTML, expectedToastMsg);
   });
 
   it('renders with fake data', async () => {

--- a/client-src/elements/chromedash-toast.js
+++ b/client-src/elements/chromedash-toast.js
@@ -117,6 +117,17 @@ class ChromedashToast extends LitElement {
     this.open = true;
   }
 
+  reset() {
+    if (this.currentTimeout !== null) {
+      clearTimeout(this.currentTimeout);
+    }
+    this.msg = '';
+    this.actionLabel = '';
+    this.open = false;
+    this.currentTimeout = null;
+    this.waitingForTransition = false;
+  }
+
   render() {
     return html`
       <span id="msg">${this.msg}</span>

--- a/client-src/elements/chromedash-toast.js
+++ b/client-src/elements/chromedash-toast.js
@@ -117,17 +117,6 @@ class ChromedashToast extends LitElement {
     this.open = true;
   }
 
-  reset() {
-    if (this.currentTimeout !== null) {
-      clearTimeout(this.currentTimeout);
-    }
-    this.msg = '';
-    this.actionLabel = '';
-    this.open = false;
-    this.currentTimeout = null;
-    this.waitingForTransition = false;
-  }
-
   render() {
     return html`
       <span id="msg">${this.msg}</span>


### PR DESCRIPTION
Also, stop showing skeleton upon feature not being found.

Add two new Errors to cs-client.js:
- ChromeStatusHttpError
- FeatureNotFoundError

ChromeStatusHttpError is meant to be returned at the doFetch level FeatureNotFoundError is meant at the getFeature level. getFeature interprets ChromeStatusHttpError and returns as necessary.

Add isFeatureLoaded to chromedash-feature-page.
Allows us to detect the case that we have finished loading but nothing was loaded.

Use that function to detect when to show main feature components or show nothing.

In the event a feature is not found. A blank page with the normal header is shown. A toast appears and says: `Feature not found.`


Fixes #2257