### PR TITLE
Make feature list faster while still including stages.

### DIFF
--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -565,8 +565,9 @@ def get_by_ids(feature_ids: list[int],
       futures_by_id[feature_id] = FeatureEntry.get_by_id_async(feature_id)
 
   stages_dict = {}
-  if feature_ids:
-    stages_list = Stage.query(Stage.feature_id.IN(feature_ids)).fetch(None)
+  if futures_by_id:
+    needed_ids = list(futures_by_id.keys())
+    stages_list = Stage.query(Stage.feature_id.IN(needed_ids)).fetch(None)
     stages_dict = stage_helpers.organize_all_stages_by_feature(stages_list)
 
   for future in futures_by_id.values():

--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -538,7 +538,7 @@ def get_all(limit: Optional[int]=None,
 
 
 def get_by_ids(feature_ids: list[int],
-    update_cache: bool=False) -> list[dict[str, Any]]:
+               update_cache: bool=True) -> list[dict[str, Any]]:
   """Return a list of JSON dicts for the specified features.
 
   Because the cache may rarely have stale data, this should only be
@@ -547,21 +547,34 @@ def get_by_ids(feature_ids: list[int],
   data from NDB directly.
   """
   result_dict = {}
-  futures = []
+  futures_by_id = {}
+
+  if update_cache:
+    lookup_keys = [
+        FeatureEntry.feature_cache_key(
+            FeatureEntry.DEFAULT_CACHE_KEY, feature_id)
+        for feature_id in feature_ids]
+    cached_features = rediscache.get_multi(lookup_keys)
+    if cached_features:
+      result_dict = {f['id']: f
+                     for f in cached_features.values()
+                     if f is not None and f.get('id')}
 
   for feature_id in feature_ids:
-    lookup_key = FeatureEntry.feature_cache_key(
-        FeatureEntry.DEFAULT_CACHE_KEY, feature_id)
-    feature = rediscache.get(lookup_key)
-    if feature is None or update_cache:
-      futures.append(FeatureEntry.get_by_id_async(feature_id))
-    else:
-      result_dict[feature_id] = feature
+    if result_dict.get(feature_id) is None:
+      futures_by_id[feature_id] = FeatureEntry.get_by_id_async(feature_id)
 
-  for future in futures:
+  stages_dict = {}
+  if feature_ids:
+    stages_list = Stage.query(Stage.feature_id.IN(feature_ids)).fetch(None)
+    stages_dict = stage_helpers.organize_all_stages_by_feature(stages_list)
+
+  for future in futures_by_id.values():
     unformatted_feature: Optional[FeatureEntry] = future.get_result()
     if unformatted_feature and not unformatted_feature.deleted:
-      feature = converters.feature_entry_to_json_verbose(unformatted_feature)
+      feature_id = unformatted_feature.key.integer_id()
+      feature = converters.feature_entry_to_json_verbose(
+          unformatted_feature, prefetched_stages=stages_dict.get(feature_id))
       if unformatted_feature.updated is not None:
         feature['updated_display'] = (
             unformatted_feature.updated.strftime("%Y-%m-%d"))
@@ -571,10 +584,16 @@ def get_by_ids(feature_ids: list[int],
           unformatted_feature.blink_components, unformatted_feature.bug_url,
           unformatted_feature.impl_status_chrome,
           unformatted_feature.owner_emails)
-      store_key = FeatureEntry.feature_cache_key(
-          FeatureEntry.DEFAULT_CACHE_KEY,  unformatted_feature.key.integer_id())
-      rediscache.set(store_key, feature)
-      result_dict[unformatted_feature.key.integer_id()] = feature
+      result_dict[feature_id] = feature
+
+  if update_cache:
+    to_cache = {}
+    for feature_id in futures_by_id:
+      if feature_id in result_dict:
+        store_key = FeatureEntry.feature_cache_key(
+            FeatureEntry.DEFAULT_CACHE_KEY, feature_id)
+        to_cache[store_key] = result_dict[feature_id]
+    rediscache.set_multi(to_cache)
 
   result_list = [
       result_dict[feature_id] for feature_id in feature_ids


### PR DESCRIPTION
This is my second attempt at addressing the speed issue in the comments on #1915.

In this PR:
* Do cache operations using batch methods
* Keep the _verbose JSON generation, but prefetch the stages in one big batch
* Default update_cache to True

Since we are still loading stages, the performance improvements are not as good as my first approach:
* Original code: cache miss 7s, cache hit 2s
* This code: cache miss 5.5 to 7s, cache hit 1.6 to 1.9s

I think the speedup in this PR is worth merging, but we need to follow up with another change that uses the _basic() conversion function again, even if that requires some client-side changes and additional requests on the myfeatures page.
