### PR TITLE
Display devrel under the Metadata section

### DIFF
--- a/client-src/elements/chromedash-guide-metadata.js
+++ b/client-src/elements/chromedash-guide-metadata.js
@@ -143,7 +143,7 @@ export class ChromedashGuideMetadata extends LitElement {
             </tr>
 
             <tr>
-              <th>Owners</th>
+              <th>DevRel</th>
               <td>
                 ${this.feature.browsers.chrome.devrel.map((dev) => html`
                   <a href="mailto:${dev}">${dev}</a>

--- a/client-src/elements/chromedash-guide-metadata.js
+++ b/client-src/elements/chromedash-guide-metadata.js
@@ -143,6 +143,15 @@ export class ChromedashGuideMetadata extends LitElement {
             </tr>
 
             <tr>
+              <th>Owners</th>
+              <td>
+                ${this.feature.browsers.chrome.devrel.map((dev) => html`
+                  <a href="mailto:${dev}">${dev}</a>
+                `)}
+              </td>
+            </tr>
+
+            <tr>
               <th>Category</th>
               <td>${this.feature.category}</td>
             </tr>

--- a/client-src/elements/chromedash-guide-metadata_test.js
+++ b/client-src/elements/chromedash-guide-metadata_test.js
@@ -11,6 +11,7 @@ describe('chromedash-guide-metadata', () => {
     feature_type: 'fake feature type',
     intent_stage: 'fake intent stage',
     new_crbug_url: 'fake crbug link',
+    devrel: ['devrel1@example.com', 'devrel2@example.com'],
     cc_recipients: ['fake chrome cc one', 'fake chrome cc two'],
     browsers: {
       chrome: {
@@ -51,6 +52,9 @@ describe('chromedash-guide-metadata', () => {
     // feature owners are listed
     assert.include(metadataDiv.innerHTML, 'href="mailto:fake chrome owner one"');
     assert.include(metadataDiv.innerHTML, 'href="mailto:fake chrome owner two"');
+    // devrel recipients are listed
+    assert.include(metadataDiv.innerHTML, 'href="mailto:devrel1@example.com"');
+    assert.include(metadataDiv.innerHTML, 'href="mailto:devrel2@example.com"');
     // cc recipients are listed
     assert.include(metadataDiv.innerHTML, 'href="mailto:fake chrome cc one"');
     assert.include(metadataDiv.innerHTML, 'href="mailto:fake chrome cc two"');

--- a/client-src/elements/chromedash-guide-metadata_test.js
+++ b/client-src/elements/chromedash-guide-metadata_test.js
@@ -11,13 +11,13 @@ describe('chromedash-guide-metadata', () => {
     feature_type: 'fake feature type',
     intent_stage: 'fake intent stage',
     new_crbug_url: 'fake crbug link',
-    devrel: ['devrel1@example.com', 'devrel2@example.com'],
     cc_recipients: ['fake chrome cc one', 'fake chrome cc two'],
     browsers: {
       chrome: {
         blink_components: ['Blink'],
         owners: ['fake chrome owner one', 'fake chrome owner two'],
         status: {text: 'fake chrome status text'},
+        devrel: ['devrel1@example.com', 'devrel2@example.com'],
       },
       ff: {view: {text: 'fake ff view text'}},
       safari: {view: {text: 'fake safari view text'}},

--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -158,6 +158,7 @@ export const FLAT_METADATA_FIELDS = {
         'owner',
         'editors',
         'cc_recipients',
+        'devrel',
         'category',
         'feature_type',
         'search_tags',

--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -254,7 +254,6 @@ const FLAT_DEV_TRIAL_FIELDS = {
         'wpt',
         'wpt_descr',
         'sample_links',
-        'devrel',
       ],
     },
     // Implementation
@@ -480,7 +479,6 @@ const DEPRECATION_DEV_TRIAL_FIELDS = {
         'wpt',
         'wpt_descr',
         'sample_links',
-        'devrel',
       ],
     },
     // Implementation


### PR DESCRIPTION
Fix #2766. Move devrel_emails to the metadata section. See "Developer Relations Emails" field below

### Test
Feature detail page

<img width="785" alt="Screenshot 2023-02-23 at 4 33 51 PM" src="https://user-images.githubusercontent.com/8611520/221063153-492bc9d5-0f09-4d59-b5e2-144364013023.png">

New Metadata edit page
<img width="888" alt="Screenshot 2023-02-23 at 4 34 18 PM" src="https://user-images.githubusercontent.com/8611520/221063190-2fd2b8db-847c-4c62-b712-6600d7e399b2.png">

Old edit all page
<img width="972" alt="Screenshot 2023-02-23 at 4 34 34 PM" src="https://user-images.githubusercontent.com/8611520/221063244-88ff804c-fb32-4ea3-aafe-a5745ed830b4.png">

