### PR TITLE
Update converter to give a list of stage info

### DIFF
--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -173,9 +173,8 @@ class ConvertersTest(testing_config.CustomTestCase):
   def test_feature_entry_to_json_verbose__normal(self):
     """Converts feature entry to complete JSON with stage data."""
     result = converters.feature_entry_to_json_verbose(self.fe_1)
-    # Remove the stages and gates objects for a more apt comparison.
+    # Remove the stages list for a more apt comparison.
     result.pop('stages')
-    result.pop('gates')
 
     expected = {
       'id': 123,

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -361,8 +361,7 @@ class ChromedashFeatureDetail extends LitElement {
         ${this.renderControls()}
       </h2>
       ${this.renderMetadataSection()}
-      ${Object.values(this.feature.stages).flat(1).map(feStage =>
-      this.renderStageSection(feStage))}
+      ${this.feature.stages.map(feStage => this.renderStageSection(feStage))}
       ${this.renderActivitySection()}
     `;
   }

--- a/client-src/elements/chromedash-feature-page_test.js
+++ b/client-src/elements/chromedash-feature-page_test.js
@@ -93,32 +93,18 @@ describe('chromedash-feature-page', () => {
       maturity: {text: 'Unknown standards status - check spec link for status'},
     },
     tags: ['tag_one'],
-    stages: {
-      110: [{
-        'id': 3525,
-        'feature_id': 3523,
-        'stage_type': 110,
-        'desktop_first': null,
-        'desktop_last': null,
-        'android_first': null,
-        'android_last': null,
-        'ios_first': null,
-        'ios_last': null,
-        'webview_first': null,
-        'webview_last': null,
-        'pm_emails': [],
-        'tl_emails': [],
-        'ux_emails': [],
-        'te_emails': [],
-        'experiment_goals': null,
-        'experiment_risks': null,
-        'experiment_extension_reason': null,
-        'intent_thread_url': null,
-        'origin_trial_feedback_url': null,
-        'announcement_url': null,
-        'ot_stage_id': null,
-      }],
-    },
+    stages: [
+      {
+        stage_id: 1,
+        stage_type: 110,
+        intent_stage: 1,
+      },
+      {
+        stage_id: 2,
+        stage_type: 120,
+        intent_stage: 2,
+      },
+    ],
   });
 
   /* window.csClient and <chromedash-toast> are initialized at spa.html

--- a/client-src/elements/chromedash-guide-edit-page_test.js
+++ b/client-src/elements/chromedash-guide-edit-page_test.js
@@ -21,6 +21,18 @@ describe('chromedash-guide-edit-page', () => {
     feature_type: 'fake feature type',
     intent_stage: 'fake intent stage',
     new_crbug_url: 'fake crbug link',
+    stages: [
+      {
+        stage_id: 1,
+        stage_type: 110,
+        intent_stage: 1,
+      },
+      {
+        stage_id: 2,
+        stage_type: 120,
+        intent_stage: 2,
+      },
+    ],
     browsers: {
       chrome: {
         blink_components: ['Blink'],

--- a/internals/stage_helpers.py
+++ b/internals/stage_helpers.py
@@ -16,6 +16,7 @@
 from collections import defaultdict
 
 from internals.core_models import Stage
+from internals.core_models import INTENT_STAGES_BY_STAGE_TYPE
 
 
 def get_feature_stages(feature_id: int) -> dict[int, list[Stage]]:
@@ -37,3 +38,14 @@ def organize_all_stages_by_feature(stages: list[Stage]):
   for stage in stages:
     stages_by_feature[stage.feature_id].append(stage)
   return stages_by_feature
+
+def get_feature_stage_ids_list(feature_id: int) -> list[dict[str, int]]:
+  """Return a list of stage types and IDs associated with a given feature."""
+  q = Stage.query(Stage.feature_id == feature_id)
+  q = q.order(Stage.stage_type)
+  return [
+    {
+      'stage_id': s.key.integer_id(),
+      'stage_type': s.stage_type,
+      'intent_stage': INTENT_STAGES_BY_STAGE_TYPE[s.stage_type]
+    } for s in q]


### PR DESCRIPTION
 Change stages field on FeatureEntry json to be a simple list of dictionaries representing stages associated with the feature, sorted by stage type and containing stage_id, stage_type, and intent_stage fields. Remove gates field from the feature converter, as it is currently not used.