### PR TITLE
Remove bad input from rollout_platforms

### DIFF
--- a/pages/guide.py
+++ b/pages/guide.py
@@ -275,7 +275,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
         val = self.form.getlist(field)
         # Occasionally, input will give an empty string as the first element.
         # It needs to be removed.
-        if val and len(val[0]) == 0:
+        if val and val[0] == '':
           val = val[1:]
         return val
       elif field == 'blink_components' and len(val) == 0:

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -271,12 +271,16 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     elif field_type == 'str':
       return self.form.get(field)
     elif field_type == 'split_str':
-      val = self.split_input(field, delim=',')
       if field == 'rollout_platforms':
         val = self.form.getlist(field)
+        # Occasionally, input will give an empty string as the first element.
+        # It needs to be removed.
+        if val and len(val[0]) == 0:
+          val = val[1:]
+        return val
       elif field == 'blink_components' and len(val) == 0:
         return [settings.DEFAULT_COMPONENT]
-      return val
+      return self.split_input(field, delim=',')
     raise ValueError(f'Unknown field data type: {field_type}')
 
   def _add_changed_field(self, fe: FeatureEntry, field: str, new_val: Any,


### PR DESCRIPTION
For enterprise features, occasionally, the multi-select form field for the rollout_platforms field would give an additional empty string as a user-selected value. This was causing incorrect values and views.

![Screen Shot 2022-11-30 at 11 04 25 AM](https://user-images.githubusercontent.com/56164590/204886394-ba685db8-c018-47ce-a4a8-16cb577292b2.png)

This is a simple workaround to this issue (although I do not yet know the root cause).