### PR TITLE
Update to shoelace-2.0.0 and fix validity test for textarea

### DIFF
--- a/client-src/elements/chromedash-textarea_test.js
+++ b/client-src/elements/chromedash-textarea_test.js
@@ -18,27 +18,32 @@ describe('chromedash-textarea', () => {
   describe('when using constraint validation', () => {
     it('should be valid by default', async () => {
       const el = await fixture(html` <chromedash-textarea></chromedash-textarea> `);
-      assert.equal(el.invalid, false);
+      assert.exists(el);
+      await el.updateComplete;
+      assert.equal(el.checkValidity(), true);
     });
 
     it('should be invalid when required and empty', async () => {
       const el = await fixture(html` <chromedash-textarea required></chromedash-textarea> `);
-      assert.equal(el.invalid, true);
+      assert.exists(el);
+      await el.updateComplete;
+      assert.equal(el.checkValidity(), false);
     });
 
     it('should be invalid when required and after removing disabled ', async () => {
       const el = await fixture(html` <chromedash-textarea disabled required></chromedash-textarea> `);
-
+      assert.exists(el);
       el.disabled = false;
       await el.updateComplete;
-      assert.equal(el.invalid, true);
+      assert.equal(el.checkValidity(), false);
     });
 
     it('should be invalid when required and disabled is removed', async () => {
       const el = await fixture(html` <chromedash-textarea disabled required></chromedash-textarea> `);
+      assert.exists(el);
       el.disabled = false;
       await el.updateComplete;
-      assert.equal(el.invalid, true);
+      assert.equal(el.checkValidity(), false);
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@open-wc/testing": "^3.1.7",
         "@rollup/plugin-babel": "^6.0.3",
         "@rollup/plugin-node-resolve": "^15.0.1",
-        "@shoelace-style/shoelace": "^2.0.0-beta.88",
+        "@shoelace-style/shoelace": "^2.0.0",
         "@web/test-runner": "^0.15.0",
         "@web/test-runner-playwright": "^0.9.0",
         "acorn": ">=8.8.2",
@@ -1820,18 +1820,18 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.2.tgz",
-      "integrity": "sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-PL7g3dhA4dHgZfujkuD8Q+tfJJynEtnNQSPzmucCnxMvkxf4cLBJw/ZYqZUn4HCh33U3WHrAfv2R2tbi9UCSmw==",
       "dev": true
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.7.tgz",
-      "integrity": "sha512-6RsqvCYe0AYWtsGvuWqCm7mZytnXAZCjWtsWu1Kg8dI3INvj/DbKlDsZO+mKSaQdPT12uxIW9W2dAWJkPx4Y5g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.1.tgz",
+      "integrity": "sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==",
       "dev": true,
       "dependencies": {
-        "@floating-ui/core": "^1.0.2"
+        "@floating-ui/core": "^1.1.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1939,9 +1939,9 @@
       }
     },
     "node_modules/@lit-labs/react": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.1.0.tgz",
-      "integrity": "sha512-uvdOtzACm1WzTySpKnqXth62iPL+4yDow7cSZH7m7jHbDr+tZVXn44DJ5IoJuMjEevORRe57lNrOywFW6d4Fyg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-9TC+/ZWb6BJlWCyUr14FKFlaGnyKpeEDorufXozQgke/VoVrslUQNaL7nBmrAWdNrmzx5jWgi8lFmWwrxMjnlA==",
       "dev": true
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
@@ -2255,17 +2255,17 @@
       "dev": true
     },
     "node_modules/@shoelace-style/shoelace": {
-      "version": "2.0.0-beta.88",
-      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.0.0-beta.88.tgz",
-      "integrity": "sha512-AoT3jtD7Gh5jgEtvbyqgOL+VDmxlcW0UYpKBZ0FzfF7bV38UeZqosnfeXZzQXaP/U/s4BpgkSS0+ZpPuepjDtw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.0.0.tgz",
+      "integrity": "sha512-2pTXOUlU9CZcsr1hkac9G4RNR0TTNj1rfxLqcNZ1GKtd94BL7NgYp6EHMyVnGzTN+iaLfJVVIFTiLGXIA6SwnQ==",
       "dev": true,
       "dependencies": {
         "@ctrl/tinycolor": "^3.5.0",
-        "@floating-ui/dom": "^1.0.7",
-        "@lit-labs/react": "^1.1.0",
+        "@floating-ui/dom": "^1.1.0",
+        "@lit-labs/react": "^1.1.1",
         "@shoelace-style/animations": "^1.1.0",
         "@shoelace-style/localize": "^3.0.4",
-        "lit": "^2.4.1",
+        "lit": "^2.6.1",
         "qr-creator": "^1.0.0"
       },
       "engines": {
@@ -14866,18 +14866,18 @@
       }
     },
     "@floating-ui/core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.2.tgz",
-      "integrity": "sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-PL7g3dhA4dHgZfujkuD8Q+tfJJynEtnNQSPzmucCnxMvkxf4cLBJw/ZYqZUn4HCh33U3WHrAfv2R2tbi9UCSmw==",
       "dev": true
     },
     "@floating-ui/dom": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.7.tgz",
-      "integrity": "sha512-6RsqvCYe0AYWtsGvuWqCm7mZytnXAZCjWtsWu1Kg8dI3INvj/DbKlDsZO+mKSaQdPT12uxIW9W2dAWJkPx4Y5g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.1.tgz",
+      "integrity": "sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==",
       "dev": true,
       "requires": {
-        "@floating-ui/core": "^1.0.2"
+        "@floating-ui/core": "^1.1.0"
       }
     },
     "@humanwhocodes/config-array": {
@@ -14965,9 +14965,9 @@
       }
     },
     "@lit-labs/react": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.1.0.tgz",
-      "integrity": "sha512-uvdOtzACm1WzTySpKnqXth62iPL+4yDow7cSZH7m7jHbDr+tZVXn44DJ5IoJuMjEevORRe57lNrOywFW6d4Fyg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-9TC+/ZWb6BJlWCyUr14FKFlaGnyKpeEDorufXozQgke/VoVrslUQNaL7nBmrAWdNrmzx5jWgi8lFmWwrxMjnlA==",
       "dev": true
     },
     "@lit-labs/ssr-dom-shim": {
@@ -15225,17 +15225,17 @@
       "dev": true
     },
     "@shoelace-style/shoelace": {
-      "version": "2.0.0-beta.88",
-      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.0.0-beta.88.tgz",
-      "integrity": "sha512-AoT3jtD7Gh5jgEtvbyqgOL+VDmxlcW0UYpKBZ0FzfF7bV38UeZqosnfeXZzQXaP/U/s4BpgkSS0+ZpPuepjDtw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.0.0.tgz",
+      "integrity": "sha512-2pTXOUlU9CZcsr1hkac9G4RNR0TTNj1rfxLqcNZ1GKtd94BL7NgYp6EHMyVnGzTN+iaLfJVVIFTiLGXIA6SwnQ==",
       "dev": true,
       "requires": {
         "@ctrl/tinycolor": "^3.5.0",
-        "@floating-ui/dom": "^1.0.7",
-        "@lit-labs/react": "^1.1.0",
+        "@floating-ui/dom": "^1.1.0",
+        "@lit-labs/react": "^1.1.1",
         "@shoelace-style/animations": "^1.1.0",
         "@shoelace-style/localize": "^3.0.4",
-        "lit": "^2.4.1",
+        "lit": "^2.6.1",
         "qr-creator": "^1.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@open-wc/testing": "^3.1.7",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-node-resolve": "^15.0.1",
-    "@shoelace-style/shoelace": "^2.0.0-beta.88",
+    "@shoelace-style/shoelace": "^2.0.0",
     "@web/test-runner": "^0.15.0",
     "@web/test-runner-playwright": "^0.9.0",
     "acorn": ">=8.8.2",


### PR DESCRIPTION
This PR fixes the problem raised in [#2703.](https://github.com/GoogleChrome/chromium-dashboard/pull/2703)

No idea how this passed previously, since the invalid instance var should have been incorrect.
