### PR TITLE
Revert "Bump werkzeug from 2.1.2 to 2.2.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ flask-cors==3.0.10
 funcsigs==1.0.2
 Jinja2==3.1.2
 MarkupSafe==2.1.1
-Werkzeug==2.2.3
+Werkzeug==2.1.2
 click==8.1.3
 itsdangerous==2.1.2
 


### PR DESCRIPTION
Reverts GoogleChrome/chromium-dashboard#2740

The new version of werkzeug seems to be giving 405 responses when we try to POST a feature edit.