### PR TITLE
Do not display empty deprecated fields on feature detail page

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -1,7 +1,7 @@
 import {LitElement, css, html, nothing} from 'lit';
 import {openAddStageDialog} from './chromedash-add-stage-dialog';
 import {DISPLAY_FIELDS_IN_STAGES} from './form-field-specs';
-import {PLATFORMS_DISPLAYNAME, STAGE_SPECIFIC_FIELDS} from './form-field-enums';
+import {DEPRECATED_FIELDS, PLATFORMS_DISPLAYNAME, STAGE_SPECIFIC_FIELDS} from './form-field-enums';
 import '@polymer/iron-icon';
 import './chromedash-activity-log';
 import './chromedash-callout';
@@ -280,10 +280,18 @@ class ChromedashFeatureDetail extends LitElement {
     const icon = this.isDefinedValue(value) ?
       html`<sl-icon library="material" name="check_circle_20px"></sl-icon>` :
       html`<sl-icon library="material" name="blank_20px"></sl-icon>`;
+
+
+    const isDefinedValue = this.isDefinedValue(value);
+    const isDeprecatedField = DEPRECATED_FIELDS.has(fieldId);
+    if (!isDefinedValue && isDeprecatedField) {
+      return nothing;
+    }
+
     return html`
       <dt id=${fieldId}>${icon} ${fieldDisplayName}</dt>
       <dd>
-       ${this.isDefinedValue(value) ?
+       ${isDefinedValue ?
           this.renderValue(fieldType, value) :
           html`<i>No information provided yet</i>`}
       </dd>

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -281,7 +281,6 @@ class ChromedashFeatureDetail extends LitElement {
       html`<sl-icon library="material" name="check_circle_20px"></sl-icon>` :
       html`<sl-icon library="material" name="blank_20px"></sl-icon>`;
 
-
     const isDefinedValue = this.isDefinedValue(value);
     const isDeprecatedField = DEPRECATED_FIELDS.has(fieldId);
     if (!isDefinedValue && isDeprecatedField) {

--- a/client-src/elements/form-field-enums.js
+++ b/client-src/elements/form-field-enums.js
@@ -122,6 +122,14 @@ export const STAGE_SPECIFIC_FIELDS = new Set([
   'ready_for_trial_url',
 ]);
 
+export const DEPRECATED_FIELDS = new Set([
+  'experiment_timeline',
+  'i2e_lgtms',
+  'i2s_lgtms',
+  'r4dt_lgtms',
+  'standardization',
+]);
+
 export const IMPLEMENTATION_STATUS = {
   NO_ACTIVE_DEV: [1, 'No active development'],
   PROPOSED: [2, 'Proposed'],


### PR DESCRIPTION
This change removes the "No information provided" dialog for deprecated fields on the feature detail page, as they cannot be updated or added to with the current implementation.