### PR TITLE
Exclude enterprise features from search results by default.

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -55,9 +55,10 @@ class FeaturesAPI(basehandlers.APIHandler):
     num = self.get_int_arg('num', search.DEFAULT_RESULTS_PER_PAGE)
     start = self.get_int_arg('start', 0)
 
+    show_enterprise = 'feature_type' in user_query
     features_on_page, total_count = search.process_query(
         user_query, sort_spec=sort_spec, show_unlisted=show_unlisted_features,
-        start=start, num=num)
+        show_enterprise=show_enterprise, start=start, num=num)
 
     return {
         'total_count': total_count,

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -519,6 +519,11 @@ def convert_enum_int_to_string(property_name, value):
 
 def convert_enum_string_to_int(property_name, value):
   """If the property is an enum, return its enum value, else -1."""
+  try:
+    return int(value)
+  except ValueError:
+    pass
+
   enum_dict = PROPERTY_NAMES_TO_ENUM_DICTS.get(property_name, {})
   for index, enum_str in enum_dict.items():
     if enum_str == value:

--- a/internals/core_enums_test.py
+++ b/internals/core_enums_test.py
@@ -55,6 +55,12 @@ class EnumsFunctionsTest(testing_config.CustomTestCase):
         'impl_status_chrome', 99)
     self.assertEqual(99, actual)
 
+  def test_convert_enum_string_to_int__already_numeric(self):
+    """If the value passed in is already an int, go with it."""
+    actual = core_enums.convert_enum_string_to_int(
+        'impl_status_chrome', str(core_enums.NO_ACTIVE_DEV))
+    self.assertEqual(core_enums.NO_ACTIVE_DEV, actual)
+
   def test_convert_enum_string_to_int__enum_found(self):
     """We use the enum representation if it is defined."""
     actual = core_enums.convert_enum_string_to_int(

--- a/internals/search.py
+++ b/internals/search.py
@@ -294,7 +294,7 @@ def create_future_operations_from_queries(terms):
 
 def process_or_operations(or_clauses):
   """Process OR operations for all id sets."""
-  # If there were no conditions, then all features match.
+  # If there were no conditions, all features match.
   if not or_clauses:
     return fetch_all_feature_ids_set()
 

--- a/internals/search.py
+++ b/internals/search.py
@@ -24,6 +24,7 @@ from google.cloud.ndb.tasklets import Future  # for type checking only
 from framework import users
 from framework import utils
 from internals import approval_defs
+from internals import core_enums
 from internals import core_models
 from internals import feature_helpers
 from internals import notifier
@@ -201,19 +202,23 @@ def _sort_by_total_order(
 
 def process_query(
     user_query: str, sort_spec: str = None,
-    show_unlisted=False, show_deleted=False,
+    show_unlisted=False, show_deleted=False, show_enterprise=False,
     start=0, num=DEFAULT_RESULTS_PER_PAGE) -> tuple[list[dict[str, Any]], int]:
   """Parse the user's query, run it, and return a list of features."""
   # 1a. Parse the user query into terms.
   terms = TERM_RE.findall(user_query + ' ')[:MAX_TERMS] or []
 
-  # 1b. Add permission terms.
+  # 1b. Add permission and search scope terms.
   permission_terms = []
   if not show_deleted:
     permission_terms.append(('', 'deleted', '=', 'false', None))
   # TODO(jrobbins): include unlisted features that the user is allowed to view.
   if not show_unlisted:
     permission_terms.append(('', 'unlisted', '=', 'false', None))
+  if not show_enterprise:
+    permission_terms.append(
+        ('', 'feature_type', '<=',
+         str(core_enums.FEATURE_TYPE_DEPRECATION_ID), None))
 
   # 1c. Parse the sort directive.
   sort_spec = sort_spec or '-created.when'
@@ -233,30 +238,22 @@ def process_query(
   # 3. Get the result of each future and combine them into a result ID set.
   logging.info('now waiting on futures')
 
-  # 3a. Process all negation operations.
+  # 3a. Process user query: negation, AND, and OR.
   feature_id_future_ops = process_negation_operations(feature_id_future_ops)
+  query_clauses = process_and_operations(feature_id_future_ops)
+  result_id_set = process_or_operations(query_clauses)
 
-  # 3b. Process all AND operations.
-  or_clauses = process_and_operations(feature_id_future_ops)
-
-  # 3c. Process all OR operations.
-  result_id_set = process_or_operations(or_clauses)
-
-  # 3d. Process all permission ops.
-  permission_ids = process_and_operations(permissions_future_ops)
-  if len(permission_ids) == 1:
-    if terms == []:
-      # Empty search terms.
-      result_id_set = permission_ids[0]
-    else:
-      result_id_set.intersection_update(permission_ids[0])
+  # 3b. Process all permission ops, then interesect to apply permisisons.
+  permission_clauses = process_and_operations(permissions_future_ops)
+  permission_ids = process_or_operations(permission_clauses)
+  result_id_set.intersection_update(permission_ids)
 
   result_id_list = list(result_id_set)
   total_count = len(result_id_list)
-  # 3d. Finish getting the total sort order.
-  total_order_ids = _resolve_promise_to_id_list(total_order_promise)
 
-  # 4. Sort the IDs according to their position in the complete sorted list.
+  # 4. Finish getting the total sort order. Then, sort the IDs according
+  # to their position in the complete sorted list.
+  total_order_ids = _resolve_promise_to_id_list(total_order_promise)
   sorted_id_list = _sort_by_total_order(result_id_list, total_order_ids)
 
   # 5. Paginate
@@ -296,7 +293,11 @@ def create_future_operations_from_queries(terms):
 
 
 def process_or_operations(or_clauses):
-  """ Process OR operations for all id sets."""
+  """Process OR operations for all id sets."""
+  # If there were no conditions, then all features match.
+  if not or_clauses:
+    return fetch_all_feature_ids_set()
+
   result_id_set = set()
   for id_set in or_clauses:
     result_id_set.update(id_set)
@@ -343,7 +344,7 @@ def process_negation_operations(feature_id_future_ops):
       continue
 
     if all_ids_set is None:
-        all_ids_set = fetch_all_feature_ids_set()
+      all_ids_set = fetch_all_feature_ids_set()
 
     feature_ids = _resolve_promise_to_id_list(future)
     result_set = all_ids_set.difference(feature_ids)


### PR DESCRIPTION
We want enterprise features to only show up when the user is explicitly asking for enterprise features.
This PR makes feature search default to excluding enterprise features, unless the user's query includes a mention of feature_type.

In this PR:
* features_api.py: pass show_enterprise as True only if the user query mentions feature_type.
* core_enums.py: allow enums fields to be specified by enum string or numeric string, because sometimes using the numbers is more convenient.
* search.py:
  *  Accept a new show_enterprise=False parameter and treat it like the way we treat permissions terms so that it applies to all OR-clauses of the user's query.
  * Re-group some lines under comments more concisely.
  * Process the permission terms more like we treat the regular terms: allow OR clauses even through we currently don't use them because that allows the following fix
  * In process_or_terms(), treat zero terms as unconstrained, so it returns the universe of all feature IDs

That change to process_or_terms() fixes a bug and an incorrect existing unit test that was previously testing that an empty query and no permission checks returned an empty list rather than a list of all features.