### PR TITLE
add "motivation" field to deprecation plan stage

### DIFF
--- a/client-src/elements/chromedash-process-overview.js
+++ b/client-src/elements/chromedash-process-overview.js
@@ -154,7 +154,7 @@ export class ChromedashProcessOverview extends LitElement {
     return (viewedIncomingStageIndex > featureStageIndex);
   }
 
-  renderAction(action, stage) {
+  renderAction(action, stage, feStage) {
     const label = action.name;
     const url = action.url
       .replace('{feature_id}', this.feature.id)
@@ -191,7 +191,7 @@ export class ChromedashProcessOverview extends LitElement {
           ${prereqItems.map((item) => html`
           <li class="pending">
             ${item.stage.name}:
-            ${item.name} ${this.renderEditLink(item.stage, item)}
+            ${item.name} ${this.renderEditLink(item.stage, feStage, item)}
           </li>`)}
         </ol>
         <sl-button href="${url}" target="_blank" variant="primary" size="small">
@@ -207,24 +207,24 @@ export class ChromedashProcessOverview extends LitElement {
       </li>`;
   }
 
-  renderActions(stage) {
+  renderActions(stage, feStage) {
     if (stage.actions) {
       return html`
         <ol>
-         ${stage.actions.map(act => this.renderAction(act, stage))}
+         ${stage.actions.map(act => this.renderAction(act, stage, feStage))}
         </ol>`;
     } else {
       return nothing;
     }
   }
 
-  renderEditLink(stage, item) {
+  renderEditLink(stage, feStage, item) {
     const featureId = this.feature.id;
     let editEl = nothing;
     if (item.field) {
       editEl = html`
         <a class="edit-progress-item"
-           href="/guide/stage/${featureId}/${stage.outgoing_stage}#id_${item.field}">
+           href="/guide/stage/${featureId}/${stage.outgoing_stage}/${feStage.id}#id_${item.field}">
           Edit
         </a>
       `;
@@ -232,8 +232,8 @@ export class ChromedashProcessOverview extends LitElement {
     return editEl;
   }
 
-  renderProgressItem(stage, item) {
-    const editEl = this.renderEditLink(stage, item);
+  renderProgressItem(stage, feStage, item) {
+    const editEl = this.renderEditLink(stage, feStage, item);
 
     if (!this.progress.hasOwnProperty(item.name)) {
       return html`
@@ -321,11 +321,11 @@ export class ChromedashProcessOverview extends LitElement {
         </td>
         <td>
           ${processStage.progress_items.map(item =>
-                      this.renderProgressItem(processStage, item))}
+                      this.renderProgressItem(processStage, feStage, item))}
         </td>
         <td>
           ${button}
-          ${this.renderActions(processStage)}
+          ${this.renderActions(processStage, feStage)}
         </td>
       </tr>`;
   }

--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -433,6 +433,19 @@ const PSA_PREPARE_TO_SHIP_FIELDS = {
   ],
 };
 
+const DEPRECATION_PLAN_FIELDS = {
+  name: 'Write up motivation',
+  sections: [
+    {
+      name: 'Write up motivation',
+      fields: [
+        'motivation',
+        'spec_link',
+      ],
+    },
+  ],
+};
+
 const DEPRECATION_DEV_TRIAL_FIELDS = {
   name: 'Dev trial of deprecation',
   sections: [
@@ -573,7 +586,7 @@ const STAGE_PSA_DEV_TRIAL = 330;
 const STAGE_PSA_SHIPPING = 360;
 
 // For deprecating a feature: the "DEP" process.
-// const STAGE_DEP_PLAN = 410;
+const STAGE_DEP_PLAN = 410;
 const STAGE_DEP_DEV_TRIAL = 430;
 const STAGE_DEP_DEPRECATION_TRIAL = 450;
 // const STAGE_DEP_EXTEND_DEPRECATION_TRIAL = 451;
@@ -605,6 +618,7 @@ export const FORMS_BY_STAGE_TYPE = {
   [STAGE_PSA_DEV_TRIAL]: FLAT_DEV_TRIAL_FIELDS,
   [STAGE_PSA_SHIPPING]: PSA_PREPARE_TO_SHIP_FIELDS,
 
+  [STAGE_DEP_PLAN]: DEPRECATION_PLAN_FIELDS,
   [STAGE_DEP_DEV_TRIAL]: DEPRECATION_DEV_TRIAL_FIELDS,
   [STAGE_DEP_DEPRECATION_TRIAL]: DEPRECATION_ORIGIN_TRIAL_FIELDS,
   [STAGE_DEP_SHIPPING]: DEPRECATION_PREPARE_TO_SHIP_FIELDS,


### PR DESCRIPTION
This change adds a specific definition for the deprecation planning stage, including fields that are otherwise missing ("motivation" and "spec_link") and fixes the URLs that link to edit the specific pieces of stage information.