### PR TITLE
Show stage short name in front of row of gate chips.

### DIFF
--- a/client-src/elements/chromedash-feature-row.js
+++ b/client-src/elements/chromedash-feature-row.js
@@ -1,6 +1,6 @@
 import {LitElement, css, html, nothing} from 'lit';
 import {SHARED_STYLES} from '../sass/shared-css.js';
-import {GATE_SHORT_NAMES} from './form-field-enums.js';
+import {STAGE_SHORT_NAMES} from './form-definition.js';
 
 
 class ChromedashFeatureRow extends LitElement {
@@ -159,26 +159,37 @@ class ChromedashFeatureRow extends LitElement {
           gates: featureGates.filter(g => g.stage_id == stage.id),
         });
       }
+      for (const extension of stage.extensions || []) {
+        if (activeStageIds.has(extension.id)) {
+          activeStagesAndTheirGates.push({
+            stage: extension,
+            gates: featureGates.filter(g => g.stage_id == extension.id),
+          });
+        }
+      }
     }
     return activeStagesAndTheirGates;
   }
 
-  getGateShortName(gate) {
-    return `${GATE_SHORT_NAMES[gate.gate_type]}: ` || nothing;
+  getStageShortName(stage) {
+    if (STAGE_SHORT_NAMES[stage.stage_type]) {
+      return `${STAGE_SHORT_NAMES[stage.stage_type]}: `;
+    } else {
+      return nothing;
+    }
   }
 
   renderActiveStageAndGates(stageAndGates) {
     return html`
       <div>
+        ${this.getStageShortName(stageAndGates.stage)}
         ${stageAndGates.gates.map(gate => html`
-          <div>
-            ${this.getGateShortName(gate)}
-            <chromedash-gate-chip
-              .feature=${this.feature}
-              .stage=${stageAndGates.stage}
-              .gate=${gate}
-            ></chromedash-gate-chip>
-          </div>`)}
+          <chromedash-gate-chip
+            .feature=${this.feature}
+            .stage=${stageAndGates.stage}
+            .gate=${gate}
+          ></chromedash-gate-chip>
+         `)}
       </div>
     `;
   }
@@ -186,7 +197,6 @@ class ChromedashFeatureRow extends LitElement {
   renderHighlights(feature) {
     if (this.columns == 'approvals') {
       const activeStages = this.getActiveStages(feature);
-      // TODO(jrobbins): group gates by stage
 
       return html`
         <div class="highlights">

--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -660,6 +660,36 @@ export const OT_EXTENSION_STAGE_MAPPING = {
 };
 
 
+export const STAGE_SHORT_NAMES = {
+  [STAGE_BLINK_INCUBATE]: 'Incubate',
+  [STAGE_BLINK_PROTOTYPE]: 'Prototype',
+  [STAGE_BLINK_DEV_TRIAL]: 'DevTrial',
+  [STAGE_BLINK_EVAL_READINESS]: 'Eval readiness',
+  [STAGE_BLINK_ORIGIN_TRIAL]: 'OT',
+  [STAGE_BLINK_EXTEND_ORIGIN_TRIAL]: 'Extend OT',
+  [STAGE_BLINK_SHIPPING]: 'Ship',
+
+  [STAGE_FAST_PROTOTYPE]: 'Prototype',
+  [STAGE_FAST_DEV_TRIAL]: 'DevTrial',
+  [STAGE_FAST_ORIGIN_TRIAL]: 'OT',
+  [STAGE_FAST_EXTEND_ORIGIN_TRIAL]: 'Extend OT',
+  [STAGE_FAST_SHIPPING]: 'Ship',
+
+  [STAGE_PSA_IMPLEMENT_FIELDS]: 'Implement',
+  [STAGE_PSA_DEV_TRIAL]: 'DevTrial',
+  [STAGE_PSA_SHIPPING]: 'Ship',
+
+  [STAGE_DEP_PLAN]: 'Plan',
+  [STAGE_DEP_DEV_TRIAL]: 'DevTrial',
+  [STAGE_DEP_DEPRECATION_TRIAL]: 'Dep Trial',
+  [STAGE_DEP_EXTEND_DEPRECATION_TRIAL]: 'Extend Dep Trial',
+  [STAGE_DEP_SHIPPING]: 'Ship',
+
+  [STAGE_ENT_ROLLOUT]: 'Rollout',
+  [STAGE_ENT_SHIPPED]: 'Ship',
+};
+
+
 const BLINK_GENERIC_QUESTIONNAIRE = (
   'Use the link above to generate an intent messsage, ' +
   'and then post that message to blink-dev@chromium.org.\n' +

--- a/client-src/elements/form-field-enums.js
+++ b/client-src/elements/form-field-enums.js
@@ -140,13 +140,6 @@ export const GATE_TYPES = {
   SHIP: 4,
 };
 
-export const GATE_SHORT_NAMES = {
-  [GATE_TYPES.PROTOTYPE]: 'Prototype',
-  [GATE_TYPES.ORIGIN_TRIAL]: 'OT',
-  [GATE_TYPES.EXTEND_ORIGIN_TRIAL]: 'OT Extension',
-  [GATE_TYPES.SHIP]: 'Ship',
-};
-
 export const OT_MILESTONE_END_FIELDS = {
   'ot_milestone_desktop_end': 'desktop_last',
   'ot_milestone_android_end': 'android_last',


### PR DESCRIPTION
This is a tweak to your previous change to show the gate names for issue #2519.    I think I got mixed up between stages and gates when I was explaining it to you verbally.  The gate chips are grouped by stage, we just need to display the stage name as a label for each row of gate chips.   Gates also have a name, but we are currently showing the team name for each gate.

Visually, the app looks the same before and after this PR.  The difference will come when we start defining more gates for other approving teams.  Those gate chips will be compactly displayed on a single row for each stage.

In this PR:
* Redo the short name constants because we need stage names
* Remove a layer of <div>s because we want multiple gate chips to display on a single row
* Add logic to consider OT extension stages, however there is no way for a user to request an extension review via the UI yet, so this logic does not render anything yet.