### PR TITLE
Use shift-click to open gate-column and X icon to close.

### DIFF
--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -249,6 +249,10 @@ class ChromedashApp extends LitElement {
     this.showSidebar();
   }
 
+  handleShowGateColumn(e) {
+    this.showGateColumn(e.detail.feature, e.detail.stage, e.detail.gate);
+  }
+
   /**
  * Update window.locaton with new query params.
  * @param {string} key is the key of the query param.
@@ -304,7 +308,8 @@ class ChromedashApp extends LitElement {
       `;
     } else {
       return html`
-        <div id="content-component-wrapper">
+        <div id="content-component-wrapper"
+          @show-gate-column=${(e) => this.handleShowGateColumn(e)}>
           ${this.pageComponent}
         </div>
         <div id="content-sidebar-space">

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -309,10 +309,11 @@ class ChromedashFeatureDetail extends LitElement {
     return this.renderSection('Metadata', content);
   }
 
-  renderGateChip(gate) {
+  renderGateChip(feStage, gate) {
     return html`
       <chromedash-gate-chip
         .feature=${this.feature}
+        .stage=${feStage}
         .gate=${gate}
       >
       </chromedash-gate-chip>
@@ -323,7 +324,7 @@ class ChromedashFeatureDetail extends LitElement {
     const gatesForStage = this.gates.filter(g => g.stage_id == feStage.stage_id);
     return html`
       <div class="gates">
-        ${gatesForStage.map(g => this.renderGateChip(g))}
+        ${gatesForStage.map(g => this.renderGateChip(feStage, g))}
       </div>
     `;
   }

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -203,6 +203,8 @@ export class ChromedashFeaturePage extends LitElement {
   // TODO(jrobbins): Make it specific.
   handleOpenApprovals(e) {
     e.preventDefault();
+    // open old approvals dialog.
+    // TODO(jrobbins): Phase this out after approvals column is done.
     openApprovalsDialog(this.user, e.detail.feature);
   }
 

--- a/client-src/elements/chromedash-feature-row.js
+++ b/client-src/elements/chromedash-feature-row.js
@@ -151,11 +151,13 @@ class ChromedashFeatureRow extends LitElement {
     const activeGates = featureGates.filter(g => this.isActiveGate(g));
     const activeStageIds = new Set(activeGates.map(g => g.stage_id));
     const activeStagesAndTheirGates = [];
-    for (const activeStageId of activeStageIds) {
-      activeStagesAndTheirGates.push({
-        stageId: activeStageId,
-        gates: featureGates.filter(g => g.stage_id == activeStageId),
-      });
+    for (const stage of feature.stages) {
+      if (activeStageIds.has(stage.stage_id)) {
+        activeStagesAndTheirGates.push({
+          stage: stage,
+          gates: featureGates.filter(g => g.stage_id == stage.stage_id),
+        });
+      }
     }
     return activeStagesAndTheirGates;
   }
@@ -168,6 +170,7 @@ class ChromedashFeatureRow extends LitElement {
         ${stageAndGates.gates.map(gate => html`
           <chromedash-gate-chip
             .feature=${this.feature}
+            .stage=${stageAndGates.stage}
             .gate=${gate}
           ></chromedash-gate-chip>`)}
       </div>

--- a/client-src/elements/chromedash-gate-chip.js
+++ b/client-src/elements/chromedash-gate-chip.js
@@ -29,6 +29,7 @@ class ChromedashGateChip extends LitElement {
   static get properties() {
     return {
       feature: {type: Object},
+      stage: {type: Object},
       gate: {type: Object},
     };
   }
@@ -36,6 +37,7 @@ class ChromedashGateChip extends LitElement {
   constructor() {
     super();
     this.feature = {};
+    this.stage = {};
     this.gate = {};
   }
 
@@ -116,11 +118,21 @@ class ChromedashGateChip extends LitElement {
     this.dispatchEvent(event);
   }
 
-  openApprovalsDialog() {
-    // Handled in chromedash-myfeatures-page.js.
-    this._fireEvent('open-approvals-event', {
-      feature: this.feature,
-    });
+  openApprovalsDialog(e) {
+    if (e.shiftKey) {
+      // Handled in chromedash-app.js.
+      this._fireEvent('show-gate-column', {
+        feature: this.feature,
+        stage: this.stage,
+        gate: this.gate,
+      });
+    } else {
+      // Handled in chromedash-myfeatures-page.js and chromedash-feature-page.
+      this._fireEvent('open-approvals-event', {
+        feature: this.feature,
+        gate: this.gate,
+      });
+    }
   }
 
   render() {

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -21,12 +21,19 @@ class ChromedashGateColumn extends LitElement {
     return [
       ...SHARED_STYLES,
       css`
+       #close-button {
+         font-size: 2em;
+         position: absolute;
+         top: var(--content-padding-quarter);
+         right: var(--content-padding-quarter);
+       }
+
        #votes-area {
          margin: var(--content-padding) 0;
        }
 
        #votes-area table {
-         border-spacing: var(--content-padding-half) var(--content-padding);;
+         border-spacing: var(--content-padding-half) var(--content-padding);
        }
 
        #votes-area th {
@@ -62,7 +69,7 @@ class ChromedashGateColumn extends LitElement {
     this.process = {};
     this.votes = [];
     this.comments = [];
-    this.loading = false;
+    this.loading = true; // Avoid errors before first usage.
     this.needsSave = false;
   }
 
@@ -104,10 +111,12 @@ class ChromedashGateColumn extends LitElement {
 
   renderHeadingsSkeleton() {
     return html`
-      <h3 class="sl-skeleton-header-container">
+      <h3 class="sl-skeleton-header-container"
+          style="width: 60%">
         <sl-skeleton effect="sheen"></sl-skeleton>
       </h3>
-      <h2 class="sl-skeleton-header-container">
+      <h2 class="sl-skeleton-header-container"
+          style="margin-top: 4px; width: 75%">
         <sl-skeleton effect="sheen"></sl-skeleton>
       </h2>
     `;
@@ -234,6 +243,10 @@ class ChromedashGateColumn extends LitElement {
 
   render() {
     return html`
+      <sl-icon-button title="Close" name="x" id="close-button"
+        @click=${() => this.handleCancel()}
+        ></sl-icon-button>
+
         ${this.loading ?
           this.renderHeadingsSkeleton() :
           this.renderHeadings()}


### PR DESCRIPTION
This is progress on implementing the gate column, but it is still not ready to be seen by most users.

In this PR:
* Add an X icon to close the gate column.
* When the user SHIFT clicks on a gate chip, the app will open the gate column
* Also, go back to setting loading=true by default to avoid errors before the gate column is initially opened.