### PR TITLE
Adjust select and menu size

### DIFF
--- a/client-src/elements/chromedash-feature-filter.js
+++ b/client-src/elements/chromedash-feature-filter.js
@@ -293,17 +293,7 @@ class ChromedashFeatureFilter extends LitElement {
         margin: 6px 3px;
       }
       .field-name-select {
-        // The smallest width to accommodate the
-        // largest text, Webview Shipping Milestone.
         width: 240px;
-      }
-      .field-name-menu {
-        // The smallest width without showing
-        // horizontal scroll.
-        width: 265px;
-        position: absolute;
-        // Half of the field-name-select width.
-        left: -120px;
       }
       .enum-select {
         flex: 1 1 auto;
@@ -353,7 +343,7 @@ class ChromedashFeatureFilter extends LitElement {
               value=${fieldName}
               @sl-change="${(e) => this.handleChangeField(e.target.value, index)}">
        ${QUERIABLE_FIELDS.map((item) => html`
-         <sl-menu-item class="field-name-menu" value="${item.name}">
+         <sl-menu-item value="${item.name}">
            ${item.display}
          </sl-menu-item>
         `)}
@@ -502,7 +492,7 @@ class ChromedashFeatureFilter extends LitElement {
           placeholder="Select a field name"
               @sl-change="${this.addFilterCondition}">
        ${QUERIABLE_FIELDS.map((item) => html`
-         <sl-menu-item class="field-name-menu" value="${item.name}">
+         <sl-menu-item value="${item.name}">
            ${item.display}
          </sl-menu-item>
         `)}

--- a/client-src/elements/chromedash-feature-filter.js
+++ b/client-src/elements/chromedash-feature-filter.js
@@ -292,8 +292,18 @@ class ChromedashFeatureFilter extends LitElement {
       .filterrow * {
         margin: 6px 3px;
       }
-      .cond-field-menu {
-        width: 180px;
+      .field-name-select {
+        // The smallest width to accomodate the
+        // largest text, Webview Shipping Milestone.
+        width: 240px;
+      }
+      .field-name-menu {
+        // The smallest width without showing
+        // horizontal scroll.
+        width: 265px;
+        position: absolute;
+        // Half of the field-name-select width.
+        left: -120px;
       }
       .cond-op-menu {
         width: 150px;
@@ -336,11 +346,11 @@ class ChromedashFeatureFilter extends LitElement {
 
   renderFilterFieldMenu(fieldName, index) {
     return html`
-      <sl-select class="cond-field-menu" size="small"
+      <sl-select class="field-name-select" size="small"
               value=${fieldName}
               @sl-change="${(e) => this.handleChangeField(e.target.value, index)}">
        ${QUERIABLE_FIELDS.map((item) => html`
-         <sl-menu-item value="${item.name}">
+         <sl-menu-item class="field-name-menu" value="${item.name}">
            ${item.display}
          </sl-menu-item>
         `)}
@@ -485,11 +495,11 @@ class ChromedashFeatureFilter extends LitElement {
   renderBlankCondition() {
     return html`
      <div class="filterrow">
-      <sl-select id="choose_field" class="cond-field-menu" size="small"
+      <sl-select id="choose_field" class="field-name-select" size="small"
           placeholder="Select a field name"
               @sl-change="${this.addFilterCondition}">
        ${QUERIABLE_FIELDS.map((item) => html`
-         <sl-menu-item value="${item.name}">
+         <sl-menu-item class="field-name-menu" value="${item.name}">
            ${item.display}
          </sl-menu-item>
         `)}

--- a/client-src/elements/chromedash-feature-filter.js
+++ b/client-src/elements/chromedash-feature-filter.js
@@ -293,7 +293,7 @@ class ChromedashFeatureFilter extends LitElement {
         margin: 6px 3px;
       }
       .field-name-select {
-        // The smallest width to accomodate the
+        // The smallest width to accommodate the
         // largest text, Webview Shipping Milestone.
         width: 240px;
       }
@@ -304,6 +304,9 @@ class ChromedashFeatureFilter extends LitElement {
         position: absolute;
         // Half of the field-name-select width.
         left: -120px;
+      }
+      .enum-select {
+        flex: 1 1 auto;
       }
       .cond-op-menu {
         width: 150px;
@@ -420,7 +423,7 @@ class ChromedashFeatureFilter extends LitElement {
     if (cond.op == EQ_OP) {
       if (inputType == ENUM_TYPE) {
         return html`
-          <sl-select size="small" placeholder="Select a field value"
+          <sl-select class="enum-select" size="small" placeholder="Select a field value"
                 @sl-change="${(e) => this.handleChangeValue(e.target.value, index)}">
             ${Object.values(field.choices).map(
               (val) => html`


### PR DESCRIPTION
Fix #2412. Increase the size of select and dropdown menu:
- Increase the sl-select to 240px, the smallest width to accommodate the largest text, Webview Shipping Milestone
- Set enum drop-down menu flex 1 1 auto, aligned with other input fields