### PR TITLE
Add preflight dialog when generating intent via gate column.

### DIFF
--- a/client-src/elements/chromedash-preflight-dialog.js
+++ b/client-src/elements/chromedash-preflight-dialog.js
@@ -99,18 +99,16 @@ export class ChromedashPreflightDialog extends LitElement {
   }
 
   renderEditLink(stage, feStage, pi) {
-    const featureId = this.feature.id;
-    let editEl = nothing;
-    if (pi.field) {
-      editEl = html`
+    if (pi.field && stage && feStage) {
+      return html`
         <a class="edit-progress-item"
-           href="/guide/stage/${featureId}/${stage.outgoing_stage}/${feStage.id}#id_${pi.field}"
+           href="/guide/stage/${this.feature.id}/${stage.outgoing_stage}/${feStage.id}#id_${pi.field}"
            @click=${this.closeDialog}>
           Edit
         </a>
       `;
     }
-    return editEl;
+    return nothing;
   }
 
   makePrereqItem(itemName) {


### PR DESCRIPTION
This should resolve issue #2730.

In this PR:
* Load the feature progress when opening the gate column
* For the stage actions, which are the links to generate the intent: instead of directly linking to the intent generation page, check the prerequisites and open the preflight dialog if needed.
* Make a little bit of the logic for the preflight "Edit" links simpler and more robust.