### PR TITLE
blink_components guide edit page bug fix

### DIFF
--- a/pages/guide.py
+++ b/pages/guide.py
@@ -271,6 +271,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     elif field_type == 'str':
       return self.form.get(field)
     elif field_type == 'split_str':
+      val = self.split_input(field, delim=',')
       if field == 'rollout_platforms':
         val = self.form.getlist(field)
         # Occasionally, input will give an empty string as the first element.
@@ -280,7 +281,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
         return val
       elif field == 'blink_components' and len(val) == 0:
         return [settings.DEFAULT_COMPONENT]
-      return self.split_input(field, delim=',')
+      return val
     raise ValueError(f'Unknown field data type: {field_type}')
 
   def _add_changed_field(self, fe: FeatureEntry, field: str, new_val: Any,


### PR DESCRIPTION
This was originally changed to avoid the `self.split_input()` call if it wasn't necessary, but missed the logic where it was needed to handling the `blink_components` field.