### PR TITLE
script to create trial extension stages

### DIFF
--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -325,6 +325,13 @@ STAGE_TYPES_ROLLOUT: dict[int, Optional[int]] = {
     FEATURE_TYPE_ENTERPRISE_ID: STAGE_ENT_ROLLOUT
   }
 
+# Origin trial stage types mapped to extension stage types.
+OT_EXTENSION_STAGE_TYPES_MAPPING: dict[int, int] = {
+  STAGE_BLINK_ORIGIN_TRIAL: STAGE_BLINK_EXTEND_ORIGIN_TRIAL,
+  STAGE_FAST_ORIGIN_TRIAL: STAGE_FAST_EXTEND_ORIGIN_TRIAL,
+  STAGE_DEP_DEPRECATION_TRIAL: STAGE_DEP_EXTEND_DEPRECATION_TRIAL,
+}
+
 # Mapping of original field names to the new stage types the fields live on.
 STAGE_TYPES_BY_FIELD_MAPPING: dict[str, dict[int, Optional[int]]] = {
     'finch_url': STAGE_TYPES_SHIPPING,

--- a/main.py
+++ b/main.py
@@ -253,6 +253,8 @@ internals_routes: list[Route] = [
     schema_migration.WriteMissingGates),
   Route('/admin/schema_migration_active_stage',
       schema_migration.CalcActiveStages),
+  Route('/admin/schema_migration_extension_stages',
+    schema_migration.CreateTrialExtensionStages),
 ]
 
 dev_routes: list[Route] = []


### PR DESCRIPTION
This script ensures that each origin trial stage has an associated trial extension stage that houses extension-specific fields, and creates any if needed. This is to make sure that there are no instances of a user not being able to mutate any trial extension fields.