### PR TITLE
Create Stages API

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -20,7 +20,7 @@ from framework import permissions
 from framework import rediscache
 from framework import users
 from internals.core_enums import *
-from internals.core_models import Feature, FeatureEntry
+from internals.core_models import FeatureEntry
 from internals import feature_helpers
 from internals import search
 

--- a/api/stages_api.py
+++ b/api/stages_api.py
@@ -1,0 +1,261 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+import logging
+from typing import Any, Optional
+from google.cloud import ndb  # type: ignore
+
+# Appengine imports.
+from framework import rediscache
+
+from framework import basehandlers
+from framework import permissions
+from internals import core_enums, notifier_helpers
+from internals import stage_helpers
+from internals.core_models import FeatureEntry, MilestoneSet, Stage
+from internals.review_models import Gate
+import settings
+
+
+
+
+class StagesAPI(basehandlers.APIHandler):
+
+  # Categorized field names of the Stage kind.
+  GENERAL_FIELDS: tuple[str] = (
+      'stage_type',
+      'browser',
+      'pm_emails',
+      'tl_emails',
+      'ux_emails',
+      'te_emails',
+      'intent_thread_url')
+
+  MILESTONE_FIELDS: tuple[str] = (
+      'desktop_first',
+      'desktop_last',
+      'android_first',
+      'android_last',
+      'ios_first',
+      'ios_last',
+      'webview_first',
+      'webview_last')
+
+  OT_FIELDS: tuple[str] = (
+      'experiment_goals',
+      'experiment_risks',
+      'origin_trial_feedback_url')
+
+  OT_EXTENSION_FIELDS: tuple[str] = (
+      'experiment_extension_reason',
+      'ot_stage_id')
+
+  SHIPPING_FIELDS: tuple[str] = (
+      'announcement_url',
+      'finch_url')
+  
+  ENTERPRISE_FIELDS: tuple[str] = (
+      'rollout_milestone',
+      'rollout_platforms',
+      'rollout_details',
+      'enterprise_policies')
+
+  # Fields that should default to an empty list if null.
+  FIELDS_DEFAULT_TO_LIST: tuple[str] = (
+      'pm_emails',
+      'tl_emails',
+      'ux_emails',
+      'te_emails',
+      'rollout_platforms',
+      'enterprise_policies')
+
+  def _stage_to_json_dict(self, stage: Stage) -> dict:
+    """Create a JSON representation of a given stage."""
+    stage_dict = {}
+    # Get a list of every non-milestone field.
+    all_fields = (self.GENERAL_FIELDS + self.OT_FIELDS +
+        self.OT_EXTENSION_FIELDS + self.SHIPPING_FIELDS +
+        self.ENTERPRISE_FIELDS)
+    for field in all_fields:
+      stage_dict[field] = getattr(stage, field)
+    for field in self.MILESTONE_FIELDS:
+      if stage.milestones is not None:
+        stage_dict[field] = getattr(stage.milestones, field)
+      else:
+        stage_dict[field] = None
+
+    # Set list fields as empty list if null.
+    for field in self.FIELDS_DEFAULT_TO_LIST:
+      if getattr(stage, field) is None:
+        stage_dict[field] = []
+
+    stage_dict['id'] = stage.key.integer_id()
+    stage_dict['feature_id'] = stage.feature_id
+    return stage_dict
+
+  def _create_gate_for_stage(
+      self, feature_id: int, stage_id: int, gate_type: int) -> None:
+    """Create a Gate entity for the given stage type."""
+    gate = Gate(feature_id=feature_id, stage_id=stage_id, gate_type=gate_type,
+        state=Gate.PREPARING)
+    gate.put()
+
+  def _add_given_stage_vals(self,
+      stage: Stage, kwargs: dict, fields: tuple[str]) -> None:
+    """Add given fields of the stage entity."""
+    for field in fields:
+      if field in kwargs:
+        setattr(stage, field, kwargs[field])
+
+  def _update_stage_vals(self, stage: Stage, feature_type: int,
+      kwargs: dict, create_gate: bool=False) -> None:
+    """Check for relevant stage fields and update stage as needed."""
+    if 'stage_type' in kwargs:
+      stage.stage_type = kwargs['stage_type']
+    s_type = stage.stage_type
+
+
+    for field in self.GENERAL_FIELDS:
+      if field in kwargs:
+        setattr(stage, field, kwargs[field])
+
+    # Update milestone fields.
+    for field in self.MILESTONE_FIELDS:
+      if field in kwargs:
+        if stage.milestones is None:
+          stage.milestones = MilestoneSet()
+        setattr(stage.milestones, field, kwargs['field'])
+    
+    # Keep the gate type that might need to be created for the stage type.
+    gate_type: int | None = None
+    # Update type-specific fields.
+    if s_type == core_enums.STAGE_TYPES_DEV_TRIAL[feature_type]:
+      gate_type = core_enums.GATE_PROTOTYPE
+
+    if s_type == core_enums.STAGE_TYPES_ORIGIN_TRIAL[feature_type]:
+      self._add_given_stage_vals(stage, kwargs, self.OT_FIELDS)
+      gate_type = core_enums.GATE_ORIGIN_TRIAL
+
+    if s_type == core_enums.STAGE_TYPES_EXTEND_ORIGIN_TRIAL[feature_type]:
+      self._add_given_stage_vals(stage, kwargs, self.OT_EXTENSION_FIELDS)
+      gate_type = core_enums.GATE_EXTEND_ORIGIN_TRIAL
+
+    if s_type == core_enums.STAGE_TYPES_SHIPPING[feature_type]:
+      self._add_given_stage_vals(stage, kwargs, self.SHIPPING_FIELDS)
+      gate_type = core_enums.GATE_SHIP
+
+    stage.put()
+
+    # If we should create a gate and this is a stage that requires a gate,
+    # create it.
+    if create_gate and gate_type is not None:
+      self._create_gate_for_stage(
+          stage.feature_id, stage.key.integer_id(), gate_type)
+
+
+  def do_get(self, **kwargs):
+    """Return a specified stage based on the given ID."""
+    stage_id = kwargs.get('stage_id', None)
+
+    if stage_id is None:
+      self.abort(404, msg='No stage specified.')
+    
+    stage: Stage | None = Stage.get_by_id(stage_id)
+    if stage is None:
+      self.abort(404, msg=f'Stage {stage_id} not found')
+
+    return self._stage_to_json_dict(stage)
+
+  def do_post(self, **kwargs):
+    """Create a new stage."""
+    feature_id = kwargs.get('feature_id', None)
+    if feature_id is None:
+      self.abort(404, msg='No feature specified.')
+
+    feature: FeatureEntry | None = FeatureEntry.get_by_id(feature_id)
+    if feature is None:
+      self.abort(404, msg=f'Feature {feature_id} not found')
+
+    # Validate the user has edit permissions and redirect if needed.
+    redirect_resp = permissions.validate_feature_edit_permission(
+        self, feature_id)
+    if redirect_resp:
+      return redirect_resp
+
+    if 'stage_type' not in kwargs:
+      self.abort(404, msg='Stage type not specified.')
+
+    # Create the stage.
+    stage = Stage(feature_id=feature_id)
+    # Add the specified field values to the stage. Create a gate if needed.
+    self._update_stage_vals(
+        stage, feature.feature_type, kwargs, create_gate=True)
+
+    # Return  the newly created stage ID.
+    return {'message': 'Stage created.', 'stage_id': stage.key.integer_id()}
+  
+  def do_patch(self, **kwargs):
+    """Update an existing stage based on the stage ID."""
+    stage_id = kwargs.get('stage_id', None)
+
+    if stage_id is None:
+      self.abort(404, msg='No stage specified.')
+
+    stage: Stage | None = Stage.get_by_id(stage_id)
+    if stage is None:
+      self.abort(404, msg=f'Stage {stage_id} not found')
+
+    feature: FeatureEntry | None = FeatureEntry.get_by_id(stage.feature_id)
+    if feature is None:
+      self.abort(404, msg=(f'Feature {stage.feature_id} not found '
+          f'associated with stage {stage_id}'))
+    feature_id = feature.key.integer_id()
+    # Validate the user has edit permissions and redirect if needed.
+    redirect_resp = permissions.validate_feature_edit_permission(
+        self, feature_id)
+    if redirect_resp:
+      return redirect_resp
+
+    # The stage_type field should not be able to change.
+    if 'stage_type' in kwargs:
+      self.abort(404, msg='stage_type field cannot be mutated.')
+
+    # Update specified fields. No need to create a gate for existing stage.
+    self._update_stage_vals(
+        stage, feature.feature_type, kwargs, create_gate=False)
+
+    return {'message': 'Stage values updated.'}
+
+  def do_delete(self, **kwargs):
+    """Delete an existing stage."""
+    stage_id = kwargs.get('stage_id', None)
+    if stage_id is None:
+      self.abort(404, msg='No stage specified.')
+    
+    stage: Stage | None = Stage.get_by_id(stage_id)
+    if stage is None:
+      self.abort(404, msg=f'Stage {stage_id} not found.')
+    
+    # Validate the user has edit permissions and redirect if needed.
+    redirect_resp = permissions.validate_feature_edit_permission(
+        self, stage.feature_id)
+    if redirect_resp:
+      return redirect_resp
+    
+    stage.deleted = True
+    stage.put()
+
+    return {'message': 'Stage deleted.'}

--- a/api/stages_api.py
+++ b/api/stages_api.py
@@ -13,21 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
-import logging
-from typing import Any, Optional
-from google.cloud import ndb  # type: ignore
-
-# Appengine imports.
-from framework import rediscache
-
 from framework import basehandlers
 from framework import permissions
-from internals import core_enums, notifier_helpers
-from internals import stage_helpers
+from internals import core_enums
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
 from internals.review_models import Gate
-import settings
 
 
 
@@ -35,16 +25,16 @@ import settings
 class StagesAPI(basehandlers.APIHandler):
 
   # Categorized field names of the Stage kind.
-  GENERAL_FIELDS: tuple[str] = (
+  GENERAL_FIELDS: list[str] = [
       'stage_type',
       'browser',
       'pm_emails',
       'tl_emails',
       'ux_emails',
       'te_emails',
-      'intent_thread_url')
+      'intent_thread_url']
 
-  MILESTONE_FIELDS: tuple[str] = (
+  MILESTONE_FIELDS: list[str] = [
       'desktop_first',
       'desktop_last',
       'android_first',
@@ -52,35 +42,35 @@ class StagesAPI(basehandlers.APIHandler):
       'ios_first',
       'ios_last',
       'webview_first',
-      'webview_last')
+      'webview_last']
 
-  OT_FIELDS: tuple[str] = (
+  OT_FIELDS: list[str] = [
       'experiment_goals',
       'experiment_risks',
-      'origin_trial_feedback_url')
+      'origin_trial_feedback_url']
 
-  OT_EXTENSION_FIELDS: tuple[str] = (
+  OT_EXTENSION_FIELDS: list[str] = [
       'experiment_extension_reason',
-      'ot_stage_id')
+      'ot_stage_id']
 
-  SHIPPING_FIELDS: tuple[str] = (
+  SHIPPING_FIELDS: list[str] = [
       'announcement_url',
-      'finch_url')
+      'finch_url']
   
-  ENTERPRISE_FIELDS: tuple[str] = (
+  ENTERPRISE_FIELDS: list[str] = [
       'rollout_milestone',
       'rollout_platforms',
       'rollout_details',
-      'enterprise_policies')
+      'enterprise_policies']
 
   # Fields that should default to an empty list if null.
-  FIELDS_DEFAULT_TO_LIST: tuple[str] = (
+  FIELDS_DEFAULT_TO_LIST: list[str] = [
       'pm_emails',
       'tl_emails',
       'ux_emails',
       'te_emails',
       'rollout_platforms',
-      'enterprise_policies')
+      'enterprise_policies']
 
   def _stage_to_json_dict(self, stage: Stage) -> dict:
     """Create a JSON representation of a given stage."""
@@ -114,7 +104,7 @@ class StagesAPI(basehandlers.APIHandler):
     gate.put()
 
   def _add_given_stage_vals(self,
-      stage: Stage, kwargs: dict, fields: tuple[str]) -> None:
+      stage: Stage, kwargs: dict, fields: list[str]) -> None:
     """Add given fields of the stage entity."""
     for field in fields:
       if field in kwargs:

--- a/api/stages_api_test.py
+++ b/api/stages_api_test.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config  # Must be imported before the module under test.
+
+import flask
+from unittest import mock
+from google.cloud import ndb  # type: ignore
+import werkzeug.exceptions
+
+from api import stages_api
+from internals.user_models import AppUser
+from internals.core_models import FeatureEntry, MilestoneSet, Stage
+from internals.review_models import Gate
+
+test_app = flask.Flask(__name__)
+
+class StagesAPITest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.feature_owner = AppUser(email='feature_owner@example.com')
+    self.feature_owner.put()
+
+    self.basic_user = AppUser(email='basic_user@example.com')
+    self.basic_user.put()
+
+    self.fe = FeatureEntry(id=1, name='feature one', summary='summary',
+        owner_emails=[self.feature_owner.email], feature_type=0, category=1)
+    self.fe.put()
+
+    # Origin trial stage.
+    self.stage_1 = Stage(id=10, feature_id=1, stage_type=150, browser='Chrome',
+        ux_emails=['ux_person@example.com'],
+        intent_thread_url='https://example.com/intent',
+        milestones=MilestoneSet(desktop_first=100),
+        experiment_goals='To be the very best.')
+    self.stage_1.put()
+    # Shipping stage.
+    self.stage_2 = Stage(id=11, feature_id=1, stage_type=160)
+    self.stage_2.put()
+
+    self.expected_stage_1 = {
+        'id': 10,
+        'feature_id': 1,
+        'stage_type': 150,
+        'browser': 'Chrome',
+        'pm_emails': [],
+        'tl_emails': [],
+        'ux_emails': ['ux_person@example.com'],
+        'te_emails': [],
+        'intent_thread_url': 'https://example.com/intent',
+        'desktop_first': 100,
+        'desktop_last': None,
+        'android_first': None,
+        'android_last': None,
+        'ios_first': None,
+        'ios_last': None,
+        'webview_first': None,
+        'webview_last': None,
+        'experiment_goals': 'To be the very best.',
+        'experiment_risks': None,
+        'origin_trial_feedback_url': None,
+        'experiment_extension_reason': None,
+        'ot_stage_id': None,
+        'announcement_url': None,
+        'finch_url': None,
+        'rollout_milestone': None,
+        'rollout_platforms': [],
+        'rollout_details': None,
+        'enterprise_policies': []}
+
+    self.handler = stages_api.StagesAPI()
+    self.request_path = '/api/v0/stages/'
+
+    self.maxDiff = None
+
+  def tearDown(self):
+    testing_config.sign_out()
+    kinds: list[ndb.Model] = [AppUser, FeatureEntry, Gate, MilestoneSet, Stage]
+    for kind in kinds:
+      for entity in kind.query():
+        entity.key.delete()
+
+  @mock.patch('flask.abort')
+  def test_get__bad_id(self, mock_abort):
+    """Raises 404 if stage ID does not match any stage."""
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_get(stage_id=3001)
+    mock_abort.assert_called_once_with(404, description=f'Stage 3001 not found')
+
+  @mock.patch('flask.abort')
+  def test_get__no_id(self, mock_abort):
+    """Raises 404 if stage ID is not specified."""
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_get()
+    mock_abort.assert_called_once_with(404, description='No stage specified.')
+
+  def test_get__valid(self):
+    """Returns stage data if requesting a valid stage ID."""
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_get(stage_id=10)
+
+    self.assertEqual(self.expected_stage_1, actual)
+
+  @mock.patch('flask.abort')
+  def test_post__not_allowed(self, mock_abort):
+    """Raises 403 if user has no edit access to feature."""
+    testing_config.sign_in('basic_user@example.com', 123)
+    mock_abort.side_effect = werkzeug.exceptions.Forbidden
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
+        self.handler.do_post(feature_id=1, stage_type=151,
+            intent_thread_url='https://example.com/different')
+    mock_abort.assert_called_once_with(403)
+
+  @mock.patch('flask.abort')
+  def test_post__bad_id(self, mock_abort):
+    """Raises 404 if ID does not match any feature."""
+    testing_config.sign_in('feature_owner@example.com', 123)
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post(feature_id=3001, stage_type=151,
+            intent_thread_url='https://example.com/different')
+    mock_abort.assert_called_once_with(
+        404, description=f'Feature 3001 not found')
+
+  @mock.patch('flask.abort')
+  def test_post__no_id(self, mock_abort):
+    """Raises 404 if no feature ID was given."""
+    testing_config.sign_in('feature_owner@example.com', 123)
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post(stage_type=151)
+    mock_abort.assert_called_once_with(404, description='No feature specified.')
+
+  @mock.patch('flask.abort')
+  def test_post__no_stage_type(self, mock_abort):
+    """Raises 404 if no stage type was given."""
+    testing_config.sign_in('feature_owner@example.com', 123)
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post(feature_id=1)
+    mock_abort.assert_called_once_with(
+        404, description='Stage type not specified.')
+
+  def test_post__valid(self):
+    """A valid POST request should create a new stage."""
+    testing_config.sign_in('feature_owner@example.com', 123)
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_post(feature_id=1, stage_type=151,
+          intent_thread_url='https://example.com/different')
+    self.assertEqual(actual['message'], 'Stage created.')
+    stage_id = actual['stage_id']
+    stage: Stage | None = Stage.get_by_id(stage_id)
+    self.assertIsNotNone(stage)
+    self.assertEqual(stage.stage_type, 151)
+    self.assertEqual(stage.intent_thread_url, 'https://example.com/different')
+
+  def test_post__gate_created(self):
+    """A Gate entity is created when a gated stage is created."""
+    testing_config.sign_in('feature_owner@example.com', 123)
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_post(feature_id=1, stage_type=151,
+          intent_thread_url='https://example.com/different')
+    self.assertEqual(actual['message'], 'Stage created.')
+    stage_id = actual['stage_id']
+    gates: list[Gate] = Gate.query(Gate.stage_id == stage_id).fetch()
+    self.assertTrue(len(gates) == 1)
+
+  def test_post__gate_not_needed(self):
+    """A Gate entity is created when a non-gated stage is created."""
+    testing_config.sign_in('feature_owner@example.com', 123)
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_post(feature_id=1, stage_type=110,
+          intent_thread_url='https://example.com/different')
+    self.assertEqual(actual['message'], 'Stage created.')
+    stage_id = actual['stage_id']
+    gates: list[Gate] = Gate.query(Gate.stage_id == stage_id).fetch()
+    self.assertTrue(len(gates) == 0)
+
+  @mock.patch('flask.abort')
+  def test_patch__not_allowed(self, mock_abort):
+    """Raises 403 if user does not have edit access to the stage."""
+    testing_config.sign_in('basic_user@example.com', 123)
+    mock_abort.side_effect = werkzeug.exceptions.Forbidden
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
+        self.handler.do_patch(stage_id=10,
+            intent_thread_url='https://example.com/different')
+    mock_abort.assert_called_once_with(403)
+
+  @mock.patch('flask.abort')
+  def test_patch__bad_id(self, mock_abort):
+    """Raises 404 if ID does not match any stage."""
+    testing_config.sign_in('feature_owner@example.com', 123)
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_patch(stage_id=3001,
+            intent_thread_url='https://example.com/different')
+    mock_abort.assert_called_once_with(
+        404, description=f'Stage 3001 not found')
+
+  @mock.patch('flask.abort')
+  def test_patch__no_id(self, mock_abort):
+    """Raises 404 if no stage ID was given."""
+    testing_config.sign_in('feature_owner@example.com', 123)
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_patch(intent_thread_url='https://example.com/different')
+    mock_abort.assert_called_once_with(404, description='No stage specified.')
+
+  @mock.patch('flask.abort')
+  def test_patch__stage_type_change_attempt(self, mock_abort):
+    """Raises 404 if stage_type is supplied. This field cannot be mutated."""
+    testing_config.sign_in('feature_owner@example.com', 123)
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_patch(stage_id=10, stage_type=260,
+            intent_thread_url='https://example.com/different')
+    mock_abort.assert_called_once_with(
+        404, description='stage_type field cannot be mutated.')
+
+  def test_patch__valid(self):
+    """A valid PATCH request should update an existing stage."""
+    testing_config.sign_in('feature_owner@example.com', 123)
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_patch(stage_id=10,
+          intent_thread_url='https://example.com/different',
+          announcement_url='https://example.com/announce',
+          experiment_risks='No risks.', browser=None)
+    self.assertEqual(actual['message'], 'Stage values updated.')
+    stage = self.stage_1
+    self.assertEqual(stage.experiment_risks, 'No risks.')
+    self.assertEqual(stage.intent_thread_url, 'https://example.com/different')
+    # Values can be set to null.
+    self.assertIsNone(stage.browser)
+    # Type-specific stage fields should not be put onto incorrect stages.
+    self.assertIsNone(stage.announcement_url)
+    # Existing fields not specified should not be changed.
+    self.assertEqual(stage.experiment_goals, 'To be the very best.')
+
+  @mock.patch('flask.abort')
+  def test_delete__not_allowed(self, mock_abort):
+    """Raises 403 if user does not have edit access to the stage."""
+    testing_config.sign_in('basic_user@example.com', 123)
+    mock_abort.side_effect = werkzeug.exceptions.Forbidden
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
+        self.handler.do_delete(stage_id=10)
+    mock_abort.assert_called_once_with(403)
+
+  @mock.patch('flask.abort')
+  def test_delete__no_id(self, mock_abort):
+    """Raises 404 if no stage ID was given."""
+    testing_config.sign_in('feature_owner@example.com', 123)
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_delete()
+    mock_abort.assert_called_once_with(404, description='No stage specified.')
+
+  @mock.patch('flask.abort')
+  def test_delete__bad_id(self, mock_abort):
+    """Raises 404 if ID does not match any stage."""
+    testing_config.sign_in('feature_owner@example.com', 123)
+    mock_abort.side_effect = werkzeug.exceptions.BadRequest
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_delete(stage_id=3001)
+    mock_abort.assert_called_once_with(404, description='Stage 3001 not found.')
+
+  def test_delete__valid(self):
+    """A valid DELETE request should mark the existing stage as deleted."""
+    testing_config.sign_in('feature_owner@example.com', 123)
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_delete(stage_id=10)
+    self.assertEqual(actual['message'], 'Stage deleted.')
+    self.assertEqual(self.stage_1.deleted, True)

--- a/api/stages_api_test.py
+++ b/api/stages_api_test.py
@@ -82,7 +82,7 @@ class StagesAPITest(testing_config.CustomTestCase):
         'enterprise_policies': []}
 
     self.handler = stages_api.StagesAPI()
-    self.request_path = '/api/v0/stages/'
+    self.request_path = '/api/v0/features/'
 
     self.maxDiff = None
 

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -87,6 +87,10 @@ class BaseHandler(flask.views.MethodView):
       self.abort(403, msg='User must be signed in')
     return current_user
 
+  def get_json_param_dict(self) -> dict:
+    """Return the JSON content in the body of the request."""
+    return self.request.get_json(force=True, silent=True) or {}
+
   def get_param(
       self, name, default=None, required=True, validator=None, allowed=None):
     """Get the specified JSON parameter."""

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -495,4 +495,4 @@ class Stage(ndb.Model):
   rollout_details = ndb.TextProperty()
   enterprise_policies = ndb.StringProperty(repeated=True)
 
-  deleted = ndb.BooleanProperty(default=False)
+  archived = ndb.BooleanProperty(default=False)

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -494,3 +494,5 @@ class Stage(ndb.Model):
   rollout_platforms = ndb.StringProperty(repeated=True)
   rollout_details = ndb.TextProperty()
   enterprise_policies = ndb.StringProperty(repeated=True)
+
+  deleted = ndb.BooleanProperty(default=False)

--- a/main.py
+++ b/main.py
@@ -113,7 +113,6 @@ api_routes: list[Route] = [
         processes_api.ProcessesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/progress',
         processes_api.ProgressAPI),
-    Route(f'{API_BASE}/features/<int:feature_id>/stages', stages_api.StagesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/stages/<int:stage_id>',
             stages_api.StagesAPI),
 

--- a/main.py
+++ b/main.py
@@ -29,6 +29,7 @@ from api import metricsdata
 from api import permissions_api
 from api import processes_api
 from api import settings_api
+from api import stages_api
 from api import stars_api
 from api import token_refresh_api
 from framework import basehandlers
@@ -112,6 +113,9 @@ api_routes: list[Route] = [
         processes_api.ProcessesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/progress',
         processes_api.ProgressAPI),
+    Route(f'{API_BASE}/features/<int:feature_id>/stages', stages_api.StagesAPI),
+    Route(f'{API_BASE}/features/<int:feature_id>/stages/<int:stage_id>',
+            stages_api.StagesAPI),
 
     Route(f'{API_BASE}/blinkcomponents',
         blink_components_api.BlinkComponentsAPI),


### PR DESCRIPTION
This PR creates a new Stages API that allows CRUD functionality for feature stages.

These new endpoints are available for `api/v0/features/<feature_id>/stages/<stage_id>`:
- `GET`: List the details of a given stage based on the stage ID.
- `POST`: Create a new stage.
- `PATCH`: Edit an existing stage.
- `DELETE`: Archive an existing stage.