### PR TITLE
Fix missing gate chips.

### DIFF
--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -282,7 +282,7 @@ class ChromedashApp extends LitElement {
   }
 
   handleShowGateColumn(e) {
-    this.showGateColumn(e.detail.feature, e.detail.stage.stage_id, e.detail.gate);
+    this.showGateColumn(e.detail.feature, e.detail.stage.id, e.detail.gate);
   }
 
   /**

--- a/client-src/elements/chromedash-feature-page_test.js
+++ b/client-src/elements/chromedash-feature-page_test.js
@@ -96,12 +96,12 @@ describe('chromedash-feature-page', () => {
     tags: ['tag_one'],
     stages: [
       {
-        stage_id: 1,
+        id: 1,
         stage_type: 110,
         intent_stage: 1,
       },
       {
-        stage_id: 2,
+        id: 2,
         stage_type: 120,
         intent_stage: 2,
       },

--- a/client-src/elements/chromedash-feature-row.js
+++ b/client-src/elements/chromedash-feature-row.js
@@ -152,10 +152,10 @@ class ChromedashFeatureRow extends LitElement {
     const activeStageIds = new Set(activeGates.map(g => g.stage_id));
     const activeStagesAndTheirGates = [];
     for (const stage of feature.stages) {
-      if (activeStageIds.has(stage.stage_id)) {
+      if (activeStageIds.has(stage.id)) {
         activeStagesAndTheirGates.push({
           stage: stage,
-          gates: featureGates.filter(g => g.stage_id == stage.stage_id),
+          gates: featureGates.filter(g => g.stage_id == stage.id),
         });
       }
     }

--- a/client-src/elements/chromedash-guide-edit-page_test.js
+++ b/client-src/elements/chromedash-guide-edit-page_test.js
@@ -23,12 +23,12 @@ describe('chromedash-guide-edit-page', () => {
     new_crbug_url: 'fake crbug link',
     stages: [
       {
-        stage_id: 1,
+        id: 1,
         stage_type: 110,
         intent_stage: 1,
       },
       {
-        stage_id: 2,
+        id: 2,
         stage_type: 120,
         intent_stage: 2,
       },

--- a/client-src/elements/chromedash-guide-stage-page_test.js
+++ b/client-src/elements/chromedash-guide-stage-page_test.js
@@ -17,7 +17,7 @@ describe('chromedash-guide-stage-page', () => {
     new_crbug_url: 'fake crbug link',
     stages: [
       {
-        stage_id: 10,
+        id: 10,
         stage_type: 160,
         intent_stage: 3,
       },


### PR DESCRIPTION
A recent PR must have changed the JSON representation of stages from using `stage_id` to just plain `id`.  This PR just updates places where the old `stage_id` was referenced.