### PR TITLE
Convert most sl-menu-item to sl-option

### DIFF
--- a/client-src/components.js
+++ b/client-src/components.js
@@ -17,6 +17,7 @@ import '@shoelace-style/shoelace/dist/components/icon-button/icon-button.js';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/menu/menu.js';
 import '@shoelace-style/shoelace/dist/components/menu-item/menu-item.js';
+import '@shoelace-style/shoelace/dist/components/option/option.js';
 import '@shoelace-style/shoelace/dist/components/popup/popup.js';
 import '@shoelace-style/shoelace/dist/components/progress-bar/progress-bar.js';
 import '@shoelace-style/shoelace/dist/components/relative-time/relative-time.js';

--- a/client-src/elements/chromedash-add-stage-dialog.js
+++ b/client-src/elements/chromedash-add-stage-dialog.js
@@ -64,9 +64,9 @@ class ChromedashAddStageDialog extends LitElement {
       // Get the name of the stage from the form definition based on the stage type.
       const stageInfo = FORMS_BY_STAGE_TYPE[stageType];
       menuItems.push(html`
-      <sl-menu-item value="${stageType}">
+      <sl-option value="${stageType}">
         ${stageInfo.name}
-      </sl-menu-item>
+      </sl-option>
       `);
     }
     return menuItems;
@@ -100,7 +100,7 @@ class ChromedashAddStageDialog extends LitElement {
         @sl-change=${this.checkCanSubmit}
         style="width:16rem"
       >
-        <sl-menu-item value="0" disabled>Select a stage to create</sl-menu-item>
+        <sl-option value="0" disabled>Select a stage to create</sl-option>
         ${this.renderSelectMenuItems()}
       </sl-select>
       <sl-button variant="primary"

--- a/client-src/elements/chromedash-approvals-dialog.js
+++ b/client-src/elements/chromedash-approvals-dialog.js
@@ -245,8 +245,8 @@ class ChromedashApprovalsDialog extends LitElement {
             hoist size="small"
           >
               ${STATE_NAMES.map((valName) => html`
-                <sl-menu-item value="${valName[0]}"
-                 >${valName[1]}</sl-menu-item>`,
+                <sl-option value="${valName[0]}"
+                 >${valName[1]}</sl-option>`,
                 )}
         </sl-select>` : html`
            ${this.findStateName(voteValue.state)}
@@ -418,11 +418,11 @@ class ChromedashApprovalsDialog extends LitElement {
     }
     const postToSelect = html`
       <sl-select placement="top" value=0 id="post_to_approval_field" size="small">
-        <sl-menu-item value="0">Don't post to mailing list</sl-menu-item>
+        <sl-option value="0">Don't post to mailing list</sl-option>
         ${APPROVAL_DEFS.map((apprDef) => html`
-          <sl-menu-item value="${apprDef.id}"
+          <sl-option value="${apprDef.id}"
                   ?disabled=${!this.canPostTo(this.feature[apprDef.threadField])}
-          >Post to ${apprDef.name} thread</sl-menu-item>
+          >Post to ${apprDef.name} thread</sl-option>
         `)}
       </sl-select>
       `;

--- a/client-src/elements/chromedash-feature-filter.js
+++ b/client-src/elements/chromedash-feature-filter.js
@@ -354,9 +354,9 @@ class ChromedashFeatureFilter extends LitElement {
               value=${fieldName}
               @sl-change="${(e) => this.handleChangeField(e.target.value, index)}">
        ${QUERIABLE_FIELDS.map((item) => html`
-         <sl-menu-item value="${item.name}">
+         <sl-option value="${item.name}">
            ${item.display}
-         </sl-menu-item>
+         </sl-option>
         `)}
       </sl-select>
     `;
@@ -380,9 +380,9 @@ class ChromedashFeatureFilter extends LitElement {
               value=${cond.op}
               @sl-change="${(e) => this.handleChangeOp(e.target.value, index)}">
        ${operatorOptions.map(opOption => html`
-         <sl-menu-item value="${opOption}">
+         <sl-option value="${opOption}">
            ${opOption}
-         </sl-menu-item>
+         </sl-option>
         `)}
       </sl-select>
     `;
@@ -428,7 +428,7 @@ class ChromedashFeatureFilter extends LitElement {
                 @sl-change="${(e) => this.handleChangeValue(e.target.value, index)}">
             ${Object.values(field.choices).map(
               (val) => html`
-                <sl-menu-item value="${val[1]}"> ${val[1]} </sl-menu-item>
+                <sl-option value="${val[1]}"> ${val[1]} </sl-option>
               `,
             )}
           </sl-select>
@@ -503,9 +503,9 @@ class ChromedashFeatureFilter extends LitElement {
           placeholder="Select a field name"
               @sl-change="${this.addFilterCondition}">
        ${QUERIABLE_FIELDS.map((item) => html`
-         <sl-menu-item value="${item.name}">
+         <sl-option value="${item.name}">
            ${item.display}
-         </sl-menu-item>
+         </sl-option>
         `)}
       </sl-select>
      </div>

--- a/client-src/elements/chromedash-form-field.js
+++ b/client-src/elements/chromedash-form-field.js
@@ -106,7 +106,7 @@ export class ChromedashFormField extends LitElement {
           ?disabled=${fieldDisabled || this.disabled || this.loading}>
           ${Object.values(choices).map(
             ([value, label]) => html`
-              <sl-menu-item value="${value}"> ${label} </sl-menu-item>
+              <sl-option value="${value}"> ${label} </sl-option>
             `,
           )}
         </sl-select>
@@ -126,7 +126,7 @@ export class ChromedashFormField extends LitElement {
           ?disabled=${fieldDisabled || this.disabled || this.loading}>
           ${Object.values(choices).map(
             ([value, label]) => html`
-              <sl-menu-item value="${value}"> ${label} </sl-menu-item>
+              <sl-option value="${value}"> ${label} </sl-option>
             `,
           )}
         </sl-select>

--- a/client-src/elements/chromedash-form-field_test.js
+++ b/client-src/elements/chromedash-form-field_test.js
@@ -32,7 +32,7 @@ describe('chromedash-form-field', () => {
     const renderElement = component.renderRoot;
     assert.include(renderElement.innerHTML, 'category');
     assert.include(renderElement.innerHTML, 'sl-select');
-    assert.include(renderElement.innerHTML, 'sl-menu-item');
+    assert.include(renderElement.innerHTML, 'sl-option');
   });
 
   it('renders a input type of field (with extraHelp)', async () => {

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -430,7 +430,7 @@ export class ChromedashGateColumn extends LitElement {
                  @sl-change=${this.handleSelectChanged}
                  hoist size="small">
         ${Object.values(STATE_NAMES).map((valName) => html`
-          <sl-menu-item value="${valName[0]}">${valName[1]}</sl-menu-item>`,
+          <sl-option value="${valName[0]}">${valName[1]}</sl-option>`,
         )}
       </sl-select>
     `;


### PR DESCRIPTION
Shoelace rewrote the `sl-select` component to use `sl-option` child elements instead of `sl-menu-item`.
This was listed as a "BREAKING" change in the shoelace release notes, but we did not check it:
https://shoelace.style/resources/changelog

There are still some `sl-menu-item` elements that are used as part of `sl-menu` elements.