### PR TITLE
Introduce permission to comment. More perms checks in approvals dialog.

### DIFF
--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -102,6 +102,9 @@ class CommentsAPI(basehandlers.APIHandler):
     comment_content = self.get_param('comment', required=False)
 
     if comment_content:
+      if not permissions.can_comment(user):
+        self.abort(403, msg='User is not allowed to comment')
+
       # TODO(danielrsmith): After UI changes, gate_id should be passed in
       # post request and not queried for.
       gates: list[Gate] = Gate.query(

--- a/api/permissions_api.py
+++ b/api/permissions_api.py
@@ -20,7 +20,7 @@ from internals import approval_defs
 
 
 class PermissionsAPI(basehandlers.APIHandler):
-  """Permissions determine whether a user can create, approve, 
+  """Permissions determine whether a user can create, approve,
   or edit any feature, or admin the site"""
 
   def do_get(self, **kwargs):
@@ -28,7 +28,7 @@ class PermissionsAPI(basehandlers.APIHandler):
 
     # No user data if not signed in
     user_data = None
-    
+
     # get user permission data if signed in
     user = self.get_current_user()
     if user:
@@ -38,6 +38,7 @@ class PermissionsAPI(basehandlers.APIHandler):
         'can_create_feature': permissions.can_create_feature(user),
         'can_approve': permissions.can_approve_feature(
             user, None, approvers),
+        'can_comment': permissions.can_comment(user),
         'can_edit_all': permissions.can_edit_any_feature(user),
         'is_admin': permissions.can_admin_site(user),
         'email': user.email(),

--- a/api/permissions_api_test.py
+++ b/api/permissions_api_test.py
@@ -24,7 +24,7 @@ test_app = flask.Flask(__name__)
 
 class PermissionsAPITest(testing_config.CustomTestCase):
 
-  def setUp(self):    
+  def setUp(self):
     self.handler = permissions_api.PermissionsAPI()
     self.request_path = '/api/v0/currentuser/permissions'
 
@@ -47,6 +47,7 @@ class PermissionsAPITest(testing_config.CustomTestCase):
       'user': {
         'can_create_feature': False,
         'can_approve': False,
+        'can_comment': False,
         'can_edit_all': False,
         'is_admin': False,
         'email': 'one@example.com',
@@ -63,6 +64,7 @@ class PermissionsAPITest(testing_config.CustomTestCase):
       'user': {
         'can_create_feature': True,
         'can_approve': False,
+        'can_comment': True,
         'can_edit_all': False,
         'is_admin': False,
         'email': 'one@google.com',

--- a/client-src/elements/chromedash-approvals-dialog.js
+++ b/client-src/elements/chromedash-approvals-dialog.js
@@ -229,6 +229,8 @@ class ChromedashApprovalsDialog extends LitElement {
     const placeholderOption = (voteValue.state === -1) ?
       html`<sl-menu-item value="-1" selected>No value</sl-menu-item>` :
       nothing;
+    const canVote = (this.user?.can_approve &&
+                     voteValue.set_by == this.user?.email);
 
     // hoist is needed when <sl-select> is in overflow:hidden context.
     return html`
@@ -236,7 +238,7 @@ class ChromedashApprovalsDialog extends LitElement {
         <span class="set_by">${voteValue.set_by}</span>
         <span class="set_on">${this.formatDate(voteValue.set_on)}</span>
         <span class="appr_val">
-          ${voteValue.set_by == this.user?.email ? html`
+          ${canVote ? html`
         <sl-select name="${voteValue.gate_type}"
             value="${selectedValue}"
             data-field="${voteValue.gate_type}"
@@ -257,7 +259,7 @@ class ChromedashApprovalsDialog extends LitElement {
   }
 
   renderAddApproval(fieldId) {
-    if (!this.user) return nothing;
+    if (!this.user || !this.user.can_approve) return nothing;
     const existingApprovalByMe = this.approvals.some((a) =>
       a.gate_type == fieldId && a.set_by == this.user.email);
     if (existingApprovalByMe) {
@@ -403,7 +405,7 @@ class ChromedashApprovalsDialog extends LitElement {
   }
 
   renderControls() {
-    if (!this.user) return nothing;
+    if (!this.user || !this.user.can_comment) return nothing;
     let showAllCheckbox = nothing;
     if (this.subsetPending) {
       showAllCheckbox = html`

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -62,6 +62,11 @@ def can_create_feature(user: User) -> bool:
   return False
 
 
+def can_comment(user: User) -> bool:
+  """Return true if the user is allowed to post review comments."""
+  return can_create_feature(user)
+
+
 def can_edit_any_feature(user: User) -> bool:
   """Return True if the user is allowed to edit all features."""
   if not user:


### PR DESCRIPTION
Now that gate chips allow more users to open the approvals dialog, be more careful about which widgets they see in that dialog.  Also, limit commenting to only registered users so that we don't need to deal with spam.