### PR TITLE
Remove intent stage select field

### DIFF
--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -96,7 +96,7 @@ export const NEW_FEATURE_FORM_FIELDS = [
 export const METADATA_FORM_FIELDS = [
   'name', 'summary', 'unlisted', 'breaking_change', 'owner',
   'editors', 'cc_recipients', 'category',
-  'feature_type', 'intent_stage',
+  'feature_type',
   'search_tags',
   // Implemention
   'impl_status_chrome',
@@ -105,7 +105,7 @@ export const METADATA_FORM_FIELDS = [
 ];
 
 export const VERIFY_ACCURACY_FORM_FIELDS = [
-  'summary', 'owner', 'editors', 'cc_recipients', 'impl_status_chrome', 'intent_stage',
+  'summary', 'owner', 'editors', 'cc_recipients', 'impl_status_chrome',
   'dt_milestone_android_start', 'dt_milestone_desktop_start',
   'dt_milestone_ios_start', 'ot_milestone_android_start',
   'ot_milestone_android_end', 'ot_milestone_desktop_start',
@@ -119,7 +119,7 @@ const FLAT_METADATA_FIELDS = [
   // Standardizaton
   'name', 'summary', 'unlisted', 'breaking_change', 'owner',
   'editors', 'cc_recipients', 'category',
-  'feature_type', 'intent_stage',
+  'feature_type',
   'search_tags',
   // Implementtion
   'impl_status_chrome',

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -254,17 +254,6 @@ export const ALL_FIELDS = {
       draft information or revising a previous stage.`,
   },
 
-  'intent_stage': {
-    type: 'select',
-    choices: INTENT_STAGES,
-    initial: INTENT_STAGES.INTENT_IMPLEMENT[0],
-    label: 'Process stage',
-    help_text: html`
-        Select the appropriate spec process stage. If you select
-        Dev trials, Origin Trial, or Shipped, be sure to set the
-        equivalent Implementation status.`,
-  },
-
   'search_tags': {
     type: 'input',
     attrs: TEXT_FIELD_ATTRS,
@@ -1224,8 +1213,7 @@ function makeDisplaySpecs(fields) {
 
 export const DISPLAY_FIELDS_IN_STAGES = {
   'Metadata': makeDisplaySpecs([
-    'category', 'feature_type', 'intent_stage', 'accurate_as_of',
-    'breaking_change',
+    'category', 'feature_type', 'accurate_as_of', 'breaking_change',
   ]),
   [INTENT_STAGES.INTENT_INCUBATE[0]]: makeDisplaySpecs([
     'initial_public_proposal_url', 'explainer_links',


### PR DESCRIPTION
This field does not change its options dynamically based on feature type even now, so it can allow the user to choose irrelevant intent stages as options. Additionally, the stages now will need to be set based on the stage ID. This field can still be set by checking the box to make the stage the active stage on the edit stage page.