### PR TITLE
Fixes "Edit" link from guide links below form label.

### DIFF
--- a/client-src/elements/chromedash-guide-stage-page.js
+++ b/client-src/elements/chromedash-guide-stage-page.js
@@ -162,7 +162,9 @@ export class ChromedashGuideStagePage extends LitElement {
       const hash = decodeURIComponent(location.hash);
       if (hash) {
         const el = this.shadowRoot.querySelector(hash);
-        el.scrollIntoView(true, {behavior: 'smooth'});
+        if (el) {
+          this.shadowRoot.querySelector(`chromedash-form-field[name="${el.name}"] tr th b`).scrollIntoView(true, {behavior: 'smooth'});
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes "Edit" link from guide links below form label #2637 

Updated `scrollToPosition` of `chromedash-guide-stage-page`.

Currently `scrollIntoView` is being called on `sl-select` fetched using id and its scrolling to select element
![image](https://user-images.githubusercontent.com/62694340/212411661-6dff9322-86c5-4602-9949-711aacbcf478.png)


Proposed changes
To call `scrollIntoView`  on the heading element (`<b>Safari views:</b>`)
![image](https://user-images.githubusercontent.com/62694340/212410585-718c6c32-b6c9-488d-9421-099673e33ac3.png)

cc: @jrobbins 