### PR TITLE
Fix preflight Edit links to prior stages.

### DIFF
--- a/client-src/elements/chromedash-process-overview.js
+++ b/client-src/elements/chromedash-process-overview.js
@@ -1,6 +1,8 @@
 import {LitElement, css, html, nothing} from 'lit';
 import './chromedash-callout';
-import {findProcessStage} from './utils';
+import {findProcessStage,
+  findFirstFeatureStage,
+} from './utils';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
 export class ChromedashProcessOverview extends LitElement {
@@ -33,7 +35,7 @@ export class ChromedashProcessOverview extends LitElement {
         display: block;
         position: relative;
         box-sizing: border-box;
-        /* Don't do this, since it interferes with dialog placement. 
+        /* Don't do this, since it interferes with dialog placement.
         contain: content;  */
         overflow: hidden;
         background: inherit;
@@ -191,7 +193,12 @@ export class ChromedashProcessOverview extends LitElement {
           ${prereqItems.map((item) => html`
           <li class="pending">
             ${item.stage.name}:
-            ${item.name} ${this.renderEditLink(item.stage, feStage, item)}
+            ${item.name}
+            ${this.renderEditLink(
+                item.stage,
+                findFirstFeatureStage(
+                  item.stage.outgoing_stage, feStage, this.feature),
+                item)}
           </li>`)}
         </ol>
         <sl-button href="${url}" target="_blank" variant="primary" size="small">

--- a/client-src/elements/utils.js
+++ b/client-src/elements/utils.js
@@ -44,6 +44,19 @@ export function findProcessStage(feStage, process) {
   return null;
 }
 
+/* Given a process stage, find the first feature entry stage of the same type. */
+export function findFirstFeatureStage(intentStage, currentStage, fe) {
+  if (intentStage == currentStage.intent_stage) {
+    return currentStage;
+  }
+  for (const feStage of fe.stages) {
+    if (intentStage == feStage.intent_stage) {
+      return feStage;
+    }
+  }
+  return null;
+}
+
 
 /* Given a stage form definition, return a flat array of the fields associated with the stage. */
 export function flattenSections(stage) {


### PR DESCRIPTION
Fix for #2683.

The stage editing pages now use the ID of the Stage entity in the URL, so these "Edit" links need the ID of the Stage that contains the fields to be edited rather than the ID of the Stage that the user is currently on.  Usually those are the same thing, but some of the preflight checks refer to prior stages.