### PR TITLE
Add Gate info to verbose converter; fix bug

### DIFF
--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -308,7 +308,14 @@ class FeatureConvertersTest(testing_config.CustomTestCase):
             'notes': 'other notes',
           }
         }
-      }
+      },
+
+      # Default empty lists for unfilled list fields.
+      'cc_recipients': [],
+      'explainer_links': [],
+      'gates': [],
+      'spec_mentors': [],
+      'tags': []
     }
     self.assertEqual(result, expected)
 

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -15,6 +15,7 @@
 
 from typing import Any, Optional
 
+from api import converters
 from framework import basehandlers
 from framework import permissions
 from framework import rediscache
@@ -28,10 +29,10 @@ class FeaturesAPI(basehandlers.APIHandler):
   """Features are the the main records that we track."""
 
   def get_one_feature(self, feature_id: int) -> dict[str, Any]:
-    features = feature_helpers.get_by_ids([feature_id])
-    if not features:
+    feature = FeatureEntry.get_by_id(feature_id)
+    if not feature:
       self.abort(404, msg='Feature %r not found' % feature_id)
-    return features[0]
+    return converters.feature_entry_to_json_verbose(feature)
 
   def do_search(self) -> dict[str, Any]:
     user = users.get_current_user()

--- a/client-src/elements/chromedash-guide-metadata.js
+++ b/client-src/elements/chromedash-guide-metadata.js
@@ -133,7 +133,7 @@ export class ChromedashGuideMetadata extends LitElement {
             <tr>
               <th>CC</th>
               <td>
-                ${this.feature.cc_recipients ?
+                ${this.feature.cc_recipients && this.feature.cc_recipients.length ?
                   this.feature.cc_recipients.map((ccRecipient)=> html`
                   <a href="mailto:${ccRecipient}">${ccRecipient}</a>
                   `): html`
@@ -145,9 +145,13 @@ export class ChromedashGuideMetadata extends LitElement {
             <tr>
               <th>DevRel</th>
               <td>
-                ${this.feature.browsers.chrome.devrel.map((dev) => html`
+                ${this.feature.browsers.chrome.devrel &&
+                  this.feature.browsers.chrome.devrel.length ?
+                  this.feature.browsers.chrome.devrel.map((dev) => html`
                   <a href="mailto:${dev}">${dev}</a>
-                `)}
+                `) : html`
+                None
+              `}
               </td>
             </tr>
 
@@ -166,7 +170,7 @@ export class ChromedashGuideMetadata extends LitElement {
               <td>${this.feature.intent_stage}</td>
             </tr>
 
-            ${this.feature.tags ? html`
+            ${this.feature.tags && this.feature.tags.length ? html`
               <tr>
                 <th>Search tags</th>
                 <td>


### PR DESCRIPTION
This change is required for #2693.

This change adds the `gates` property to the FeatureEntry JSON converter, which contains information about each gate associated with the feature.

Additionally, this change fixes a small bug that caused a read error when displaying the metadata section of a feature and some fields were not yet filled (cc_recipients, tags, and devrel fields that are stored as lists).