### PR TITLE
Get the correct gate state before change

### DIFF
--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -52,6 +52,7 @@ class VotesAPI(basehandlers.APIHandler):
     if gate.feature_id != feature_id:
       self.abort(400, msg='Mismatched feature and gate')
 
+    old_state = gate.state
     self.require_permissions(user, feature, gate, new_state)
 
     # Note: We no longer write Approval entities.
@@ -62,7 +63,7 @@ class VotesAPI(basehandlers.APIHandler):
       notifier_helpers.notify_approvers_of_reviews(feature, gate)
     else:
       notifier_helpers.notify_subscribers_of_vote_changes(
-          feature, gate, user.email(), new_state)
+          feature, gate, user.email(), new_state, old_state)
 
     # Callers don't use the JSON response for this API call.
     return {'message': 'Done'}

--- a/api/reviews_api_test.py
+++ b/api/reviews_api_test.py
@@ -223,7 +223,7 @@ class VotesAPITest(testing_config.CustomTestCase):
     self.assertEqual(vote.state, Vote.NEEDS_WORK)
 
     mock_notifier.assert_called_once_with(self.feature_1,
-        self.gate_1, 'reviewer1@example.com', Vote.NEEDS_WORK)
+        self.gate_1, 'reviewer1@example.com', Vote.NEEDS_WORK, Vote.NA)
 
   @mock.patch('internals.notifier_helpers.notify_subscribers_of_vote_changes')
   @mock.patch('internals.approval_defs.get_approvers')
@@ -248,7 +248,7 @@ class VotesAPITest(testing_config.CustomTestCase):
     self.assertEqual(vote.state, Vote.DENIED)
 
     mock_notifier.assert_called_once_with(self.feature_1,
-        self.gate_1, 'reviewer1@example.com', Vote.DENIED)
+        self.gate_1, 'reviewer1@example.com', Vote.DENIED, Vote.NA)
 
   @mock.patch('internals.notifier_helpers.notify_approvers_of_reviews')
   @mock.patch('internals.approval_defs.get_approvers')

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -98,7 +98,7 @@ def notify_approvers_of_reviews(fe: 'FeatureEntry', gate: Gate) -> None:
 
 
 def notify_subscribers_of_vote_changes(fe: 'FeatureEntry', gate: Gate,
-    email: str, new_state: int) -> None:
+    email: str, new_state: int, old_state: int) -> None:
   """Notify subscribers of a vote change and save amendments."""
   stage = core_models.Stage.get_by_id(gate.stage_id)
   stage_enum = core_enums.INTENT_STAGES_BY_STAGE_TYPE.get(
@@ -116,7 +116,7 @@ def notify_subscribers_of_vote_changes(fe: 'FeatureEntry', gate: Gate,
                       author=email, content=acitivity_content)
   activity.put()
 
-  old_state = Vote.VOTE_VALUES[gate.state]
+  old_state = Vote.VOTE_VALUES[old_state]
   gate_url = 'https://chromestatus.com/feature/%s?gate=%s' % (
     gate.feature_id, gate_id)
   changed_props = {

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -116,12 +116,12 @@ def notify_subscribers_of_vote_changes(fe: 'FeatureEntry', gate: Gate,
                       author=email, content=acitivity_content)
   activity.put()
 
-  old_state = Vote.VOTE_VALUES[old_state]
+  old_state_name = Vote.VOTE_VALUES[old_state]
   gate_url = 'https://chromestatus.com/feature/%s?gate=%s' % (
     gate.feature_id, gate_id)
   changed_props = {
       'prop_name': '%s set review status in %s' % (email, gate_url),
-      'old_val': old_state,
+      'old_val': old_state_name,
       'new_val': state_name,
   }
 

--- a/internals/notifier_helpers_test.py
+++ b/internals/notifier_helpers_test.py
@@ -93,7 +93,7 @@ class ActivityTest(testing_config.CustomTestCase):
   @mock.patch('framework.cloud_tasks_helpers.enqueue_task')
   def test_vote_changes_activities__created(self, mock_task_helpers):
     notifier_helpers.notify_subscribers_of_vote_changes(
-        self.feature_1, self.gate_1, 'abc@example.com', Vote.DENIED)
+        self.feature_1, self.gate_1, 'abc@example.com', Vote.DENIED, Vote.NA)
     expected_content = ('abc@example.com set review status for stage'
                 ': Start prototyping, gate: Intent to Prototype to denied.')
     feature_id = self.feature_1.key.integer_id()


### PR DESCRIPTION
Get the correct gate state before change. The old_state and  new_state were the same [before this change](https://groups.google.com/a/google.com/g/cr-status-staging-emails/c/GAjgQUaEJJc)