### PR TITLE
Offer API Owners a checkbox to post to the intent thread.

### DIFF
--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -169,7 +169,7 @@ class ChromedashApp extends LitElement {
       this.pageComponent.contextLink = this.contextLink;
       this.currentPage = ctx.path;
       this.pageComponent.appTitle = this.appTitle;
-      if (this.pageComponent.featureId != this.gateColumnRef.value.feature?.id) {
+      if (this.pageComponent.featureId != this.gateColumnRef.value?.feature?.id) {
         this.hideSidebar();
       }
     });
@@ -269,13 +269,13 @@ class ChromedashApp extends LitElement {
     this.sidebarHidden = true;
   }
 
-  showGateColumn(feature, stage, gate) {
-    this.gateColumnRef.value.setContext(feature, stage, gate);
+  showGateColumn(feature, stageId, gate) {
+    this.gateColumnRef.value.setContext(feature, stageId, gate);
     this.showSidebar();
   }
 
   handleShowGateColumn(e) {
-    this.showGateColumn(e.detail.feature, e.detail.stage, e.detail.gate);
+    this.showGateColumn(e.detail.feature, e.detail.stage.stage_id, e.detail.gate);
   }
 
   /**

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -29,6 +29,7 @@ export const ACTIVE_REVIEW_STATES = [
 export class ChromedashGateColumn extends LitElement {
   voteSelectRef = createRef();
   commentAreaRef = createRef();
+  postToThreadRef = createRef();
 
   static get styles() {
     return [
@@ -121,19 +122,20 @@ export class ChromedashGateColumn extends LitElement {
     this.needsPost = false;
   }
 
-  setContext(feature, stage, gate) {
+  setContext(feature, stageId, gate) {
     this.loading = true;
     this.feature = feature;
-    this.stage = stage;
     this.gate = gate;
     const featureId = this.feature.id;
     Promise.all([
       window.csClient.getFeatureProcess(featureId),
+      window.csClient.getStage(featureId, stageId),
       window.csClient.getApprovals(featureId),
       // TODO(jrobbins): Include activities for this gate
       window.csClient.getComments(featureId),
-    ]).then(([process, approvalRes, commentRes]) => {
+    ]).then(([process, stage, approvalRes, commentRes]) => {
       this.process = process;
+      this.stage = stage;
       this.votes = approvalRes.approvals.filter((v) =>
         v.gate_id == this.gate.id);
       this.comments = commentRes.comments;
@@ -204,8 +206,8 @@ export class ChromedashGateColumn extends LitElement {
   handlePost() {
     const commentArea = this.commentAreaRef.value;
     const commentText = commentArea.value.trim();
-    const postToApprovalFieldId = 0; // Don't post to thread.
-    // TODO(jrobbins): Also post to intent thread
+    const postToApprovalFieldId = (
+        this.postToThreadRef.value?.checked ? this.gate.gate_type : 0);
     if (commentText != '') {
       window.csClient.postComment(
         this.feature.id, null, null, commentText,
@@ -476,9 +478,39 @@ export class ChromedashGateColumn extends LitElement {
     `;
   }
 
+  gateHasIntentThread() {
+    return this.gate.team_name == 'API Owners';
+  }
+
+  canPostTo(threadArchiveUrl) {
+    return (
+      threadArchiveUrl &&
+        (threadArchiveUrl.startsWith(
+          'https://groups.google.com/a/chromium.org/d/msgid/blink-dev/') ||
+         threadArchiveUrl.startsWith(
+           'https://groups.google.com/d/msgid/jrobbins-test')));
+  }
+
   renderControls() {
     if (!this.user || !this.user.can_comment) return nothing;
-    // TODO(jrobbins): checkbox to also post to intent thread.
+
+    const postButton = html`
+      <sl-button variant="primary"
+        @click=${this.handlePost}
+        ?disabled=${!this.needsPost}
+        size="small"
+        >Post</sl-button>
+    `;
+    const postToThreadCheckbox = (
+      this.gateHasIntentThread() ?
+        html`
+            <sl-checkbox
+              ${ref(this.postToThreadRef)}
+              ?disabled=${!this.canPostTo(this.stage.intent_thread_url)}
+              size="small"
+              >Also post to intent thread</sl-checkbox>
+          ` :
+        nothing);
 
     return html`
       <sl-textarea id="comment_area" rows=2 cols=40 ${ref(this.commentAreaRef)}
@@ -487,11 +519,8 @@ export class ChromedashGateColumn extends LitElement {
         placeholder="Add a comment"
         ></sl-textarea>
        <div id="controls">
-         <sl-button variant="primary"
-           @click=${this.handlePost}
-           ?disabled=${!this.needsPost}
-           size="small"
-           >Post</sl-button>
+         ${postButton}
+         ${postToThreadCheckbox}
        </div>
     `;
   }

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -501,14 +501,21 @@ export class ChromedashGateColumn extends LitElement {
         size="small"
         >Post</sl-button>
     `;
+    const checkboxLabel = (
+      this.stage.intent_thread_url ?
+        html`
+            Also post to
+              <a href=${this.stage.intent_thread_url} target="_blank"
+                 >intent thread</a>
+          ` : 'Also post to intent thread');
     const postToThreadCheckbox = (
       this.gateHasIntentThread() ?
         html`
-            <sl-checkbox
-              ${ref(this.postToThreadRef)}
-              ?disabled=${!this.canPostTo(this.stage.intent_thread_url)}
-              size="small"
-              >Also post to intent thread</sl-checkbox>
+          <sl-checkbox
+            ${ref(this.postToThreadRef)}
+            ?disabled=${!this.canPostTo(this.stage.intent_thread_url)}
+            size="small"
+            >${checkboxLabel}</sl-checkbox>
           ` :
         nothing);
 

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -479,7 +479,7 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   gateHasIntentThread() {
-    return this.gate.team_name == 'API Owners';
+    return this.gate.team_name === 'API Owners';
   }
 
   canPostTo(threadArchiveUrl) {


### PR DESCRIPTION
This is progress on issue #2334.  The old approvals dialog had a sl-select menu to allow the API owners to choose which intent thread to post their comment to, or to just post in chromestatus.   For the new gate column, exactly one gate is ever shown at a time, so we just need a checkbox.  It is shown for the "API Owners" gates, and it is enabled iff the thread URL has an email message ID that our server will be able to reply to (so that the message appears in the correct thread).

In this PR:
* Fix a bug in chrome status-app that caused an exception on first SPA load.
* setContext() now takes a stageId rather than a full Stage JS object because the stage parts of the feature don't have all the fields of the Stage model.  Now the gate column fetches the full Stage using the stages API.
* Logic to include the gate_type when posting a comment with the checkbox checked.
* Logic to render the checkbox. 