### PR TITLE
Remove redundant section title

### DIFF
--- a/client-src/elements/chromedash-guide-stage-page.js
+++ b/client-src/elements/chromedash-guide-stage-page.js
@@ -203,7 +203,6 @@ export class ChromedashGuideStagePage extends LitElement {
           </a>
         </h2>
       </div>
-      <h3>${this.stageName}</h3>
     `;
   }
 


### PR DESCRIPTION
This change removes the repeated section header that is displayed when editing a specific stage.