### PR TITLE
Fix sidebar width on mobile.

### DIFF
--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -65,6 +65,7 @@ class ChromedashApp extends LitElement {
           top: 0;
           right: 0;
           width: var(--sidebar-width);
+          max-width: var(--sidebar-max-width);
           bottom: 0;
         }
         #sidebar[hidden] {

--- a/client-src/sass/theme.scss
+++ b/client-src/sass/theme.scss
@@ -75,6 +75,7 @@
 
   --sidebar-space: 410px;
   --sidebar-width: 400px;
+  --sidebar-max-width: 96vw;
   --sidebar-bg: white;
   --sidebar-border: 2px solid hsl(0, 0%, 85%);
   --sidebar-radius: var(--large-border-radius);


### PR DESCRIPTION
On mobile in vertical orientation, the gate column width could be wider than the device screen, which is very awkward.   So, I set a max-width based on the the view width.  