### PR TITLE
Refactor the preflight dialog into its own element.

### DIFF
--- a/client-src/components.js
+++ b/client-src/components.js
@@ -72,6 +72,7 @@ import './elements/chromedash-header';
 import './elements/chromedash-legend';
 import './elements/chromedash-metadata';
 import './elements/chromedash-myfeatures-page';
+import './elements/chromedash-preflight-dialog';
 import './elements/chromedash-process-overview';
 import './elements/chromedash-settings-page';
 import './elements/chromedash-stack-rank';

--- a/client-src/elements/chromedash-preflight-dialog.js
+++ b/client-src/elements/chromedash-preflight-dialog.js
@@ -125,9 +125,7 @@ export class ChromedashPreflightDialog extends LitElement {
   }
 
   renderDialogContent() {
-    console.log(this);
     if (this.feature == null) {
-      console.log('feature is null');
       return nothing;
     }
     const prereqItems = [];

--- a/client-src/elements/chromedash-preflight-dialog.js
+++ b/client-src/elements/chromedash-preflight-dialog.js
@@ -1,0 +1,175 @@
+import {LitElement, css, html, nothing} from 'lit';
+import './chromedash-callout';
+import {findFirstFeatureStage} from './utils';
+import {SHARED_STYLES} from '../sass/shared-css.js';
+
+
+let preflightDialogEl;
+
+export async function openPreflightDialog(
+  feature, progress, process, action, stage, feStage) {
+  if (!preflightDialogEl) {
+    preflightDialogEl = document.createElement('chromedash-preflight-dialog');
+    document.body.appendChild(preflightDialogEl);
+    await preflightDialogEl.updateComplete;
+  }
+  preflightDialogEl.openWithContext(
+    feature, progress, process, action, stage, feStage);
+}
+
+
+export function somePendingPrereqs(action, progress) {
+  return action.prerequisites.some(
+    itemName => !progress.hasOwnProperty(itemName));
+}
+
+
+export class ChromedashPreflightDialog extends LitElement {
+  static get properties() {
+    return {
+      feature: {type: Object},
+      progress: {type: Object},
+      process: {type: Object},
+      action: {type: Object},
+      stage: {type: Object},
+      feStage: {type: Object},
+      progress: {type: Object},
+    };
+  }
+
+  constructor() {
+    super();
+    this.feature = null;
+    this.progress = null;
+    this.process = null;
+    this.action = null;
+    this.stage = null;
+    this.feStage = null;
+    this.progress = null;
+  }
+
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      css`
+      ol {
+        list-style: none;
+        padding: 0;
+      }
+
+      ol li {
+        margin-top: .5em;
+      }
+
+      .missing-prereqs-list {
+        padding-bottom: 1em;
+      }
+
+      .missing-prereqs-list li {
+        list-style: circle;
+        margin-left: 2em;
+      }
+
+      .edit-progress-item {
+        visibility: hidden;
+        margin-left: var(--content-padding-half);
+      }
+
+      .active .edit-progress-item,
+      .missing-prereqs .edit-progress-item,
+      .pending:hover .edit-progress-item,
+      .done:hover .edit-progress-item {
+        visibility: visible;
+      }
+    `];
+  }
+
+  openWithContext(feature, progress, process, action, stage, feStage) {
+    this.feature = feature;
+    this.progress = progress;
+    this.process = process;
+    this.action = action;
+    this.stage = stage;
+    this.feStage = feStage;
+    this.shadowRoot.querySelector('sl-dialog').show();
+  }
+
+  closeDialog() {
+    this.shadowRoot.querySelector('sl-dialog').hide();
+  }
+
+  renderEditLink(stage, feStage, pi) {
+    const featureId = this.feature.id;
+    let editEl = nothing;
+    if (pi.field) {
+      editEl = html`
+        <a class="edit-progress-item"
+           href="/guide/stage/${featureId}/${stage.outgoing_stage}/${feStage.id}#id_${pi.field}"
+           @click=${this.closeDialog}>
+          Edit
+        </a>
+      `;
+    }
+    return editEl;
+  }
+
+  makePrereqItem(itemName) {
+    for (const s of (this.process.stages || [])) {
+      for (const pi of s.progress_items) {
+        if (itemName == pi.name) {
+          return {...pi, stage: s};
+        }
+      }
+    }
+    throw new Error('prerequiste is not a defined progress item');
+  }
+
+  renderDialogContent() {
+    console.log(this);
+    if (this.feature == null) {
+      console.log('feature is null');
+      return nothing;
+    }
+    const prereqItems = [];
+    for (const itemName of (this.action.prerequisites || [])) {
+      if (!this.progress.hasOwnProperty(itemName)) {
+        prereqItems.push(this.makePrereqItem(itemName));
+      }
+    }
+
+    const url = this.action.url
+      .replace('{feature_id}', this.feature.id)
+      .replace('{outgoing_stage}', this.stage.outgoing_stage);
+
+    return html`
+      Before you ${this.action.name}, you should first do the following:
+      <ol class="missing-prereqs-list">
+        ${prereqItems.map((item) => html`
+        <li class="pending">
+          ${item.stage.name}:
+          ${item.name}
+          ${this.renderEditLink(
+              item.stage,
+              findFirstFeatureStage(
+                item.stage.outgoing_stage, this.stage, this.feature),
+              item)}
+        </li>`)}
+      </ol>
+      <sl-button href="${url}" target="_blank" variant="primary" size="small">
+        Proceed to Draft Email
+      </sl-button>
+    `;
+  }
+
+  render() {
+    return html`
+      <sl-dialog class="missing-prereqs"
+        label="Missing Prerequisites"
+        style="--width:fit-content">
+        ${this.renderDialogContent()}
+      </sl-dialog>
+    `;
+  }
+};
+
+customElements.define('chromedash-preflight-dialog', ChromedashPreflightDialog);


### PR DESCRIPTION
I'd like to reuse the preflight dialog on the new gate column UI when the user requests to generate an intent email.
There should be no user-visible change in this PR.

In this PR:
* Refactor the dialog into a separate custom element
* Make it work more like our other dialogs:
   * Instead of each action having its own non-visible dialog, create only one dialog instance, and populate it when opening it.
* Rather than precompute item_stage_map, the code now creates specific entries as needed.  That can be more CPU cycles, but the number of iterations on these loops is well under 100. 