### PR TITLE
Clean up do_post in Comment APIs

### DIFF
--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -82,7 +82,7 @@ class CommentsAPI(basehandlers.APIHandler):
     feature = self.get_specified_feature(feature_id=feature_id)
     user = self.get_current_user(required=True)
     gate_type = self.get_param(
-        'gate_type', required=False)
+        'gateType', required=False)
 
     comment_content = self.get_param('comment', required=False)
     if comment_content:

--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -81,8 +81,8 @@ class CommentsAPI(basehandlers.APIHandler):
     gate_id = kwargs.get('gate_id', None)
     feature = self.get_specified_feature(feature_id=feature_id)
     user = self.get_current_user(required=True)
-    gate_type = self.get_param(
-        'gateType', required=False)
+    post_to_thread_type = self.get_param(
+        'postToThreadType', required=False)
 
     comment_content = self.get_param('comment', required=False)
     if comment_content:
@@ -93,9 +93,9 @@ class CommentsAPI(basehandlers.APIHandler):
           author=user.email(), content=comment_content)
       comment_activity.put()
 
-    if gate_type:
+    if post_to_thread_type:
       notifier.post_comment_to_mailing_list(
-          feature, gate_type, user.email(), comment_content)
+          feature, post_to_thread_type, user.email(), comment_content)
 
     # Callers don't use the JSON response for this API call.
     return {'message': 'Done'}

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -202,13 +202,13 @@ class CommentsAPITest(testing_config.CustomTestCase):
     with test_app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_post(
-            feature_id=self.feature_id, gate_type=self.gate_1.gate_type)
+            feature_id=self.feature_id, gate_id=self.gate_1_id)
 
     params = {'state': 999}
     with test_app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_post(
-            feature_id=self.feature_id, gate_type=self.gate_1.gate_type)
+            feature_id=self.feature_id, gate_id=self.gate_1_id)
 
   def test_post__feature_not_found(self):
     """Handler rejects requests that don't match an existing feature."""
@@ -216,7 +216,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
     params = {'state': review_models.Approval.NEEDS_WORK }
     with test_app.test_request_context(bad_path, json=params):
       with self.assertRaises(werkzeug.exceptions.NotFound):
-        self.handler.do_post(feature_id=12345, gate_type=self.gate_1.gate_type)
+        self.handler.do_post(feature_id=12345, gate_id=self.gate_1_id)
 
   @mock.patch('internals.approval_defs.get_approvers')
   def test_post__forbidden(self, mock_get_approvers):
@@ -228,19 +228,19 @@ class CommentsAPITest(testing_config.CustomTestCase):
     with test_app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.do_post(
-            feature_id=self.feature_id, gate_type=self.gate_1.gate_type)
+            feature_id=self.feature_id, gate_id=self.gate_1_id)
 
     testing_config.sign_in('user7@example.com', 123567890)
     with test_app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.do_post(
-            feature_id=self.feature_id, gate_type=self.gate_1.gate_type)
+            feature_id=self.feature_id, gate_id=self.gate_1_id)
 
     testing_config.sign_in('user@google.com', 123567890)
     with test_app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.do_post(
-            feature_id=self.feature_id, gate_type=self.gate_1.gate_type)
+            feature_id=self.feature_id, gate_id=self.gate_1_id)
 
   def test_patch__forbidden(self):
     """Handler rejects requests from users who can't edit the given comment."""
@@ -306,7 +306,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
     params = {'comment': 'Congratulations'}
     with test_app.test_request_context(self.request_path, json=params):
       actual = self.handler.do_post(feature_id=self.feature_id,
-          gate_type=self.gate_1.gate_type)
+          gate_id=self.gate_1_id)
 
     self.assertEqual(actual, {'message': 'Done'})
     updated_approvals = review_models.Approval.get_approvals(
@@ -336,4 +336,4 @@ class CommentsAPITest(testing_config.CustomTestCase):
     with test_app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.do_post(
-            feature_id=self.feature_id, gate_type=self.gate_1.gate_type)
+            feature_id=self.feature_id, gate_id=self.gate_1_id)

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -91,12 +91,6 @@ class CommentsAPITest(testing_config.CustomTestCase):
     self.request_path = ('/api/v0/features/%d/approvals/%d/comments' %
                          (self.feature_id, self.gate_1_id))
 
-    self.appr_1_1 = review_models.Approval(
-        feature_id=self.feature_id, field_id=1,
-        set_by='owner1@example.com', set_on=NOW,
-        state=review_models.Approval.APPROVED)
-    self.appr_1_1.put()
-
     self.act_1_1 = review_models.Activity(
       feature_id=self.feature_id, gate_id=self.gate_1_id,
       author='owner1@example.com', created=NOW, content='Good job')
@@ -196,51 +190,12 @@ class CommentsAPITest(testing_config.CustomTestCase):
     comment = resp['comments'][0]
     self.assertNotEqual(comment['content'], '[Deleted]')
 
-  def test_post__bad_state(self):
-    """Handler rejects requests that don't specify a state correctly."""
-    params = {'state': 'not an int'}
-    with test_app.test_request_context(self.request_path, json=params):
-      with self.assertRaises(werkzeug.exceptions.BadRequest):
-        self.handler.do_post(
-            feature_id=self.feature_id, gate_id=self.gate_1_id)
-
-    params = {'state': 999}
-    with test_app.test_request_context(self.request_path, json=params):
-      with self.assertRaises(werkzeug.exceptions.BadRequest):
-        self.handler.do_post(
-            feature_id=self.feature_id, gate_id=self.gate_1_id)
-
   def test_post__feature_not_found(self):
     """Handler rejects requests that don't match an existing feature."""
     bad_path = '/api/v0/features/12345/approvals/1/comments'
-    params = {'state': review_models.Approval.NEEDS_WORK }
-    with test_app.test_request_context(bad_path, json=params):
+    with test_app.test_request_context(bad_path, json={}):
       with self.assertRaises(werkzeug.exceptions.NotFound):
         self.handler.do_post(feature_id=12345, gate_id=self.gate_1_id)
-
-  @mock.patch('internals.approval_defs.get_approvers')
-  def test_post__forbidden(self, mock_get_approvers):
-    """Handler rejects requests from anon users and non-approvers."""
-    mock_get_approvers.return_value = ['owner1@example.com']
-    params = {'state': review_models.Approval.NEEDS_WORK}
-
-    testing_config.sign_out()
-    with test_app.test_request_context(self.request_path, json=params):
-      with self.assertRaises(werkzeug.exceptions.Forbidden):
-        self.handler.do_post(
-            feature_id=self.feature_id, gate_id=self.gate_1_id)
-
-    testing_config.sign_in('user7@example.com', 123567890)
-    with test_app.test_request_context(self.request_path, json=params):
-      with self.assertRaises(werkzeug.exceptions.Forbidden):
-        self.handler.do_post(
-            feature_id=self.feature_id, gate_id=self.gate_1_id)
-
-    testing_config.sign_in('user@google.com', 123567890)
-    with test_app.test_request_context(self.request_path, json=params):
-      with self.assertRaises(werkzeug.exceptions.Forbidden):
-        self.handler.do_post(
-            feature_id=self.feature_id, gate_id=self.gate_1_id)
 
   def test_patch__forbidden(self):
     """Handler rejects requests from users who can't edit the given comment."""
@@ -309,14 +264,6 @@ class CommentsAPITest(testing_config.CustomTestCase):
           gate_id=self.gate_1_id)
 
     self.assertEqual(actual, {'message': 'Done'})
-    updated_approvals = review_models.Approval.get_approvals(
-        feature_id=self.feature_id)
-    self.assertEqual(1, len(updated_approvals))
-    appr = updated_approvals[0]
-    self.assertEqual(appr.feature_id, self.feature_id)
-    self.assertEqual(appr.field_id, 1)
-    self.assertEqual(appr.set_by, 'owner1@example.com')  # Unchanged
-    self.assertEqual(appr.state, review_models.Approval.APPROVED)  # Unchanged
     updated_comments = review_models.Activity.get_activities(
         self.feature_id, self.gate_1.key.integer_id(), comments_only=True)
     cmnt = updated_comments[0]

--- a/client-src/elements/chromedash-approvals-dialog.js
+++ b/client-src/elements/chromedash-approvals-dialog.js
@@ -521,12 +521,12 @@ class ChromedashApprovalsDialog extends LitElement {
     const commentText = commentArea.value.trim();
     const postToSelect = this.shadowRoot.querySelector(
       '#post_to_approval_field');
-    const postToApprovalFieldId = postToSelect && postToSelect.value || 0;
+    const gate_type = postToSelect && postToSelect.value || 0;
     if (commentText != '') {
       promises.push(
         window.csClient.postComment(
-          this.feature.id, null, null, commentText,
-          Number(postToApprovalFieldId)));
+          this.feature.id, null, commentText,
+          Number(gate_type)));
     }
     Promise.all(promises).then(() => {
       this.shadowRoot.querySelector('sl-dialog').hide();

--- a/client-src/elements/chromedash-approvals-dialog.js
+++ b/client-src/elements/chromedash-approvals-dialog.js
@@ -521,12 +521,12 @@ class ChromedashApprovalsDialog extends LitElement {
     const commentText = commentArea.value.trim();
     const postToSelect = this.shadowRoot.querySelector(
       '#post_to_approval_field');
-    const gate_type = postToSelect && postToSelect.value || 0;
+    const gateType = postToSelect && postToSelect.value || 0;
     if (commentText != '') {
       promises.push(
         window.csClient.postComment(
           this.feature.id, null, commentText,
-          Number(gate_type)));
+          Number(gateType)));
     }
     Promise.all(promises).then(() => {
       this.shadowRoot.querySelector('sl-dialog').hide();

--- a/client-src/elements/chromedash-approvals-dialog.js
+++ b/client-src/elements/chromedash-approvals-dialog.js
@@ -521,12 +521,12 @@ class ChromedashApprovalsDialog extends LitElement {
     const commentText = commentArea.value.trim();
     const postToSelect = this.shadowRoot.querySelector(
       '#post_to_approval_field');
-    const gateType = postToSelect && postToSelect.value || 0;
+    const postToThreadType = postToSelect && postToSelect.value || 0;
     if (commentText != '') {
       promises.push(
         window.csClient.postComment(
           this.feature.id, null, commentText,
-          Number(gateType)));
+          Number(postToThreadType)));
     }
     Promise.all(promises).then(() => {
       this.shadowRoot.querySelector('sl-dialog').hide();

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -206,12 +206,12 @@ export class ChromedashGateColumn extends LitElement {
   handlePost() {
     const commentArea = this.commentAreaRef.value;
     const commentText = commentArea.value.trim();
-    const postToApprovalFieldId = (
+    const gate_type = (
         this.postToThreadRef.value?.checked ? this.gate.gate_type : 0);
     if (commentText != '') {
       window.csClient.postComment(
-        this.feature.id, null, null, commentText,
-        Number(postToApprovalFieldId))
+        this.feature.id, this.gate.id, commentText,
+        Number(gate_type))
         .then(() => this.reloadComments());
     }
   }

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -206,12 +206,12 @@ export class ChromedashGateColumn extends LitElement {
   handlePost() {
     const commentArea = this.commentAreaRef.value;
     const commentText = commentArea.value.trim();
-    const gateType = (
+    const postToThreadType = (
         this.postToThreadRef.value?.checked ? this.gate.gate_type : 0);
     if (commentText != '') {
       window.csClient.postComment(
         this.feature.id, this.gate.id, commentText,
-        Number(gateType))
+        Number(postToThreadType))
         .then(() => this.reloadComments());
     }
   }

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -206,12 +206,12 @@ export class ChromedashGateColumn extends LitElement {
   handlePost() {
     const commentArea = this.commentAreaRef.value;
     const commentText = commentArea.value.trim();
-    const gate_type = (
+    const gateType = (
         this.postToThreadRef.value?.checked ? this.gate.gate_type : 0);
     if (commentText != '') {
       window.csClient.postComment(
         this.feature.id, this.gate.id, commentText,
-        Number(gate_type))
+        Number(gateType))
         .then(() => this.reloadComments());
     }
   }

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -250,15 +250,15 @@ class ChromeStatusClient {
     return this.doGet(url);
   }
 
-  postComment(featureId, gateId, comment, gate_type) {
+  postComment(featureId, gateId, comment, gateType) {
     if (gateId) {
       return this.doPost(
           `/features/${featureId}/approvals/${gateId}/comments`,
-          {comment, gate_type});
+          {comment, gateType});
     } else {
       return this.doPost(
           `/features/${featureId}/approvals/comments`,
-          {comment, gate_type});
+          {comment, gateType});
     }
   }
 

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -250,15 +250,15 @@ class ChromeStatusClient {
     return this.doGet(url);
   }
 
-  postComment(featureId, gateId, comment, gateType) {
+  postComment(featureId, gateId, comment, postToThreadType) {
     if (gateId) {
       return this.doPost(
           `/features/${featureId}/approvals/${gateId}/comments`,
-          {comment, gateType});
+          {comment, postToThreadType});
     } else {
       return this.doPost(
           `/features/${featureId}/approvals/comments`,
-          {comment, gateType});
+          {comment, postToThreadType});
     }
   }
 

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -250,15 +250,15 @@ class ChromeStatusClient {
     return this.doGet(url);
   }
 
-  postComment(featureId, gateId, state, comment, postToApprovalFieldId) {
+  postComment(featureId, gateId, comment, gate_type) {
     if (gateId) {
       return this.doPost(
           `/features/${featureId}/approvals/${gateId}/comments`,
-          {state, comment, postToApprovalFieldId});
+          {comment, gate_type});
     } else {
       return this.doPost(
           `/features/${featureId}/approvals/comments`,
-          {comment, postToApprovalFieldId});
+          {comment, gate_type});
     }
   }
 


### PR DESCRIPTION
Fix https://github.com/GoogleChrome/chromium-dashboard/issues/2639.
- Remove the set_approval and set_vote in comment POST API
- Remove new_state from the API
- Rename field_id to gate_type
- Rename gate_type to gate_id in the API params
- Pass in gate_id when post comments


### TODO 
Staging tests