### PR TITLE
Ensure that enterprise features are not shown on roadmap.

### DIFF
--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -20,6 +20,20 @@ from api import converters
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
 
 
+class DelNoneTest(testing_config.CustomTestCase):
+
+  def test_del_none(self):
+    d = {}
+    self.assertEqual(
+        {},
+        converters.del_none(d))
+
+    d = {1: 'one', 2: None, 3: {33: None}, 4:{44: 44, 45: None}}
+    self.assertEqual(
+        {1: 'one', 3: {}, 4: {44: 44}},
+        converters.del_none(d))
+
+
 class ConvertersTest(testing_config.CustomTestCase):
 
   def setUp(self):

--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -328,6 +328,7 @@ def get_in_milestone(milestone: int,
     # Start each query asynchronously in parallel.
 
     # Shipping stages with a matching desktop milestone.
+    # Note: Enterprise features use STAGE_ENT_ROLLOUT and are NOT included.
     q = Stage.query(Stage.milestones.desktop_first == milestone,
         ndb.OR(Stage.stage_type == STAGE_BLINK_SHIPPING,
             Stage.stage_type == STAGE_PSA_SHIPPING,


### PR DESCRIPTION
Enterprise features should not be shown on the roadmap page.
It turns out that that is already the case, so this PR did not need any change to the logic of the product code.

In this PR:
* Add a comment to clarify that enterprise features are not included in get_in_milestone().
* Add a unit test to confirm that enterprise features are not returned by get_in_milestone().
* Shift existing feature_helper.py unit tests into feature_helper_test.py.
* Shift one unit test into converters_test.py.
* Delete one unit test that was a duplicate of one in stage_helpers_test.py.