### PR TITLE
Display metadata even without devrel val

### DIFF
--- a/client-src/elements/chromedash-guide-metadata.js
+++ b/client-src/elements/chromedash-guide-metadata.js
@@ -152,9 +152,12 @@ export class ChromedashGuideMetadata extends LitElement {
               <tr>
                 <th>DevRel</th>
                 <td>
-                  ${this.feature.browsers.chrome.devrel.map((dev) => html`
+                  ${this.feature.browsers.chrome.devrel ?
+                    this.feature.browsers.chrome.devrel.map((dev) => html`
                     <a href="mailto:${dev}">${dev}</a>
-                  `)}
+                  `): html`
+                  None
+                `}
                 </td>
               </tr>` :
             nothing}


### PR DESCRIPTION
Fixes a small bug that stops the feature metadata section from rendering if there are no devrel emails associated with the feature.