### PR TITLE
Display correct comments for gate

### DIFF
--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -59,11 +59,11 @@ class CommentsAPI(basehandlers.APIHandler):
   def do_get(self, **kwargs) -> dict[str, list[dict[str, Any]]]:
     """Return a list of all review comments on the given feature."""
     feature_id = kwargs['feature_id']
-    field_id = kwargs.get('field_id', None)
+    gate_id = kwargs.get('gate_id', None)
     comments_only = self.get_bool_arg('comments_only')
     # Note: We assume that anyone may view approval comments.
     comments = Activity.get_activities(
-        feature_id, field_id, comments_only=comments_only)
+        feature_id, gate_id, comments_only=comments_only)
     user = self.get_current_user()
     is_admin = permissions.can_admin_site(user)
 
@@ -78,6 +78,8 @@ class CommentsAPI(basehandlers.APIHandler):
   def do_post(self, **kwargs) -> dict[str, str]:
     """Add a review comment and possibly set a approval value."""
     feature_id = kwargs['feature_id']
+    # TODO(kyle): Fix the gate_type here as it does not exist in the main.py;
+    # it should be gate_id.
     gate_type = kwargs.get('gate_type', None)
     new_state = self.get_int_param(
         'state', required=False,
@@ -87,6 +89,7 @@ class CommentsAPI(basehandlers.APIHandler):
     post_to_approval_field_id = self.get_param(
         'postToApprovalFieldId', required=False)
 
+    # TODO(kyle): this is not working. gate_type is always None.
     if gate_type is not None and new_state is not None:
       old_approvals = Approval.get_approvals(
           feature_id=feature_id, field_id=gate_type,

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -85,10 +85,11 @@ class CommentsAPITest(testing_config.CustomTestCase):
     self.gate_1 = review_models.Gate(feature_id=self.feature_id,
         stage_id=1, gate_type=2, state=review_models.Vote.NA)
     self.gate_1.put()
+    self.gate_1_id = self.gate_1.key.integer_id()
 
     self.handler = comments_api.CommentsAPI()
     self.request_path = ('/api/v0/features/%d/approvals/%d/comments' %
-                         (self.feature_id, self.gate_1.gate_type))
+                         (self.feature_id, self.gate_1_id))
 
     self.appr_1_1 = review_models.Approval(
         feature_id=self.feature_id, field_id=1,
@@ -96,12 +97,13 @@ class CommentsAPITest(testing_config.CustomTestCase):
         state=review_models.Approval.APPROVED)
     self.appr_1_1.put()
 
-    self.act_1_1 = review_models.Activity(feature_id=self.feature_id, gate_id=2,
-        author='owner1@example.com', created=NOW, content='Good job')
+    self.act_1_1 = review_models.Activity(
+      feature_id=self.feature_id, gate_id=self.gate_1_id,
+      author='owner1@example.com', created=NOW, content='Good job')
 
     self.expected_1 = {
         'feature_id': self.feature_id,
-        'gate_id': self.gate_1.gate_type,
+        'gate_id': self.gate_1_id,
         'author': 'owner1@example.com',
         'deleted_by': None,
         'content': 'Good job',
@@ -121,9 +123,26 @@ class CommentsAPITest(testing_config.CustomTestCase):
     testing_config.sign_in('user7@example.com', 123567890)
     with test_app.test_request_context(self.request_path):
       actual_response = self.handler.do_get(
-          feature_id=self.feature_id, field_id=self.gate_1.gate_type)
+          feature_id=self.feature_id, gate_id=self.gate_1_id)
     testing_config.sign_out()
     self.assertEqual({'comments': []}, actual_response)
+
+  def test_get__legacy_comment(self):
+    """We can get legacy comments."""
+    testing_config.sign_out()
+    testing_config.sign_in('user7@example.com', 123567890)
+
+    legacy_comment = review_models.Activity(
+      feature_id=self.feature_id, author='owner1@example.com',
+      created=NOW, content='nothing')
+    legacy_comment.put()
+
+    with test_app.test_request_context(self.request_path):
+      actual_response = self.handler.do_get(
+          feature_id=self.feature_id, gate_id=self.gate_1_id)
+    testing_config.sign_out()
+    actual_comment = actual_response['comments'][0]
+    self.assertEqual('nothing', actual_comment['content'])
 
   def test_get__all_some(self):
     """We can get all comments for a given approval."""
@@ -131,9 +150,14 @@ class CommentsAPITest(testing_config.CustomTestCase):
     testing_config.sign_in('user7@example.com', 123567890)
     self.act_1_1.put()
 
+    random_activity = review_models.Activity(
+      feature_id=self.feature_id, gate_id=99,
+      author='owner1@example.com', created=NOW, content='nothing')
+    random_activity.put()
+
     with test_app.test_request_context(self.request_path):
       actual_response = self.handler.do_get(
-          feature_id=self.feature_id, field_id=self.gate_1.gate_type)
+          feature_id=self.feature_id, gate_id=self.gate_1_id)
     testing_config.sign_out()
     actual_comment = actual_response['comments'][0]
     del actual_comment['created']
@@ -151,7 +175,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
 
     with test_app.test_request_context(self.request_path):
       resp = self.handler.do_get(
-        feature_id=self.feature_id, field_id=self.gate_1.gate_type)
+        feature_id=self.feature_id, gate_id=self.gate_1_id)
     testing_config.sign_out()
     self.assertEqual(resp['comments'], [])
 
@@ -165,7 +189,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
 
     with test_app.test_request_context(self.request_path):
       resp = self.handler.do_get(
-          feature_id=self.feature_id, field_id=self.gate_1.gate_type)
+          feature_id=self.feature_id, gate_id=self.gate_1_id)
     testing_config.sign_out()
     comment = resp['comments'][0]
     self.assertNotEqual(comment['content'], '[Deleted]')
@@ -241,7 +265,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
     with test_app.test_request_context(self.request_path, json=params):
       resp = self.handler.do_patch(feature_id=self.feature_id)
       get_resp = self.handler.do_get(
-          feature_id=self.feature_id, field_id=self.gate_1.gate_type)
+          feature_id=self.feature_id, gate_id=self.gate_1_id)
     testing_config.sign_out()
     self.assertEqual(get_resp['comments'][0]['deleted_by'], user_email)
     self.assertEqual(resp, {'message': 'Done'})
@@ -262,7 +286,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
     with test_app.test_request_context(self.request_path, json=params):
       resp = self.handler.do_patch(feature_id=self.feature_id)
       get_resp = self.handler.do_get(
-          feature_id=self.feature_id, field_id=self.gate_1.gate_type)
+          feature_id=self.feature_id, gate_id=self.gate_1_id)
     testing_config.sign_out()
     self.assertEqual(get_resp['comments'][0]['deleted_by'], None)
     self.assertEqual(resp, {'message': 'Done'})

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -127,7 +127,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
     testing_config.sign_out()
     self.assertEqual({'comments': []}, actual_response)
 
-  def test_get__legacy_comment(self):
+  def test_get__legacy_comments(self):
     """We can get legacy comments."""
     testing_config.sign_out()
     testing_config.sign_in('user7@example.com', 123567890)

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -159,6 +159,8 @@ class CommentsAPITest(testing_config.CustomTestCase):
       actual_response = self.handler.do_get(
           feature_id=self.feature_id, gate_id=self.gate_1_id)
     testing_config.sign_out()
+
+    self.assertEqual(1, len(actual_response['comments']))
     actual_comment = actual_response['comments'][0]
     del actual_comment['created']
     del actual_comment['comment_id']

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -132,7 +132,7 @@ export class ChromedashGateColumn extends LitElement {
       window.csClient.getStage(featureId, stageId),
       window.csClient.getApprovals(featureId),
       // TODO(jrobbins): Include activities for this gate
-      window.csClient.getComments(featureId),
+      window.csClient.getComments(featureId, gate.id),
     ]).then(([process, stage, approvalRes, commentRes]) => {
       this.process = process;
       this.stage = stage;
@@ -154,7 +154,7 @@ export class ChromedashGateColumn extends LitElement {
     this.needsPost = false;
     Promise.all([
       // TODO(jrobbins): Include activities for this gate
-      window.csClient.getComments(this.feature.id),
+      window.csClient.getComments(this.feature.id, this.gate.id),
     ]).then(([commentRes]) => {
       this.comments = commentRes.comments;
     }).catch(() => {
@@ -170,7 +170,7 @@ export class ChromedashGateColumn extends LitElement {
       window.csClient.getGates(featureId),
       window.csClient.getApprovals(featureId),
       // TODO(jrobbins): Include activities for this gate
-      window.csClient.getComments(featureId),
+      window.csClient.getComments(featureId, this.gate.id),
     ]).then(([gatesRes, approvalRes, commentRes]) => {
       for (const g of gatesRes.gates) {
         if (g.id == this.gate.id) this.gate = g;

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -334,7 +334,8 @@ class Activity(ndb.Model):  # copy from Comment
     query = Activity.query().order(Activity.created)
     query = query.filter(Activity.feature_id == feature_id)
     if gate_id:
-      query = query.filter(Activity.gate_id == gate_id)
+      # Fetch activities with a gate_id or None value.
+      query = query.filter(Activity.gate_id.IN([gate_id, None]))
     acts = query.fetch(None)
     if comments_only:
       return [act for act in acts if act.content]

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -128,6 +128,11 @@ class CommentTest(testing_config.CustomTestCase):
         author='one@example.com',
         content='some other text')
     self.act_1_2.put()
+    self.act_1_3 = Activity(
+        feature_id=self.feature_1_id,
+        author='one@example.com',
+        content='random')
+    self.act_1_3.put()
 
     self.feature_2 = core_models.Feature(
         name='feature b', summary='sum', owner=['feature_owner@example.com'],
@@ -149,26 +154,30 @@ class CommentTest(testing_config.CustomTestCase):
   def test_get_activities__some(self):
     """We get review comments if the feature has some."""
     actual = Activity.get_activities(self.feature_1_id)
-    self.assertEqual(2, len(actual))
+    self.assertEqual(3, len(actual))
     self.assertEqual(
-        ['some text', 'some other text'],
+        ['some text', 'some other text', 'random'],
         [c.content for c in actual])
 
   def test_get_activities__specific_fields(self):
     """We get review comments for specific approval fields if requested."""
     actual_1 = Activity.get_activities(
         self.feature_1_id, 1, comments_only=True)
-    self.assertEqual(1, len(actual_1))
-    self.assertEqual('some text', actual_1[0].content)
+    self.assertEqual(2, len(actual_1))
+    self.assertEqual(
+        ['some text', 'random'],
+        [c.content for c in actual_1])
 
     actual_2 = Activity.get_activities(
         self.feature_1_id, 2, comments_only=True)
-    self.assertEqual(1, len(actual_2))
-    self.assertEqual('some other text', actual_2[0].content)
+    self.assertEqual(2, len(actual_2))
+    self.assertEqual(
+        ['some other text', 'random'],
+        [c.content for c in actual_2])
 
     actual_3 = Activity.get_activities(
         self.feature_1_id, 3, comments_only=True)
-    self.assertEqual([], actual_3)
+    self.assertEqual('random', actual_3[0].content)
 
 
 class GateTest(testing_config.CustomTestCase):

--- a/main.py
+++ b/main.py
@@ -111,7 +111,7 @@ api_routes: list[Route] = [
         reviews_api.GatesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/approvals/comments',
         comments_api.CommentsAPI),
-    Route(f'{API_BASE}/features/<int:feature_id>/approvals/<int:field_id>/comments',
+    Route(f'{API_BASE}/features/<int:feature_id>/approvals/<int:gate_id>/comments',
         comments_api.CommentsAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/process',
         processes_api.ProcessesAPI),


### PR DESCRIPTION
#2639. Display comments on a per-gate basis. Remove incorrect use of gate_type on the server side.


- Change field_id to gate_id in the comment APIs
- Retrieve comments by querying gate_id on the server side.
- Display comments in activities that have the gate_id set to the current gate, plus legacy comments that have no gate_id set.

### Follow-up PRs
Fix do_post() in Comment APIs
Test on staging after fixing Post