### PR TITLE
Add scrollIntoView to editall-page.  Fix link to explainer-links.

### DIFF
--- a/client-src/elements/chromedash-guide-editall-page.js
+++ b/client-src/elements/chromedash-guide-editall-page.js
@@ -70,7 +70,7 @@ export class ChromedashGuideEditallPage extends LitElement {
 
   /* Add the form's event listener after Shoelace event listeners are attached
    * see more at https://github.com/GoogleChrome/chromium-dashboard/issues/2014 */
-  async registerFormSubmitHandler(el) {
+  async registerHandlers(el) {
     if (!el) return;
 
     await el.updateComplete;
@@ -78,6 +78,8 @@ export class ChromedashGuideEditallPage extends LitElement {
     hiddenTokenField.form.addEventListener('submit', (event) => {
       this.handleFormSubmit(event, hiddenTokenField);
     });
+
+    this.scrollToPosition();
   }
 
   handleFormSubmit(event, hiddenTokenField) {
@@ -92,6 +94,18 @@ export class ChromedashGuideEditallPage extends LitElement {
 
   handleCancelClick() {
     window.location.href = `/guide/edit/${this.featureId}`;
+  }
+
+  scrollToPosition() {
+    if (location.hash) {
+      const hash = decodeURIComponent(location.hash);
+      if (hash) {
+        const el = this.shadowRoot.querySelector(hash);
+        if (el) {
+          this.shadowRoot.querySelector(`chromedash-form-field[name="${el.name}"] tr th b`).scrollIntoView(true, {behavior: 'smooth'});
+        }
+      }
+    }
   }
 
   renderSkeletons() {
@@ -251,7 +265,7 @@ export class ChromedashGuideEditallPage extends LitElement {
         <input type="hidden" name="token">
         <input type="hidden" name="nextPage" value=${this.getNextPage()} >
         <input type="hidden" name="form_fields" value=${allFormFields.join(',')}>
-        <chromedash-form-table ${ref(this.registerFormSubmitHandler)}>
+        <chromedash-form-table ${ref(this.registerHandlers)}>
           ${formsToRender}
         </chromedash-form-table>
 

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -312,7 +312,7 @@ export const ALL_FIELDS = {
         Explain why the web needs this change. It may be useful
         to describe what web developers are forced to do without
         it. When possible, add links to your explainer
-        (under <a href="#explainer_links">Explainer link(s)</a>)
+        (under <a href="#id_explainer_links">Explainer link(s)</a>)
         backing up your claims.
         <br/><br/>
         This text is sometimes included with the summary in the


### PR DESCRIPTION
This PR adds the scrollIntoView behavior for links on the editall-page, like it is done on the stage-page.

Links to form fields should be prefixed with "id_". 