### PR TITLE
Support for multiple trial extension stages

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -237,7 +237,8 @@ def _prep_stage_gate_info(
   rollout_type = STAGE_TYPES_ROLLOUT[fe.feature_type]
 
   # Get all stages associated with the feature, sorted by stage type.
-  stages = Stage.query(Stage.feature_id == d['id']).order(Stage.stage_type)
+  stages: list[Stage] = Stage.query(
+      Stage.feature_id == d['id']).order(Stage.stage_type)
 
   major_stages: dict[str, Optional[Stage]] = {
       'proto': None,
@@ -250,21 +251,34 @@ def _prep_stage_gate_info(
   # Write a list of stages associated with the feature.
   d['stages'] = []
 
+  # Keep track of trial stage indexes so that we can add trial extension
+  # stages as a property of the trial stage later.
+  ot_stage_indexes: dict[int, int] = {}
   for s in stages:
-    d['stages'].append(stage_to_json_dict(s, fe.feature_type))
+    stage_dict = stage_to_json_dict(s, fe.feature_type)
     # Keep major stages for referencing additional fields.
     if s.stage_type == proto_type:
       major_stages['proto'] = s
     elif s.stage_type == dev_trial_type:
       major_stages['dev_trial'] = s
     elif s.stage_type == ot_type:
+      # Keep the stage's index to add trial extensions later.
+      ot_stage_indexes[s.key.integer_id()] = len(d['stages'])
+      stage_dict['extensions'] = []
       major_stages['ot'] = s
     elif s.stage_type == extend_type:
+      # Trial extensions are kept as a list on the associated trial stage dict.
+      if s.ot_stage_id and s.ot_stage_id in ot_stage_indexes:
+        (d['stages'][ot_stage_indexes[s.ot_stage_id]]['extensions']
+            .append(stage_dict))
       major_stages['extend'] = s
+      # No need to append the extension stage to the overall stages list.
+      continue
     elif s.stage_type == ship_type:
       major_stages['ship'] = s
     elif s.stage_type == rollout_type:
       major_stages['rollout'] = s
+    d['stages'].append(stage_dict)
 
   return major_stages
 
@@ -318,6 +332,7 @@ def stage_to_json_dict(
     d['experiment_extension_reason'] = stage.experiment_extension_reason
     d['intent_to_extend_experiment_url'] = stage.intent_thread_url
     d['ot_stage_id'] = stage.ot_stage_id
+    milestone_field_names = MilestoneSet.OT_EXTENSION_MILESTONE_FIELD_NAMES
   elif d['stage_type'] == STAGE_TYPES_SHIPPING[feature_type]:
     d['intent_to_ship_url'] = stage.intent_thread_url
     d['finch_url'] = stage.finch_url

--- a/api/stages_api.py
+++ b/api/stages_api.py
@@ -18,7 +18,7 @@ from api import converters
 from framework import basehandlers
 from framework import permissions
 from framework import rediscache
-from internals import core_enums
+from internals import core_enums, stage_helpers
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
 from internals.review_models import Gate
 
@@ -148,7 +148,13 @@ class StagesAPI(basehandlers.APIHandler):
     if stage is None:
       self.abort(404, msg=f'Stage {stage_id} not found')
 
-    return converters.stage_to_json_dict(stage)
+    stage_dict = converters.stage_to_json_dict(stage)
+    # Add extensions associated with the stage if they exist.
+    extensions = stage_helpers.get_ot_stage_extensions(stage_dict['id'])
+    if extensions:
+      stage_dict['extensions'] = extensions
+    
+    return stage_dict
 
   def do_post(self, **kwargs):
     """Create a new stage."""

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -224,6 +224,10 @@ class ChromedashFeatureDetail extends LitElement {
     this.calcMaxMilestone(milestoneFieldName, feStage);
 
     const maxMilestoneFieldName = `max_${milestoneFieldName}`;
+    // Display only extension milestone if the original milestone has not been added.
+    if (feStage[maxMilestoneFieldName] && !feStage[fieldName]) {
+      return `Extended to ${feStage[maxMilestoneFieldName]}`;
+    }
     // If the trial has been extended past the original milestone, display the extension
     // milestone with additional text reminding of the original milestone end date.
     if (feStage[maxMilestoneFieldName] && feStage[maxMilestoneFieldName] > feStage[fieldName]) {

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -200,7 +200,11 @@ class ChromedashFeatureDetail extends LitElement {
     return !(value === undefined || value === null || value.length == 0);
   }
 
+  // Look at all extension milestones and calculate the highest milestone that an origin trial
+  // is available. This is used to display the highest milestone available, but to preserve the
+  // milestone that the trial was originally available for without extensions.
   calcMaxMilestone(fieldName, feStage) {
+    // If the max milestone has already been calculated, or no trial extensions exist, do nothing.
     if (feStage[`max_${fieldName}`] || !feStage.extensions) {
       return;
     }
@@ -210,14 +214,18 @@ class ChromedashFeatureDetail extends LitElement {
         maxMilestone = Math.max(maxMilestone, extension[fieldName]);
       }
     }
+    // Save the findings with the "max_" prefix as a prop of the stage for reference.
     feStage[`max_${fieldName}`] = maxMilestone;
   }
 
+  // Get the milestone value that is displayed to the user regarding the origin trial end date.
   getMilestoneExtensionValue(fieldName, feStage) {
     const milestoneFieldName = OT_MILESTONE_END_FIELDS[fieldName];
     this.calcMaxMilestone(milestoneFieldName, feStage);
 
     const maxMilestoneFieldName = `max_${milestoneFieldName}`;
+    // If the trial has been extended past the original milestone, display the extension
+    // milestone with additional text reminding of the original milestone end date.
     if (feStage[maxMilestoneFieldName] && feStage[maxMilestoneFieldName] > feStage[fieldName]) {
       return `${feStage[maxMilestoneFieldName]} (extended from ${feStage[milestoneFieldName]})`;
     }
@@ -230,6 +238,7 @@ class ChromedashFeatureDetail extends LitElement {
       if (fieldName === 'rollout_platforms' && value) {
         return value.map(platformId => PLATFORMS_DISPLAYNAME[platformId]);
       } else if (fieldName in OT_MILESTONE_END_FIELDS) {
+        // If an origin trial end date is being displayed, handle extension milestones as well.
         return this.getMilestoneExtensionValue(fieldName, feStage);
       }
       return feStage[fieldName];
@@ -342,6 +351,8 @@ class ChromedashFeatureDetail extends LitElement {
     return fields.some(fieldDef => this.hasFieldValue(fieldDef[0], feStage));
   }
 
+  // Renders all fields for trial extension stages as a subsection of the
+  // origin trial stage that the extension is associated with.
   renderExtensionFields(extensionStages) {
     const extensionFields = [];
     const fieldNames = flattenSections(FLAT_TRIAL_EXTENSION_FIELDS);
@@ -362,6 +373,7 @@ class ChromedashFeatureDetail extends LitElement {
 
   renderSectionFields(fields, feStage) {
     if (this.stageHasAnyFilledFields(fields, feStage)) {
+      // Add the subsection of trial extension information if it is relevant.
       const extensionFields = (
         (feStage.extensions) ? this.renderExtensionFields(feStage.extensions) : []);
 

--- a/client-src/elements/chromedash-guide-editall-page.js
+++ b/client-src/elements/chromedash-guide-editall-page.js
@@ -235,7 +235,7 @@ export class ChromedashGuideEditallPage extends LitElement {
       const extensions = feStage.extensions || [];
       extensions.forEach(extensionStage => stageIds.push(extensionStage.id));
     });
-    return stageIds;
+    return stageIds.join(',');
   }
 
   renderForm() {

--- a/client-src/elements/chromedash-guide-editall-page.js
+++ b/client-src/elements/chromedash-guide-editall-page.js
@@ -231,6 +231,7 @@ export class ChromedashGuideEditallPage extends LitElement {
     const stageIds = [];
     this.feature.stages.forEach(feStage => {
       stageIds.push(feStage.id);
+      // Check if any trial extension exist, and collect their IDs as well.
       const extensions = feStage.extensions || [];
       extensions.forEach(extensionStage => stageIds.push(extensionStage.id));
     });

--- a/client-src/elements/chromedash-guide-editall-page.js
+++ b/client-src/elements/chromedash-guide-editall-page.js
@@ -6,7 +6,8 @@ import './chromedash-form-field';
 import {
   formatFeatureForEdit,
   FLAT_METADATA_FIELDS,
-  FORMS_BY_STAGE_TYPE} from './form-definition';
+  FORMS_BY_STAGE_TYPE,
+  FLAT_TRIAL_EXTENSION_FIELDS} from './form-definition';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 import {FORM_STYLES} from '../sass/forms-css.js';
 import {STAGE_SPECIFIC_FIELDS} from './form-field-enums.js';
@@ -208,14 +209,37 @@ export class ChromedashGuideEditallPage extends LitElement {
       formsToRender.push(this.renderStageSection(
         formattedFeature, stageForm.name, feStage, fieldsOnly));
       allFormFields = [...allFormFields, ...fieldsOnly];
+
+      // If extension stages are associated with this stage,
+      // render them in a separate section as well.
+      const extensions = feStage.extensions || [];
+      extensions.forEach((extensionStage, i) => {
+        fieldsOnly = flattenSections(FLAT_TRIAL_EXTENSION_FIELDS);
+        formsToRender.push(this.renderStageSection(
+          formattedFeature,
+          `${FLAT_TRIAL_EXTENSION_FIELDS.name} ${i + 1}`,
+          extensionStage,
+          fieldsOnly));
+        allFormFields = [...allFormFields, ...fieldsOnly];
+      });
     }
 
     return [allFormFields, formsToRender];
   }
 
+  getAllStageIds() {
+    const stageIds = [];
+    this.feature.stages.forEach(feStage => {
+      stageIds.push(feStage.id);
+      const extensions = feStage.extensions || [];
+      extensions.forEach(extensionStage => stageIds.push(extensionStage.id));
+    });
+    return stageIds;
+  }
+
   renderForm() {
     const formattedFeature = formatFeatureForEdit(this.feature);
-    const stageIds = this.feature.stages.map(feStage => feStage.id);
+    const stageIds = this.getAllStageIds();
     const [allFormFields, formsToRender] = this.getForms(formattedFeature, this.feature.stages);
     return html`
       <form name="feature_form" method="POST" action="/guide/editall/${this.featureId}">

--- a/client-src/elements/chromedash-guide-stage-page.js
+++ b/client-src/elements/chromedash-guide-stage-page.js
@@ -3,7 +3,10 @@ import {ref} from 'lit/directives/ref.js';
 import {showToastMessage} from './utils.js';
 import './chromedash-form-table';
 import './chromedash-form-field';
-import {formatFeatureForEdit, FORMS_BY_STAGE_TYPE} from './form-definition';
+import {
+  FLAT_TRIAL_EXTENSION_FIELDS,
+  formatFeatureForEdit,
+  FORMS_BY_STAGE_TYPE} from './form-definition';
 import {IMPLEMENTATION_STATUS, STAGE_SPECIFIC_FIELDS} from './form-field-enums';
 import {ALL_FIELDS} from './form-field-specs';
 import {SHARED_STYLES} from '../sass/shared-css.js';
@@ -211,17 +214,21 @@ export class ChromedashGuideStagePage extends LitElement {
     `;
   }
 
-  renderFields(formattedFeature, section) {
+  renderFields(formattedFeature, section, feStage, useStageId=false) {
+    if (!feStage) {
+      feStage = this.stage;
+    }
     return section.fields.map(field => {
       const featureJSONKey = ALL_FIELDS[field].name || field;
       let value = formattedFeature[featureJSONKey];
       if (STAGE_SPECIFIC_FIELDS.has(featureJSONKey)) {
-        value = this.stage[featureJSONKey];
+        value = feStage[featureJSONKey];
       }
       return html`
       <chromedash-form-field
         name=${field}
-        value=${value}>
+        value=${value}
+        stageId=${useStageId ? feStage.id : undefined}>
       </chromedash-form-field>
     `;
     });
@@ -251,6 +258,21 @@ export class ChromedashGuideStagePage extends LitElement {
         `);
       }
     });
+
+    if (this.stage.extensions) {
+      for (const extensionStage of this.stage.extensions) {
+        let i = 1;
+        for (const section of FLAT_TRIAL_EXTENSION_FIELDS.sections) {
+          formSections.push(html`
+            <h3>${section.name} ${i}</h3>
+            <section class="stage_form">
+              ${this.renderFields(formattedFeature, section, extensionStage, true)}
+            </section>
+          `);
+          i++;
+        }
+      }
+    }
 
     return formSections;
   }
@@ -308,11 +330,17 @@ export class ChromedashGuideStagePage extends LitElement {
   }
 
   renderForm() {
+    let extensionStageIds = null;
+    if (this.stage.extensions) {
+      extensionStageIds = this.stage.extensions.map(feStage => feStage.id);
+    }
     const formattedFeature = formatFeatureForEdit(this.feature);
     return html`
       <form name="feature_form" method="POST"
         action="/guide/stage/${this.featureId}/${this.intentStage}/${this.stageId}">
         <input type="hidden" name="token">
+        ${extensionStageIds ? html`
+        <input type="hidden" name="extension_stage_ids" value="${extensionStageIds}">` : nothing}
         <input type="hidden" name="form_fields" value=${this.getFormFields()} >
         <input type="hidden" name="nextPage" value=${this.getNextPage()} >
 

--- a/client-src/elements/chromedash-guide-stage-page.js
+++ b/client-src/elements/chromedash-guide-stage-page.js
@@ -224,6 +224,7 @@ export class ChromedashGuideStagePage extends LitElement {
       if (STAGE_SPECIFIC_FIELDS.has(featureJSONKey)) {
         value = feStage[featureJSONKey];
       }
+      // stageId is only used here for trial extension stages to be used after submission.
       return html`
       <chromedash-form-field
         name=${field}
@@ -331,6 +332,8 @@ export class ChromedashGuideStagePage extends LitElement {
 
   renderForm() {
     let extensionStageIds = null;
+    // If any trial extensions are associated with this stage,
+    // their IDs are kept to retrieve during submission to save their values separately.
     if (this.stage.extensions) {
       extensionStageIds = this.stage.extensions.map(feStage => feStage.id);
     }

--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -287,10 +287,6 @@ const FLAT_ORIGIN_TRIAL_FIELDS = {
         'i2e_lgtms',
         'intent_to_experiment_url',
         'origin_trial_feedback_url',
-
-        // Extension stage-specific fields
-        'experiment_extension_reason',
-        'intent_to_extend_experiment_url',
       ],
     },
     // Implementation
@@ -307,6 +303,22 @@ const FLAT_ORIGIN_TRIAL_FIELDS = {
       ],
       isImplementationSection: true,
       implStatusValue: IMPLEMENTATION_STATUS.ORIGIN_TRIAL[0],
+    },
+  ],
+};
+
+export const FLAT_TRIAL_EXTENSION_FIELDS = {
+  name: 'Trial extension',
+  sections: [
+    {
+      name: 'Trial extension',
+      fields: [
+        'experiment_extension_reason',
+        'intent_to_extend_experiment_url',
+        'extension_desktop_last',
+        'extension_android_last',
+        'extension_webview_last',
+      ],
     },
   ],
 };

--- a/client-src/elements/form-field-enums.js
+++ b/client-src/elements/form-field-enums.js
@@ -102,6 +102,9 @@ export const STAGE_SPECIFIC_FIELDS = new Set([
   'dt_milestone_android_start',
   'dt_milestone_ios_start',
   'dt_milestone_webview_start',
+  'extension_desktop_last',
+  'extension_android_last',
+  'extension_webview_last',
 
   // Intent fields.
   'intent_to_implement_url',
@@ -135,6 +138,12 @@ export const GATE_SHORT_NAMES = {
   2: 'OT',
   3: 'OT Extension',
   4: 'Ship',
+};
+
+export const OT_MILESTONE_END_FIELDS = {
+  'ot_milestone_desktop_end': 'desktop_last',
+  'ot_milestone_android_end': 'android_last',
+  'ot_milestone_webview_end': 'webview_last',
 };
 
 export const IMPLEMENTATION_STATUS = {

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -53,7 +53,7 @@ const TEXT_FIELD_ATTRS = {
   type: 'text',
 };
 
-const MILESTONE_NUMBER_FILED_ATTRS = {
+const MILESTONE_NUMBER_FIELD_ATTRS = {
   type: 'number',
   placeholder: 'Milestone number',
 };
@@ -802,7 +802,7 @@ export const ALL_FIELDS = {
 
   'ot_milestone_desktop_start': {
     type: 'input',
-    attrs: MILESTONE_NUMBER_FILED_ATTRS,
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: false,
     label: 'OT desktop start',
     help_text: html`
@@ -812,7 +812,7 @@ export const ALL_FIELDS = {
 
   'ot_milestone_desktop_end': {
     type: 'input',
-    attrs: MILESTONE_NUMBER_FILED_ATTRS,
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: false,
     label: 'OT desktop end',
     help_text: html`
@@ -822,7 +822,7 @@ export const ALL_FIELDS = {
 
   'ot_milestone_android_start': {
     type: 'input',
-    attrs: MILESTONE_NUMBER_FILED_ATTRS,
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: false,
     label: 'OT Android start',
     help_text: html`
@@ -832,7 +832,7 @@ export const ALL_FIELDS = {
 
   'ot_milestone_android_end': {
     type: 'input',
-    attrs: MILESTONE_NUMBER_FILED_ATTRS,
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: false,
     label: 'OT Android end',
     help_text: html`
@@ -842,7 +842,7 @@ export const ALL_FIELDS = {
 
   'ot_milestone_webview_start': {
     type: 'input',
-    attrs: MILESTONE_NUMBER_FILED_ATTRS,
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: false,
     label: 'OT WebView start',
     help_text: html`
@@ -852,7 +852,7 @@ export const ALL_FIELDS = {
 
   'ot_milestone_webview_end': {
     type: 'input',
-    attrs: MILESTONE_NUMBER_FILED_ATTRS,
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: false,
     label: 'OT WebView end',
     help_text: html`
@@ -877,6 +877,33 @@ export const ALL_FIELDS = {
     help_text: html`
       If this is a repeated or extended experiment, explain why it's
       being repeated or extended.  Also, fill in discussion link fields below.`,
+  },
+
+  'extension_desktop_last': {
+    type: 'input',
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
+    required: false,
+    label: 'Trial extension desktop end',
+    help_text: html`
+      The new last desktop milestone for which the trial has been extended. `,
+  },
+
+  'extension_android_last': {
+    type: 'input',
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
+    required: false,
+    label: 'Trial extension Android end',
+    help_text: html`
+      The new last android milestone for which the trial has been extended. `,
+  },
+
+  'extension_webview_last': {
+    type: 'input',
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
+    required: false,
+    label: 'Trial extension WebView end',
+    help_text: html`
+      The new last WebView milestone for which the trial has been extended.`,
   },
 
   'ongoing_constraints': {
@@ -1046,7 +1073,7 @@ export const ALL_FIELDS = {
 
   'shipped_milestone': {
     type: 'input',
-    attrs: MILESTONE_NUMBER_FILED_ATTRS,
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: false,
     label: 'Chrome for desktop',
     help_text: SHIPPED_HELP_TXT,
@@ -1054,7 +1081,7 @@ export const ALL_FIELDS = {
 
   'shipped_android_milestone': {
     type: 'input',
-    attrs: MILESTONE_NUMBER_FILED_ATTRS,
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: false,
     label: 'Chrome for Android',
     help_text: SHIPPED_HELP_TXT,
@@ -1062,7 +1089,7 @@ export const ALL_FIELDS = {
 
   'shipped_ios_milestone': {
     type: 'input',
-    attrs: MILESTONE_NUMBER_FILED_ATTRS,
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: false,
     label: 'Chrome for iOS (RARE)',
     help_text: SHIPPED_HELP_TXT,
@@ -1070,7 +1097,7 @@ export const ALL_FIELDS = {
 
   'shipped_webview_milestone': {
     type: 'input',
-    attrs: MILESTONE_NUMBER_FILED_ATTRS,
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: false,
     label: 'Android Webview',
     help_text: SHIPPED_WEBVIEW_HELP_TXT,
@@ -1110,7 +1137,7 @@ export const ALL_FIELDS = {
 
   'dt_milestone_desktop_start': {
     type: 'input',
-    attrs: MILESTONE_NUMBER_FILED_ATTRS,
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: false,
     label: 'DevTrial on desktop',
     help_text: html`
@@ -1122,7 +1149,7 @@ export const ALL_FIELDS = {
 
   'dt_milestone_android_start': {
     type: 'input',
-    attrs: MILESTONE_NUMBER_FILED_ATTRS,
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: false,
     label: 'DevTrial on Android',
     help_text: html`
@@ -1134,7 +1161,7 @@ export const ALL_FIELDS = {
 
   'dt_milestone_ios_start': {
     type: 'input',
-    attrs: MILESTONE_NUMBER_FILED_ATTRS,
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: false,
     label: 'DevTrial on iOS (RARE)',
     help_text: html`
@@ -1171,7 +1198,7 @@ export const ALL_FIELDS = {
 
   'rollout_milestone': {
     type: 'input',
-    attrs: MILESTONE_NUMBER_FILED_ATTRS,
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: false,
     label: 'Rollout milestone',
     help_text: html`

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -1256,10 +1256,14 @@ function makeHumanReadable(fieldName) {
 }
 
 // Return an array of field info
-export function makeDisplaySpec(fieldName) {
+function makeDisplaySpec(fieldName) {
   const fieldProps = ALL_FIELDS[fieldName];
   const displayName = fieldProps.label || fieldProps.displayLabel ||
         makeHumanReadable(fieldName);
   const fieldType = categorizeFieldType(fieldProps);
   return [fieldName, displayName, fieldType];
 };
+
+export function makeDisplaySpecs(fieldNames) {
+  return fieldNames.map(fieldName => makeDisplaySpec(fieldName));
+}

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -461,6 +461,12 @@ class MilestoneSet(ndb.Model):  # copy from milestone fields of Feature
     {'old': 'ot_milestone_webview_end', 'new': 'webview_last'},
   ]
 
+  OT_EXTENSION_MILESTONE_FIELD_NAMES = [
+    {'old': 'extension_desktop_last', 'new': 'desktop_last'},
+    {'old': 'extension_android_last', 'new': 'android_last'},
+    {'old': 'extension_webview_last', 'new': 'webview_last'},
+  ]
+
   # List of milestone fields relevant to the dev trial stage types.
   DEV_TRIAL_MILESTONE_FIELD_NAMES = [
     {'old': 'dt_milestone_desktop_start', 'new': 'desktop_first'},

--- a/internals/stage_helpers.py
+++ b/internals/stage_helpers.py
@@ -15,6 +15,7 @@
 
 from collections import defaultdict
 
+from api import converters
 from internals.core_enums import INTENT_NONE
 from internals.core_models import Stage
 from internals.core_models import INTENT_STAGES_BY_STAGE_TYPE
@@ -55,3 +56,8 @@ def get_feature_stage_ids_list(feature_id: int) -> list[dict[str, int]]:
       'stage_type': s.stage_type,
       'intent_stage': INTENT_STAGES_BY_STAGE_TYPE.get(s.stage_type, INTENT_NONE)
     } for s in q]
+
+def get_ot_stage_extensions(ot_stage_id: int):
+  """Return a list of extension stages associated with a stage in JSON format"""
+  q = Stage.query(Stage.ot_stage_id == ot_stage_id)
+  return [converters.stage_to_json_dict(stage) for stage in q]

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -328,6 +328,9 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     if new_val != old_val:
       changed_fields.append((field, old_val, new_val))
 
+  # TODO(danielrsmith): This method's logic is way too complicated to easily
+  # maintain. This needs to be scrapped and submission of edits should be
+  # handled using features_api and stages_api.
   def process_post_data(self, **kwargs) -> requests.Response:
     feature_id = kwargs.get('feature_id', None)
     stage_id = kwargs.get('stage_id', None)

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -207,6 +207,8 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
   STAGE_FIELDS: list[tuple[str, str]] = [
       ('ready_for_trial_url', 'link'),
       ('origin_trial_feedback_url', 'link'),
+      ('intent_to_extend_experiment_url', 'link'),
+      ('experiment_extension_reason', 'str'),
       ('finch_url', 'link'),
       ('experiment_goals', 'str'),
       ('experiment_risks', 'str'),
@@ -214,11 +216,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       ('rollout_platforms', 'split_str'),
       ('rollout_details', 'str'),
       ('enterprise_policies', 'split_str'),
-      ]
-
-  OT_EXTENSION_FIELDS: list[tuple[str, str]] = [
-      ('intent_to_extend_experiment_url', 'link'),
-      ('experiment_extension_reason', 'str')]
+  ]
 
   INTENT_FIELDS: list[str] = [
       'intent_to_implement_url',
@@ -242,6 +240,12 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       ('ot_milestone_ios_end', 'ios_last'),
       ('ot_milestone_webview_start', 'webview_first'),
       ('ot_milestone_webview_end', 'webview_last'),
+  ]
+
+  OT_EXTENSION_MILESTONE_FIELDS: list[tuple[str, str]] = [
+    ('extension_desktop_last', 'desktop_last'),
+    ('extension_android_last', 'android_last'),
+    ('extension_webview_last', 'webview_last'),
   ]
 
   SHIPPING_MILESTONE_FIELDS: list[tuple[str, str]] = [
@@ -409,6 +413,11 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       self.update_multiple_stages(feature_id, feature.feature_type,
           stage_update_items, changed_fields)
 
+    extension_stage_ids = self.form.get('extension_stage_ids')
+    if extension_stage_ids:
+      stage_ids_list = [int(id) for id in extension_stage_ids.split(',')]
+      self.update_stages_editall(
+          feature, fe.feature_type, stage_ids_list, changed_fields)
     # Update metadata fields.
     now = datetime.now()
     if self.form.get('accurate_as_of'):
@@ -442,34 +451,6 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     else:
       redirect_url = '/guide/edit/' + str(key.integer_id())
     return self.redirect(redirect_url)
-
-  # TODO(danielrsmith): This method should be removed and extension stage
-  # fields should be handled the same as other stages once users can create
-  # trial extension stages.
-  def _handle_ot_extension_stage_changes(self, ot_stage_id: int,
-      changed_fields: list[tuple[str, Any, Any]],
-      extension_stage: Stage | None=None,
-      is_from_editall: bool=False):
-    if extension_stage is None:
-      extension_stage = Stage.query(Stage.ot_stage_id == ot_stage_id).get()
-    if extension_stage is None:
-      return
-
-    for field, field_type in self.OT_EXTENSION_FIELDS:
-      # Update the field's name if it has been renamed.
-      old_field_name = field
-      field = self.RENAMED_FIELD_MAPPING.get(field, field)
-      old_val = getattr(extension_stage, field)
-      new_val = None
-      if is_from_editall:
-        new_val = self._get_field_val(
-            f'{old_field_name}__{ot_stage_id}', field_type)
-      else:
-        new_val = self._get_field_val(old_field_name, field_type)
-      if old_val != new_val:
-        setattr(extension_stage, field, new_val)
-        changed_fields.append((old_field_name, old_val, new_val))
-    extension_stage.put()
 
   def update_multiple_stages(self, feature_id: int, feature_type: int,
       update_items: list[tuple[str, Any]],
@@ -548,12 +529,6 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
           (changed_field, stage_to_update.intent_thread_url, intent_thread_val))
     setattr(stage_to_update, 'intent_thread_url', intent_thread_val)
 
-    # TODO(danielrsmith): Remove this and handle extension fields properly
-    # once the ability to add a trial extension is available to users.
-    if (stage_to_update.stage_type ==
-        core_enums.STAGE_TYPES_ORIGIN_TRIAL[feature_type]):
-      self._handle_ot_extension_stage_changes(stage_id, changed_fields)
-
     for field, new_val in update_items:
       # Update the field's name if it has been renamed.
       old_field_name = field
@@ -581,14 +556,6 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       if not stage:
         self.abort(404, msg=f'No stage {id} found')
 
-      # TODO(danielrsmith): Remove this and handle extension fields properly
-      # once the ability to add a trial extension is available to users.
-      if (stage.stage_type ==
-          core_enums.STAGE_TYPES_EXTEND_ORIGIN_TRIAL[feature_type]):
-        self._handle_ot_extension_stage_changes(
-            stage.ot_stage_id, changed_fields,
-            extension_stage=stage, is_from_editall=True)
-
       # Update the stage-specific fields.
       for field, field_type in self.STAGE_FIELDS:
         # To differentiate stages that have the same fields, the stage ID
@@ -610,6 +577,10 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       if stage.stage_type == core_enums.STAGE_TYPES_ORIGIN_TRIAL[feature_type]:
         intent_thread_field = 'intent_to_experiment_url'
         milestone_fields = self.OT_MILESTONE_FIELDS
+      if (stage.stage_type ==
+          core_enums.STAGE_TYPES_EXTEND_ORIGIN_TRIAL[feature_type]):
+        intent_thread_field = 'intent_to_extend_experiment_url'
+        milestone_fields = self.OT_EXTENSION_MILESTONE_FIELDS
       if stage.stage_type == core_enums.STAGE_TYPES_SHIPPING[feature_type]:
         intent_thread_field = 'intent_to_ship_url'
         milestone_fields = self.SHIPPING_MILESTONE_FIELDS
@@ -626,7 +597,6 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
         field_with_id = f'{field}__{id}'
         old_val = None
         new_val = self._get_field_val(field_with_id, 'int')
-
         milestoneset_entity = stage.milestones
         setattr(feature, field, new_val)
         milestoneset_entity = getattr(stage, 'milestones')


### PR DESCRIPTION
Part of #2642

This PR adds the ability to interpret multiple trial extension stage associated with an origin trial stage, as well as differentiating "original" OT milestone fields from extension milestone fields.

This PR does **NOT** add the ability for feature owners to add new trial extension stages. This will come in a following PR.

Description of changes by file:
- api/converters.py: When creating the list of stages associated with a feature in `feature_entry_to_json_verbose`, keep the trial extension stages as a property of the origin trial stages that they are a extending. The extension stages will no longer appear in the list of stages and only in the `extensions` property on origin trial stages.
- api/stages_api.py: Add information about trial extension stages as a property of origin trial stages when making a GET request for a specific stage.
- client-src/elements/chromedash-feature-detail.js: Add `calcMaxMilestone` and `getMaxExtensionValue` functions to calculate the highest milestone that a trial is available while taking extensions into account. Additionally, `renderExtensionFields` is used to render a subsection of trial extension fields that will display with a subheader on the origin trial stage.
- client-src/elements/chromedash-guide-editall-page.js: Add the ability to edit trial extension stages on the edit-all page.
- client-src/elements/chromedash-guide-stage-page.js: Display trial extension fields for editing if the stage being edited is an origin trial stage.
- client-src/elements/form-definition.js: Define the fields that are displayed for the trial extension stage, and remove them from the origin trial stage.
- client-src/elements/form-field-enums.js: Add extension milestone fields to the list of stage-specific fields and create a mapping for origin trial end milestone field form names to their corresponding trial extension end milestone name.
- client-src/elements/form-field-specs.js: Write the field definitions for trial extension milestone fields, as well as fix a variable name typo. Also, add a small function for `makeDisplaySpecs` to export where `makeDisplaySpec` was used (this function was regularly used for each field name in a list, so this function simplifies its use a bit).
- internals/core_models.py: Define trial extension milestone field names.
- internals/stage_helpers.py: Create a function that returns a list of trial extension stages associated with a specific stage.
- pages/guide.py: Remove the temporary fix to edit trial extension information as part of origin trial stages and instead make changes to trial extension stages the same as each other stage.

---
Trial extension information will now be editable as a separate section in the origin trial's stage edit page.
![Screenshot 2023-01-11 at 10 59 14 AM](https://user-images.githubusercontent.com/56164590/211894810-cd1b330b-a1fe-49f2-abb7-ea2e576989bf.png)

---
Trial extension information will now be displayed in a subsection of the origin trial stage on the feature detail page.
![Screenshot 2023-01-11 at 10 59 43 AM](https://user-images.githubusercontent.com/56164590/211894908-7810df84-8ef3-4410-9f80-a94eede514d3.png)

---
If trial extension milestones have been filled out, the trial stage end milestones will display with their extension milestone, along with a reminder of their original milestone before extension.
![Screenshot 2023-01-11 at 11 00 25 AM](https://user-images.githubusercontent.com/56164590/211895440-13ae6212-091c-449d-aa11-3c4662921980.png)
