### PR TITLE
move flattenSections function to utils.js

### DIFF
--- a/client-src/elements/chromedash-guide-editall-page.js
+++ b/client-src/elements/chromedash-guide-editall-page.js
@@ -1,6 +1,6 @@
 import {LitElement, css, html, nothing} from 'lit';
 import {ref} from 'lit/directives/ref.js';
-import {showToastMessage} from './utils.js';
+import {showToastMessage, flattenSections} from './utils.js';
 import './chromedash-form-table';
 import './chromedash-form-field';
 import {
@@ -136,11 +136,6 @@ export class ChromedashGuideEditallPage extends LitElement {
     return FORMS_BY_STAGE_TYPE[stageType] || null;
   }
 
-  // Flatten the sections to create a single array with all fields.
-  flattenSections(stageSections) {
-    return stageSections.reduce((combined, section) => [...combined, ...section.fields], []);
-  }
-
   renderStageSection(formattedFeature, name, stageId, stageFields) {
     if (!stageFields) return nothing;
 
@@ -169,7 +164,7 @@ export class ChromedashGuideEditallPage extends LitElement {
    */
   getForms(formattedFeature, feStages) {
     // All features display the metadata section.
-    let fieldsOnly = this.flattenSections(FLAT_METADATA_FIELDS.sections);
+    let fieldsOnly = flattenSections(FLAT_METADATA_FIELDS);
     const formsToRender = [
       this.renderStageSection(formattedFeature, FLAT_METADATA_FIELDS.name, 0, fieldsOnly)];
 
@@ -183,7 +178,7 @@ export class ChromedashGuideEditallPage extends LitElement {
         continue;
       }
 
-      fieldsOnly = this.flattenSections(stageForm.sections);
+      fieldsOnly = flattenSections(stageForm);
       formsToRender.push(this.renderStageSection(
         formattedFeature, stageForm.name, feStage.stage_id, fieldsOnly));
       allFormFields = [...allFormFields, ...fieldsOnly];

--- a/client-src/elements/chromedash-guide-metadata.js
+++ b/client-src/elements/chromedash-guide-metadata.js
@@ -1,6 +1,6 @@
 import {LitElement, css, html, nothing} from 'lit';
 import {ref} from 'lit/directives/ref.js';
-import {autolink} from './utils.js';
+import {autolink, flattenSections} from './utils.js';
 import './chromedash-form-table';
 import './chromedash-form-field';
 import {formatFeatureForEdit, FLAT_METADATA_FIELDS} from './form-definition';
@@ -216,15 +216,16 @@ export class ChromedashGuideMetadata extends LitElement {
 
   renderEditForm() {
     const formattedFeature = formatFeatureForEdit(this.feature);
+    const metadataFields = flattenSections(FLAT_METADATA_FIELDS);
     return html`
       <div id="metadata-editing">
         <form name="overview_form" method="POST" action="/guide/stage/${this.feature.id}/0">
           <input type="hidden" name="token">
           <input type="hidden" name="form_fields"
-             value="${FLAT_METADATA_FIELDS.join(',')}">
+             value="${metadataFields.join(',')}">
 
           <chromedash-form-table ${ref(this.registerFormSubmitHandler)}>
-            ${FLAT_METADATA_FIELDS.map((field) => html`
+            ${metadataFields.map((field) => html`
               <chromedash-form-field
                 name=${field}
                 value=${formattedFeature[field]}>

--- a/client-src/elements/utils.js
+++ b/client-src/elements/utils.js
@@ -43,3 +43,9 @@ export function findProcessStage(feStage, process) {
   }
   return null;
 }
+
+
+/* Given a stage form definition, return a flat array of the fields associated with the stage. */
+export function flattenSections(stage) {
+  return stage.sections.reduce((combined, section) => [...combined, ...section.fields], []);
+}


### PR DESCRIPTION
This change moves the `flattenSections` function a the utils.js and fixes an issue where the metadata form was referencing the form fields definition with the old structure.