### PR TITLE
Use Python 3.10 in start-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For a one-click setup that leverages devcontainers, check out the devcontainer
 1. Install other developer tools commands
     1. node and npm.
     1. Gulp: `npm install --global gulp-cli`
-    1. Python virtual environment: `sudo apt install python3.9-venv`
+    1. Python virtual environment: `sudo apt install python3.10-venv`
 1. We recommend using an older node version, e.g. node 18
     1. Use `node -v` to check the default node version
     2. `nvm use 18` to switch to node 18

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -4,7 +4,7 @@
 #
 # Copyright 2017 Eric Bidelman <ericbidelman@chromium.org>
 
-export PYTHONPATH=cs-env/lib/python3.9/site-packages:$PYTHONPATH
+export PYTHONPATH=cs-env/lib/python3.10/site-packages:$PYTHONPATH
 export GOOGLE_CLOUD_PROJECT='cr-status-staging'
 export SERVER_SOFTWARE='gunicorn'
 export GAE_ENV='localdev'


### PR DESCRIPTION
The outdated python 3.9 command causes following errors on devcontainer:

```
File "/workspace/main.py", line 19, in <module>
    from api import accounts_api, dev_api
  File "/workspace/api/accounts_api.py", line 18, in <module>
    from google.cloud import ndb  # type: ignore
  File "/workspace/cs-env/lib/python3.9/site-packages/google/cloud/ndb/__init__.py", line 28, in <module>
    from google.cloud.ndb.client import Client
  File "/workspace/cs-env/lib/python3.9/site-packages/google/cloud/ndb/client.py", line 18, in <module>
    import grpc
  File "/workspace/cs-env/lib/python3.9/site-packages/grpc/__init__.py", line 22, in <module>
    from grpc import _compression
  File "/workspace/cs-env/lib/python3.9/site-packages/grpc/_compression.py", line 15, in <module>
    from grpc._cython import cygrpc
ImportError: cannot import name 'cygrpc' from 'grpc._cython' (/workspace/cs-env/lib/python3.9/site-packages/grpc/_cython/__init__.py)
```