### PR TITLE
Display comments in gate column.

### DIFF
--- a/client-src/elements/chromedash-activity-log.js
+++ b/client-src/elements/chromedash-activity-log.js
@@ -75,6 +75,7 @@ export class ChromedashActivity extends LitElement {
       user: {type: Object},
       feature: {type: Object},
       activity: {type: Object},
+      narrow: {type: Boolean},
     };
   }
 
@@ -83,6 +84,7 @@ export class ChromedashActivity extends LitElement {
     this.user = null;
     this.feature = {};
     this.activity = null;
+    this.narrow = false;
   }
 
   static get styles() {
@@ -90,7 +92,18 @@ export class ChromedashActivity extends LitElement {
       ...SHARED_STYLES,
       css`
         .comment_header {
-          height: 24px;
+          min-height: 24px;
+        }
+
+        .comment_header.narrow .author {
+          font-weight: 500;
+        }
+        .comment_header.narrow .preposition {
+          display: none;
+        }
+        .comment_header.narrow .date {
+          display: block;
+          padding-bottom: var(--content-padding);
         }
 
         .comment {
@@ -214,12 +227,13 @@ export class ChromedashActivity extends LitElement {
     const preface = this.renderDeletedPreface();
     return html`
       <div class="comment">
-        <div class="comment_header">
-           <span class="author">${this.activity.author}</span>
-           on
-           <span class="date">${this.formatDate(this.activity.created)}</span>
-           ${this.formatRelativeDate()}
+        <div class="comment_header ${this.narrow ? 'narrow' : ''}">
            ${this.formatEditMenu()}
+           <span class="author">${this.activity.author}</span>
+           <span class="preposition">on</span>
+           <span class="date">${this.formatDate(this.activity.created)}
+             ${this.formatRelativeDate()}
+           </span>
         </div>
         <div id="amendments">
           ${this.activity.amendments.map((a) => html`
@@ -257,7 +271,19 @@ export class ChromedashActivityLog extends LitElement {
       user: {type: Object},
       feature: {type: Object},
       comments: {type: Array},
+      narrow: {type: Boolean},
+      reverse: {type: Boolean},
     };
+  }
+
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      css`
+        p {
+          padding: var(--content-padding);
+        }
+    `];
   }
 
   constructor() {
@@ -265,6 +291,8 @@ export class ChromedashActivityLog extends LitElement {
     this.user = null;
     this.feature = {};
     this.comments = [];
+    this.narrow = false;
+    this.reverse = false;
   }
 
   render() {
@@ -276,15 +304,16 @@ export class ChromedashActivityLog extends LitElement {
       return html`<p>No comments yet.</p>`;
     }
 
-    return html`
-      ${this.comments.map((activity) => html`
+    const orderedComments = (
+      this.reverse ? this.comments.slice(0).reverse() : this.comments);
+    return orderedComments.map((activity) => html`
         <chromedash-activity
           .user=${this.user}
           .feature=${this.feature}
+          .narrow=${this.narrow}
           .activity=${activity}>
         </chromedash-activity>
-      `)}
-    `;
+      `);
   }
 }
 

--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -74,6 +74,7 @@ class ChromedashApp extends LitElement {
           position: sticky;
           top: 10px;
           height: 85vh;
+          overflow-y: auto;
           border: var(--sidebar-border);
           border-radius: var(--sidebar-radius);
           background: var(--sidebar-bg);

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -29,21 +29,31 @@ class ChromedashGateColumn extends LitElement {
          right: var(--content-padding-quarter);
        }
 
-       #votes-area {
-         margin: var(--content-padding) 0;
-       }
-
-       #votes-area table {
-         border-spacing: var(--content-padding-half) var(--content-padding);
-       }
-
-       #votes-area th {
-         font-weight: bold;
-       }
-
        #review-status-area {
          margin: var(--content-padding-half) 0;
        }
+
+       #votes-area {
+         margin: var(--content-padding) 0;
+       }
+       #votes-area table {
+         border-spacing: var(--content-padding-half) var(--content-padding);
+       }
+       #votes-area th {
+         font-weight: 500;
+       }
+
+        #controls {
+          padding: var(--content-padding);
+          text-align: right;
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        }
+        #controls * + * {
+          padding-left: var(--content-padding);
+        }
+
     `];
   }
 
@@ -83,6 +93,7 @@ class ChromedashGateColumn extends LitElement {
     Promise.all([
       window.csClient.getFeatureProcess(featureId),
       window.csClient.getApprovals(featureId),
+      // TODO(jrobbins): Include activities for this gate
       window.csClient.getComments(featureId),
     ]).then(([process, approvalRes, commentRes]) => {
       this.process = process;
@@ -97,6 +108,21 @@ class ChromedashGateColumn extends LitElement {
     });
   }
 
+  reloadComments() {
+    const commentArea = this.shadowRoot.querySelector('#comment_area');
+    commentArea.value = '';
+    this.needsSave = false;
+    Promise.all([
+      // TODO(jrobbins): Include activities for this gate
+      window.csClient.getComments(this.feature.id),
+    ]).then(([commentRes]) => {
+      this.comments = commentRes.comments;
+    }).catch(() => {
+      showToastMessage('Some errors occurred. Please refresh the page or try again later.');
+      this.handleCancel();
+    });
+  }
+
   _fireEvent(eventName, detail) {
     const event = new CustomEvent(eventName, {
       bubbles: true,
@@ -104,6 +130,27 @@ class ChromedashGateColumn extends LitElement {
       detail,
     });
     this.dispatchEvent(event);
+  }
+
+  checkNeedsSave() {
+    let newNeedsSave = false;
+    const commentArea = this.shadowRoot.querySelector('#comment_area');
+    const newVal = commentArea && commentArea.value.trim() || '';
+    if (newVal != '') newNeedsSave = true;
+    this.needsSave = newNeedsSave;
+  }
+
+  handlePost() {
+    const commentArea = this.shadowRoot.querySelector('#comment_area');
+    const commentText = commentArea.value.trim();
+    const postToApprovalFieldId = 0; // Don't post to thread.
+    // TODO(jrobbins): Also post to intent thread
+    if (commentText != '') {
+      window.csClient.postComment(
+        this.feature.id, null, null, commentText,
+        Number(postToApprovalFieldId))
+        .then(() => this.reloadComments());
+    }
   }
 
   handleCancel() {
@@ -192,7 +239,7 @@ class ChromedashGateColumn extends LitElement {
   }
 
   renderVoteRow(vote) {
-    const voteCell = (vote.set_by == this.user.email) ?
+    const voteCell = (vote.set_by == this.user?.email) ?
       this.renderVoteMenu(vote.state) :
       this.renderVoteReadOnly(vote);
     return html`
@@ -205,9 +252,9 @@ class ChromedashGateColumn extends LitElement {
 
   renderVotes() {
     const canVote = true; // TODO(jrobbins): permission checks.
-    const myVoteExists = this.votes.some((v) => v.set_by == this.user.email);
+    const myVoteExists = this.votes.some((v) => v.set_by == this.user?.email);
     const addVoteRow = (canVote && !myVoteExists) ?
-      this.renderVoteRow({set_by: this.user.email, state: 7}) :
+      this.renderVoteRow({set_by: this.user?.email, state: 7}) :
       nothing;
 
     return html`
@@ -235,10 +282,40 @@ class ChromedashGateColumn extends LitElement {
     `;
   }
 
+  renderControls() {
+    if (!this.user || !this.user.can_comment) return nothing;
+    // TODO(jrobbins): checkbox to also post to intent thread.
+
+    return html`
+    <sl-textarea id="comment_area" rows=2 cols=40
+      @sl-change=${this.checkNeedsSave}
+      @keypress=${this.checkNeedsSave}
+      placeholder="Add a comment"
+      ></sl-textarea>
+     <div id="controls">
+       <sl-button variant="primary"
+         @click=${this.handlePost}
+         ?disabled=${!this.needsSave}
+         size="small"
+         >Post</sl-button>
+     </div>
+    `;
+  }
+
+
   renderComments() {
     return html`
       <h2>Comments &amp; Activity</h2>
-      TODO(jrobbins): Comments go here
+      ${this.renderControls()}
+      <div id="comment-area">
+        <chromedash-activity-log
+          .user=${this.user}
+          .feature=${this.feature}
+          .narrow=${true}
+          .reverse=${true}
+          .comments=${this.comments}>
+        </chromedash-activity-log>
+      </div>
     `;
   }
 

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -287,18 +287,18 @@ class ChromedashGateColumn extends LitElement {
     // TODO(jrobbins): checkbox to also post to intent thread.
 
     return html`
-    <sl-textarea id="comment_area" rows=2 cols=40
-      @sl-change=${this.checkNeedsSave}
-      @keypress=${this.checkNeedsSave}
-      placeholder="Add a comment"
-      ></sl-textarea>
-     <div id="controls">
-       <sl-button variant="primary"
-         @click=${this.handlePost}
-         ?disabled=${!this.needsSave}
-         size="small"
-         >Post</sl-button>
-     </div>
+      <sl-textarea id="comment_area" rows=2 cols=40
+        @sl-change=${this.checkNeedsSave}
+        @keypress=${this.checkNeedsSave}
+        placeholder="Add a comment"
+        ></sl-textarea>
+       <div id="controls">
+         <sl-button variant="primary"
+           @click=${this.handlePost}
+           ?disabled=${!this.needsSave}
+           size="small"
+           >Post</sl-button>
+       </div>
     `;
   }
 
@@ -307,15 +307,13 @@ class ChromedashGateColumn extends LitElement {
     return html`
       <h2>Comments &amp; Activity</h2>
       ${this.renderControls()}
-      <div id="comment-area">
-        <chromedash-activity-log
-          .user=${this.user}
-          .feature=${this.feature}
-          .narrow=${true}
-          .reverse=${true}
-          .comments=${this.comments}>
-        </chromedash-activity-log>
-      </div>
+      <chromedash-activity-log
+        .user=${this.user}
+        .feature=${this.feature}
+        .narrow=${true}
+        .reverse=${true}
+        .comments=${this.comments}>
+      </chromedash-activity-log>
     `;
   }
 
@@ -348,7 +346,6 @@ class ChromedashGateColumn extends LitElement {
         ${this.loading ?
           this.renderCommentsSkeleton() :
           this.renderComments()}
-
     `;
   }
 }


### PR DESCRIPTION
This is progress on issue #2334.  This PR replaces a TODO for rendering comments with code to actually render comments.  

Unlike comments in the approval dialog, the gate column is a more narrow space where some details are better laid out vertically.  And, the comments in the gate column are intended to be in reverse chronological order with the text field above the newest comment.

The comment posting behavior of the gate column is different than the approvals dialog: the dialog closes after posting, whereas the gate column updates to show the new comment list (including the user's newly posted comment).

In this PR:
* chromedash-activity-log: Add two new properties `narrow` and `reverse` to configure the display as needed for the gate column context.
* chromedash-app: add an auto scrollbar if the sidebar content gets too tall to fit.
* chromedash-gate-column: Add the activity log component and form controls to post.  When the user posts a comment, reset the form and reload the comments.
* Also, I added some `?` operators to handle the case where the user is signed out so that `this.user` is null.
* And, I am now using `font-weight: 500` instead of `font-weight: bold` because 500 looks better in safari.