### PR TITLE
devcontainer: run `npm run setup` again

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -55,7 +55,11 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// pip version https://github.com/microsoft/vscode-python/issues/18802
 	// Need to install pylint inside the virutalenv because the global one does not honor it.
-	"postCreateCommand": "npm run clean-setup; . cs-env/bin/activate; python -m pip install pylint==2.13.4",
+	// Recently, when running `npm run clean-setup` in the container, it has
+	// not been installing the packages in the virtual environment. Instead,
+	// it has been installing in the default Python environment. We will
+	// need to call npm run setup again once the environment has been activated.
+	"postCreateCommand": "npm run clean-setup; . cs-env/bin/activate; npm run setup; python -m pip install pylint==2.13.4",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"


### PR DESCRIPTION
Recently, when running `npm run clean-setup` in the container, it has not been installing the packages in the virtual environment. Instead, it has been installing in the default Python environment. We will need to call npm run setup again once the environment has been activated.

This problem hasn't been reported for local development setups. This is a workaround to not mess up the local development setup.

By running npm run setup again, the container doesn't need to download the packages again. The packages are cached and are just copied over. So it doesn't increase setup time that much.