### PR TITLE
Phase out Set Approval APIs on frontend

### DIFF
--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -280,9 +280,8 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   handleReviewRequested() {
-    // TODO(jrobbins): This should specify gate ID rather than gate type.
-    window.csClient.setApproval(
-      this.feature.id, this.gate.gate_type, REVIEW_REQUESTED)
+    window.csClient.setVote(
+      this.feature.id, this.gate.id, REVIEW_REQUESTED)
       .then(() => {
         this._fireEvent('refetch-needed', {});
       });

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -199,13 +199,6 @@ class ChromeStatusClient {
     // TODO: catch((error) => { display message }
   }
 
-  // Approvals, configs, and review comments
-  setApproval(featureId, gateType, state) {
-    return this.doPost(
-        `/features/${featureId}/approvals`,
-        {gateType: Number(gateType), state: Number(state)});
-  }
-
   getVotes(featureId, gateId) {
     if (gateId) {
       return this.doGet(`/features/${featureId}/votes/${gateId}`);


### PR DESCRIPTION
Migrate SetApprovals to SetVotes. 

Gate ID is used in the APIs instead of Field ID, assuming that there is a one-to-one relationship between Gate ID and Gate Type (Field ID) per feature. It won't be true once we introduce multiple stage entities for the same type of stage, e.g. multiple shipping gates.