### PR TITLE
Speed up search results that don't need stages.

### DIFF
--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -538,7 +538,7 @@ def get_all(limit: Optional[int]=None,
 
 
 def get_by_ids(feature_ids: list[int],
-    update_cache: bool=False) -> list[dict[str, Any]]:
+               update_cache: bool=True) -> list[dict[str, Any]]:
   """Return a list of JSON dicts for the specified features.
 
   Because the cache may rarely have stale data, this should only be
@@ -547,21 +547,26 @@ def get_by_ids(feature_ids: list[int],
   data from NDB directly.
   """
   result_dict = {}
-  futures = []
+  futures_by_id = {}
+
+  if update_cache:
+    lookup_keys = [
+        FeatureEntry.feature_cache_key(
+            FeatureEntry.DEFAULT_CACHE_KEY + '|basic', feature_id)
+        for feature_id in feature_ids]
+    cached_features = rediscache.get_multi(lookup_keys)
+    result_dict = {f['id']: f
+                   for f in cached_features.values()
+                   if f is not None and f.get('id')}
 
   for feature_id in feature_ids:
-    lookup_key = FeatureEntry.feature_cache_key(
-        FeatureEntry.DEFAULT_CACHE_KEY, feature_id)
-    feature = rediscache.get(lookup_key)
-    if feature is None or update_cache:
-      futures.append(FeatureEntry.get_by_id_async(feature_id))
-    else:
-      result_dict[feature_id] = feature
+    if result_dict.get(feature_id) is None:
+      futures_by_id[feature_id] = FeatureEntry.get_by_id_async(feature_id)
 
-  for future in futures:
+  for future in futures_by_id.values():
     unformatted_feature: Optional[FeatureEntry] = future.get_result()
     if unformatted_feature and not unformatted_feature.deleted:
-      feature = converters.feature_entry_to_json_verbose(unformatted_feature)
+      feature = converters.feature_entry_to_json_basic(unformatted_feature)
       if unformatted_feature.updated is not None:
         feature['updated_display'] = (
             unformatted_feature.updated.strftime("%Y-%m-%d"))
@@ -571,10 +576,16 @@ def get_by_ids(feature_ids: list[int],
           unformatted_feature.blink_components, unformatted_feature.bug_url,
           unformatted_feature.impl_status_chrome,
           unformatted_feature.owner_emails)
-      store_key = FeatureEntry.feature_cache_key(
-          FeatureEntry.DEFAULT_CACHE_KEY,  unformatted_feature.key.integer_id())
-      rediscache.set(store_key, feature)
       result_dict[unformatted_feature.key.integer_id()] = feature
+
+  if update_cache:
+    to_cache = {}
+    for feature_id in futures_by_id:
+      if feature_id in result_dict:
+        store_key = FeatureEntry.feature_cache_key(
+            FeatureEntry.DEFAULT_CACHE_KEY + '|basic', feature_id)
+        to_cache[store_key] = result_dict[feature_id]
+    rediscache.set_multi(to_cache)
 
   result_list = [
       result_dict[feature_id] for feature_id in feature_ids

--- a/internals/feature_helpers_test.py
+++ b/internals/feature_helpers_test.py
@@ -199,16 +199,16 @@ class FeatureHelpersTest(testing_config.CustomTestCase):
     self.assertEqual('feature a', actual[0]['name'])
     self.assertEqual('feature b', actual[1]['name'])
 
-    lookup_key_1 = '%s|%s' % (FeatureEntry.DEFAULT_CACHE_KEY,
-                              self.feature_1.key.integer_id())
-    lookup_key_2 = '%s|%s' % (FeatureEntry.DEFAULT_CACHE_KEY,
-                              self.feature_2.key.integer_id())
+    lookup_key_1 = '%s|basic|%s' % (FeatureEntry.DEFAULT_CACHE_KEY,
+                                    self.feature_1.key.integer_id())
+    lookup_key_2 = '%s|basic|%s' % (FeatureEntry.DEFAULT_CACHE_KEY,
+                                    self.feature_2.key.integer_id())
     self.assertEqual('feature a', rediscache.get(lookup_key_1)['name'])
     self.assertEqual('feature b', rediscache.get(lookup_key_2)['name'])
 
   def test_get_by_ids__cache_hit(self):
     """We can load features from rediscache."""
-    cache_key = '%s|%s' % (
+    cache_key = '%s|basic|%s' % (
         FeatureEntry.DEFAULT_CACHE_KEY, self.feature_1.key.integer_id())
     cached_feature = {
       'name': 'fake cached_feature',


### PR DESCRIPTION
This should address the speed concerns about the new feature list page expressed in some comments on #1915.

In this PR:
* Use `converters.feature_entry_to_json_basic()` because the new feature list does not need stage data.
* Cache using a key that includes the word 'basic' so that we don't overwrite any cache entry that does include stage data.
* Load and store to redis using batch operations rather than individual operations in a loop.
* Make `get_by_ids()` keyword parameter `update_cache`  default to `True`, and only set cache values if that value is true.

Testing with a tainted version on prod I see a pretty good speed improvement:
* Old code: 7s on cache miss, 2s on cache hit
* New code: 2s on cache miss, 1.5s on cache hit
* I tested by just doing the default query on /newfeatures and then paginating forward and back
