### PR TITLE
Use active_stage_id to display active on detail page

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -381,6 +381,7 @@ def feature_entry_to_json_verbose(fe: FeatureEntry) -> dict[str, Any]:
   if fe.intent_stage is not None:
     d['intent_stage'] = INTENT_STAGES[fe.intent_stage]
     d['intent_stage_int'] = fe.intent_stage
+  d['active_stage_id'] = fe.active_stage_id
   d['created'] = {
     'by': d.pop('creator_email', None),
     'when': _date_to_str(fe.created),

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -319,7 +319,8 @@ class ChromedashFeatureDetail extends LitElement {
     const processStage = this.findProcessStage(feStage);
     if (processStage === null) return nothing;
     const fields = DISPLAY_FIELDS_IN_STAGES[processStage.outgoing_stage];
-    const isActive = (this.feature.intent_stage_int == processStage.outgoing_stage);
+    const isActive = (this.feature.active_stage_id === feStage.stage_id &&
+        this.feature.intent_stage_int == processStage.outgoing_stage);
     if (fields === undefined || fields.length == 0) {
       return nothing;
     }

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -319,8 +319,7 @@ class ChromedashFeatureDetail extends LitElement {
     const processStage = this.findProcessStage(feStage);
     if (processStage === null) return nothing;
     const fields = DISPLAY_FIELDS_IN_STAGES[processStage.outgoing_stage];
-    const isActive = (this.feature.active_stage_id === feStage.stage_id &&
-        this.feature.intent_stage_int == processStage.outgoing_stage);
+    const isActive = this.feature.active_stage_id === feStage.stage_id;
     if (fields === undefined || fields.length == 0) {
       return nothing;
     }

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -332,15 +332,18 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       setattr(feature, 'impl_status_chrome', impl_status_val)
       setattr(fe, 'impl_status_chrome', impl_status_val)
 
-    intent_stage_val: Optional[int] = None
-    if self.touched('intent_stage'):
-      intent_stage_val = self._get_field_val('intent_stage', 'int')
-    elif self.form.get('set_stage') == 'on':
-      intent_stage_val = kwargs.get('stage_id', 0)
+    active_stage_id = -1
+    intent_stage_val: int | None = None
+    if self.form.get('set_stage') == 'on':
+      active_stage_id = kwargs.get('stage_id', 0)
+      intent_stage_val = kwargs.get('intent_stage', core_enums.INTENT_NONE)
     if intent_stage_val is not None:
+      self._add_changed_field(
+          fe, 'active_stage_id', active_stage_id, changed_fields)
       self._add_changed_field(
           fe, 'intent_stage', intent_stage_val, changed_fields)
       setattr(feature, 'intent_stage', intent_stage_val)
+      setattr(fe, 'active_stage_id', active_stage_id)
       setattr(fe, 'intent_stage', intent_stage_val)
 
     for field, field_type in self.STAGE_FIELDS:


### PR DESCRIPTION
The active stage will now be determined by a matching intent stage, as well as the active_stage_id field on the feature detail page.