### PR TITLE
Phase out ApprovalsAPI Get

### DIFF
--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -34,11 +34,7 @@ class VotesAPI(basehandlers.APIHandler):
     feature_id = kwargs['feature_id']
     gate_id = kwargs.get('gate_id', None)
     # Note: We assume that anyone may view approvals.
-    if gate_id is not None:
-      votes = Vote.get_votes(feature_id=feature_id, gate_id=gate_id)
-    else:
-      votes = Vote.get_votes(feature_id=feature_id)
-
+    votes = Vote.get_votes(feature_id=feature_id, gate_id=gate_id)
     dicts = [converters.vote_value_to_json_dict(v) for v in votes]
     return {'votes': dicts}
 

--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -32,9 +32,13 @@ class VotesAPI(basehandlers.APIHandler):
   def do_get(self, **kwargs) -> dict[str, list[dict[str, Any]]]:
     """Return a list of all vote values for a given feature."""
     feature_id = kwargs['feature_id']
-    gate_id = kwargs['gate_id']
+    gate_id = kwargs.get('gate_id', None)
     # Note: We assume that anyone may view approvals.
-    votes = Vote.get_votes(feature_id=feature_id, gate_id=gate_id)
+    if gate_id is not None:
+      votes = Vote.get_votes(feature_id=feature_id, gate_id=gate_id)
+    else:
+      votes = Vote.get_votes(feature_id=feature_id)
+
     dicts = [converters.vote_value_to_json_dict(v) for v in votes]
     return {'votes': dicts}
 

--- a/client-src/elements/chromedash-approvals-dialog.js
+++ b/client-src/elements/chromedash-approvals-dialog.js
@@ -178,7 +178,7 @@ class ChromedashApprovalsDialog extends LitElement {
     this.shadowRoot.querySelector('sl-dialog').show();
     const featureId = this.feature.id;
     Promise.all([
-      window.csClient.getApprovals(featureId),
+      window.csClient.getVotes(featureId, null),
       window.csClient.getComments(featureId),
       window.csClient.getApprovalConfigs(featureId),
     ]).then(([approvalRes, commentRes, configRes]) => {

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -142,7 +142,7 @@ export class ChromedashGateColumn extends LitElement {
     Promise.all([
       window.csClient.getFeatureProcess(featureId),
       window.csClient.getStage(featureId, stageId),
-      window.csClient.getApprovals(featureId),
+      window.csClient.getVotes(featureId, null),
       // TODO(jrobbins): Include activities for this gate
       window.csClient.getComments(featureId, gate.id),
     ]).then(([process, stage, approvalRes, commentRes]) => {
@@ -180,7 +180,7 @@ export class ChromedashGateColumn extends LitElement {
     const featureId = this.feature.id;
     Promise.all([
       window.csClient.getGates(featureId),
-      window.csClient.getApprovals(featureId),
+      window.csClient.getVotes(featureId, null),
       // TODO(jrobbins): Include activities for this gate
       window.csClient.getComments(featureId, this.gate.id),
     ]).then(([gatesRes, approvalRes, commentRes]) => {

--- a/client-src/elements/chromedash-gate-column_test.js
+++ b/client-src/elements/chromedash-gate-column_test.js
@@ -11,13 +11,13 @@ describe('chromedash-settings-page', () => {
   beforeEach(async () => {
     window.csClient = new ChromeStatusClient('fake_token', 1);
     sinon.stub(window.csClient, 'getFeatureProcess');
-    sinon.stub(window.csClient, 'getApprovals');
+    sinon.stub(window.csClient, 'getVotes');
     sinon.stub(window.csClient, 'getComments');
   });
 
   afterEach(() => {
     window.csClient.getFeatureProcess.restore();
-    window.csClient.getApprovals.restore();
+    window.csClient.getVotes.restore();
     window.csClient.getComments.restore();
   });
 

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -200,11 +200,6 @@ class ChromeStatusClient {
   }
 
   // Approvals, configs, and review comments
-
-  getApprovals(featureId) {
-    return this.doGet(`/features/${featureId}/approvals`);
-  }
-
   setApproval(featureId, gateType, state) {
     return this.doPost(
         `/features/${featureId}/approvals`,
@@ -212,7 +207,10 @@ class ChromeStatusClient {
   }
 
   getVotes(featureId, gateId) {
+  if (gateId) {
     return this.doGet(`/features/${featureId}/votes/${gateId}`);
+  }
+    return this.doGet(`/features/${featureId}/votes`);
   }
 
   setVote(featureId, gateId, state) {

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -207,9 +207,9 @@ class ChromeStatusClient {
   }
 
   getVotes(featureId, gateId) {
-  if (gateId) {
-    return this.doGet(`/features/${featureId}/votes/${gateId}`);
-  }
+    if (gateId) {
+      return this.doGet(`/features/${featureId}/votes/${gateId}`);
+    }
     return this.doGet(`/features/${featureId}/votes`);
   }
 

--- a/main.py
+++ b/main.py
@@ -105,6 +105,8 @@ api_routes: list[Route] = [
         approvals_api.ApprovalsAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/configs',
         approvals_api.ApprovalConfigsAPI),
+    Route(f'{API_BASE}/features/<int:feature_id>/votes',
+        reviews_api.VotesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/votes/<int:gate_id>',
         reviews_api.VotesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/gates',


### PR DESCRIPTION
A follow-up for #2586, phasing out the ApprovalsAPI GET method on the frontend.

- **gate_type** in do_get of ApprovalsAPI is always None because it is not required in the API (see deleted **getApprovals(featureId)**). Make this **gate_type** None in the VotesAPI
- Add an optional parameter **gate_id** for VotesAPI
- Phase out all ApprovalsAPI GET methods