### PR TITLE
Populate query from URL

### DIFF
--- a/client-src/elements/chromedash-all-features-page.js
+++ b/client-src/elements/chromedash-all-features-page.js
@@ -15,6 +15,8 @@ export class ChromedashAllFeaturesPage extends LitElement {
 
   static get properties() {
     return {
+      rawQuery: {type: Object},
+      query: {type: String},
       user: {type: Object},
       starredFeatures: {type: Object},
     };
@@ -22,13 +24,26 @@ export class ChromedashAllFeaturesPage extends LitElement {
 
   constructor() {
     super();
+    this.query = '';
     this.user = {};
     this.starredFeatures = new Set();
   }
 
   connectedCallback() {
     super.connectedCallback();
+    this.initializeQuery();
     this.fetchData();
+  }
+
+  initializeQuery() {
+    if (!this.rawQuery) {
+      return;
+    }
+
+    if (!this.rawQuery.hasOwnProperty('q')) {
+      return;
+    }
+    this.query = this.rawQuery['q'];
   }
 
   fetchData() {
@@ -63,7 +78,7 @@ export class ChromedashAllFeaturesPage extends LitElement {
   renderBox(query) {
     return html`
       <chromedash-feature-table
-        query="${query}"
+        .query=${query}
         showQuery
         ?signedIn=${Boolean(this.user)}
         ?canEdit=${this.user && this.user.can_edit_all}
@@ -77,7 +92,7 @@ export class ChromedashAllFeaturesPage extends LitElement {
   }
 
   renderFeatureList() {
-    return this.renderBox('');
+    return this.renderBox(this.query);
   }
 
   render() {

--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -113,6 +113,7 @@ class ChromedashApp extends LitElement {
     page('/newfeatures', (ctx) => {
       this.pageComponent = document.createElement('chromedash-all-features-page');
       this.pageComponent.user = this.user;
+      this.pageComponent.rawQuery = window.csClient.parseRawQuery(ctx.querystring);
       this.contextLink = ctx.path;
       this.currentPage = ctx.path;
     });

--- a/client-src/elements/chromedash-feature-filter.js
+++ b/client-src/elements/chromedash-feature-filter.js
@@ -324,7 +324,7 @@ class ChromedashFeatureFilter extends LitElement {
   renderSearchBar() {
     return html`
       <div>
-        <sl-input id="searchbar" placeholder="Search"
+        <sl-input id="searchbar" placeholder="Search" value=${this.query}
             @keyup="${this.handleSearchKey}">
           <sl-icon-button library="material" name="search" slot="prefix"
                @click="${this.handleSearchClick}">

--- a/client-src/elements/chromedash-feature-table.js
+++ b/client-src/elements/chromedash-feature-table.js
@@ -154,6 +154,7 @@ class ChromedashFeatureTable extends LitElement {
     if (this.showQuery) {
       return html`
        <chromedash-feature-filter
+        .query=${this.query}
         @search="${this.handleSearch}"
        ></chromedash-feature-filter>
       `;

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -326,6 +326,11 @@ class ChromeStatusClient {
     return this.doGet(`/channels?start=${start}&end=${end}`);
   }
 
+  /**
+  * Parses URL query strings into a dict.
+  * @param {string} rawQuery a raw URL query string, e.g. q=abc&num=1;
+  * @return {object} A key-value pair dictionary for the query string.
+  */
   parseRawQuery(rawQuery) {
     const params = new URLSearchParams(rawQuery);
     const result = {};

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -325,6 +325,20 @@ class ChromeStatusClient {
   getSpecifiedChannels(start, end) {
     return this.doGet(`/channels?start=${start}&end=${end}`);
   }
+
+  parseRawQuery(rawQuery) {
+    const params = new URLSearchParams(rawQuery);
+    const result = {};
+    for (const param of params.keys()) {
+      const values = params.getAll(param);
+      if (!values.length) {
+        continue;
+      }
+      // Assume there is only one value.
+      result[param] = values[0];
+    }
+    return result;
+  }
 };
 
 exports.ChromeStatusClient = ChromeStatusClient;

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -327,10 +327,10 @@ class ChromeStatusClient {
   }
 
   /**
-  * Parses URL query strings into a dict.
-  * @param {string} rawQuery a raw URL query string, e.g. q=abc&num=1;
-  * @return {object} A key-value pair dictionary for the query string.
-  */
+   * Parses URL query strings into a dict.
+   * @param {string} rawQuery a raw URL query string, e.g. q=abc&num=1;
+   * @return {object} A key-value pair dictionary for the query string.
+   */
   parseRawQuery(rawQuery) {
     const params = new URLSearchParams(rawQuery);
     const result = {};


### PR DESCRIPTION
A part of #2521. 

- Parse search parameters "q" in the URL to populate the search widgets
- Show the default search results based on the URL
- q's value should be encoded

### Test
Go to /newfeatures?q=abc. Query abc should be populated in the searchbar and its result is shown.