### PR TITLE
Display feature stages rather than process stages

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -361,8 +361,8 @@ class ChromedashFeatureDetail extends LitElement {
         ${this.renderControls()}
       </h2>
       ${this.renderMetadataSection()}
-      ${Object.values(this.feature.stages).map(feStageList =>
-      this.renderStageSection(feStageList[0]))}
+      ${Object.values(this.feature.stages).flat(1).map(feStage =>
+      this.renderStageSection(feStage))}
       ${this.renderActivitySection()}
     `;
   }

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -306,27 +306,38 @@ class ChromedashFeatureDetail extends LitElement {
     return this.renderSection('Metadata', content);
   }
 
-  renderStageSection(stage) {
-    const fields = DISPLAY_FIELDS_IN_STAGES[stage.outgoing_stage];
-    const isActive = (this.feature.intent_stage_int == stage.outgoing_stage);
+  findProcessStage(feStage) {
+    for (const processStage of this.process.stages) {
+      if (feStage.stage_type == processStage.stage_type) {
+        return processStage;
+      }
+    }
+    return null;
+  }
+
+  renderStageSection(feStage) {
+    const processStage = this.findProcessStage(feStage);
+    if (processStage === null) return nothing;
+    const fields = DISPLAY_FIELDS_IN_STAGES[processStage.outgoing_stage];
+    const isActive = (this.feature.intent_stage_int == processStage.outgoing_stage);
     if (fields === undefined || fields.length == 0) {
       return nothing;
     }
     const editButton = html`
       <sl-button size="small" style="float:right"
-           href="/guide/stage/${this.feature.id}/${stage.outgoing_stage}"
+           href="/guide/stage/${this.feature.id}/${processStage.outgoing_stage}"
            >Edit fields</sl-button>
     `;
     const content = html`
       <p class="description">
         ${this.canEdit ? editButton : nothing}
-        ${stage.description}
+        ${processStage.description}
       </p>
       <section class="card">
         ${this.renderSectionFields(fields)}
       </section>
     `;
-    return this.renderSection(stage.name, content, isActive);
+    return this.renderSection(processStage.name, content, isActive);
   }
 
   renderActivitySection() {
@@ -350,7 +361,8 @@ class ChromedashFeatureDetail extends LitElement {
         ${this.renderControls()}
       </h2>
       ${this.renderMetadataSection()}
-      ${this.process.stages.map(stage => this.renderStageSection(stage))}
+      ${Object.values(this.feature.stages).map(feStageList =>
+      this.renderStageSection(feStageList[0]))}
       ${this.renderActivitySection()}
     `;
   }

--- a/client-src/elements/chromedash-feature-page_test.js
+++ b/client-src/elements/chromedash-feature-page_test.js
@@ -93,6 +93,32 @@ describe('chromedash-feature-page', () => {
       maturity: {text: 'Unknown standards status - check spec link for status'},
     },
     tags: ['tag_one'],
+    stages: {
+      110: [{
+        "id": 3525,
+        "feature_id": 3523,
+        "stage_type": 110,
+        "desktop_first": null,
+        "desktop_last": null,
+        "android_first": null,
+        "android_last": null,
+        "ios_first": null,
+        "ios_last": null,
+        "webview_first": null,
+        "webview_last": null,
+        "pm_emails": [],
+        "tl_emails": [],
+        "ux_emails": [],
+        "te_emails": [],
+        "experiment_goals": null,
+        "experiment_risks": null,
+        "experiment_extension_reason": null,
+        "intent_thread_url": null,
+        "origin_trial_feedback_url": null,
+        "announcement_url": null,
+        "ot_stage_id": null
+      }]
+    }
   });
 
   /* window.csClient and <chromedash-toast> are initialized at spa.html

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -143,6 +143,7 @@ STAGE_BLINK_EVAL_READINESS = 140
 STAGE_BLINK_ORIGIN_TRIAL = 150
 STAGE_BLINK_EXTEND_ORIGIN_TRIAL = 151
 STAGE_BLINK_SHIPPING = 160
+STAGE_BLINK_SHIPPED = 170
 # Note: We might define post-ship support stage(s) later.
 
 # For implementing existing standards: the "fast track" process.
@@ -151,11 +152,13 @@ STAGE_FAST_DEV_TRIAL = 230
 STAGE_FAST_ORIGIN_TRIAL = 250
 STAGE_FAST_EXTEND_ORIGIN_TRIAL = 251
 STAGE_FAST_SHIPPING = 260
+STAGE_FAST_SHIPPED = 270
 
 # For developer-facing code changes not impacting a standard: the "PSA" process.
 STAGE_PSA_IMPLEMENT = 320
 STAGE_PSA_DEV_TRIAL = 330
 STAGE_PSA_SHIPPING = 360
+STAGE_PSA_SHIPPED = 370
 
 # For deprecating a feature: the "DEP" process.
 STAGE_DEP_PLAN = 410
@@ -166,9 +169,10 @@ STAGE_DEP_SHIPPING = 460
 STAGE_DEP_REMOVE_CODE = 470
 # TODO(jrobbins): reverse origin trial stage?
 
-# Note STAGE_* enum values 500-9999 are reseverd for future WP processes.
+# Note STAGE_* enum values 500-999 are reseverd for future WP processes.
 
 # Define enterprise feature processes.
+STAGE_ENT_PLAN = 1010
 # Note: This stage can ge added to any feature that is following any process.
 STAGE_ENT_ROLLOUT = 1061
 

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -172,9 +172,9 @@ STAGE_DEP_REMOVE_CODE = 470
 # Note STAGE_* enum values 500-999 are reseverd for future WP processes.
 
 # Define enterprise feature processes.
-STAGE_ENT_PLAN = 1010
 # Note: This stage can ge added to any feature that is following any process.
 STAGE_ENT_ROLLOUT = 1061
+STAGE_ENT_SHIPPED = 1070
 
 # Gate types
 GATE_PROTOTYPE = 1

--- a/internals/processes.py
+++ b/internals/processes.py
@@ -538,7 +538,7 @@ ENTERPRISE_STAGES = [
       [],
       [],
       core_enums.INTENT_NONE, core_enums.INTENT_ROLLOUT,
-      stage_type=core_enums.STAGE_ENT_PLAN),
+      stage_type=core_enums.STAGE_ENT_ROLLOUT),
   ProcessStage(
       'Ship',
       'Enable the feature by default.',
@@ -547,7 +547,7 @@ ENTERPRISE_STAGES = [
       [],
       [],
       core_enums.INTENT_ROLLOUT, core_enums.INTENT_SHIPPED,
-      stage_type=core_enums.STAGE_ENT_ROLLOUT),
+      stage_type=core_enums.STAGE_ENT_SHIPPED),
 ]
 
 

--- a/internals/processes.py
+++ b/internals/processes.py
@@ -43,6 +43,7 @@ class ProcessStage:
   approvals: list[approval_defs.ApprovalFieldDef]
   incoming_stage: int
   outgoing_stage: int
+  stage_type: int
 
 @dataclass
 class Process:
@@ -169,7 +170,8 @@ BLINK_PROCESS_STAGES = [
       ],
       [],
       [],
-      core_enums.INTENT_NONE, core_enums.INTENT_INCUBATE),
+      core_enums.INTENT_NONE, core_enums.INTENT_INCUBATE,
+      stage_type=core_enums.STAGE_BLINK_INCUBATE),
 
   ProcessStage(
       'Start prototyping',
@@ -184,7 +186,8 @@ BLINK_PROCESS_STAGES = [
               [PI_INITIAL_PUBLIC_PROPOSAL.name, PI_MOTIVATION.name,
                PI_EXPLAINER.name])],
       [approval_defs.PrototypeApproval],
-      core_enums.INTENT_INCUBATE, core_enums.INTENT_IMPLEMENT),
+      core_enums.INTENT_INCUBATE, core_enums.INTENT_IMPLEMENT,
+      stage_type=core_enums.STAGE_BLINK_PROTOTYPE),
 
   ProcessStage(
       'Dev trials and iterate on design',
@@ -203,7 +206,8 @@ BLINK_PROCESS_STAGES = [
               [PI_INITIAL_PUBLIC_PROPOSAL.name, PI_MOTIVATION.name,
                PI_EXPLAINER.name, PI_SPEC_LINK.name])],
       [],
-      core_enums.INTENT_IMPLEMENT, core_enums.INTENT_EXPERIMENT),
+      core_enums.INTENT_IMPLEMENT, core_enums.INTENT_EXPERIMENT,
+      stage_type=core_enums.STAGE_BLINK_DEV_TRIAL),
 
   ProcessStage(
       'Evaluate readiness to ship',
@@ -217,7 +221,8 @@ BLINK_PROCESS_STAGES = [
       ],
       [],
       [],
-      core_enums.INTENT_EXPERIMENT, core_enums.INTENT_IMPLEMENT_SHIP),
+      core_enums.INTENT_EXPERIMENT, core_enums.INTENT_IMPLEMENT_SHIP,
+      stage_type=core_enums.STAGE_BLINK_EVAL_READINESS),
 
   ProcessStage(
       'Origin Trial',
@@ -234,7 +239,8 @@ BLINK_PROCESS_STAGES = [
                PI_EXPLAINER.name, PI_SPEC_LINK.name,
                PI_EST_TARGET_MILESTONE.name])],
       [approval_defs.ExperimentApproval],
-      core_enums.INTENT_IMPLEMENT_SHIP, core_enums.INTENT_EXTEND_TRIAL),
+      core_enums.INTENT_IMPLEMENT_SHIP, core_enums.INTENT_EXTEND_TRIAL,
+      stage_type=core_enums.STAGE_BLINK_ORIGIN_TRIAL),
 
   ProcessStage(
       'Prepare to ship',
@@ -253,7 +259,8 @@ BLINK_PROCESS_STAGES = [
                PI_TAG_ADDRESSED.name, PI_UPDATED_VENDOR_SIGNALS.name,
                PI_UPDATED_TARGET_MILESTONE.name])],
       [approval_defs.ShipApproval],
-      core_enums.INTENT_IMPLEMENT_SHIP, core_enums.INTENT_SHIP),
+      core_enums.INTENT_IMPLEMENT_SHIP, core_enums.INTENT_SHIP,
+      stage_type=core_enums.STAGE_BLINK_SHIPPING),
 
   ProcessStage(
       'Ship',
@@ -264,7 +271,8 @@ BLINK_PROCESS_STAGES = [
       ],
       [],
       [],
-      core_enums.INTENT_SHIP, core_enums.INTENT_SHIPPED),
+      core_enums.INTENT_SHIP, core_enums.INTENT_SHIPPED,
+      stage_type=core_enums.STAGE_BLINK_SHIPPED),
   ]
 
 
@@ -286,7 +294,8 @@ BLINK_FAST_TRACK_STAGES = [
       [Action('Draft Intent to Prototype email', INTENT_EMAIL_URL,
               [PI_SPEC_LINK.name])],
       [approval_defs.PrototypeApproval],
-      core_enums.INTENT_NONE, core_enums.INTENT_IMPLEMENT),
+      core_enums.INTENT_NONE, core_enums.INTENT_IMPLEMENT,
+      stage_type=core_enums.STAGE_FAST_PROTOTYPE),
 
   ProcessStage(
       'Dev trials and iterate on implementation',
@@ -302,7 +311,8 @@ BLINK_FAST_TRACK_STAGES = [
       [Action('Draft Ready for Trial email', INTENT_EMAIL_URL,
               [PI_SPEC_LINK.name, PI_EST_TARGET_MILESTONE.name])],
       [],
-      core_enums.INTENT_IMPLEMENT, core_enums.INTENT_EXPERIMENT),
+      core_enums.INTENT_IMPLEMENT, core_enums.INTENT_EXPERIMENT,
+      stage_type=core_enums.STAGE_FAST_DEV_TRIAL),
 
   ProcessStage(
       'Origin Trial',
@@ -317,7 +327,8 @@ BLINK_FAST_TRACK_STAGES = [
       [Action('Draft Intent to Experiment email', INTENT_EMAIL_URL,
               [PI_SPEC_LINK.name, PI_EST_TARGET_MILESTONE.name])],
       [approval_defs.ExperimentApproval],
-      core_enums.INTENT_EXPERIMENT, core_enums.INTENT_EXTEND_TRIAL),
+      core_enums.INTENT_EXPERIMENT, core_enums.INTENT_EXTEND_TRIAL,
+      stage_type=core_enums.STAGE_FAST_ORIGIN_TRIAL),
 
   ProcessStage(
       'Prepare to ship',
@@ -331,7 +342,8 @@ BLINK_FAST_TRACK_STAGES = [
       [Action('Draft Intent to Ship email', INTENT_EMAIL_URL,
               [PI_SPEC_LINK.name, PI_UPDATED_TARGET_MILESTONE.name])],
       [approval_defs.ShipApproval],
-      core_enums.INTENT_EXPERIMENT, core_enums.INTENT_SHIP),
+      core_enums.INTENT_EXPERIMENT, core_enums.INTENT_SHIP,
+      stage_type=core_enums.STAGE_FAST_SHIPPING),
 
   ProcessStage(
       'Ship',
@@ -342,7 +354,8 @@ BLINK_FAST_TRACK_STAGES = [
       ],
       [],
       [],
-      core_enums.INTENT_SHIP, core_enums.INTENT_SHIPPED),
+      core_enums.INTENT_SHIP, core_enums.INTENT_SHIPPED,
+      stage_type=core_enums.STAGE_FAST_SHIPPED),
   ]
 
 
@@ -362,7 +375,8 @@ PSA_ONLY_STAGES = [
       ],
       [],
       [],
-      core_enums.INTENT_NONE, core_enums.INTENT_IMPLEMENT),
+      core_enums.INTENT_NONE, core_enums.INTENT_IMPLEMENT,
+      stage_type=core_enums.STAGE_PSA_IMPLEMENT),
 
   ProcessStage(
       'Dev trials and iterate on implementation',
@@ -375,7 +389,8 @@ PSA_ONLY_STAGES = [
       [Action('Draft Ready for Trial email', INTENT_EMAIL_URL,
               [PI_SPEC_LINK.name, PI_EST_TARGET_MILESTONE.name])],
       [],
-      core_enums.INTENT_IMPLEMENT, core_enums.INTENT_EXPERIMENT),
+      core_enums.INTENT_IMPLEMENT, core_enums.INTENT_EXPERIMENT,
+      stage_type=core_enums.STAGE_PSA_DEV_TRIAL),
 
   ProcessStage(
       'Prepare to ship',
@@ -387,7 +402,8 @@ PSA_ONLY_STAGES = [
       [Action('Draft Intent to Ship email', INTENT_EMAIL_URL,
               [PI_SPEC_LINK.name, PI_UPDATED_TARGET_MILESTONE.name])],
       [approval_defs.ShipApproval],
-      core_enums.INTENT_EXPERIMENT, core_enums.INTENT_SHIP),
+      core_enums.INTENT_EXPERIMENT, core_enums.INTENT_SHIP,
+      stage_type=core_enums.STAGE_PSA_SHIPPING),
 
   ProcessStage(
       'Ship',
@@ -398,7 +414,8 @@ PSA_ONLY_STAGES = [
       ],
       [],
       [],
-      core_enums.INTENT_SHIP, core_enums.INTENT_SHIPPED),
+      core_enums.INTENT_SHIP, core_enums.INTENT_SHIPPED,
+      stage_type=core_enums.STAGE_PSA_SHIPPED),
   ]
 
 
@@ -421,7 +438,8 @@ DEPRECATION_STAGES = [
       [Action('Draft Intent to Deprecate and Remove email', INTENT_EMAIL_URL,
               [PI_MOTIVATION.name])],
       [approval_defs.PrototypeApproval],
-      core_enums.INTENT_NONE, core_enums.INTENT_IMPLEMENT),
+      core_enums.INTENT_NONE, core_enums.INTENT_IMPLEMENT,
+      stage_type=core_enums.STAGE_DEP_PLAN),
 
   # TODO(cwilso): Work out additional steps for flag defaulting to disabled.
   ProcessStage(
@@ -435,7 +453,8 @@ DEPRECATION_STAGES = [
               [PI_MOTIVATION.name, PI_VENDOR_SIGNALS.name,
                PI_EST_TARGET_MILESTONE.name])],
       [],
-      core_enums.INTENT_IMPLEMENT, core_enums.INTENT_EXPERIMENT),
+      core_enums.INTENT_IMPLEMENT, core_enums.INTENT_EXPERIMENT,
+      stage_type=core_enums.STAGE_DEP_DEV_TRIAL),
 
   ProcessStage(
       'Prepare for Deprecation Trial',
@@ -451,7 +470,8 @@ DEPRECATION_STAGES = [
                PI_EST_TARGET_MILESTONE.name])],
       # TODO(jrobbins): Intent to extend deprecation.
       [approval_defs.ExperimentApproval],
-      core_enums.INTENT_EXPERIMENT, core_enums.INTENT_EXTEND_TRIAL),
+      core_enums.INTENT_EXPERIMENT, core_enums.INTENT_EXTEND_TRIAL,
+      stage_type=core_enums.STAGE_DEP_DEPRECATION_TRIAL),
 
   ProcessStage(
       'Prepare to ship',
@@ -465,7 +485,8 @@ DEPRECATION_STAGES = [
               [PI_MOTIVATION.name, PI_VENDOR_SIGNALS.name,
                PI_UPDATED_TARGET_MILESTONE.name])],
       [approval_defs.ShipApproval],
-      core_enums.INTENT_EXPERIMENT, core_enums.INTENT_SHIP),
+      core_enums.INTENT_EXPERIMENT, core_enums.INTENT_SHIP,
+      stage_type=core_enums.STAGE_DEP_SHIPPING),
 
   ProcessStage(
       'Remove code',
@@ -478,7 +499,8 @@ DEPRECATION_STAGES = [
                PI_UPDATED_TARGET_MILESTONE.name]),
        ],
       [],
-      core_enums.INTENT_SHIP, core_enums.INTENT_REMOVED),
+      core_enums.INTENT_SHIP, core_enums.INTENT_REMOVED,
+      stage_type=core_enums.STAGE_DEP_REMOVE_CODE),
   ]
 
 
@@ -497,7 +519,8 @@ FEATURE_ROLLOUT_STAGE = ProcessStage(
       ],
       [],
       [],
-      core_enums.INTENT_SHIP, core_enums.INTENT_ROLLOUT)
+      core_enums.INTENT_SHIP, core_enums.INTENT_ROLLOUT,
+      stage_type=core_enums.STAGE_ENT_ROLLOUT)
 
 # Thise are the stages for a feature that has the enterprise feature type.
 ENTERPRISE_STAGES = [
@@ -514,7 +537,8 @@ ENTERPRISE_STAGES = [
       ],
       [],
       [],
-      core_enums.INTENT_NONE, core_enums.INTENT_ROLLOUT),
+      core_enums.INTENT_NONE, core_enums.INTENT_ROLLOUT,
+      stage_type=core_enums.STAGE_ENT_PLAN),
   ProcessStage(
       'Ship',
       'Enable the feature by default.',
@@ -522,7 +546,8 @@ ENTERPRISE_STAGES = [
       ],
       [],
       [],
-      core_enums.INTENT_ROLLOUT, core_enums.INTENT_SHIPPED),
+      core_enums.INTENT_ROLLOUT, core_enums.INTENT_SHIPPED,
+      stage_type=core_enums.STAGE_ENT_ROLLOUT),
 ]
 
 

--- a/internals/processes_test.py
+++ b/internals/processes_test.py
@@ -42,6 +42,8 @@ PI_COLD_DOUGH = processes.ProgressItem('Cold dough', 'dough')
 PI_LOAF = processes.ProgressItem('A loaf', None)
 PI_DIRTY_PAN = processes.ProgressItem('A dirty pan', None)
 
+STAGE_BAKE_DOUGH = 110
+STAGE_BAKE_BAKE = 120
 
 class HelperFunctionsTest(testing_config.CustomTestCase):
 
@@ -57,14 +59,14 @@ class HelperFunctionsTest(testing_config.CustomTestCase):
             [processes.Action(
                 'Share kneeding video', 'https://example.com', [])],
             [],
-            0, 1),
+            0, 1, STAGE_BAKE_DOUGH),
          processes.ProcessStage(
              'Bake it',
              'Heat at 375 for 40 minutes',
              [PI_LOAF, PI_DIRTY_PAN],
              [],
              [BakeApproval],
-             1, 2),
+             1, 2, STAGE_BAKE_BAKE),
          ])
     expected = {
         'name': 'Baking',
@@ -80,7 +82,8 @@ class HelperFunctionsTest(testing_config.CustomTestCase):
                  'prerequisites': []}],
              'approvals': [],
              'incoming_stage': 0,
-             'outgoing_stage': 1},
+             'outgoing_stage': 1,
+             'stage_type': 110},
             {'name': 'Bake it',
              'description': 'Heat at 375 for 40 minutes',
              'progress_items': [
@@ -89,7 +92,8 @@ class HelperFunctionsTest(testing_config.CustomTestCase):
              'actions': [],
              'approvals': [BAKE_APPROVAL_DEF_DICT],
              'incoming_stage': 1,
-             'outgoing_stage': 2},
+             'outgoing_stage': 2,
+             'stage_type': 120},
         ]
     }
     actual = processes.process_to_dict(process)


### PR DESCRIPTION
The exiting code for displaying stages on the feature detail page iterated over the stages defined in the process.  However, a given feature could have additional stages added to it.  So, instead of using the process as the main list of stages, the PR makes the page use the feature's stages and it only references the process stages to get the name and description of each stage.