### PR TITLE
Add attr hoist to the add-a-stage menu.

### DIFF
--- a/client-src/elements/chromedash-add-stage-dialog.js
+++ b/client-src/elements/chromedash-add-stage-dialog.js
@@ -93,7 +93,7 @@ class ChromedashAddStageDialog extends LitElement {
     return html`
     <div id="controls">
       <sl-select
-        placement="top"
+        placement="top" hoist
         value=0
         id="stage_create_select"
         size="small"


### PR DESCRIPTION
Shoelace elements seem to be a little wonky with menu placement.
See 'hoist' in
https://shoelace.style/components/select?id=attributes-amp-properties