### PR TITLE
Lgtm fields migration

### DIFF
--- a/main.py
+++ b/main.py
@@ -260,6 +260,8 @@ internals_routes: list[Route] = [
     schema_migration.CreateTrialExtensionStages),
   Route('/admin/schema_migration_subject_line',
     schema_migration.MigrateSubjectLineField),
+  Route('/admin/schema_migration_lgtm_fields',
+    schema_migration.MigrateLGTMFields),
 ]
 
 dev_routes: list[Route] = []


### PR DESCRIPTION
Fix #2665. Migrate LGTM fields from feature entities to Vote entities. This PR caps the number of migration per run at 100, in case of App Engine timeout.

This endpoint needs to be hit repeatedly until it returns `0 of 0 lgtms fields migrated.`