### PR TITLE
Show both early stable and stable dates

### DIFF
--- a/client-src/elements/chromedash-roadmap-milestone-card.js
+++ b/client-src/elements/chromedash-roadmap-milestone-card.js
@@ -160,10 +160,6 @@ class ChromedashRoadmapMilestoneCard extends LitElement {
 
 
   renderCardHeader() {
-    // Starting with M110, display Early Stable Release dates.
-    const stableStart = (this.channel.version >= 110) ?
-      this.channel.final_beta : this.channel.stable_date;
-
     return html `
       <div class="layout vertical center">
         <h1 class="channel_label">${this.templateContent.channelLabel}</h1>
@@ -184,10 +180,15 @@ class ChromedashRoadmapMilestoneCard extends LitElement {
       </div>
       <div class="milestone_info layout horizontal center-center">
         <h3>
-          <span class="channel_label">Stable</span> ${this._computeDaysUntil(stableStart)}
-          <span class="release-stable">(${this._computeDate(stableStart, true)})</span>
+          <span class="channel_label">Early Stable</span> ${this._computeDaysUntil(this.channel.final_beta)}
+          <span class="early-stable">(${this._computeDate(this.channel.final_beta, true)})</span>
+        </h3>
+      </div>
+      <div class="milestone_info layout horizontal center-center">
+        <h3>
+          <span class="channel_label">Stable</span> ${this._computeDaysUntil(this.channel.stable_date)}
+          <span class="release-stable">(${this._computeDate(this.channel.stable_date, true)})</span>
           ${this.renderInfoIcon()}
-
         </h3>
       </div>
       ` : nothing}

--- a/client-src/sass/elements/chromedash-roadmap-milestone-card-css.js
+++ b/client-src/sass/elements/chromedash-roadmap-milestone-card-css.js
@@ -120,7 +120,7 @@ export const ROADMAP_MILESTONE_CARD_CSS = [
     .milestone_info {
       margin-bottom: 8px;
     }
-    .milestone_info:nth-of-type(3) {
+    .milestone_info:nth-of-type(4) {
       border-bottom: 1px solid #e6e6e6;
       padding-bottom: 16px;
     }


### PR DESCRIPTION
The roadmap page currently shows "early stable" as "stable" instead, this leads to confusion, which is evident by the two linked issues.  

To fix this we can show both dates to the user.

Fixes: #2729, #2725

Screenshots:

New:

![image](https://user-images.githubusercontent.com/34372791/223419987-053f9756-092f-4adb-9db0-e4070e566097.png)

Old:

![image](https://user-images.githubusercontent.com/34372791/223377500-c465b5d9-58ee-44ee-8476-cbea1a746e7f.png)
