### PR TITLE
Add extra help for Explainer link(s)

### DIFF
--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -352,12 +352,14 @@ export const ALL_FIELDS = {
     required: false,
     label: 'Initial public proposal URL',
     help_text: html`
-        Link to the first public proposal to create this feature, e.g.,
-        a WICG discourse post.`,
+        Link to the first public proposal to create this feature.`,
     extra_help: html`
-        Add a reference to your <a href="https://github.com/WICG/proposals#what-does-a-proposal-look-like">
-        WICG proposal</a>
-        and start socializing the problem with other vendors and developers.`
+        If there isn't another obvious place to propose your feature, create a
+        <a href="https://github.com/WICG/proposals#what-does-a-proposal-look-like">
+        WICG proposal</a>.
+        You can use your proposal document to help you socialize the problem with other vendors
+        and developers.`,
+
   },
 
   'explainer_links': {
@@ -377,15 +379,13 @@ export const ALL_FIELDS = {
         for several examples of good explainers and tips for effective explainers.
         </p>
         <p>
-        You will need to publish this explainer by sharing it on a public forum,
-        and kick off "standards incubation" by proposing this to a relevant standards venue.
-        If you've already made an initial public proposal, post your explainer to that thread. Otherwise, your initial proposal can refer to your explainer.
+        If you've already made an initial public proposal (see above),
+        post your explainer to that thread.
+        Otherwise, make an initial proposal based on your explainer.
         </p>
         <p>
         Once a second organization is interested in the WICG proposal, you can move the explainer into the WICG. The <a href="https://wicg.github.io/admin/charter.html#chairs">WICG co-chairs</a> can help you.
         </p>
-
-
         <p>
         If you want help, ask for a <a href="https://sites.google.com/a/chromium.org/dev/blink/spec-mentors">specification mentor</a>.
         </p>`,

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -310,7 +310,8 @@ export const ALL_FIELDS = {
     help_text: html`
         Explain why the web needs this change. It may be useful
         to describe what web developers are forced to do without
-        it. When possible, add links to your explainer (under Explainer link(s))
+        it. When possible, add links to your explainer
+        (under <a href="#explainer_links">Explainer link(s)</a>)
         backing up your claims.
         <br/><br/>
         This text is sometimes included with the summary in the
@@ -368,23 +369,23 @@ export const ALL_FIELDS = {
         standards bodies, or other interested parties.`,
     extra_help: html`
         <p>
-        You will need to publish this explainer by sharig it on a public forum,
+        See the TAG guide to writing <a href="https://tag.w3.org/explainers/">Explainers</a>
+        for several examples of good explainers and tips for effective explainers.
+        </p>
+        <p>
+        You will need to publish this explainer by sharing it on a public forum,
         and kick off "standards incubation" by proposing this to a relevant standards venue.
-        Frequently, this means you should make a WICG proposal and start socializing
+        Frequently, this means you should
+        <a href="https://github.com/WICG/proposals#what-does-a-proposal-look-like">
+          make a WICG proposal</a> and start socializing
         the problem with other vendors and developers.
         Enter a reference to the public proposal in “Initial Public Proposal” field;
-        if there is interest in the WICG proposal and it can be moved into the WICG at this point, do so. The WICG co-chairs can help you.
+        if there is interest in the WICG proposal and it can be moved into the WICG at this point, do so. The <a href="https://wicg.github.io/admin/charter.html#chairs">WICG co-chairs</a> can help you.
         </p>
-        <p>
-        It's also a good idea to discuss your idea with the team/team lead (TL) or area expert in the feature area, prior to checking in code in the area.
-        </p>
-        <p>
-        Start sketching out a proposed solution in your (public) explainer, detailing API design (IDL) in your incubation.
 
-      See the TAG guide to writing <a href="https://tag.w3.org/explainers/">Explainers</a> for several examples of good explainers and tips for effective explainers.
-        </p>
-        <p></p>
-        If you are a Googler, you may wish to review this with your specification mentor before proceeding.
+
+        <p>
+        If you want help, ask for a <a href="https://sites.google.com/a/chromium.org/dev/blink/spec-mentors">specification mentor</a>.
         </p>`,
   },
 
@@ -397,6 +398,14 @@ export const ALL_FIELDS = {
         Link to the spec, if and when available. When implementing
         a spec update, please link to a heading in a published spec
         rather than a pull request when possible.`,
+    extra_help: html`
+        <p>
+        In addition to starting or updating your specification,
+        start sketching out a proposed solution in your (public) explainer
+        during your prototyping, detailing the API design (using webIDL).
+        It's also a good idea to discuss your idea with the team/team lead (TL)
+        or area expert in the feature area, prior to checking in code in the area.
+        </p>`,
   },
 
   'comments': {

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -310,7 +310,7 @@ export const ALL_FIELDS = {
     help_text: html`
         Explain why the web needs this change. It may be useful
         to describe what web developers are forced to do without
-        it. When possible, add links to your explainer
+        it. When possible, add links to your explainer (under Explainer link(s))
         backing up your claims.
         <br/><br/>
         This text is sometimes included with the summary in the
@@ -366,6 +366,26 @@ export const ALL_FIELDS = {
         public forum before sending an Intent to Prototype in
         order to enable discussion with other browser vendors,
         standards bodies, or other interested parties.`,
+    extra_help: html`
+        <p>
+        You will need to publish this explainer by sharig it on a public forum,
+        and kick off "standards incubation" by proposing this to a relevant standards venue.
+        Frequently, this means you should make a WICG proposal and start socializing
+        the problem with other vendors and developers.
+        Enter a reference to the public proposal in “Initial Public Proposal” field;
+        if there is interest in the WICG proposal and it can be moved into the WICG at this point, do so. The WICG co-chairs can help you.
+        </p>
+        <p>
+        It's also a good idea to discuss your idea with the team/team lead (TL) or area expert in the feature area, prior to checking in code in the area.
+        </p>
+        <p>
+        Start sketching out a proposed solution in your (public) explainer, detailing API design (IDL) in your incubation.
+
+      See the TAG guide to writing <a href="https://tag.w3.org/explainers/">Explainers</a> for several examples of good explainers and tips for effective explainers.
+        </p>
+        <p></p>
+        If you are a Googler, you may wish to review this with your specification mentor before proceeding.
+        </p>`,
   },
 
   'spec_link': {

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -354,6 +354,10 @@ export const ALL_FIELDS = {
     help_text: html`
         Link to the first public proposal to create this feature, e.g.,
         a WICG discourse post.`,
+    extra_help: html`
+        Add a reference to your <a href="https://github.com/WICG/proposals#what-does-a-proposal-look-like">
+        WICG proposal</a>
+        and start socializing the problem with other vendors and developers.`
   },
 
   'explainer_links': {
@@ -375,12 +379,10 @@ export const ALL_FIELDS = {
         <p>
         You will need to publish this explainer by sharing it on a public forum,
         and kick off "standards incubation" by proposing this to a relevant standards venue.
-        Frequently, this means you should
-        <a href="https://github.com/WICG/proposals#what-does-a-proposal-look-like">
-          make a WICG proposal</a> and start socializing
-        the problem with other vendors and developers.
-        Enter a reference to the public proposal in “Initial Public Proposal” field;
-        if there is interest in the WICG proposal and it can be moved into the WICG at this point, do so. The <a href="https://wicg.github.io/admin/charter.html#chairs">WICG co-chairs</a> can help you.
+        If you've already made an initial public proposal, post your explainer to that thread. Otherwise, your initial proposal can refer to your explainer.
+        </p>
+        <p>
+        Once a second organization is interested in the WICG proposal, you can move the explainer into the WICG. The <a href="https://wicg.github.io/admin/charter.html#chairs">WICG co-chairs</a> can help you.
         </p>
 
 
@@ -398,14 +400,6 @@ export const ALL_FIELDS = {
         Link to the spec, if and when available. When implementing
         a spec update, please link to a heading in a published spec
         rather than a pull request when possible.`,
-    extra_help: html`
-        <p>
-        In addition to starting or updating your specification,
-        start sketching out a proposed solution in your (public) explainer
-        during your prototyping, detailing the API design (using webIDL).
-        It's also a good idea to discuss your idea with the team/team lead (TL)
-        or area expert in the feature area, prior to checking in code in the area.
-        </p>`,
   },
 
   'comments': {

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -359,7 +359,6 @@ export const ALL_FIELDS = {
         WICG proposal</a>.
         You can use your proposal document to help you socialize the problem with other vendors
         and developers.`,
-
   },
 
   'explainer_links': {
@@ -384,7 +383,10 @@ export const ALL_FIELDS = {
         Otherwise, make an initial proposal based on your explainer.
         </p>
         <p>
-        Once a second organization is interested in the WICG proposal, you can move the explainer into the WICG. The <a href="https://wicg.github.io/admin/charter.html#chairs">WICG co-chairs</a> can help you.
+        Once a second organization is interested in the WICG proposal,
+        you can move the explainer into the WICG.
+        The <a href="https://wicg.github.io/admin/charter.html#chairs">WICG co-chairs</a>
+        can help you.
         </p>
         <p>
         If you want help, ask for a <a href="https://sites.google.com/a/chromium.org/dev/blink/spec-mentors">specification mentor</a>.


### PR DESCRIPTION
This text is mostly from the Chrome launch process.

@jyasskin 
@cwilso 