### PR TITLE
Add INTERNAL_REVIEW and NO_RESPONSE vote values.

### DIFF
--- a/client-src/elements/chromedash-approvals-dialog.js
+++ b/client-src/elements/chromedash-approvals-dialog.js
@@ -6,15 +6,17 @@ import {showToastMessage} from './utils.js';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
 export const STATE_NAMES = [
-  // Not used: [0, 'Needs review'],
+  // Not used: [0, 'Preparing'],
+  [7, 'No response'],
   [1, 'N/a or Ack'],
   [2, 'Review requested'],
   [3, 'Review started'],
   [4, 'Needs work'],
+  [8, 'Internal review'],
   [5, 'Approved'],
   [6, 'Denied'],
 ];
-const PENDING_STATES = [2, 3, 4];
+const PENDING_STATES = [2, 3, 4, 8];
 
 const APPROVAL_DEFS = [
   {name: 'Intent to Prototype',

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -11,6 +11,7 @@ export const STATE_NAMES = [
   [2, 'Review requested'],
   [3, 'Review started'],
   [4, 'Needs work'],
+  [8, 'Internal review'],
   [5, 'Approved'],
   [6, 'Denied'],
 ];

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -26,21 +26,25 @@ from google.cloud import ndb  # type: ignore
 class Approval(ndb.Model):
   """Describes the current state of one approval on a feature."""
 
-  # Not used: NEEDS_REVIEW = 0
+  # Not used: PREPARING = 0
   NA = 1
   REVIEW_REQUESTED = 2
   REVIEW_STARTED = 3
   NEEDS_WORK = 4
   APPROVED = 5
   DENIED = 6
+  NO_RESPONSE = 7
+  INTERNAL_REVIEW = 8
   APPROVAL_VALUES = {
-      # Not used: NEEDS_REVIEW: 'needs_review',
+      # Not used: PREPARING: 'preparing',
       NA: 'na',
       REVIEW_REQUESTED: 'review_requested',
       REVIEW_STARTED: 'review_started',
       NEEDS_WORK: 'needs_work',
       APPROVED: 'approved',
       DENIED: 'denied',
+      NO_RESPONSE: 'no_response',
+      INTERNAL_REVIEW: 'internal_review',
   }
 
   FINAL_STATES = [NA, APPROVED, DENIED]
@@ -202,13 +206,15 @@ class OwnersFile(ndb.Model):
 class Vote(ndb.Model):  # copy from Approval
   """One approver's vote on what the state of a gate should be."""
 
-  # Not used: NEEDS_REVIEW = 0
+  # Not used: PREPARING = 0
   NA = 1
   REVIEW_REQUESTED = 2
   REVIEW_STARTED = 3
   NEEDS_WORK = 4
   APPROVED = 5
   DENIED = 6
+  NO_RESPONSE = 7
+  INTERNAL_REVIEW = 8
   VOTE_VALUES = {
       # Not used: PREPARING: 'preparing',
       NA: 'na',
@@ -217,6 +223,8 @@ class Vote(ndb.Model):  # copy from Approval
       NEEDS_WORK: 'needs_work',
       APPROVED: 'approved',
       DENIED: 'denied',
+      NO_RESPONSE: 'no_response',
+      INTERNAL_REVIEW: 'internal_review',
   }
 
   FINAL_STATES = [NA, APPROVED, DENIED]
@@ -263,7 +271,9 @@ class Gate(ndb.Model):  # copy from ApprovalConfig
   """Gates regulate the completion of a stage."""
 
   PREPARING = 0
-  PENDING_STATES = [Vote.REVIEW_REQUESTED, Vote.REVIEW_STARTED, Vote.NEEDS_WORK]
+  PENDING_STATES = [
+      Vote.REVIEW_REQUESTED, Vote.REVIEW_STARTED, Vote.NEEDS_WORK,
+      Vote.INTERNAL_REVIEW]
   FINAL_STATES = [Vote.NA, Vote.APPROVED, Vote.DENIED]
 
   feature_id = ndb.IntegerProperty(required=True)


### PR DESCRIPTION
One requirement that we have from Dharani is that a gate could be marked for "internal review," meaning that discussion needs to happen via an internal tool or some other way outside of our tool.   I think that we can basically treat this like no vote at all, which means that the gate state would not change until the person who voted for internal_review eventually updates their vote to approved or denied.

In this PR:
+ Define some new constants in multiple places for client-side and server-side and old code and new code.
+ Make consistent comments that the vote value 0 is named "PREPARING", meaning that the user is still entering field information and has not requested a review yet.