### PR TITLE
Implement voting in gate column

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -613,13 +613,14 @@ def gate_value_to_json_dict(gate: Gate) -> dict[str, Any]:
   requested_on = str(gate.requested_on) if gate.requested_on else None
   appr_def = approval_defs.APPROVAL_FIELDS_BY_ID[gate.gate_type]
   return {
+      'id': gate.key.integer_id(),
       'feature_id': gate.feature_id,
       'stage_id': gate.stage_id,
       'gate_type': gate.gate_type,
       'team_name': appr_def.team_name,
       'gate_name': appr_def.name,
       'state': gate.state,
-      'requested_on': requested_on,  # YYYY-MM-DD or None
+      'requested_on': requested_on,  # YYYY-MM-DD HH:MM:SS or None
       'owners': gate.owners,
       'next_action': next_action,  # YYYY-MM-DD or None
       'additional_review': gate.additional_review

--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -345,12 +345,18 @@ class VoteConvertersTest(testing_config.CustomTestCase):
 
 class GateConvertersTest(testing_config.CustomTestCase):
 
+  def tearDown(self) -> None:
+    for g in Gate.query():
+      g.key.delete()
+
   def test_minimal(self):
     """If a Gate has only required fields set, we can convert it to JSON."""
     gate = Gate(feature_id=1, stage_id=2, gate_type=3, state=4)
+    gate.put()
     actual = converters.gate_value_to_json_dict(gate)
     appr_def = approval_defs.APPROVAL_FIELDS_BY_ID[gate.gate_type]
     expected = {
+      'id': gate.key.integer_id(),
       'feature_id': 1,
       'stage_id': 2,
       'gate_type': 3,
@@ -370,11 +376,13 @@ class GateConvertersTest(testing_config.CustomTestCase):
         feature_id=1, stage_id=2, gate_type=3, state=4,
         requested_on=datetime(2022, 12, 14, 1, 2, 3),
         owners=['appr1@example.com', 'appr2@example.com'],
-        next_action=datetime(2022, 12, 25, 4, 5, 6),
+        next_action=datetime(2022, 12, 25),
         additional_review=True)
+    gate.put()
     actual = converters.gate_value_to_json_dict(gate)
     appr_def = approval_defs.APPROVAL_FIELDS_BY_ID[gate.gate_type]
     expected = {
+      'id': gate.key.integer_id(),
       'feature_id': 1,
       'stage_id': 2,
       'gate_type': 3,
@@ -383,7 +391,7 @@ class GateConvertersTest(testing_config.CustomTestCase):
       'state': 4,
       'requested_on': '2022-12-14 01:02:03',
       'owners': ['appr1@example.com', 'appr2@example.com'],
-      'next_action': '2022-12-25 04:05:06',
+      'next_action': '2022-12-25',
       'additional_review': True,
       }
     self.assertEqual(expected, actual)

--- a/api/permissions_api.py
+++ b/api/permissions_api.py
@@ -36,8 +36,11 @@ class PermissionsAPI(basehandlers.APIHandler):
       approvers = approval_defs.get_approvers(field_id)
       user_data = {
         'can_create_feature': permissions.can_create_feature(user),
+        # TODO(jrobbins): phase out can_approve and use approvable_gate_types
         'can_approve': permissions.can_approve_feature(
             user, None, approvers),
+        'approvable_gate_types': sorted(
+            approval_defs.fields_approvable_by(user)),
         'can_comment': permissions.can_comment(user),
         'can_edit_all': permissions.can_edit_any_feature(user),
         'is_admin': permissions.can_admin_site(user),

--- a/api/permissions_api_test.py
+++ b/api/permissions_api_test.py
@@ -46,6 +46,7 @@ class PermissionsAPITest(testing_config.CustomTestCase):
     expected = {
       'user': {
         'can_create_feature': False,
+        'approvable_gate_types': [],
         'can_approve': False,
         'can_comment': False,
         'can_edit_all': False,
@@ -63,6 +64,7 @@ class PermissionsAPITest(testing_config.CustomTestCase):
     expected = {
       'user': {
         'can_create_feature': True,
+        'approvable_gate_types': [],
         'can_approve': False,
         'can_comment': True,
         'can_edit_all': False,

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -1,4 +1,5 @@
 import {LitElement, css, html, nothing} from 'lit';
+import {ref, createRef} from 'lit/directives/ref.js';
 import './chromedash-activity-log';
 import {showToastMessage, findProcessStage} from './utils.js';
 
@@ -17,7 +18,10 @@ export const STATE_NAMES = [
 ];
 
 
-class ChromedashGateColumn extends LitElement {
+export class ChromedashGateColumn extends LitElement {
+  voteSelectRef = createRef();
+  commentAreaRef = createRef();
+
   static get styles() {
     return [
       ...SHARED_STYLES,
@@ -68,6 +72,8 @@ class ChromedashGateColumn extends LitElement {
       comments: {type: Array},
       loading: {type: Boolean},
       needsSave: {type: Boolean},
+      showSaved: {type: Boolean},
+      needsPost: {type: Boolean},
     };
   }
 
@@ -82,6 +88,8 @@ class ChromedashGateColumn extends LitElement {
     this.comments = [];
     this.loading = true; // Avoid errors before first usage.
     this.needsSave = false;
+    this.showSaved = false;
+    this.needsPost = false;
   }
 
   setContext(feature, stage, gate) {
@@ -101,6 +109,7 @@ class ChromedashGateColumn extends LitElement {
         v.gate_id == this.gate.id);
       this.comments = commentRes.comments;
       this.needsSave = false;
+      this.needsPost = false;
       this.loading = false;
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
@@ -109,9 +118,9 @@ class ChromedashGateColumn extends LitElement {
   }
 
   reloadComments() {
-    const commentArea = this.shadowRoot.querySelector('#comment_area');
+    const commentArea = this.commentAreaRef.value;
     commentArea.value = '';
-    this.needsSave = false;
+    this.needsPost = false;
     Promise.all([
       // TODO(jrobbins): Include activities for this gate
       window.csClient.getComments(this.feature.id),
@@ -132,16 +141,16 @@ class ChromedashGateColumn extends LitElement {
     this.dispatchEvent(event);
   }
 
-  checkNeedsSave() {
-    let newNeedsSave = false;
-    const commentArea = this.shadowRoot.querySelector('#comment_area');
+  checkNeedsPost() {
+    let newNeedsPost = false;
+    const commentArea = this.commentAreaRef.value;
     const newVal = commentArea && commentArea.value.trim() || '';
-    if (newVal != '') newNeedsSave = true;
-    this.needsSave = newNeedsSave;
+    if (newVal != '') newNeedsPost = true;
+    this.needsPost = newNeedsPost;
   }
 
   handlePost() {
-    const commentArea = this.shadowRoot.querySelector('#comment_area');
+    const commentArea = this.commentAreaRef.value;
     const commentText = commentArea.value.trim();
     const postToApprovalFieldId = 0; // Don't post to thread.
     // TODO(jrobbins): Also post to intent thread
@@ -151,6 +160,21 @@ class ChromedashGateColumn extends LitElement {
         Number(postToApprovalFieldId))
         .then(() => this.reloadComments());
     }
+  }
+
+  handleSelectChanged() {
+    this.needsSave = true;
+  }
+
+  handleSave() {
+    // TODO(jrobbins): This should specify gate ID rather than gate type.
+    window.csClient.setApproval(
+      this.feature.id, this.gate.gate_type,
+      this.voteSelectRef.value.value)
+      .then(() => {
+        this.needsSave = false;
+        this.showSaved = true;
+      });
   }
 
   handleCancel() {
@@ -225,10 +249,10 @@ class ChromedashGateColumn extends LitElement {
   }
 
   renderVoteMenu(state) {
-    // hoist is needed when <sl-select> is in overflow:hidden context.
+    // hoist is needed when <sl-select> is in overflow:auto context.
     return html`
       <sl-select name="${this.gate.id}"
-                 value="${state}"
+                 value="${state}" ${ref(this.voteSelectRef)}
                  @sl-change=${this.handleSelectChanged}
                  hoist size="small">
         ${STATE_NAMES.map((valName) => html`
@@ -240,13 +264,28 @@ class ChromedashGateColumn extends LitElement {
 
   renderVoteRow(vote) {
     const shortVoter = vote.set_by.split('@')[0] + '@';
-    const voteCell = (vote.set_by == this.user?.email) ?
-      this.renderVoteMenu(vote.state) :
-      this.renderVoteReadOnly(vote);
+    let saveButton = nothing;
+    let voteCell = this.renderVoteReadOnly(vote);
+
+    if (vote.set_by == this.user?.email) {
+      voteCell = this.renderVoteMenu(vote.state);
+      if (this.needsSave) {
+        saveButton = html`
+          <sl-button
+            size="small" pill variant="primary"
+            @click=${this.handleSave}
+            >Save</sl-button>
+          `;
+      } else if (this.showSaved) {
+        saveButton = html`<b>Saved</b>`;
+      }
+    }
+
     return html`
       <tr>
        <td title=${vote.set_by}>${shortVoter}</td>
        <td>${voteCell}</td>
+       <td>${saveButton}</td>
       </tr>
     `;
   }
@@ -259,6 +298,12 @@ class ChromedashGateColumn extends LitElement {
     const addVoteRow = (canVote && !myVoteExists) ?
       this.renderVoteRow({set_by: this.user?.email, state: 7}) :
       nothing;
+
+    if (!canVote && this.votes.length === 0) {
+      return html`
+        <p>No review activity yet.</p>
+      `;
+    }
 
     return html`
       <table>
@@ -290,15 +335,15 @@ class ChromedashGateColumn extends LitElement {
     // TODO(jrobbins): checkbox to also post to intent thread.
 
     return html`
-      <sl-textarea id="comment_area" rows=2 cols=40
-        @sl-change=${this.checkNeedsSave}
-        @keypress=${this.checkNeedsSave}
+      <sl-textarea id="comment_area" rows=2 cols=40 ${ref(this.commentAreaRef)}
+        @sl-change=${this.checkNeedsPost}
+        @keypress=${this.checkNeedsPost}
         placeholder="Add a comment"
         ></sl-textarea>
        <div id="controls">
          <sl-button variant="primary"
            @click=${this.handlePost}
-           ?disabled=${!this.needsSave}
+           ?disabled=${!this.needsPost}
            size="small"
            >Post</sl-button>
        </div>

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -192,19 +192,22 @@ class ChromedashGateColumn extends LitElement {
   }
 
   renderVoteRow(vote) {
+    const shortVoter = vote.set_by.split('@')[0] + '@';
     const voteCell = (vote.set_by == this.user.email) ?
       this.renderVoteMenu(vote.state) :
       this.renderVoteReadOnly(vote);
     return html`
       <tr>
-       <td>${vote.set_by}</td>
+       <td title=${vote.set_by}>${shortVoter}</td>
        <td>${voteCell}</td>
       </tr>
     `;
   }
 
   renderVotes() {
-    const canVote = true; // TODO(jrobbins): permission checks.
+    const canVote = (
+      this.user &&
+        this.user.approvable_gate_types.includes(this.gate.gate_type));
     const myVoteExists = this.votes.some((v) => v.set_by == this.user.email);
     const addVoteRow = (canVote && !myVoteExists) ?
       this.renderVoteRow({set_by: this.user.email, state: 7}) :

--- a/client-src/elements/chromedash-gate-column_test.js
+++ b/client-src/elements/chromedash-gate-column_test.js
@@ -1,0 +1,31 @@
+import {html} from 'lit';
+import {assert, fixture} from '@open-wc/testing';
+import {ChromedashGateColumn} from './chromedash-gate-column';
+import '../js-src/cs-client';
+import sinon from 'sinon';
+
+describe('chromedash-settings-page', () => {
+  /* window.csClient is initialized in spa.html
+   * which is not available here, so we initialize it before each test.
+   * We also stub out the API calls here so that they return test data. */
+  beforeEach(async () => {
+    window.csClient = new ChromeStatusClient('fake_token', 1);
+    sinon.stub(window.csClient, 'getFeatureProcess');
+    sinon.stub(window.csClient, 'getApprovals');
+    sinon.stub(window.csClient, 'getComments');
+  });
+
+  afterEach(() => {
+    window.csClient.getFeatureProcess.restore();
+    window.csClient.getApprovals.restore();
+    window.csClient.getComments.restore();
+  });
+
+  it('can be added to the page before being opened', async () => {
+    const component = await fixture(
+      html`<chromedash-gate-column></chromedash-gate-column>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashGateColumn);
+  });
+
+});


### PR DESCRIPTION
This is progress on #2334.  The gate column will now correctly display existing votes and allow a user who has permission to vote submit a new vote.

In this PR:
* converters.py: Add the gate ID to the gate JSON representation.  And, clarify that requested_on is a datetime, whereas next_action is just a date.  In the unit tests, the gate must be saved to NDB so that it has an ID generated.
* permissions_api.py: Instead of just a boolean that says that the current user can approve anything, pass a list of the specific gate types that the user is allowed to vote on.
* chromedash-gate-column.js:
    * Use lit refs instead of querySelector() for cleaner code.
    * Change the meaning of `this.needsSave` to be about saving votes.  Use `this.needsPost` for the "Post" button.
    * Add a `this.showSaved` property to control when a "Saved" text is shown after the user has saved their vote.
    * When the user selects a value from the vote menu, show a "Save" button which actually saves the new value to the server.
    * Save horizontal space by only showing the username@ rather than the full email address for votes.  The full email address is shown on hover.
    * Where has been no voting yet, and the current user cannot vote, show a "No review activity yet" message rather than an empty table of votes.