### PR TITLE
Fix edit icon permission checking

### DIFF
--- a/client-src/elements/chromedash-feature-table.js
+++ b/client-src/elements/chromedash-feature-table.js
@@ -216,7 +216,7 @@ class ChromedashFeatureTable extends LitElement {
          .feature=${feature}
          columns=${this.columns}
          ?signedIn=${this.signedIn}
-         ?canEdit=${this.canApprove}
+         ?canEdit=${this.canEdit}
          ?canApprove=${this.canApprove}
          .starredFeatures=${this.starredFeatures}
          .gates=${this.gates}


### PR DESCRIPTION
Today I noticed that the API Owners all had the pencil icons showing up for every feature in the lists on the myfeatures page, regardless of whether or not they actually had permission to edit.  It was because of this editing error.

This fix is important to deploy to users, but I think it can wait until our upcoming weekly release because the bug only affects the myfeatures page (and the unreleased new feature list page).  Users have other ways to get to the edit page: the pencil icons on the old feature page and the feature detail page are not affected by this bug.