### PR TITLE
Reland Create /tasks/email-reviewers in notifier

### DIFF
--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -10,5 +10,8 @@ dispatch:
 - url: "*/tasks/email-subscribers"
   service: notifier
 
+- url: "*/tasks/email-reviewers"
+  service: notifier
+
 - url: "*/*"
   service: default

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -146,15 +146,11 @@ def apply_subscription_rules(
   return results
 
 
-def make_email_tasks(fe: FeatureEntry, is_update: bool=False,
-    changes: Optional[list]=None):
+def make_email_tasks(fe: FeatureEntry, target_emails: list[str],
+    is_update: bool = False, changes: Optional[list] = None):
   """Return a list of task dicts to notify users of feature changes."""
   if changes is None:
     changes = []
-
-  watchers: list[FeatureOwner] = FeatureOwner.query(
-      FeatureOwner.watching_all_features == True).fetch(None)
-  watcher_emails: list[str] = [watcher.email for watcher in watchers]
 
   fe_stages = stage_helpers.get_feature_stages(fe.key.integer_id())
 
@@ -181,7 +177,7 @@ def make_email_tasks(fe: FeatureEntry, is_update: bool=False,
     'You are CC\'d on this feature'
   )
   accumulate_reasons(
-      addr_reasons, watcher_emails,
+      addr_reasons, target_emails,
       'You are watching all feature changes')
 
   # There will always be at least one component.
@@ -369,7 +365,37 @@ class FeatureChangeHandler(basehandlers.FlaskHandler):
     # Load feature directly from NDB so as to never get a stale cached copy.
     fe = FeatureEntry.get_by_id(feature['id'])
     if fe and (is_update and len(changes) or not is_update):
-      email_tasks = make_email_tasks(fe, is_update=is_update, changes=changes)
+      watchers: list[FeatureOwner] = FeatureOwner.query(
+          FeatureOwner.watching_all_features == True).fetch(None)
+      watcher_emails: list[str] = [watcher.email for watcher in watchers]
+
+      email_tasks = make_email_tasks(fe, target_emails=watcher_emails,
+          is_update=is_update, changes=changes)
+      send_emails(email_tasks)
+
+    return {'message': 'Done'}
+
+
+class FeatureReviewHandler(basehandlers.FlaskHandler):
+  """This task handles feature review requests by making email tasks."""
+
+  IS_INTERNAL_HANDLER = True
+
+  def process_post_data(self, **kwargs):
+    self.require_task_header()
+
+    feature = self.get_param('feature')
+    gate_type = self.get_param('gate_type')
+    changes = self.get_param('changes', required=False) or []
+
+    logging.info('Starting to notify reviewers for feature %s',
+                 repr(feature)[:settings.MAX_LOG_LINE])
+
+    fe = FeatureEntry.get_by_id(feature['id'])
+    if fe:
+      approvers = approval_defs.get_approvers(gate_type)
+      email_tasks = make_email_tasks(fe, target_emails=approvers,
+          is_update=True, changes=changes)
       send_emails(email_tasks)
 
     return {'message': 'Done'}

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -147,7 +147,7 @@ def apply_subscription_rules(
 
 
 def make_email_tasks(fe: FeatureEntry, target_emails: list[str],
-    is_update: bool = False, changes: Optional[list] = None):
+    is_update: bool=False, changes: Optional[list]=None, is_review: bool=False):
   """Return a list of task dicts to notify users of feature changes."""
   if changes is None:
     changes = []
@@ -176,9 +176,14 @@ def make_email_tasks(fe: FeatureEntry, target_emails: list[str],
     addr_reasons, fe.cc_emails,
     'You are CC\'d on this feature'
   )
-  accumulate_reasons(
-      addr_reasons, target_emails,
-      'You are watching all feature changes')
+  if is_review:
+    accumulate_reasons(
+        addr_reasons, target_emails,
+        'You received a review request for this feature')
+  else:
+    accumulate_reasons(
+        addr_reasons, target_emails,
+        'You are watching all feature changes')
 
   # There will always be at least one component.
   for component_name in fe.blink_components:
@@ -395,7 +400,7 @@ class FeatureReviewHandler(basehandlers.FlaskHandler):
     if fe:
       approvers = approval_defs.get_approvers(gate_type)
       email_tasks = make_email_tasks(fe, target_emails=approvers,
-          is_update=True, changes=changes)
+          is_update=True, changes=changes, is_review=True)
       send_emails(email_tasks)
 
     return {'message': 'Done'}

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -146,11 +146,14 @@ def apply_subscription_rules(
   return results
 
 
-def make_email_tasks(fe: FeatureEntry, target_emails: list[str],
-    is_update: bool=False, changes: Optional[list]=None, is_review: bool=False):
+def make_feature_changes_email(fe: FeatureEntry, is_update: bool=False,
+    changes: Optional[list]=None):
   """Return a list of task dicts to notify users of feature changes."""
   if changes is None:
     changes = []
+  watchers: list[FeatureOwner] = FeatureOwner.query(
+      FeatureOwner.watching_all_features == True).fetch(None)
+  watcher_emails: list[str] = [watcher.email for watcher in watchers]
 
   fe_stages = stage_helpers.get_feature_stages(fe.key.integer_id())
 
@@ -176,14 +179,9 @@ def make_email_tasks(fe: FeatureEntry, target_emails: list[str],
     addr_reasons, fe.cc_emails,
     'You are CC\'d on this feature'
   )
-  if is_review:
-    accumulate_reasons(
-        addr_reasons, target_emails,
-        'You received a review request for this feature')
-  else:
-    accumulate_reasons(
-        addr_reasons, target_emails,
-        'You are watching all feature changes')
+  accumulate_reasons(
+      addr_reasons, watcher_emails,
+      'You are watching all feature changes')
 
   # There will always be at least one component.
   for component_name in fe.blink_components:
@@ -208,6 +206,27 @@ def make_email_tasks(fe: FeatureEntry, target_emails: list[str],
   for reason, sub_addrs in rule_results.items():
     accumulate_reasons(addr_reasons, sub_addrs, reason)
 
+  all_tasks = [convert_reasons_to_task(
+                   addr, reasons, email_html, subject, triggering_user_email)
+               for addr, reasons in sorted(addr_reasons.items())]
+  return all_tasks
+
+
+def make_review_requests_email(fe: FeatureEntry, gate_type: int, changes: Optional[list]=None):
+  """Return a list of task dicts to notify approvers of review requests."""
+  if changes is None:
+    changes = []
+  fe_stages = stage_helpers.get_feature_stages(fe.key.integer_id())
+  email_html = format_email_body(True, fe, fe_stages, changes)
+
+  subject = 'Review Request for feature: %s' % fe.name
+  triggering_user_email = fe.updater_email
+
+  approvers = approval_defs.get_approvers(gate_type)
+  reasons = 'You received a review request for this feature'
+
+  addr_reasons: dict[str, list[str]] = collections.defaultdict(list)
+  accumulate_reasons(addr_reasons, approvers, reasons)
   all_tasks = [convert_reasons_to_task(
                    addr, reasons, email_html, subject, triggering_user_email)
                for addr, reasons in sorted(addr_reasons.items())]
@@ -370,12 +389,7 @@ class FeatureChangeHandler(basehandlers.FlaskHandler):
     # Load feature directly from NDB so as to never get a stale cached copy.
     fe = FeatureEntry.get_by_id(feature['id'])
     if fe and (is_update and len(changes) or not is_update):
-      watchers: list[FeatureOwner] = FeatureOwner.query(
-          FeatureOwner.watching_all_features == True).fetch(None)
-      watcher_emails: list[str] = [watcher.email for watcher in watchers]
-
-      email_tasks = make_email_tasks(fe, target_emails=watcher_emails,
-          is_update=is_update, changes=changes)
+      email_tasks = make_feature_changes_email(fe, is_update=is_update, changes=changes)
       send_emails(email_tasks)
 
     return {'message': 'Done'}
@@ -398,9 +412,7 @@ class FeatureReviewHandler(basehandlers.FlaskHandler):
 
     fe = FeatureEntry.get_by_id(feature['id'])
     if fe:
-      approvers = approval_defs.get_approvers(gate_type)
-      email_tasks = make_email_tasks(fe, target_emails=approvers,
-          is_update=True, changes=changes, is_review=True)
+      email_tasks = make_review_requests_email(fe, gate_type, changes)
       send_emails(email_tasks)
 
     return {'message': 'Done'}

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -302,7 +302,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     """We send email to component owners and subscribers for new features."""
     mock_f_e_b.return_value = 'mock body html'
     actual_tasks = notifier.make_email_tasks(
-        self.fe_1, is_update=False, changes=[])
+        self.fe_1, ['watcher_1@example.com'], is_update=False, changes=[])
     self.assertEqual(5, len(actual_tasks))
     (feature_cc_task, feature_editor_task, feature_owner_task,
      component_owner_task, watcher_task) = actual_tasks
@@ -352,7 +352,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     """We send email to component owners and subscribers for edits."""
     mock_f_e_b.return_value = 'mock body html'
     actual_tasks = notifier.make_email_tasks(
-        self.fe_1, True, self.changes)
+        self.fe_1, ['watcher_1@example.com'], True, self.changes)
     self.assertEqual(5, len(actual_tasks))
     (feature_cc_task, feature_editor_task, feature_owner_task,
      component_owner_task, watcher_task) = actual_tasks
@@ -408,7 +408,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     notifier.FeatureStar.set_star(
         'starrer_1@example.com', self.fe_1.key.integer_id())
     actual_tasks = notifier.make_email_tasks(
-        self.fe_1, True, self.changes)
+        self.fe_1, ['watcher_1@example.com'], True, self.changes)
     self.assertEqual(6, len(actual_tasks))
     (feature_cc_task, feature_editor_task, feature_owner_task,
      component_owner_task, starrer_task, watcher_task) = actual_tasks
@@ -476,7 +476,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     notifier.FeatureStar.set_star(
         'starrer_2@example.com', self.feature_2.key.integer_id())
     actual_tasks = notifier.make_email_tasks(
-        self.fe_2, True, self.changes)
+        self.fe_2, ['watcher_1@example.com'], True, self.changes)
     self.assertEqual(4, len(actual_tasks))
     # Note: There is no starrer_task.
     (feature_editor_task, feature_owner_task, component_owner_task,

--- a/main.py
+++ b/main.py
@@ -236,6 +236,7 @@ internals_routes: list[Route] = [
 
   Route('/tasks/email-subscribers', notifier.FeatureChangeHandler),
   Route('/tasks/detect-intent', detect_intent.IntentEmailHandler),
+  Route('/tasks/email-reviewers', notifier.FeatureReviewHandler),
 
   Route('/admin/schema_migration_delete_entities',
       schema_migration.DeleteNewEntities),

--- a/notifier.staging.yaml
+++ b/notifier.staging.yaml
@@ -10,6 +10,10 @@ handlers:
   script: auto
   # Header checks prevent raw access to this handler.  Tasks have headers.
 
+- url: /tasks/email-reviewers
+  script: auto
+  # Header checks prevent raw access to this handler.  Tasks have headers.
+
 app_engine_apis: true
 
 # Set up VPC Access Connector for Redis.

--- a/notifier.yaml
+++ b/notifier.yaml
@@ -10,6 +10,10 @@ handlers:
   script: auto
   # Header checks prevent raw access to this handler.  Tasks have headers.
 
+- url: /tasks/email-reviewers
+  script: auto
+  # Header checks prevent raw access to this handler.  Tasks have headers.
+
 app_engine_apis: true
 
 # Set up VPC Access Connector for Redis in prod.


### PR DESCRIPTION
#2340. Create a /tasks/email-reviewers in notifier. This task receives gate_type as a param and retrieves approvers as the email recipients.
