### PR TITLE
Remove stamp icons.

### DIFF
--- a/client-src/elements/chromedash-all-features-page.js
+++ b/client-src/elements/chromedash-all-features-page.js
@@ -1,5 +1,4 @@
 import {LitElement, css, html} from 'lit';
-import {openApprovalsDialog} from './chromedash-approvals-dialog';
 import {showToastMessage} from './utils.js';
 import './chromedash-feature-table';
 import {SHARED_STYLES} from '../sass/shared-css.js';
@@ -84,10 +83,6 @@ export class ChromedashAllFeaturesPage extends LitElement {
       });
   }
 
-  handleOpenApprovals(e) {
-    openApprovalsDialog(this.user, e.detail.feature);
-  }
-
   renderBox(query) {
     return html`
       <chromedash-feature-table
@@ -97,10 +92,8 @@ export class ChromedashAllFeaturesPage extends LitElement {
         showQuery
         ?signedIn=${Boolean(this.user)}
         ?canEdit=${this.user && this.user.can_edit_all}
-        ?canApprove=${this.user && this.user.can_approve}
         .starredFeatures=${this.starredFeatures}
         @star-toggle-event=${this.handleStarToggle}
-        @open-approvals-event=${this.handleOpenApprovals}
         alwaysOfferPagination columns="normal">
       </chromedash-feature-table>
     `;

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -217,12 +217,6 @@ export class ChromedashFeaturePage extends LitElement {
     });
   }
 
-  /* Open the general approvals dialog when the user clicks on stamp icon. */
-  handleApprovalClick(e) {
-    e.preventDefault();
-    openApprovalsDialog(this.user, this.feature);
-  }
-
   /* Open the specific approvals dialog when the user clicks on a gate chip. */
   // TODO(jrobbins): Make it specific.
   handleOpenApprovals(e) {
@@ -294,13 +288,6 @@ export class ChromedashFeaturePage extends LitElement {
               <iron-icon icon="chromestatus:link"></iron-icon>
             </a>
           </span>
-          ${this.user && this.user.can_approve ? html`
-            <span class="tooltip" title="Review approvals">
-              <a href="#" id="approvals-icon" data-tooltip @click=${this.handleApprovalClick}>
-                <iron-icon icon="chromestatus:approval"></iron-icon>
-              </a>
-            </span>
-          `: nothing}
           ${canEdit ? html`
             <span class="tooltip" title="Edit this feature">
               <a href="/guide/edit/${this.featureId}" class="editfeature" data-tooltip>

--- a/client-src/elements/chromedash-feature.js
+++ b/client-src/elements/chromedash-feature.js
@@ -18,7 +18,6 @@ class ChromedashFeature extends LitElement {
     return {
       feature: {type: Object},
       canEdit: {type: Boolean},
-      canApprove: {type: Boolean},
       signedin: {type: Boolean},
       open: {type: Boolean, reflect: true}, // Attribute used in the parent for styling
       starred: {type: Boolean},
@@ -197,25 +196,10 @@ class ChromedashFeature extends LitElement {
       });
   }
 
-  openApprovalsDialog(feature) {
-    // handled in chromedash-myfeatures-page.js
-    this._fireEvent('open-approvals-event', {
-      feature: feature,
-    });
-  }
-
   render() {
     return html`
       <hgroup @click="${this._togglePanelExpansion}">
         <h2><a href="/feature/${this.feature.id}">${this.feature.name}</a>
-          ${this.canApprove ? html`
-            <span class="tooltip" title="Review approvals">
-              <a id="approvals-icon" data-tooltip
-                 @click="${() => this.openApprovalsDialog(this.feature)}">
-                <iron-icon icon="chromestatus:approval"></iron-icon>
-              </a>
-            </span>
-            `: nothing}
           ${this.canEdit ? html`
             <span class="tooltip" title="Edit this feature">
               <a href="/guide/edit/${this.feature.id}" data-tooltip>

--- a/client-src/elements/chromedash-featurelist.js
+++ b/client-src/elements/chromedash-featurelist.js
@@ -1,5 +1,4 @@
 import {LitElement, html} from 'lit';
-import {openApprovalsDialog} from './chromedash-approvals-dialog';
 // eslint-disable-next-line no-unused-vars
 import './chromedash-feature';
 import {FEATURELIST_CSS} from '../sass/elements/chromedash-featurelist-css.js';
@@ -13,7 +12,6 @@ class ChromedashFeaturelist extends LitElement {
     return {
       user: {type: Object},
       isSiteEditor: {type: Boolean},
-      canApprove: {type: Boolean},
       signedInUser: {type: String},
       editableFeatures: {type: Object},
       features: {attribute: false}, // Directly edited and accessed in template/features.html
@@ -34,7 +32,6 @@ class ChromedashFeaturelist extends LitElement {
     this.metadataEl = document.querySelector('chromedash-metadata');
     this.searchEl = document.querySelector('.search input');
     this.isSiteEditor = false;
-    this.canApprove = false;
     this.signedInUser = '';
     this._hasInitialized = false; // Used to check initialization code.
     this._hasScrolledByUser = false; // Used to set the app header state.
@@ -52,7 +49,6 @@ class ChromedashFeaturelist extends LitElement {
      * to be bound to `this`. */
     this._onFeatureToggledBound = this._onFeatureToggled.bind(this);
     this._onStarToggledBound = this._onStarToggled.bind(this);
-    this._onOpenApprovalsBound = this._onOpenApprovals.bind(this);
 
     this._loadData();
   }
@@ -172,10 +168,6 @@ class ChromedashFeaturelist extends LitElement {
       newStarredFeatures.delete(feature.id);
     }
     this.starredFeatures = newStarredFeatures;
-  }
-
-  _onOpenApprovals(e) {
-    openApprovalsDialog(this.user, e.detail.feature);
   }
 
   _filterProperty(propPath, regExp, feature) {
@@ -371,10 +363,8 @@ class ChromedashFeaturelist extends LitElement {
                  ?starred="${item.starred}"
                  @feature-toggled="${this._onFeatureToggledBound}"
                  @star-toggled="${this._onStarToggledBound}"
-                 @open-approvals-event="${this._onOpenApprovalsBound}"
                  .feature="${item.feature}"
                  ?canEdit="${item.canEditFeature}"
-                 ?canApprove="${this.canApprove}"
                  ?signedIn="${this.signedInUser != ''}"
           ></chromedash-feature>
           </div>


### PR DESCRIPTION
Remove the stamp icons from the old feature list and feature detail page.
Also, remove some code for the approvals dialog box on the new feature list page.  It was never reachable because we don't show gate chips on that page (yet).

This is a follow up to my recent PR that made the gate column activate on a regular click.  Because gate chips are now the expected way to access the approvals functionality, we will not longer display the stamp icon.