### PR TITLE
Do not log None -> "[]" amendments for feature fields

### DIFF
--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -29,7 +29,8 @@ def _get_changes_as_amendments(
   amendments = []
   for field, old_val, new_val in changed_fields:
     if new_val != old_val:
-      if (new_val == '' or new_val == False) and old_val is None:
+      # Don't log if the old value was null and now it's falsey.
+      if old_val is None and not bool(new_val):
         continue
       amendments.append(
           review_models.Amendment(field_name=field,

--- a/internals/notifier_helpers_test.py
+++ b/internals/notifier_helpers_test.py
@@ -62,3 +62,13 @@ class ActivityTest(testing_config.CustomTestCase):
     feature_id = self.feature_1.key.integer_id()
     activities = Activity.get_activities(feature_id)
     self.assertEqual(len(activities), 0)
+
+  def test_activities_created__empty_list_not_created(self):
+    """No amendment should be logged if the value moved from None to empty list."""
+    changed_fields = [('editor_emails', None, [])]
+    notifier_helpers.notify_subscribers_and_save_amendments(
+        self.feature_1, changed_fields)
+    
+    activities = Activity.get_activities(self.feature_1.key.integer_id())
+    # No activity entity created.
+    self.assertTrue(len(activities) == 0)


### PR DESCRIPTION
Addresses #2424 

Avoid logging changes that represent null feature field values becoming their empty null-equivalent types (empty lists, etc.)