### PR TITLE
Implement the layout and some details for the "gate column"

### DIFF
--- a/client-src/components.js
+++ b/client-src/components.js
@@ -58,6 +58,7 @@ import './elements/chromedash-footer';
 import './elements/chromedash-form-field';
 import './elements/chromedash-form-table';
 import './elements/chromedash-gate-chip';
+import './elements/chromedash-gate-column';
 import './elements/chromedash-gantt';
 import './elements/chromedash-guide-edit-page';
 import './elements/chromedash-guide-editall-page';

--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -43,6 +43,32 @@ class ChromedashApp extends LitElement {
           width: 100%;
         }
 
+        #content-sidebar-space {
+          position: sticky;
+          flex-shrink: 100;
+          width: 360px;
+        }
+
+        #sidebar {
+          position: absolute;
+          top: 0;
+          right: 0;
+          width: var(--sidebar-width);
+          bottom: 0;
+        }
+        #sidebar[hidden] {
+          display: none;
+        }
+        #sidebar-content {
+          position: sticky;
+          top: 10px;
+          height: 85vh;
+          border: var(--sidebar-border);
+          border-radius: var(--sidebar-radius);
+          background: var(--sidebar-bg);
+          padding: var(--content-padding);
+        }
+
         @media only screen and (max-width: 700px) {
           #content {
             margin-left: 0;
@@ -63,6 +89,7 @@ class ChromedashApp extends LitElement {
       bannerTime: {type: Number},
       pageComponent: {attribute: false},
       contextLink: {type: String}, // used for the back button in the feature page
+      sidebarHidden: {type: Boolean},
     };
   }
 
@@ -77,6 +104,7 @@ class ChromedashApp extends LitElement {
     this.bannerTime = null;
     this.pageComponent = null;
     this.contextLink = '/features';
+    this.sidebarHidden = true;
   }
 
   connectedCallback() {
@@ -197,6 +225,14 @@ class ChromedashApp extends LitElement {
     this.updateURLParams('q', e.detail.query);
   }
 
+  showSidebar() {
+    this.sidebarHidden = false;
+  }
+
+  hideSidebar() {
+    this.sidebarHidden = true;
+  }
+
   /**
  * Update window.locaton with new query params.
  * @param {string} key is the key of the query param.
@@ -240,6 +276,32 @@ class ChromedashApp extends LitElement {
     return url;
   }
 
+  renderContentAndSidebar() {
+    const wide = (this.pageComponent &&
+                  this.pageComponent.tagName == 'CHROMEDASH-ROADMAP-PAGE');
+    if (wide) {
+      return html`
+        <div id="content-component-wrapper" wide>
+          ${this.pageComponent}
+        </div>
+      `;
+    } else {
+      return html`
+        <div id="content-component-wrapper">
+          ${this.pageComponent}
+        </div>
+        <div id="content-sidebar-space">
+          <div id="sidebar" ?hidden=${this.sidebarHidden}>
+            <div id="sidebar-content">
+              <chromedash-gate-column .user=${this.user}>
+              </chromedash-gate-column>
+            </div>
+          </div>
+        </div>
+      `;
+    }
+  }
+
   render() {
     // The <slot> below is for the Google sign-in button, this is because
     // Google Identity Services Library cannot find elements in a shadow DOM,
@@ -265,11 +327,7 @@ class ChromedashApp extends LitElement {
               .timestamp=${this.bannerTime}>
             </chromedash-banner>
             <div id="content-flex-wrapper">
-              <div id="content-component-wrapper"
-                ?wide=${this.pageComponent &&
-                  this.pageComponent.tagName == 'CHROMEDASH-ROADMAP-PAGE'}>
-                ${this.pageComponent}
-              </div>
+              ${this.renderContentAndSidebar()}
             </div>
           </div>
 

--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -57,7 +57,7 @@ class ChromedashApp extends LitElement {
         #content-sidebar-space {
           position: sticky;
           flex-shrink: 100;
-          width: 360px;
+          width: var(--sidebar-space);
         }
 
         #sidebar {
@@ -311,13 +311,15 @@ class ChromedashApp extends LitElement {
           <div id="sidebar" ?hidden=${this.sidebarHidden}>
             <div id="sidebar-content">
               <chromedash-gate-column
-                .user=${this.user} ${ref(this.gateColumnRef)}>
+                .user=${this.user} ${ref(this.gateColumnRef)}
+                @close=${() => this.hideSidebar()}>
               </chromedash-gate-column>
             </div>
           </div>
         </div>
       `;
     }
+  }
 
   renderRolloutBanner(currentPage) {
     if (currentPage.startsWith('/newfeatures')) {

--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -1,10 +1,13 @@
 import {LitElement, css, html, nothing} from 'lit';
+import {ref, createRef} from 'lit/directives/ref.js';
 import {showToastMessage} from './utils';
 import page from 'page';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
 
 class ChromedashApp extends LitElement {
+  gateColumnRef = createRef();
+
   static get styles() {
     return [
       ...SHARED_STYLES,
@@ -233,6 +236,11 @@ class ChromedashApp extends LitElement {
     this.sidebarHidden = true;
   }
 
+  showGateColumn(feature, stage, gate) {
+    this.gateColumnRef.value.setContext(feature, stage, gate);
+    this.showSidebar();
+  }
+
   /**
  * Update window.locaton with new query params.
  * @param {string} key is the key of the query param.
@@ -293,7 +301,8 @@ class ChromedashApp extends LitElement {
         <div id="content-sidebar-space">
           <div id="sidebar" ?hidden=${this.sidebarHidden}>
             <div id="sidebar-content">
-              <chromedash-gate-column .user=${this.user}>
+              <chromedash-gate-column
+                .user=${this.user} ${ref(this.gateColumnRef)}>
               </chromedash-gate-column>
             </div>
           </div>

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -5,7 +5,7 @@ import '@polymer/iron-icon';
 import './chromedash-activity-log';
 import './chromedash-callout';
 import './chromedash-gate-chip';
-import {autolink} from './utils.js';
+import {autolink, findProcessStage} from './utils.js';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
 const LONG_TEXT = 60;
@@ -328,17 +328,8 @@ class ChromedashFeatureDetail extends LitElement {
     `;
   }
 
-  findProcessStage(feStage) {
-    for (const processStage of this.process.stages) {
-      if (feStage.stage_type == processStage.stage_type) {
-        return processStage;
-      }
-    }
-    return null;
-  }
-
   renderStageSection(feStage) {
-    const processStage = this.findProcessStage(feStage);
+    const processStage = findProcessStage(feStage, this.process);
     if (processStage === null) return nothing;
     const fields = DISPLAY_FIELDS_IN_STAGES[processStage.outgoing_stage];
     const isActive = (this.feature.intent_stage_int == processStage.outgoing_stage);

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -89,6 +89,19 @@ class ChromedashGateColumn extends LitElement {
     });
   }
 
+  _fireEvent(eventName, detail) {
+    const event = new CustomEvent(eventName, {
+      bubbles: true,
+      composed: true,
+      detail,
+    });
+    this.dispatchEvent(event);
+  }
+
+  handleCancel() {
+    this._fireEvent('close', {});
+  }
+
   renderHeadingsSkeleton() {
     return html`
       <h3 class="sl-skeleton-header-container">

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -36,7 +36,6 @@ class ChromedashGateColumn extends LitElement {
        #review-status-area {
          margin: var(--content-padding-half) 0;
        }
-
     `];
   }
 

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -171,14 +171,12 @@ class ChromedashGateColumn extends LitElement {
     // hoist is needed when <sl-select> is in overflow:hidden context.
     return html`
       <sl-select name="${this.gate.id}"
-          value="${state}"
-          @sl-change=${this.handleSelectChanged}
-          hoist size="small"
-        >
-            ${STATE_NAMES.map((valName) => html`
-              <sl-menu-item value="${valName[0]}"
-               >${valName[1]}</sl-menu-item>`,
-              )}
+                 value="${state}"
+                 @sl-change=${this.handleSelectChanged}
+                 hoist size="small">
+        ${STATE_NAMES.map((valName) => html`
+          <sl-menu-item value="${valName[0]}">${valName[1]}</sl-menu-item>`,
+        )}
       </sl-select>
     `;
   }

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -62,7 +62,7 @@ class ChromedashGateColumn extends LitElement {
     this.process = {};
     this.votes = [];
     this.comments = [];
-    this.loading = true;
+    this.loading = false;
     this.needsSave = false;
   }
 

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -1,0 +1,162 @@
+import {LitElement, css, html, nothing} from 'lit';
+import {SHARED_STYLES} from '../sass/shared-css.js';
+
+
+class ChromedashGateColumn extends LitElement {
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      css`
+       #votes-area {
+         margin: var(--content-padding) 0;
+       }
+
+       #votes-area th {
+         font-weight: bold;
+       }
+
+       #review-status-area {
+         margin: var(--content-padding-half) 0;
+       }
+
+    `];
+  }
+
+  static get properties() {
+    return {
+      user: {type: Object},
+      loading: {type: Boolean},
+    };
+  }
+
+  constructor() {
+    super();
+    this.user = {};
+    this.loading = false;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.loading = true;
+    // TODO(jrobbins): Just simulate loading data for now.
+    window.setTimeout(() => {
+      this.loading = false;
+    }, 2000);
+  }
+
+  renderHeadingsSkeleton() {
+    return html`
+      <h3 class="sl-skeleton-header-container">
+        <sl-skeleton effect="sheen"></sl-skeleton>
+      </h3>
+      <h2 class="sl-skeleton-header-container">
+        <sl-skeleton effect="sheen"></sl-skeleton>
+      </h2>
+    `;
+  }
+
+  renderHeadings() {
+    return html`
+      <h3>Stage</h3>
+      <h2>Gate</h2>
+    `;
+  }
+
+  renderReviewStatusSkeleton() {
+    return html`
+      <h3 class="sl-skeleton-header-container">
+        Status: <sl-skeleton effect="sheen"></sl-skeleton>
+      </h3>
+    `;
+  }
+
+  renderReviewStatus() {
+    return html`
+      <h3>
+        Status: Review requested
+      </h3>
+    `;
+  }
+
+  renderVotesSkeleton() {
+    return html`
+      <table cellspacing=4>
+        <tr><th>Reviewer</th><th>Vote</th></tr>
+        <tr>
+         <td><sl-skeleton effect="sheen"></sl-skeleton></td>
+         <td><sl-skeleton effect="sheen"></sl-skeleton></td>
+        </tr>
+      </table>
+    `;
+  }
+
+  renderVotes() {
+    return html`
+      <table cellspacing=4>
+        <tr><th>Reviewer</th><th>Vote</th></tr>
+        <tr>
+         <td>user1@example.com</td>
+         <td>Needs work</td>
+        </tr>
+        <tr>
+         <td>user2@example.com</td>
+         <td>Review started</td>
+        </tr>
+      </table>
+    `;
+  }
+
+  renderQuestionnaireSkeleton() {
+    return nothing;
+  }
+
+  renderQuestionnaire() {
+    // TODO(jrobbins): Implement questionnaires later.
+    return nothing;
+  }
+
+  renderCommentsSkeleton() {
+    return html`
+      <h2>Comments &amp; Activity</h2>
+      <sl-skeleton effect="sheen"></sl-skeleton>
+    `;
+  }
+
+  renderComments() {
+    return html`
+      <h2>Comments &amp; Activity</h2>
+      TODO(jrobbins): Comments go here
+    `;
+  }
+
+  render() {
+    return html`
+        ${this.loading ?
+          this.renderHeadingsSkeleton() :
+          this.renderHeadings()}
+
+        <div id="review-status-area">
+          ${this.loading ?
+            this.renderReviewStatusSkeleton() :
+            this.renderReviewStatus()}
+        </div>
+
+        <div id="votes-area">
+          ${this.loading ?
+            this.renderVotesSkeleton() :
+            this.renderVotes()}
+        </div>
+
+        ${this.loading ?
+          this.renderQuestionnaireSkeleton() :
+          this.renderQuestionnaire()}
+
+        ${this.loading ?
+          this.renderCommentsSkeleton() :
+          this.renderComments()}
+
+    `;
+  }
+}
+
+customElements.define('chromedash-gate-column', ChromedashGateColumn);

--- a/client-src/elements/utils.js
+++ b/client-src/elements/utils.js
@@ -32,3 +32,14 @@ export function slotAssignedElements(component, slotName) {
 export function clamp(val, lowerBound, upperBound) {
   return Math.max(lowerBound, Math.min(upperBound, val));
 }
+
+
+/* Given a feature entry stage entity, look up the related process stage. */
+export function findProcessStage(feStage, process) {
+  for (const processStage of process.stages) {
+    if (feStage.stage_type == processStage.stage_type) {
+      return processStage;
+    }
+  }
+  return null;
+}

--- a/client-src/sass/theme.scss
+++ b/client-src/sass/theme.scss
@@ -72,6 +72,12 @@
   --leftnav-selected-color: var(--md-blue-900);
   --leftnav-divider-border: 1px solid var(--md-gray-100-alpha);
 
+  --sidebar-space: 360px;
+  --sidebar-width: 350px;
+  --sidebar-bg: white;
+  --sidebar-border: 2px solid hsl(0, 0%, 85%);
+  --sidebar-radius: var(--large-border-radius);
+
   --button-background: inherit;
   --button-color: var(--md-gray-900-alpha);
   --button-font-size: 10pt;

--- a/client-src/sass/theme.scss
+++ b/client-src/sass/theme.scss
@@ -72,8 +72,8 @@
   --leftnav-selected-color: var(--md-blue-900);
   --leftnav-divider-border: 1px solid var(--md-gray-100-alpha);
 
-  --sidebar-space: 360px;
-  --sidebar-width: 350px;
+  --sidebar-space: 410px;
+  --sidebar-width: 400px;
   --sidebar-bg: white;
   --sidebar-border: 2px solid hsl(0, 0%, 85%);
   --sidebar-radius: var(--large-border-radius);


### PR DESCRIPTION
This new element will eventually replace the approvals dialog.   The "gate column" is sort of like a tall, narrow version of the approvals dialog except that it shows exactly one gate at a time (whereas the dialog mixed together four gates).

This PR is not a complete implementation, in fact, it makes no user-visible change yet, but I think that it is enough to review and merge so that we can build on it.

In this PR:
* chromestatus-app.js: Refactor the way that the app content is laid out so that some pages shift the content to the left, leaving room for a sidebar on the right.  Define a method to show the gate column.   The CSS for the sidebar is a little tricky in that it positions the sidebar relative to the blank space reserved for it, but it also allows the sidebar to overlap the main page content if the window is narrow, and it keeps the sidebar in view as the user scrolls.
* chromedash-feature-detail.js and util.js: Refactor a method to a util function so that it can be reused.
* chromedash-gate-column.js: This lays out the pieces of information that will be displayed in the gate column, but it doesn't get real data for everything yet.

