### PR TITLE
"rollout_platforms" field enum expansion bug fix

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -197,6 +197,10 @@ class ChromedashFeatureDetail extends LitElement {
 
   getFieldValue(fieldName, feStage) {
     if (STAGE_SPECIFIC_FIELDS.has(fieldName)) {
+      const value = feStage[fieldName];
+      if (fieldName === 'rollout_platforms' && value) {
+        return value.map(platformId => PLATFORMS_DISPLAYNAME[platformId]);
+      }
       return feStage[fieldName];
     }
 
@@ -236,9 +240,6 @@ class ChromedashFeatureDetail extends LitElement {
           value = value[step];
         }
       }
-    }
-    if (fieldName == 'rollout_platforms' && value) {
-      value = value.map(platformId => PLATFORMS_DISPLAYNAME[platformId]);
     }
     return value;
   }


### PR DESCRIPTION
This change fixes a bug where the `rollout_platforms` field was displayed using its base enum values rather than the expanded readable versions.

`rollout_platforms` is a stage-specific field, so the value needs to be expanded while checking for stage-specific fields.