### PR TITLE
Add back created and updated fields to features_v2.json

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -507,6 +507,14 @@ def feature_entry_to_json_basic(fe: FeatureEntry,
       'samples': fe.sample_links or [],
       'docs': fe.doc_links or [],
     },
+    'created': {
+      'by': fe.creator_email,
+      'when': _date_to_str(fe.created)
+    },
+    'updated': {
+      'by': fe.updater_email,
+      'when': _date_to_str(fe.updated)
+    },
     'standards': {
       'spec': fe.spec_link,
       'maturity': {

--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -93,6 +93,7 @@ class FeatureConvertersTest(testing_config.CustomTestCase):
   def test_feature_entry_to_json_basic__normal(self):
     """Converts feature entry to basic JSON dictionary."""
     result = converters.feature_entry_to_json_basic(self.fe_1)
+    expected_date = str(self.date)
     expected = {
       'id': 123,
       'name': 'feature template',
@@ -105,6 +106,14 @@ class FeatureConvertersTest(testing_config.CustomTestCase):
       'resources': {
         'samples': ['https://example.com/samples'],
         'docs': ['https://example.com/docs'],
+      },
+      'created': {
+        'by': 'creator@example.com',
+        'when': expected_date
+      },
+      'updated': {
+        'by': 'updater@example.com',
+        'when': expected_date
       },
       'standards': {
         'spec': 'https://example.com/spec',


### PR DESCRIPTION
This is a quick fix for #2581. It is likely that additional fields need to be added to mimic the legacy version of our JSON converter, but the legacy version itself will become unusable/unreliable shortly due to the new schema changes, so it is likely better to replicate the functionality as best as possible.