### PR TITLE
Make the gate column open with regular click on a gate chip.

### DIFF
--- a/client-src/elements/chromedash-gate-chip.js
+++ b/client-src/elements/chromedash-gate-chip.js
@@ -125,7 +125,7 @@ class ChromedashGateChip extends LitElement {
   }
 
   openApprovalsDialog(e) {
-    if (e.shiftKey) {
+    if (!e.altKey) {
       // Handled in chromedash-app.js.
       this._fireEvent('show-gate-column', {
         feature: this.feature,


### PR DESCRIPTION
This makes the gate column the main UI for approvals, while still keeping the approvals dialog available for us to use for debugging if needed.

Now the gate column will open when the user does a normal click on a gate chip.  It also opens with a shift-click because the API Owners have been using shift-click recently.

The approvals dialog is now accessed via alt-click, which I don't expect any users to know.