### PR TITLE
Display gate status or "Request review" button.

### DIFF
--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -305,6 +305,15 @@ class ChromedashApp extends LitElement {
     return url;
   }
 
+  /* The user edited something, so tell components to refetch data. */
+  refetch() {
+    if (this.pageComponent?.refetch) {
+      this.pageComponent.refetch();
+    }
+    if (this.gateColumnRef.value?.refetch) {
+      this.gateColumnRef.value.refetch();
+    }
+  }
 
   renderContentAndSidebar() {
     const wide = (this.pageComponent &&
@@ -318,7 +327,9 @@ class ChromedashApp extends LitElement {
     } else {
       return html`
         <div id="content-component-wrapper"
-          @show-gate-column=${(e) => this.handleShowGateColumn(e)}>
+          @show-gate-column=${this.handleShowGateColumn}
+          @refetch-needed=${this.refetch}
+          >
           ${this.pageComponent}
         </div>
         <div id="content-sidebar-space">
@@ -326,7 +337,9 @@ class ChromedashApp extends LitElement {
             <div id="sidebar-content">
               <chromedash-gate-column
                 .user=${this.user} ${ref(this.gateColumnRef)}
-                @close=${() => this.hideSidebar()}>
+                @close=${this.hideSidebar}
+                @refetch-needed=${this.refetch}
+                >
               </chromedash-gate-column>
             </div>
           </div>

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -154,6 +154,26 @@ export class ChromedashFeaturePage extends LitElement {
     });
   }
 
+  refetch() {
+    this.loading = true;
+    Promise.all([
+      window.csClient.getFeature(this.featureId),
+      window.csClient.getGates(this.featureId),
+      window.csClient.getComments(this.featureId, null, false),
+    ]).then(([feature, gatesRes, commentRes]) => {
+      this.feature = feature;
+      this.gates = gatesRes.gates;
+      this.comments = commentRes.comments;
+      this.loading = false;
+    }).catch((error) => {
+      if (error instanceof FeatureNotFoundError) {
+        this.loading = false;
+      } else {
+        showToastMessage('Some errors occurred. Please refresh the page or try again later.');
+      }
+    });
+  }
+
   disconnectedCallback() {
     super.disconnectedCallback();
     document.title = this.appTitle;

--- a/client-src/elements/chromedash-feature-table.js
+++ b/client-src/elements/chromedash-feature-table.js
@@ -65,6 +65,10 @@ class ChromedashFeatureTable extends LitElement {
     });
   }
 
+  refetch() {
+    this.fetchFeatures();
+  }
+
   loadGateData() {
     for (const feature of this.features) {
       window.csClient.getGates(feature.id).then(res => {

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -6,15 +6,23 @@ import {showToastMessage, findProcessStage} from './utils.js';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
 
-export const STATE_NAMES = [
-  [7, 'No response'],
-  [1, 'N/a or Ack'],
-  [2, 'Review requested'],
-  [3, 'Review started'],
-  [4, 'Needs work'],
-  [8, 'Internal review'],
-  [5, 'Approved'],
-  [6, 'Denied'],
+export const PREPARING = 0;
+export const REVIEW_REQUESTED = 2;
+export const STATE_NAMES = {
+  NO_RESPONSE: [7, 'No response'],
+  NA: [1, 'N/a or Ack'],
+  REVIEW_STARTED: [3, 'Review started'],
+  NEEDS_WORK: [4, 'Needs work'],
+  INTERNAL_REVIEW: [8, 'Internal review'],
+  APPROVED: [5, 'Approved'],
+  DENIED: [6, 'Denied'],
+};
+
+export const ACTIVE_REVIEW_STATES = [
+  REVIEW_REQUESTED,
+  STATE_NAMES.REVIEW_STARTED[0],
+  STATE_NAMES.NEEDS_WORK[0],
+  STATE_NAMES.INTERNAL_REVIEW[0],
 ];
 
 
@@ -35,6 +43,27 @@ export class ChromedashGateColumn extends LitElement {
 
        #review-status-area {
          margin: var(--content-padding-half) 0;
+       }
+       .status {
+         display: flex;
+         gap: var(--content-padding-half);
+         align-items: center;
+         font-weight: 500;
+       }
+       sl-icon {
+         font-size: 1.3rem;
+       }
+       .approved {
+         color: var(--gate-approved-color);
+       }
+       .approved sl-icon {
+         color: var(--gate-approved-icon-color);
+       }
+       .denied {
+         color: var(--gate-denied-color);
+       }
+       .denied sl-icon {
+         color: var(--gate-denied-icon-color);
        }
 
        #votes-area {
@@ -132,6 +161,29 @@ export class ChromedashGateColumn extends LitElement {
     });
   }
 
+  /* Reload all data for the currently displayed items. */
+  refetch() {
+    const featureId = this.feature.id;
+    Promise.all([
+      window.csClient.getGates(featureId),
+      window.csClient.getApprovals(featureId),
+      // TODO(jrobbins): Include activities for this gate
+      window.csClient.getComments(featureId),
+    ]).then(([gatesRes, approvalRes, commentRes]) => {
+      for (const g of gatesRes.gates) {
+        if (g.id == this.gate.id) this.gate = g;
+      }
+      this.votes = approvalRes.approvals.filter((v) =>
+        v.gate_id == this.gate.id);
+      this.comments = commentRes.comments;
+      this.needsSave = false;
+      this.loading = false;
+    }).catch(() => {
+      showToastMessage('Some errors occurred. Please refresh the page or try again later.');
+      this.handleCancel();
+    });
+  }
+
   _fireEvent(eventName, detail) {
     const event = new CustomEvent(eventName, {
       bubbles: true,
@@ -164,6 +216,7 @@ export class ChromedashGateColumn extends LitElement {
 
   handleSelectChanged() {
     this.needsSave = true;
+    this.showSaved = false;
   }
 
   handleSave() {
@@ -174,6 +227,7 @@ export class ChromedashGateColumn extends LitElement {
       .then(() => {
         this.needsSave = false;
         this.showSaved = true;
+        this._fireEvent('refetch-needed', {});
       });
   }
 
@@ -211,13 +265,96 @@ export class ChromedashGateColumn extends LitElement {
     `;
   }
 
-  renderReviewStatus() {
-    // TODO(jrobbins): display gate state name and requested_on or reviewed_on.
+  handleReviewRequested() {
+    // TODO(jrobbins): This should specify gate ID rather than gate type.
+    window.csClient.setApproval(
+      this.feature.id, this.gate.gate_type, REVIEW_REQUESTED)
+      .then(() => {
+        this._fireEvent('refetch-needed', {});
+      });
+  }
+
+  formatDate(dateStr) {
+    return dateStr.split(' ')[0]; // Ignore time of day
+  }
+
+  formatRelativeDate(dateStr) {
+    // Format date to "YYYY-MM-DDTHH:mm:ss.sssZ" to represent UTC.
+    dateStr = dateStr || '';
+    dateStr = dateStr.replace(' ', 'T');
+    const dateObj = new Date(`${dateStr}Z`);
+    if (isNaN(dateObj)) {
+      return nothing;
+    }
     return html`
-      <div>
-        Review requested on YYYY-MM-DD
+      <span class="relative_date">
+        (<sl-relative-time date="${dateObj.toISOString()}">
+        </sl-relative-time>)
+      </span>`;
+  }
+
+  /* A user that can edit the current feature can request a review. */
+  userCanRequestReview() {
+    return (this.user &&
+            (this.user.can_edit_all ||
+             this.user.editable_features.includes(this.feature.id)));
+  }
+
+  renderReviewStatusPreparing() {
+    if (this.userCanRequestReview()) {
+      return html`
+       <sl-button pill size=small variant=primary
+         @click=${this.handleReviewRequested}
+         >Request review</sl-button>
+      `;
+    } else {
+      return html`
+        Review has not been requested yet.
+      `;
+    }
+  }
+
+  renderReviewStatusActive() {
+    return html`
+      Review requested on ${this.formatDate(this.gate.requested_on)}
+      ${this.formatRelativeDate(this.gate.requested_on)}
+    `;
+  }
+
+  renderReviewStatusApproved() {
+    // TODO(jrobbins): Show date of approval.
+    return html`
+      <div class="status approved">
+        <sl-icon library="material" name="check_circle_filled_20px"></sl-icon>
+        Approved
       </div>
     `;
+  }
+
+  renderReviewStatusDenied() {
+    // TODO(jrobbins): Show date of denial.
+    return html`
+      <div class="status denied">
+        <sl-icon library="material" name="block_20px"></sl-icon>
+        Denied
+      </div>
+    `;
+  }
+
+  renderReviewStatus() {
+    if (this.gate.state == PREPARING) {
+      return this.renderReviewStatusPreparing();
+    } else if (ACTIVE_REVIEW_STATES.includes(this.gate.state)) {
+      return this.renderReviewStatusActive();
+    } else if (this.gate.state == STATE_NAMES.APPROVED[0]) {
+      return this.renderReviewStatusApproved();
+    } else if (this.gate.state == STATE_NAMES.DENIED[0]) {
+      return this.renderReviewStatusDenied();
+    } else {
+      console.log('Unexpected gate state');
+      console.log(this.gate);
+      return nothing;
+    }
   }
 
   renderVotesSkeleton() {
@@ -233,7 +370,10 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   findStateName(state) {
-    for (const item of STATE_NAMES) {
+    if (state == REVIEW_REQUESTED) {
+      return 'Review requested';
+    }
+    for (const item of Object.values(STATE_NAMES)) {
       if (item[0] == state) {
         return item[1];
       }
@@ -255,7 +395,7 @@ export class ChromedashGateColumn extends LitElement {
                  value="${state}" ${ref(this.voteSelectRef)}
                  @sl-change=${this.handleSelectChanged}
                  hoist size="small">
-        ${STATE_NAMES.map((valName) => html`
+        ${Object.values(STATE_NAMES).map((valName) => html`
           <sl-menu-item value="${valName[0]}">${valName[1]}</sl-menu-item>`,
         )}
       </sl-select>
@@ -268,11 +408,16 @@ export class ChromedashGateColumn extends LitElement {
     let voteCell = this.renderVoteReadOnly(vote);
 
     if (vote.set_by == this.user?.email) {
-      voteCell = this.renderVoteMenu(vote.state);
+      // If the current reviewer was the one who requested the review,
+      // select "No response" in the menu because there is no
+      // "Review requested" menu item now.
+      const state = (vote.state == REVIEW_REQUESTED ?
+        STATE_NAMES.NO_RESPONSE[0] : vote.state);
+      voteCell = this.renderVoteMenu(state);
       if (this.needsSave) {
         saveButton = html`
           <sl-button
-            size="small" pill variant="primary"
+            size="small" variant="primary"
             @click=${this.handleSave}
             >Save</sl-button>
           `;
@@ -324,8 +469,9 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   renderCommentsSkeleton() {
+    // TODO(jrobbins): Include activities too.
     return html`
-      <h2>Comments &amp; Activity</h2>
+      <h2>Comments</h2>
       <sl-skeleton effect="sheen"></sl-skeleton>
     `;
   }
@@ -352,8 +498,9 @@ export class ChromedashGateColumn extends LitElement {
 
 
   renderComments() {
+    // TODO(jrobbins): Include relevant activities too.
     return html`
-      <h2>Comments &amp; Activity</h2>
+      <h2>Comments</h2>
       ${this.renderControls()}
       <chromedash-activity-log
         .user=${this.user}

--- a/client-src/elements/chromedash-gate-column_test.js
+++ b/client-src/elements/chromedash-gate-column_test.js
@@ -27,5 +27,4 @@ describe('chromedash-settings-page', () => {
     assert.exists(component);
     assert.instanceOf(component, ChromedashGateColumn);
   });
-
 });

--- a/client-src/elements/chromedash-myfeatures-page.js
+++ b/client-src/elements/chromedash-myfeatures-page.js
@@ -42,6 +42,13 @@ export class ChromedashMyFeaturesPage extends LitElement {
     });
   }
 
+  refetch() {
+    const tables = this.shadowRoot.querySelectorAll('chromedash-feature-table');
+    for (const table of tables) {
+      table.refetch();
+    }
+  }
+
   // Handles the Star-Toggle event fired by any one of the child components
   handleStarToggle(e) {
     const newStarredFeatures = new Set(this.starredFeatures);


### PR DESCRIPTION
This is progress toward issues #2334 and #2337.  Basically, an area near the top of the gate column is supposed to show a "Request review" button, and then later display the status of the overall review gate, until it ultimately becomes a checkmark icon and the word "Approved" or an anti icon and the word "Denied".

Also, when the user casts their vote, the app will now update everything on the page to reflect the new state of that gate.

Code in this PR to update page content after a vote:
* chromedash-app: Listen for event `refetch-needed` and then call the `refetch()` method on both the main page content element and the gate column.   Iff that method is implemented.
* chromedash-feature-page: Implement `refetch()` to reload all gate data so that the content in the middle of the page has the up-to-date icons and activity.
* chromedash-feature-page, chromedash-myfeatures-page, and chromedash-feature-table:  Implement `refetch()` to refresh the feature list.

Main code changes to chromedash-gate-column: 
* Represent the vote options the same way that we represent other enums.
* Implement refetch()
* Fix a bug where it was possible for the user to see both the "Save" button and the "Saved" notification at the same time.
* Fire the `refetch-needed` event when the user requests a review or saves a vote.
* Rendering logic and permission checking to display the gate state or "Request review" button.
* The vote menu no longer includes "Review requested" because that will be done via a button, however we still display "Review requested" read-only value for the user who requested the review.  In the case where a reviewer requested the review, we preselect "No response" for their vote.