### PR TITLE
Gate chips display a short name for the gate type

### DIFF
--- a/client-src/elements/chromedash-feature-row.js
+++ b/client-src/elements/chromedash-feature-row.js
@@ -1,5 +1,6 @@
 import {LitElement, css, html, nothing} from 'lit';
 import {SHARED_STYLES} from '../sass/shared-css.js';
+import {GATE_SHORT_NAMES} from './form-field-enums.js';
 
 
 class ChromedashFeatureRow extends LitElement {
@@ -162,17 +163,22 @@ class ChromedashFeatureRow extends LitElement {
     return activeStagesAndTheirGates;
   }
 
+  getGateShortName(gate) {
+    return `${GATE_SHORT_NAMES[gate.gate_type]}: ` || nothing;
+  }
+
   renderActiveStageAndGates(stageAndGates) {
-    const stageName = ''; // TODO(jrobbins) get this data.
     return html`
       <div>
-        ${stageName}
         ${stageAndGates.gates.map(gate => html`
-          <chromedash-gate-chip
-            .feature=${this.feature}
-            .stage=${stageAndGates.stage}
-            .gate=${gate}
-          ></chromedash-gate-chip>`)}
+          <div>
+            ${this.getGateShortName(gate)}
+            <chromedash-gate-chip
+              .feature=${this.feature}
+              .stage=${stageAndGates.stage}
+              .gate=${gate}
+            ></chromedash-gate-chip>
+          </div>`)}
       </div>
     `;
   }

--- a/client-src/elements/form-field-enums.js
+++ b/client-src/elements/form-field-enums.js
@@ -130,6 +130,13 @@ export const DEPRECATED_FIELDS = new Set([
   'standardization',
 ]);
 
+export const GATE_SHORT_NAMES = {
+  1: 'Prototype',
+  2: 'OT',
+  3: 'OT Extension',
+  4: 'Ship',
+};
+
 export const IMPLEMENTATION_STATUS = {
   NO_ACTIVE_DEV: [1, 'No active development'],
   PROPOSED: [2, 'Proposed'],


### PR DESCRIPTION
This change adds a short name that is displayed next to the gate chips that are visible on the "Features pending my approval" section of the My Features page. It is only visible to those who can view the view and review the gate.

![Screenshot 2023-01-09 at 11 23 04 AM](https://user-images.githubusercontent.com/56164590/211390922-3895dfa7-bea9-4336-91b0-3c20ccf5c9f6.png)
