### PR TITLE
Stop showing "Saved" indicator when switching to a new gate.

### DIFF
--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -152,6 +152,7 @@ export class ChromedashGateColumn extends LitElement {
         v.gate_id == this.gate.id);
       this.comments = commentRes.comments;
       this.needsSave = false;
+      this.showSaved = false;
       this.needsPost = false;
       this.loading = false;
     }).catch(() => {


### PR DESCRIPTION
This fixes a small bug in the gate column behavior: after the reviewer saves their vote, the word "Saved" is shown, but it is incorrectly still shown even if the reviewer navigates to a different gate.

In this PR:
* Stop showing the "Saved" indicator whenever the gate column context is set.