### PR TITLE
Send a review notification when a new review is requested

### DIFF
--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -21,8 +21,8 @@ from typing import Any, Optional
 from api import converters
 from framework import basehandlers
 from framework import permissions
-from internals import approval_defs
-from internals.review_models import Approval, ApprovalConfig, Gate, Vote
+from internals import approval_defs, notifier_helpers
+from internals.review_models import Gate, Vote
 
 
 class VotesAPI(basehandlers.APIHandler):
@@ -57,6 +57,9 @@ class VotesAPI(basehandlers.APIHandler):
     # Note: We no longer write Approval entities.
     approval_defs.set_vote(feature_id, None, new_state,
         user.email(), gate_id)
+
+    if new_state == Vote.REVIEW_REQUESTED:
+      notifier_helpers.notify_approvers_of_reviews(feature, gate)
 
     # Callers don't use the JSON response for this API call.
     return {'message': 'Done'}

--- a/api/reviews_api_test.py
+++ b/api/reviews_api_test.py
@@ -242,8 +242,9 @@ class VotesAPITest(testing_config.CustomTestCase):
     self.assertEqual(vote.set_by, 'reviewer1@example.com')
     self.assertEqual(vote.state, Vote.DENIED)
 
+  @mock.patch('internals.notifier_helpers.notify_approvers_of_reviews')
   @mock.patch('internals.approval_defs.get_approvers')
-  def test_post__request_review(self, mock_get_approvers):
+  def test_post__request_review(self, mock_get_approvers, mock_notifier):
     """Handler allows a feature owner to rquest a review."""
     mock_get_approvers.return_value = ['reviewer1@example.com']
     testing_config.sign_in('owner1@example.com', 123567890)
@@ -261,3 +262,5 @@ class VotesAPITest(testing_config.CustomTestCase):
     self.assertEqual(vote.gate_id, 1)
     self.assertEqual(vote.set_by, 'owner1@example.com')
     self.assertEqual(vote.state, Vote.REVIEW_REQUESTED)
+
+    mock_notifier.assert_called_once_with(self.feature_1, self.gate_1)

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -17,13 +17,13 @@ from typing import Any, TYPE_CHECKING
 from api import converters
 from framework import cloud_tasks_helpers, users
 from internals import core_enums
-from internals import review_models
+from internals.review_models import Gate, Amendment, Activity
 
 if TYPE_CHECKING:
   from internals.core_models import FeatureEntry
 
 def _get_changes_as_amendments(
-    changed_fields: list[tuple[str, Any, Any]]) -> list[review_models.Amendment]:
+    changed_fields: list[tuple[str, Any, Any]]) -> list[Amendment]:
   """Convert list of field changes to Amendment entities."""
   # Diff values to see what properties have changed.
   amendments = []
@@ -33,12 +33,12 @@ def _get_changes_as_amendments(
       if old_val is None and not bool(new_val):
         continue
       amendments.append(
-          review_models.Amendment(field_name=field,
+          Amendment(field_name=field,
           old_value=str(old_val), new_value=str(new_val)))
   return amendments
 
 def notify_feature_subscribers_of_changes(fe: 'FeatureEntry',
-    amendments: list[review_models.Amendment]) -> None:
+    amendments: list[Amendment]) -> None:
   """Async notifies subscribers of new features and property changes to
       features by posting to a task queue.
   """
@@ -68,10 +68,29 @@ def notify_subscribers_and_save_amendments(fe: 'FeatureEntry',
   if len(amendments) > 0:
     user = users.get_current_user()
     email = user.email() if user else None
-    activity = review_models.Activity(feature_id=fe.key.integer_id(),
+    activity = Activity(feature_id=fe.key.integer_id(),
         author=email, content='')
     activity.amendments = amendments
     activity.put()
 
   if notify:
     notify_feature_subscribers_of_changes(fe, amendments)
+
+
+def notify_approvers_of_reviews(fe: 'FeatureEntry', gate: Gate) -> None:
+  """Notify approvers of a review requested from a Gate."""
+  gate_url = 'https://chromestatus.com/feature/%s?gate=%s' % (gate.feature_id, gate.id)
+  changed_props = {
+      'prop_name': 'Review status change in %s' % (gate_url),
+      'old_val': 'na',
+      'new_val': 'review_requested',
+  }
+
+  params = [{
+    'changes': changed_props,
+    'gate_type': gate.gate_type,
+    'feature': converters.feature_entry_to_json_verbose(fe)
+  }]
+
+  # Create task to email subscribers.
+  cloud_tasks_helpers.enqueue_task('/tasks/email-reviewers', params)


### PR DESCRIPTION
Fix #2340. Generate email notifications when a new review is requested. It adds a link to the feature detail page, with a gate URL param using https://github.com/GoogleChrome/chromium-dashboard/pull/2739