### PR TITLE
Fix unsatisfiable progress items.

### DIFF
--- a/api/processes_api_test.py
+++ b/api/processes_api_test.py
@@ -75,7 +75,7 @@ class ProcessesAPITest(testing_config.CustomTestCase):
     expected['stages'][-1]['incoming_stage'] = core_enums.INTENT_ROLLOUT
 
     self.assertEqual(expected, actual)
-  
+
   def test_get__feature_type_1(self):
     """We can get process for features with feature type 1 (Existing feature implementation)."""
     self.feature_1.feature_type = 1
@@ -211,5 +211,6 @@ class ProgressAPITest(testing_config.CustomTestCase):
       'Ready for Trial email': 'https://example.com/ready_for_trial',
       'Intent to Ship email': 'https://example.com/ship',
       'Spec link': 'fake spec link',
+      'Updated target milestone': 'True',
       'Web developer signals': 'True',
     }, actual)

--- a/internals/processes.py
+++ b/internals/processes.py
@@ -131,10 +131,10 @@ PI_I2S_EMAIL = ProgressItem('Intent to Ship email', 'intent_to_ship_url')
 PI_I2S_LGTMS = ProgressItem('Three LGTMs on Intent to Ship')
 
 # TODO(jrobbins): needs detector.
-PI_FINAL_VENDOR_SIGNALS = ProgressItem('Finalized vendor signals', 'safari_views')
+PI_FINAL_VENDOR_SIGNALS = ProgressItem('Final vendor signals', 'safari_views')
 # TODO(jrobbins): needs detector.
 PI_FINAL_TARGET_MILESTONE = ProgressItem(
-    'Finalized target milestone', 'shipped_milestone')
+    'Final target milestone', 'shipped_milestone')
 
 PI_CODE_IN_CHROMIUM = ProgressItem('Code in Chromium')
 
@@ -687,6 +687,11 @@ PROGRESS_DETECTORS = {
         f.safari_views != core_enums.NO_PUBLIC_SIGNALS),
 
     'Estimated target milestone':
+    lambda f, stages: bool(core_enums.STAGE_TYPES_SHIPPING[f.feature_type] and
+        stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]][0].milestones and
+        stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]][0].milestones.desktop_first),
+
+    'Updated target milestone':
     lambda f, stages: bool(core_enums.STAGE_TYPES_SHIPPING[f.feature_type] and
         stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]][0].milestones and
         stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]][0].milestones.desktop_first),


### PR DESCRIPTION
This should resolve #2762.

In this PR:
* Fix the spelling of a couple of progress items so that they match the corresponding progress detector.
* Add a progress detector for 'Updated target milestone'