### PR TITLE
Make trial extension fields editable

### DIFF
--- a/api/stages_api.py
+++ b/api/stages_api.py
@@ -170,6 +170,17 @@ class StagesAPI(basehandlers.APIHandler):
     self._update_stage_vals(
         stage, feature.feature_type, use_stage_type=True, create_gate=True)
 
+    # Create an extension stage if creating an origin trial.
+    # This is a workaround to edit extension stage fields using the old
+    # paradigm of 1 field per feature.
+    # TODO(danielrsmith): refactor to only create extension stages as needed.
+    if stage.stage_type == core_enums.STAGE_TYPES_ORIGIN_TRIAL[
+        feature.feature_type]:
+      extension_stage = Stage(feature_id=feature_id,
+          stage_type=core_enums.OT_EXTENSION_STAGE_TYPES_MAPPING[
+              stage.stage_type], ot_stage_id=stage.key.integer_id())
+      extension_stage.put()
+
     # Changing stage values means the cached feature should be invalidated.
     lookup_key = FeatureEntry.feature_cache_key(
         FeatureEntry.DEFAULT_CACHE_KEY, feature_id)

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -325,6 +325,13 @@ STAGE_TYPES_ROLLOUT: dict[int, Optional[int]] = {
     FEATURE_TYPE_ENTERPRISE_ID: STAGE_ENT_ROLLOUT
   }
 
+# Origin trial stage types mapped to extension stage types.
+OT_EXTENSION_STAGE_TYPES_MAPPING: dict[int, int] = {
+  STAGE_BLINK_ORIGIN_TRIAL: STAGE_BLINK_EXTEND_ORIGIN_TRIAL,
+  STAGE_FAST_ORIGIN_TRIAL: STAGE_FAST_EXTEND_ORIGIN_TRIAL,
+  STAGE_DEP_DEPRECATION_TRIAL: STAGE_DEP_EXTEND_DEPRECATION_TRIAL,
+}
+
 # Mapping of original field names to the new stage types the fields live on.
 STAGE_TYPES_BY_FIELD_MAPPING: dict[str, dict[int, Optional[int]]] = {
     'finch_url': STAGE_TYPES_SHIPPING,


### PR DESCRIPTION
This change preserves the functionality of the current stage extension fields, `extension_experiment_reason` and `intent_to_extend_experiment_url`, so that users can update these fields as they would if they were part of the origin trial stage, with 1 field per stage. Every origin trial stage will have 1 trial extension stage associated with it that carries these fields, and these fields are read in the UI as though they are part of the same stage.

**NOTE**: This change is not intended to be permanent. Once users have access to create a trial extension stage, this implementation will need to be changed to treat extension stages as it there can be more than 1 extension associated with a given origin trial stage. 