### PR TITLE
Implement votes_api and move some code around.

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -20,7 +20,9 @@ from internals import stage_helpers
 
 from internals.core_enums import *
 from internals.core_models import Feature, FeatureEntry, Stage
-from internals.review_models import Gate
+from internals.review_models import Vote, Gate
+from internals import approval_defs
+
 
 SIMPLE_TYPES = frozenset((int, float, bool, dict, str, list))
 
@@ -583,3 +585,33 @@ def feature_entry_to_json_basic(fe: FeatureEntry,
   d['milestone'] = milestone
 
   return d
+
+
+def vote_value_to_json_dict(vote: Vote) -> dict[str, Any]:
+
+  return {
+      'feature_id': vote.feature_id,
+      'gate_id': vote.gate_id,
+      'gate_type': vote.gate_type,
+      'state': vote.state,
+      'set_on': str(vote.set_on),  # YYYY-MM-DD HH:MM:SS.SSS
+      'set_by': vote.set_by,
+      }
+
+
+def gate_value_to_json_dict(gate: Gate) -> dict[str, Any]:
+  next_action = str(gate.next_action) if gate.next_action else None
+  requested_on = str(gate.requested_on) if gate.requested_on else None
+  appr_def = approval_defs.APPROVAL_FIELDS_BY_ID[gate.gate_type]
+  return {
+      'feature_id': gate.feature_id,
+      'stage_id': gate.stage_id,
+      'gate_type': gate.gate_type,
+      'team_name': appr_def.team_name,
+      'gate_name': appr_def.name,
+      'state': gate.state,
+      'requested_on': requested_on,  # YYYY-MM-DD or None
+      'owners': gate.owners,
+      'next_action': next_action,  # YYYY-MM-DD or None
+      'additional_review': gate.additional_review
+      }

--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import logging
+import re
+from typing import Any, Optional
+
+from api import converters
+from framework import basehandlers
+from framework import permissions
+from internals import approval_defs
+from internals.review_models import Approval, ApprovalConfig, Gate, Vote
+
+
+class VotesAPI(basehandlers.APIHandler):
+  """Users may see the set of votes on a feature, and add their own,
+  if allowed."""
+
+  def do_get(self, **kwargs) -> dict[str, list[dict[str, Any]]]:
+    """Return a list of all vote values for a given feature."""
+    feature_id = kwargs['feature_id']
+    gate_id = kwargs['gate_id']
+    # Note: We assume that anyone may view approvals.
+    votes = Vote.get_votes(feature_id=feature_id, gate_id=gate_id)
+    dicts = [converters.vote_value_to_json_dict(v) for v in votes]
+    return {'votes': dicts}
+
+  def do_post(self, **kwargs) -> dict[str, str]:
+    """Set a user's vote value for the specified feature and gate."""
+    feature_id = kwargs['feature_id']
+    gate_id = kwargs['gate_id']
+    new_state = self.get_int_param(
+        'state', validator=Approval.is_valid_state)
+    feature = self.get_specified_feature(feature_id=feature_id)
+    user = self.get_current_user(required=True)
+    gate = Gate.get_by_id(gate_id)
+    if not gate:
+      self.abort(404, msg='Gate not found')
+
+    approvers = approval_defs.get_approvers(gate.gate_type)
+    if not permissions.can_approve_feature(user, feature, approvers):
+      self.abort(403, msg='User is not an approver')
+
+    # Note: We no longer write Approval entities.
+
+    gates: list[Gate] = Gate.query(
+        Gate.feature_id == feature_id, Gate.gate_id == gate_id).fetch()
+    if len(gates) == 0:
+      return {'message': 'No gate found for given feature ID and gate ID.'}
+    new_state = self.get_int_param('state', validator=Vote.is_valid_state)
+    approval_defs.set_vote(feature_id, None, new_state,
+        user.email(), gate_id)
+
+    # Callers don't use the JSON response for this API call.
+    return {'message': 'Done'}
+
+
+class GatesAPI(basehandlers.APIHandler):
+  """Get gates for a feature."""
+
+  def do_get(self, **kwargs) -> dict[str, Any]:
+    """Return a list of all gates associated with the given feature."""
+    feature_id = kwargs.get('feature_id', None)
+    gates: list[Gate] = Gate.query(Gate.feature_id == feature_id).fetch()
+
+    # No gates associated with this feature.
+    if len(gates) == 0:
+      return {
+          'gates': [],
+          'possible_owners': {}
+          }
+
+    dicts = [converters.gate_value_to_json_dict(g) for g in gates]
+    possible_owners_by_gate_type: dict[int, list[str]] = {
+        gate_type: approval_defs.get_approvers(gate_type)
+        for gate_type in approval_defs.APPROVAL_FIELDS_BY_ID
+        }
+
+    return {
+        'gates': dicts,
+        'possible_owners': possible_owners_by_gate_type
+        }

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -211,6 +211,16 @@ class ChromeStatusClient {
         {gateType: Number(gateType), state: Number(state)});
   }
 
+  getVotes(featureId, gateId) {
+    return this.doGet(`/features/${featureId}/votes/${gateId}`);
+  }
+
+  setVote(featureId, gateId, state) {
+    return this.doPost(
+        `/features/${featureId}/votes/${gateId}`,
+        {state: Number(state)});
+  }
+
   getApprovalConfigs(featureId) {
     return this.doGet(`/features/${featureId}/configs`);
   }

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -168,11 +168,11 @@ def is_resolved(approval_values, field_id):
   return False
 
 
-def set_vote(feature_id: int,  gate_type: int, new_state: int,
-    set_by_email: str, gate_id: Optional[int]=None) -> None:
+def set_vote(feature_id: int,  gate_type: int | None, new_state: int,
+    set_by_email: str, gate_id: int | None=None) -> None:
   """Add or update an approval value."""
   gate: Optional[Gate] = None
-  if gate_id is None:
+  if gate_id is None and gate_type is not None:
     gate = get_gate_by_type(feature_id, gate_type)
     # If a vote is being set, a corresponding gate should already exist.
     if not gate:
@@ -180,6 +180,7 @@ def set_vote(feature_id: int,  gate_type: int, new_state: int,
           'Cannot set vote.')
       return
     gate_id = gate.key.integer_id()
+    gate_type = gate.gate_type
   else:
     gate = Gate.get_by_id(gate_id)
 

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ from api import logout_api
 from api import metricsdata
 from api import permissions_api
 from api import processes_api
+from api import reviews_api
 from api import settings_api
 from api import stages_api
 from api import stars_api
@@ -99,12 +100,15 @@ api_routes: list[Route] = [
     Route(f'{API_BASE}/features/<int:feature_id>', features_api.FeaturesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/approvals',
         approvals_api.ApprovalsAPI),
+    # TODO(jrobbins): Phase out approvals_api.
     Route(f'{API_BASE}/features/<int:feature_id>/approvals/<int:field_id>',
         approvals_api.ApprovalsAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/configs',
         approvals_api.ApprovalConfigsAPI),
+    Route(f'{API_BASE}/features/<int:feature_id>/votes/<int:gate_id>',
+        reviews_api.VotesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/gates',
-        approvals_api.GatesAPI),
+        reviews_api.GatesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/approvals/comments',
         comments_api.CommentsAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/approvals/<int:field_id>/comments',


### PR DESCRIPTION
We already have approvals_api, and it has been upgraded to write both Approval objects and Vote objects.  However, it is awkward to use that because it mixes the terms "approval" and "vote", and it relies on gate_type to identify a gate, whereas we should be using gate_id because gate_type could be used more than once on a feature that has repeated stages.

In this PR:
* Define the new file api/reviews_api.py with classes to deal with Votes and Gates.
* Move the existing GateAPI into that file.
* Move some JSON conversion functions in to converters.py.
* Add new routing to main.py and a new client-side API method to cs-client.js.

This PR should have no user-visible affect on the app yet because the new code is not actually called by the client.