### PR TITLE
Revise the wording of the blink gate questionnaire.

### DIFF
--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -691,7 +691,8 @@ export const STAGE_SHORT_NAMES = {
 
 
 const BLINK_GENERIC_QUESTIONNAIRE = (
-  'Use the link above to generate an intent messsage, ' +
+  'To request a review, use the "Draft intent..." button ' +
+  'above to generate an intent messsage, ' +
   'and then post that message to blink-dev@chromium.org.\n' +
   '\n' +
   'Be sure to update your feature entry in response to ' +


### PR DESCRIPTION
During a demo today I noticed that the wording of this questionnaire text was out-of-date.  It used to refer to a link, but then I changed it to be a button.