### PR TITLE
Migrate subject line fields to new schema

### DIFF
--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -517,6 +517,7 @@ class Stage(ndb.Model):
   experiment_risks = ndb.TextProperty()
   experiment_extension_reason = ndb.TextProperty()
   intent_thread_url = ndb.StringProperty()
+  intent_subject_line = ndb.StringProperty()
   origin_trial_feedback_url = ndb.StringProperty()
   announcement_url = ndb.StringProperty()
   # Origin trial stage id that this stage extends, if trial extension stage.

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -16,7 +16,7 @@ import logging
 from google.cloud import ndb  # type: ignore
 
 from framework.basehandlers import FlaskHandler
-from internals import approval_defs
+from internals import approval_defs, stage_helpers
 from internals.core_models import Feature, FeatureEntry, MilestoneSet, Stage
 from internals.review_models import Activity, Approval, Comment, Gate, Vote
 from internals.core_enums import *
@@ -631,3 +631,69 @@ class CreateTrialExtensionStages(FlaskHandler):
 
     return (f'{stages_created} extension stages created for '
         'existing trial stages.')
+
+
+class MigrateSubjectLineField(FlaskHandler):
+
+  def get_template_data(self, **kwargs) -> str:
+    """Migrates old Feature subject line fields to their respective stages."""
+    self.require_cron_header()
+
+    count = 0
+    for f in Feature.query():
+      f_id = f.key.integer_id()
+      f_type = f.feature_type
+
+      # If there are no subject line fields present, no need to migrate.
+      if (not f.intent_to_implement_subject_line and
+          not f.intent_to_ship_subject_line and
+          not f.intent_to_experiment_subject_line and
+          not f.intent_to_extend_experiment_subject_line):
+        continue
+
+      stages_to_update = []
+      stages = stage_helpers.get_feature_stages(f_id)
+
+      # Check each corresponding FeatureEntry stage to migrate the
+      # intent subject line if needed.
+      prototype_stages = stages[STAGE_TYPES_PROTOTYPE[f_type]]
+      if (f.intent_to_implement_subject_line and
+          # If there are more than 1 stage for a specific stage type,
+          # we can't be sure which is the correct intent, so don't migrate.
+          # (this should be very rare).
+          len(prototype_stages) == 1 and
+          not prototype_stages[0].intent_subject_line):
+        prototype_stages[0].intent_subject_line = (
+            f.intent_to_implement_subject_line)
+        stages_to_update.append(prototype_stages[0])
+
+      ship_stages = stages[STAGE_TYPES_SHIPPING[f_type]]
+      if (f.intent_to_ship_subject_line and
+          len(ship_stages) == 1 and
+          not ship_stages[0].intent_subject_line):
+        ship_stages[0].intent_subject_line = (
+            f.intent_to_ship_subject_line)
+        stages_to_update.append(ship_stages[0])
+
+      ot_stages = stages[STAGE_TYPES_ORIGIN_TRIAL[f_type]]
+      if (f.intent_to_experiment_subject_line and
+          len(ot_stages) == 1 and
+          not ot_stages[0].intent_subject_line):
+        ot_stages[0].intent_subject_line = (
+            f.intent_to_experiment_subject_line)
+        stages_to_update.append(ot_stages[0])
+
+      extension_stages = stages[STAGE_TYPES_EXTEND_ORIGIN_TRIAL[f_type]]
+      if (f.intent_to_extend_experiment_subject_line and
+          len(extension_stages) == 1 and
+          not extension_stages[0].intent_subject_line):
+        extension_stages[0].intent_subject_line = (
+            f.intent_to_extend_experiment_subject_line)
+        stages_to_update.append(extension_stages[0])
+
+      # Save changes to all updated Stage entities.
+      if stages_to_update:
+        ndb.put_multi(stages_to_update)
+        count += len(stages_to_update)
+
+    return f'{count} subject line fields migrated.'

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -656,7 +656,8 @@ class MigrateSubjectLineField(FlaskHandler):
 
       # Check each corresponding FeatureEntry stage to migrate the
       # intent subject line if needed.
-      prototype_stages = stages[STAGE_TYPES_PROTOTYPE[f_type]]
+      proto_stage_type = STAGE_TYPES_PROTOTYPE[f_type] or -1
+      prototype_stages = stages.get(proto_stage_type, [])
       if (f.intent_to_implement_subject_line and
           # If there are more than 1 stage for a specific stage type,
           # we can't be sure which is the correct intent, so don't migrate.
@@ -667,7 +668,8 @@ class MigrateSubjectLineField(FlaskHandler):
             f.intent_to_implement_subject_line)
         stages_to_update.append(prototype_stages[0])
 
-      ship_stages = stages[STAGE_TYPES_SHIPPING[f_type]]
+      ship_stage_type = STAGE_TYPES_SHIPPING[f_type] or -1
+      ship_stages = stages.get(ship_stage_type, [])
       if (f.intent_to_ship_subject_line and
           len(ship_stages) == 1 and
           not ship_stages[0].intent_subject_line):
@@ -675,7 +677,8 @@ class MigrateSubjectLineField(FlaskHandler):
             f.intent_to_ship_subject_line)
         stages_to_update.append(ship_stages[0])
 
-      ot_stages = stages[STAGE_TYPES_ORIGIN_TRIAL[f_type]]
+      ot_stage_type = STAGE_TYPES_ORIGIN_TRIAL[f_type] or -1
+      ot_stages = stages.get(ot_stage_type, [])
       if (f.intent_to_experiment_subject_line and
           len(ot_stages) == 1 and
           not ot_stages[0].intent_subject_line):
@@ -683,7 +686,8 @@ class MigrateSubjectLineField(FlaskHandler):
             f.intent_to_experiment_subject_line)
         stages_to_update.append(ot_stages[0])
 
-      extension_stages = stages[STAGE_TYPES_EXTEND_ORIGIN_TRIAL[f_type]]
+      extension_stage_type = STAGE_TYPES_EXTEND_ORIGIN_TRIAL[f_type] or -1
+      extension_stages = stages.get(extension_stage_type, [])
       if (f.intent_to_extend_experiment_subject_line and
           len(extension_stages) == 1 and
           not extension_stages[0].intent_subject_line):

--- a/internals/stage_helpers.py
+++ b/internals/stage_helpers.py
@@ -23,6 +23,7 @@ from internals.core_models import INTENT_STAGES_BY_STAGE_TYPE
 
 def get_feature_stages(feature_id: int) -> dict[int, list[Stage]]:
   """Return a dictionary of stages associated with a given feature."""
+  # key = stage type, value = list of stages with that stage type.
   stage_dict = defaultdict(list)
   for stage in Stage.query(Stage.feature_id == feature_id):
     stage_dict[stage.stage_type].append(stage)

--- a/main.py
+++ b/main.py
@@ -258,6 +258,8 @@ internals_routes: list[Route] = [
       schema_migration.CalcActiveStages),
   Route('/admin/schema_migration_extension_stages',
     schema_migration.CreateTrialExtensionStages),
+  Route('/admin/schema_migration_subject_line',
+    schema_migration.MigrateSubjectLineField),
 ]
 
 dev_routes: list[Route] = []


### PR DESCRIPTION
Part of #2693

This change adds a script that checks the old Feature entities for subject line fields and adds them to the corresponding new Stage field `intent_subject_line`. Adding back the subject line matching functionality for posing comments to intent threads will come in a later PR.