### PR TITLE
Sort prefetched stages by stage type

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -240,6 +240,7 @@ def _prep_stage_gate_info(
 
   # Get all stages associated with the feature, sorted by stage type.
   if prefetched_stages is not None:
+    prefetched_stages.sort(key=lambda s: s.stage_type)
     stages = prefetched_stages
   else:
     stages = Stage.query(Stage.feature_id == d['id']).order(Stage.stage_type)


### PR DESCRIPTION
Stages were showing up out of order in the feature detail page - this change makes sure that all the stages are showing in the appropriate order.