### PR TITLE
Cleanup form field validation behavior and style

### DIFF
--- a/client-src/elements/chromedash-textarea.js
+++ b/client-src/elements/chromedash-textarea.js
@@ -61,7 +61,6 @@ export class ChromedashTextarea extends SlTextarea {
   validate() {
     const invalidMsg = this.customCheckValidity(this.input.value) ? '' : 'invalid';
     this.setCustomValidity(invalidMsg);
-    this.reportValidity();
   }
 
   firstUpdated() {

--- a/client-src/sass/forms-css.js
+++ b/client-src/sass/forms-css.js
@@ -18,8 +18,8 @@ export const FORM_STYLES = [
       vertical-align: top;
     }
 
-    table td:first-of-type { 
-      width: 60% 
+    table td:first-of-type {
+      width: 60%
     }
 
     table .helptext {
@@ -118,7 +118,7 @@ export const FORM_STYLES = [
 
     /* menu items for selects should not be displayed at all, until defined */
     sl-select sl-menu-item:not(:defined) {
-      display: none 
+      display: none
     }
 
     chromedash-form-field {
@@ -183,6 +183,11 @@ export const FORM_STYLES = [
 
     chromedash-form-field .errorlist {
       color: red;
+    }
+
+    chromedash-form-field sl-input[data-user-invalid]::part(base),
+    chromedash-form-field chromedash-textarea[data-user-invalid]::part(base) {
+      border-color: red;
     }
 
     chromedash-form-field sl-details::part(base) {

--- a/client-src/sass/forms-css.js
+++ b/client-src/sass/forms-css.js
@@ -19,7 +19,7 @@ export const FORM_STYLES = [
     }
 
     table td:first-of-type {
-      width: 60%
+      width: 60%;
     }
 
     table .helptext {
@@ -118,7 +118,7 @@ export const FORM_STYLES = [
 
     /* menu items for selects should not be displayed at all, until defined */
     sl-select sl-menu-item:not(:defined) {
-      display: none
+      display: none;
     }
 
     chromedash-form-field {


### PR DESCRIPTION
This PR stops calling reportValidity for textarea after every user keystroke, which caused the "invalid" popup to show. 

We also add a data-user-invalid style for chromedash-form-field  sl-input or chromedash-textarea.  The style simply shows a thin red border, barely visible while editing because the focus border partly obscures it, but when the field is blurred, only the red border remains so it stands out.  This provides good feedback both instantly and when blurring.  

![image](https://user-images.githubusercontent.com/570125/214981424-8db80168-1515-458f-8564-2778cbdba1d9.png)
