### PR TITLE
Update reminders to use new entities

### DIFF
--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -282,6 +282,24 @@ STAGE_TYPES_BY_FIELD_MAPPING: dict[str, dict[int, Optional[int]]] = {
     'rollout_details': STAGE_TYPES_SHIPPING
   }
 
+# Mapping of the old Feature milestone field names to MilestoneSet field names.
+OLD_FEATURE_FIELDS_TO_NEW_MILESTONE_FIELDS = {
+  'ot_milestone_desktop_start': 'desktop_first',
+  'ot_milestone_desktop_end': 'desktop_last',
+  'ot_milestone_android_start': 'android_first',
+  'ot_milestone_android_end': 'android_last',
+  'ot_milestone_webview_start': 'webview_first',
+  'ot_milestone_webview_end': 'webview_last',
+  'dt_milestone_desktop_start': 'desktop_first',
+  'dt_milestone_android_start': 'android_first',
+  'dt_milestone_ios_start': 'ios_first',
+  'dt_milestone_webview_start': 'webview_first',
+  'shipped_milestone': 'desktop_first',
+  'shipped_android_milestone': 'android_first',
+  'shipped_ios_milestone': 'ios_first',
+  'shipped_webview_milestone': 'webview_first'
+}
+
 # Mapping of which stage types are associated with each gate type.
 STAGE_TYPES_BY_GATE_TYPE_MAPPING: dict[int, dict[int, Optional[int]]] = {
   GATE_PROTOTYPE: STAGE_TYPES_PROTOTYPE,

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -282,24 +282,6 @@ STAGE_TYPES_BY_FIELD_MAPPING: dict[str, dict[int, Optional[int]]] = {
     'rollout_details': STAGE_TYPES_SHIPPING
   }
 
-# Mapping of the old Feature milestone field names to MilestoneSet field names.
-OLD_FEATURE_FIELDS_TO_NEW_MILESTONE_FIELDS = {
-  'ot_milestone_desktop_start': 'desktop_first',
-  'ot_milestone_desktop_end': 'desktop_last',
-  'ot_milestone_android_start': 'android_first',
-  'ot_milestone_android_end': 'android_last',
-  'ot_milestone_webview_start': 'webview_first',
-  'ot_milestone_webview_end': 'webview_last',
-  'dt_milestone_desktop_start': 'desktop_first',
-  'dt_milestone_android_start': 'android_first',
-  'dt_milestone_ios_start': 'ios_first',
-  'dt_milestone_webview_start': 'webview_first',
-  'shipped_milestone': 'desktop_first',
-  'shipped_android_milestone': 'android_first',
-  'shipped_ios_milestone': 'ios_first',
-  'shipped_webview_milestone': 'webview_first'
-}
-
 # Mapping of which stage types are associated with each gate type.
 STAGE_TYPES_BY_GATE_TYPE_MAPPING: dict[int, dict[int, Optional[int]]] = {
   GATE_PROTOTYPE: STAGE_TYPES_PROTOTYPE,

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -113,6 +113,8 @@ class AbstractReminderHandler(basehandlers.FlaskHandler):
       stages = stage_helpers.get_feature_stages(feature.key.integer_id())
       min_milestone = None
       for field in self.MILESTONE_FIELDS:
+        # Get fields that are relevant to the milestones field specified
+        # (e.g. 'shipped_milestone' implies shipping stages)
         relevant_stages = stages[
             STAGE_TYPES_BY_FIELD_MAPPING[field][feature.feature_type]]
         for stage in relevant_stages:
@@ -125,6 +127,7 @@ class AbstractReminderHandler(basehandlers.FlaskHandler):
               min_milestone = m
             else:
               min_milestone = min(min_milestone, m)
+      # If a matching milestone was ever found, use it for the reminder.
       if min_milestone:
         result.append((feature, min_milestone))
 

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -24,8 +24,7 @@ from framework import basehandlers
 from internals import core_models
 from internals import notifier
 from internals import stage_helpers
-from internals.core_enums import (
-    STAGE_TYPES_BY_FIELD_MAPPING, OLD_FEATURE_FIELDS_TO_NEW_MILESTONE_FIELDS)
+from internals.core_enums import STAGE_TYPES_BY_FIELD_MAPPING
 import settings
 
 

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -121,7 +121,7 @@ class AbstractReminderHandler(basehandlers.FlaskHandler):
           milestones = stage.milestones
           m = (None if milestones is None
               else getattr(milestones,
-                  OLD_FEATURE_FIELDS_TO_NEW_MILESTONE_FIELDS[field]))
+                  core_models.MilestoneSet.MILESTONE_FIELD_MAPPING[field]))
           if m is not None and m >= min_mstone and m <= max_mstone:
             if min_milestone is None:
               min_milestone = m

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -23,6 +23,9 @@ from flask import render_template
 from framework import basehandlers
 from internals import core_models
 from internals import notifier
+from internals import stage_helpers
+from internals.core_enums import (
+    STAGE_TYPES_BY_FIELD_MAPPING, OLD_FEATURE_FIELDS_TO_NEW_MILESTONE_FIELDS)
 import settings
 
 
@@ -46,17 +49,21 @@ def build_email_tasks(
   email_tasks = []
   beta_date = datetime.fromisoformat(current_milestone_info['earliest_beta'])
   beta_date_str = beta_date.strftime('%Y-%m-%d')
-  for feature, mstone in features_to_notify:
+  for fe, mstone in features_to_notify:
+    # TODO(danielrsmith): the estimated-milestones-template.html is reliant
+    # on old Feature entity milestone fields and will need to be refactored
+    # to use Stage entity fields before removing this Feature use.
+    feature = core_models.Feature.get_by_id(fe.key.integer_id())
     body_data = {
-      'id': feature.key.integer_id(),
+      'id': fe.key.integer_id(),
       'feature': feature,
       'site_url': settings.SITE_URL,
       'milestone': mstone,
       'beta_date_str': beta_date_str,
     }
     html = render_template(body_template_path, **body_data)
-    subject = subject_format % feature.name
-    for owner in feature.owner:
+    subject = subject_format % fe.name
+    for owner in fe.owner_emails:
       email_tasks.append({
         'to': owner,
         'subject': subject,
@@ -103,19 +110,30 @@ class AbstractReminderHandler(basehandlers.FlaskHandler):
 
     result = []
     for feature in features:
-      field_values = [getattr(feature, field) for field in self.MILESTONE_FIELDS]
-      matching_values = [
-          m for m in field_values
-          if m is not None and m >= min_mstone and m <= max_mstone]
-      if matching_values:
-        result.append((feature, min(matching_values)))
+      stages = stage_helpers.get_feature_stages(feature.key.integer_id())
+      min_milestone = None
+      for field in self.MILESTONE_FIELDS:
+        relevant_stages = stages[
+            STAGE_TYPES_BY_FIELD_MAPPING[field][feature.feature_type]]
+        for stage in relevant_stages:
+          milestones = stage.milestones
+          m = (None if milestones is None
+              else getattr(milestones,
+                  OLD_FEATURE_FIELDS_TO_NEW_MILESTONE_FIELDS[field]))
+          if m is not None and m >= min_mstone and m <= max_mstone:
+            if min_milestone is None:
+              min_milestone = m
+            else:
+              min_milestone = min(min_milestone, m)
+      if min_milestone:
+        result.append((feature, min_milestone))
 
     return result
 
   def determine_features_to_notify(self, current_milestone_info):
     """Get all features filter them by class-specific and milestone criteria."""
-    features = core_models.Feature.query(
-        core_models.Feature.deleted == False).fetch(None)
+    features = core_models.FeatureEntry.query(
+        core_models.FeatureEntry.deleted == False).fetch()
     prefiltered_features = self.prefilter_features(
         current_milestone_info, features)
     features_milestone_pairs = self.filter_by_milestones(

--- a/internals/reminders_test.py
+++ b/internals/reminders_test.py
@@ -100,7 +100,8 @@ class FunctionTest(testing_config.CustomTestCase):
     self.maxDiff = None
   
   def tearDown(self) -> None:
-    for kind in [Feature, FeatureEntry, Stage]:
+    kinds: list[ndb.Model] = [Feature, FeatureEntry, Stage]
+    for kind in kinds:
       for entity in kind.query():
         entity.key.delete()
 

--- a/internals/reminders_test.py
+++ b/internals/reminders_test.py
@@ -18,7 +18,7 @@ import settings
 from datetime import datetime
 from unittest import mock
 
-from internals import core_models
+from internals.core_models import Feature, FeatureEntry, MilestoneSet, Stage
 from internals import reminders
 
 from google.cloud import ndb  # type: ignore
@@ -37,18 +37,39 @@ class MockResponse:
 
 
 def make_test_features():
-  feature_1 = core_models.Feature(
-      name='feature one', summary='sum', owner=['feature_owner@example.com'],
-      category=1, ot_milestone_desktop_start=100)
+  feature_1 = FeatureEntry(
+      name='feature one', summary='sum',
+      owner_emails=['feature_owner@example.com'],
+      category=1, feature_type=0)
   feature_1.put()
-  feature_2 = core_models.Feature(
+  stages = [110, 120, 130, 140, 150, 151, 160]
+  for stage_type in stages:
+    stage = Stage(feature_id=feature_1.key.integer_id(), stage_type=stage_type)
+    if stage_type == 150:
+      stage.milestones = MilestoneSet(desktop_first=100)
+    stage.put()
+
+  feature_2 = FeatureEntry(
       name='feature two', summary='sum',
-      owner=['owner_1@example.com', 'owner_2@example.com'],
-      category=1, shipped_milestone=150)
+      owner_emails=['owner_1@example.com', 'owner_2@example.com'],
+      category=1, feature_type=1)
   feature_2.put()
-  feature_3 = core_models.Feature(
-      name='feature three', summary='sum', category=1)
+
+  stages = [220, 230, 250, 251, 260]
+  for stage_type in stages:
+    stage = Stage(feature_id=feature_2.key.integer_id(), stage_type=stage_type)
+    if stage_type == 260:
+      stage.milestones = MilestoneSet(desktop_first=150)
+    stage.put()
+
+  feature_3 = FeatureEntry(
+      name='feature three', summary='sum', category=1, feature_type=2)
   feature_3.put()
+  stages = [320, 330, 360]
+  for stage_type in stages:
+    stage = Stage(feature_id=feature_3.key.integer_id(), stage_type=stage_type)
+    stage.put()
+
   return feature_1, feature_2, feature_3
 
 
@@ -58,13 +79,30 @@ class FunctionTest(testing_config.CustomTestCase):
     self.current_milestone_info = {
         'earliest_beta': '2022-09-21T12:34:56',
     }
-    self.feature_template = core_models.Feature(
-      name='feature one', summary='sum', owner=['feature_owner@example.com'],
-      category=1, ot_milestone_desktop_start=100)
-    self.feature_template.key = ndb.Key('Feature', 123)
-    # This test does not require saving to the database.
+
+    self.old_feature_template = Feature(id=123,
+        name='feature one', summary='sum', owner=['feature_owner@example.com'],
+        category=1, feature_type=0, ot_milestone_desktop_start=100)
+    self.feature_template = FeatureEntry(id=123,
+      name='feature one', summary='sum',
+      owner_emails=['feature_owner@example.com'],
+      category=1, feature_type=0)
+    stages = [110, 120, 130, 140, 150, 151, 160]
+    for stage_type in stages:
+      stage = Stage(feature_id=123, stage_type=stage_type)
+      if stage_type == 150:
+        stage.milestones = MilestoneSet(desktop_first=100)
+      stage.put()
+    
+    self.old_feature_template.put()
+    self.feature_template.put()
 
     self.maxDiff = None
+  
+  def tearDown(self) -> None:
+    for kind in [Feature, FeatureEntry, Stage]:
+      for entity in kind.query():
+        entity.key.delete()
 
   def test_build_email_tasks_feature_accuracy(self):
     with test_app.app_context():
@@ -106,6 +144,8 @@ class FeatureAccuracyHandlerTest(testing_config.CustomTestCase):
     self.feature_1.key.delete()
     self.feature_2.key.delete()
     self.feature_3.key.delete()
+    for stage in Stage.query():
+      stage.key.delete()
 
   @mock.patch('requests.get')
   def test_determine_features_to_notify__no_features(self, mock_get):


### PR DESCRIPTION
This change updates the email reminders methods to use new FeatureEntry and Stage entities in calculating who and when to send reminder emails to.

Note that the matching Feature entity is still used to render the reminder email due to the `estimated-milestones-table.html` file using the old Feature milestone fields, and will require a larger refactor to update to use Stage milestone fields.