### PR TITLE
Return 400 for query errors

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -56,9 +56,12 @@ class FeaturesAPI(basehandlers.APIHandler):
     start = self.get_int_arg('start', 0)
 
     show_enterprise = 'feature_type' in user_query
-    features_on_page, total_count = search.process_query(
-        user_query, sort_spec=sort_spec, show_unlisted=show_unlisted_features,
-        show_enterprise=show_enterprise, start=start, num=num)
+    try:
+      features_on_page, total_count = search.process_query(
+          user_query, sort_spec=sort_spec, show_unlisted=show_unlisted_features,
+          show_enterprise=show_enterprise, start=start, num=num)
+    except ValueError:
+      self.abort(400, msg=str(ValueError))
 
     return {
         'total_count': total_count,

--- a/internals/search_queries.py
+++ b/internals/search_queries.py
@@ -30,7 +30,7 @@ from internals import review_models
 
 def single_field_query_async(
     field_name: str, operator: str, val: Union[str, int, datetime.datetime],
-    limit: int = None) -> Union[list[int], Future]:
+    limit: int = 0) -> Union[list[int], Future]:
   """Create a query for one FeatureEntry field and run it, returning a promise."""
   # Note: We don't exclude deleted features, that's done by process_query.
   field_name = field_name.lower()

--- a/internals/search_queries.py
+++ b/internals/search_queries.py
@@ -30,7 +30,7 @@ from internals import review_models
 
 def single_field_query_async(
     field_name: str, operator: str, val: Union[str, int, datetime.datetime],
-    limit: int = 0) -> Union[list[int], Future]:
+    limit: int = None) -> Union[list[int], Future]:
   """Create a query for one FeatureEntry field and run it, returning a promise."""
   # Note: We don't exclude deleted features, that's done by process_query.
   field_name = field_name.lower()


### PR DESCRIPTION
Respond 400 for search query syntax errors, e.g. 
```
in single_field_query_async raise ValueError('Unexpected query operator: %r' % operator) ValueError: Unexpected query operator: ':'
```