### PR TITLE
Move legacy models to legacy_models file: review models [2/2]

### DIFF
--- a/api/approvals_api.py
+++ b/api/approvals_api.py
@@ -22,7 +22,8 @@ from api import converters
 from framework import basehandlers
 from framework import permissions
 from internals import approval_defs
-from internals.review_models import Approval, ApprovalConfig, Gate, Vote
+from internals.legacy_models import Approval, ApprovalConfig
+from internals.review_models import Gate, Vote
 
 
 class ApprovalsAPI(basehandlers.APIHandler):

--- a/api/approvals_api_test.py
+++ b/api/approvals_api_test.py
@@ -23,7 +23,8 @@ from google.cloud import ndb  # type: ignore
 from api import approvals_api
 from internals import core_enums
 from internals import core_models
-from internals.review_models import Approval, ApprovalConfig, Gate, Vote
+from internals.legacy_models import Approval, ApprovalConfig
+from internals.review_models import Gate, Vote
 
 test_app = flask.Flask(__name__)
 

--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -13,13 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from typing import Any
 
 from framework import basehandlers
 from framework import permissions
-from internals import approval_defs
-from internals.review_models import Activity, Amendment, Approval, Gate, Vote
+from internals.review_models import Activity, Amendment
 from internals import notifier
 
 

--- a/api/dev_api.py
+++ b/api/dev_api.py
@@ -18,8 +18,8 @@ from google.cloud import ndb  # type: ignore
 
 from framework.basehandlers import APIHandler
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
-from internals.legacy_models import Feature
-from internals.review_models import Activity, Approval, Comment, Gate, Vote
+from internals.legacy_models import  Approval, Comment, Feature
+from internals.review_models import Activity, Gate, Vote
 from internals.core_enums import *
 import settings
 

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -23,7 +23,8 @@ import requests
 
 from framework import permissions
 from internals import core_enums
-from internals.review_models import Approval, Gate, OwnersFile, Vote
+from internals.legacy_models import Approval
+from internals.review_models import Gate, OwnersFile, Vote
 import settings
 
 CACHE_EXPIRATION = 60 * 60  # One hour

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -24,7 +24,8 @@ import flask
 import werkzeug
 
 from internals import approval_defs
-from internals.review_models import Approval, Gate, Vote
+from internals.legacy_models import Approval
+from internals.review_models import Gate, Vote
 
 
 class FetchOwnersTest(testing_config.CustomTestCase):

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -22,8 +22,9 @@ from internals import approval_defs
 from internals import core_enums
 from internals import detect_intent
 from internals import stage_helpers
-from internals.core_models import FeatureEntry, MilestoneSet, Stage
-from internals.review_models import Approval, Gate, Vote
+from internals.core_models import FeatureEntry, Stage
+from internals.legacy_models import Approval
+from internals.review_models import Gate, Vote
 
 test_app = flask.Flask(__name__)
 
@@ -352,7 +353,7 @@ class FunctionTest(testing_config.CustomTestCase):
     self.assertFalse(detect_intent.is_lgtm_allowed(
         'other@example.com', self.feature_1, approval_defs.ShipApproval))
 
-  @mock.patch('internals.review_models.Approval.get_approvals')
+  @mock.patch('internals.legacy_models.Approval.get_approvals')
   def test_detect_new_thread(self, mock_get_approvals):
     """A thread is new if there are no previous approval values."""
     mock_get_approvals.return_value = []

--- a/internals/legacy_models.py
+++ b/internals/legacy_models.py
@@ -294,3 +294,154 @@ class Feature(DictModel):
 
   # Flag set to avoid migrating data that has already been migrated.
   stages_migrated = ndb.BooleanProperty(default=False)
+
+
+####################################
+###     Legacy review models     ###
+####################################
+class Approval(ndb.Model):
+  """Describes the current state of one approval on a feature."""
+
+  # Not used: PREPARING = 0
+  NA = 1
+  REVIEW_REQUESTED = 2
+  REVIEW_STARTED = 3
+  NEEDS_WORK = 4
+  APPROVED = 5
+  DENIED = 6
+  NO_RESPONSE = 7
+  INTERNAL_REVIEW = 8
+  APPROVAL_VALUES = {
+      # Not used: PREPARING: 'preparing',
+      NA: 'na',
+      REVIEW_REQUESTED: 'review_requested',
+      REVIEW_STARTED: 'review_started',
+      NEEDS_WORK: 'needs_work',
+      APPROVED: 'approved',
+      DENIED: 'denied',
+      NO_RESPONSE: 'no_response',
+      INTERNAL_REVIEW: 'internal_review',
+  }
+
+  FINAL_STATES = [NA, APPROVED, DENIED]
+
+  feature_id = ndb.IntegerProperty(required=True)
+  field_id = ndb.IntegerProperty(required=True)
+  state = ndb.IntegerProperty(required=True)
+  set_on = ndb.DateTimeProperty(required=True)
+  set_by = ndb.StringProperty(required=True)
+
+  @classmethod
+  def get_approvals(
+      cls, feature_id=None, field_id=None, states=None, set_by=None,
+      limit=None) -> list[Approval]:
+    """Return the requested approvals."""
+    query = Approval.query().order(Approval.set_on)
+    if feature_id is not None:
+      query = query.filter(Approval.feature_id == feature_id)
+    if field_id is not None:
+      query = query.filter(Approval.field_id == field_id)
+    if states is not None:
+      query = query.filter(Approval.state.IN(states))
+    if set_by is not None:
+      query = query.filter(Approval.set_by == set_by)
+    # Query with STRONG consistency because ndb defaults to
+    # EVENTUAL consistency and we run this query immediately after
+    # saving the user's change that we want included in the query.
+    approvals = query.fetch(limit, read_consistency=ndb.STRONG)
+    return approvals
+
+  @classmethod
+  def is_valid_state(cls, new_state):
+    """Return true if new_state is valid."""
+    return new_state in cls.APPROVAL_VALUES
+
+  @classmethod
+  def set_approval(cls, feature_id, field_id, new_state, set_by_email):
+    """Add or update an approval value."""
+    if not cls.is_valid_state(new_state):
+      raise ValueError('Invalid approval state')
+
+    now = datetime.datetime.now()
+    existing_list = cls.get_approvals(
+        feature_id=feature_id, field_id=field_id, set_by=set_by_email)
+    if existing_list:
+      existing = existing_list[0]
+      existing.set_on = now
+      existing.state = new_state
+      existing.put()
+      logging.info('existing approval is %r', existing.key.integer_id())
+      return
+
+    new_appr = Approval(
+        feature_id=feature_id, field_id=field_id, state=new_state,
+        set_on=now, set_by=set_by_email)
+    new_appr.put()
+    logging.info('new_appr is %r', new_appr.key.integer_id())
+
+  @classmethod
+  def clear_request(cls, feature_id, field_id):
+    """After the review requirement has been satisfied, remove the request."""
+    review_requests = cls.get_approvals(
+        feature_id=feature_id, field_id=field_id, states=[cls.REVIEW_REQUESTED])
+    for rr in review_requests:
+      rr.key.delete()
+
+    # Note: We keep REVIEW_REQUEST Vote entities.
+
+
+class ApprovalConfig(ndb.Model):
+  """Allows customization of an approval field for one feature."""
+
+  feature_id = ndb.IntegerProperty(required=True)
+  field_id = ndb.IntegerProperty(required=True)
+  owners = ndb.StringProperty(repeated=True)
+  next_action = ndb.DateProperty()
+  additional_review = ndb.BooleanProperty(default=False)
+
+  @classmethod
+  def get_configs(cls, feature_id):
+    """Return approval configs for all approval fields."""
+    query = ApprovalConfig.query(ApprovalConfig.feature_id == feature_id)
+    configs = query.fetch(None)
+    return configs
+
+  @classmethod
+  def set_config(
+      cls, feature_id, field_id, owners, next_action, additional_review):
+    """Add or update an approval config object."""
+    config = ApprovalConfig(feature_id=feature_id, field_id=field_id)
+    for existing in cls.get_configs(feature_id):
+      if existing.field_id == field_id:
+        config = existing
+
+    config.owners = owners or []
+    config.next_action = next_action
+    config.additional_review = additional_review
+    config.put()
+
+
+class Comment(ndb.Model):
+  """A review comment on a feature."""
+  feature_id = ndb.IntegerProperty(required=True)
+  field_id = ndb.IntegerProperty()  # The approval field_id, or general comment.
+  created = ndb.DateTimeProperty(auto_now_add=True)
+  author = ndb.StringProperty()
+  content = ndb.StringProperty()
+  deleted_by = ndb.StringProperty()
+  migrated = ndb.BooleanProperty()
+  # If the user set an approval value, we capture that here so that we can
+  # display a change log.  This could be generalized to a list of separate
+  # Amendment entities, but that complexity is not needed yet.
+  old_approval_state = ndb.IntegerProperty()
+  new_approval_state = ndb.IntegerProperty()
+
+  @classmethod
+  def get_comments(cls, feature_id, field_id=None):
+    """Return review comments for an approval."""
+    query = Comment.query().order(Comment.created)
+    query = query.filter(Comment.feature_id == feature_id)
+    if field_id:
+      query = query.filter(Comment.field_id == field_id)
+    comments = query.fetch(None)
+    return comments

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -23,154 +23,6 @@ from typing import Optional
 from google.cloud import ndb  # type: ignore
 
 
-class Approval(ndb.Model):
-  """Describes the current state of one approval on a feature."""
-
-  # Not used: PREPARING = 0
-  NA = 1
-  REVIEW_REQUESTED = 2
-  REVIEW_STARTED = 3
-  NEEDS_WORK = 4
-  APPROVED = 5
-  DENIED = 6
-  NO_RESPONSE = 7
-  INTERNAL_REVIEW = 8
-  APPROVAL_VALUES = {
-      # Not used: PREPARING: 'preparing',
-      NA: 'na',
-      REVIEW_REQUESTED: 'review_requested',
-      REVIEW_STARTED: 'review_started',
-      NEEDS_WORK: 'needs_work',
-      APPROVED: 'approved',
-      DENIED: 'denied',
-      NO_RESPONSE: 'no_response',
-      INTERNAL_REVIEW: 'internal_review',
-  }
-
-  FINAL_STATES = [NA, APPROVED, DENIED]
-
-  feature_id = ndb.IntegerProperty(required=True)
-  field_id = ndb.IntegerProperty(required=True)
-  state = ndb.IntegerProperty(required=True)
-  set_on = ndb.DateTimeProperty(required=True)
-  set_by = ndb.StringProperty(required=True)
-
-  @classmethod
-  def get_approvals(
-      cls, feature_id=None, field_id=None, states=None, set_by=None,
-      limit=None) -> list[Approval]:
-    """Return the requested approvals."""
-    query = Approval.query().order(Approval.set_on)
-    if feature_id is not None:
-      query = query.filter(Approval.feature_id == feature_id)
-    if field_id is not None:
-      query = query.filter(Approval.field_id == field_id)
-    if states is not None:
-      query = query.filter(Approval.state.IN(states))
-    if set_by is not None:
-      query = query.filter(Approval.set_by == set_by)
-    # Query with STRONG consistency because ndb defaults to
-    # EVENTUAL consistency and we run this query immediately after
-    # saving the user's change that we want included in the query.
-    approvals = query.fetch(limit, read_consistency=ndb.STRONG)
-    return approvals
-
-  @classmethod
-  def is_valid_state(cls, new_state):
-    """Return true if new_state is valid."""
-    return new_state in cls.APPROVAL_VALUES
-
-  @classmethod
-  def set_approval(cls, feature_id, field_id, new_state, set_by_email):
-    """Add or update an approval value."""
-    if not cls.is_valid_state(new_state):
-      raise ValueError('Invalid approval state')
-
-    now = datetime.datetime.now()
-    existing_list = cls.get_approvals(
-        feature_id=feature_id, field_id=field_id, set_by=set_by_email)
-    if existing_list:
-      existing = existing_list[0]
-      existing.set_on = now
-      existing.state = new_state
-      existing.put()
-      logging.info('existing approval is %r', existing.key.integer_id())
-      return
-
-    new_appr = Approval(
-        feature_id=feature_id, field_id=field_id, state=new_state,
-        set_on=now, set_by=set_by_email)
-    new_appr.put()
-    logging.info('new_appr is %r', new_appr.key.integer_id())
-
-  @classmethod
-  def clear_request(cls, feature_id, field_id):
-    """After the review requirement has been satisfied, remove the request."""
-    review_requests = cls.get_approvals(
-        feature_id=feature_id, field_id=field_id, states=[cls.REVIEW_REQUESTED])
-    for rr in review_requests:
-      rr.key.delete()
-
-    # Note: We keep REVIEW_REQUEST Vote entities.
-
-
-class ApprovalConfig(ndb.Model):
-  """Allows customization of an approval field for one feature."""
-
-  feature_id = ndb.IntegerProperty(required=True)
-  field_id = ndb.IntegerProperty(required=True)
-  owners = ndb.StringProperty(repeated=True)
-  next_action = ndb.DateProperty()
-  additional_review = ndb.BooleanProperty(default=False)
-
-  @classmethod
-  def get_configs(cls, feature_id):
-    """Return approval configs for all approval fields."""
-    query = ApprovalConfig.query(ApprovalConfig.feature_id == feature_id)
-    configs = query.fetch(None)
-    return configs
-
-  @classmethod
-  def set_config(
-      cls, feature_id, field_id, owners, next_action, additional_review):
-    """Add or update an approval config object."""
-    config = ApprovalConfig(feature_id=feature_id, field_id=field_id)
-    for existing in cls.get_configs(feature_id):
-      if existing.field_id == field_id:
-        config = existing
-
-    config.owners = owners or []
-    config.next_action = next_action
-    config.additional_review = additional_review
-    config.put()
-
-
-class Comment(ndb.Model):
-  """A review comment on a feature."""
-  feature_id = ndb.IntegerProperty(required=True)
-  field_id = ndb.IntegerProperty()  # The approval field_id, or general comment.
-  created = ndb.DateTimeProperty(auto_now_add=True)
-  author = ndb.StringProperty()
-  content = ndb.StringProperty()
-  deleted_by = ndb.StringProperty()
-  migrated = ndb.BooleanProperty()
-  # If the user set an approval value, we capture that here so that we can
-  # display a change log.  This could be generalized to a list of separate
-  # Amendment entities, but that complexity is not needed yet.
-  old_approval_state = ndb.IntegerProperty()
-  new_approval_state = ndb.IntegerProperty()
-
-  @classmethod
-  def get_comments(cls, feature_id, field_id=None):
-    """Return review comments for an approval."""
-    query = Comment.query().order(Comment.created)
-    query = query.filter(Comment.feature_id == feature_id)
-    if field_id:
-      query = query.filter(Comment.field_id == field_id)
-    comments = query.fetch(None)
-    return comments
-
-
 class OwnersFile(ndb.Model):
   """Describes the properties to store raw API_OWNERS content."""
   url = ndb.StringProperty(required=True)
@@ -203,7 +55,7 @@ class OwnersFile(ndb.Model):
     return owners_file.raw_content
 
 
-class Vote(ndb.Model):  # copy from Approval
+class Vote(ndb.Model):
   """One approver's vote on what the state of a gate should be."""
 
   # Not used: PREPARING = 0
@@ -267,7 +119,7 @@ class Vote(ndb.Model):  # copy from Approval
   # Note: set_vote() moved to approval_defs.py
 
 
-class Gate(ndb.Model):  # copy from ApprovalConfig
+class Gate(ndb.Model):
   """Gates regulate the completion of a stage."""
 
   PREPARING = 0

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -16,8 +16,8 @@ import testing_config  # Must be imported before the module under test.
 
 import datetime
 
-from internals.legacy_models import Feature
-from internals.review_models import Activity, Approval, Gate, OwnersFile, Vote
+from internals.legacy_models import Approval, Feature 
+from internals.review_models import Activity, Gate, OwnersFile, Vote
 
 
 class ApprovalTest(testing_config.CustomTestCase):

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -18,8 +18,8 @@ from google.cloud import ndb  # type: ignore
 from framework.basehandlers import FlaskHandler
 from internals import approval_defs, stage_helpers
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
-from internals.legacy_models import Feature
-from internals.review_models import Activity, Approval, Comment, Gate, Vote
+from internals.legacy_models import Feature, Approval, Comment
+from internals.review_models import Activity, Gate, Vote
 from internals.core_enums import *
 
 # Gate type enums (declared in approval_defs.py)

--- a/internals/schema_migration_test.py
+++ b/internals/schema_migration_test.py
@@ -19,8 +19,8 @@ from datetime import datetime
 
 from internals.core_enums import *
 from internals.core_models import FeatureEntry, Stage
-from internals.legacy_models import Feature
-from internals.review_models import Activity, Approval, Comment, Gate, Vote
+from internals.legacy_models import Feature, Approval, Comment
+from internals.review_models import Activity, Gate, Vote
 from internals import schema_migration
 
 

--- a/internals/search.py
+++ b/internals/search.py
@@ -22,13 +22,12 @@ from google.cloud.ndb import Key
 from google.cloud.ndb.tasklets import Future  # for type checking only
 
 from framework import users
-from framework import utils
+from internals.core_models import FeatureEntry
+from internals.review_models import Gate
 from internals import approval_defs
 from internals import core_enums
-from internals import core_models
 from internals import feature_helpers
 from internals import notifier
-from internals import review_models
 from internals import search_queries
 from internals import search_fulltext
 
@@ -45,9 +44,9 @@ def process_pending_approval_me_query() -> list[int]:
   approvable_gate_types = approval_defs.fields_approvable_by(user)
   if not approvable_gate_types:
     return []
-  query = review_models.Gate.query(
-      review_models.Gate.state.IN(review_models.Gate.PENDING_STATES),
-      review_models.Gate.gate_type.IN(approvable_gate_types))
+  query = Gate.query(
+      Gate.state.IN(Gate.PENDING_STATES),
+      Gate.gate_type.IN(approvable_gate_types))
   future_feature_ids = query.fetch_async(projection=['feature_id'])
   return future_feature_ids
 
@@ -64,8 +63,8 @@ def process_starred_me_query() -> list[int]:
 
 def process_recent_reviews_query() -> list[int]:
   """Return features that were reviewed recently."""
-  query = review_models.Gate.query(
-      review_models.Gate.state.IN(review_models.Gate.FINAL_STATES))
+  query = Gate.query(
+      Gate.state.IN(Gate.FINAL_STATES))
   future_feature_ids = query.fetch_async(projection=['feature_id'], limit=40)
   return future_feature_ids
 
@@ -355,6 +354,6 @@ def process_negation_operations(feature_id_future_ops):
 
 def fetch_all_feature_ids_set():
   """Fetch all FeatureEntry ids. """
-  all_feature_keys = core_models.FeatureEntry.query().fetch(keys_only=True)
+  all_feature_keys = FeatureEntry.query().fetch(keys_only=True)
   feature_ids_set = set(key.integer_id() for key in all_feature_keys)
   return feature_ids_set

--- a/internals/search_queries.py
+++ b/internals/search_queries.py
@@ -25,7 +25,7 @@ from framework import users
 from framework import utils
 from internals import core_enums
 from internals.core_models import FeatureEntry, Stage
-from internals import review_models
+from internals.review_models import Gate
 
 
 def single_field_query_async(
@@ -176,17 +176,17 @@ def _sorted_by_joined_model(
 def sorted_by_pending_request_date(descending: bool) -> list[int]:
   """Return feature_ids of pending approvals sorted by request date."""
   return _sorted_by_joined_model(
-      review_models.Gate,
-      review_models.Gate.state.IN(review_models.Gate.PENDING_STATES),
-      descending, review_models.Gate.requested_on)
+      Gate,
+      Gate.state.IN(Gate.PENDING_STATES),
+      descending, Gate.requested_on)
 
 
 def sorted_by_review_date(descending: bool) -> list[int]:
   """Return feature_ids of reviewed approvals sorted by last review."""
   return _sorted_by_joined_model(
-      review_models.Gate,
-      review_models.Gate.state.IN(review_models.Gate.FINAL_STATES),
-      descending, review_models.Gate.requested_on)
+      Gate,
+      Gate.state.IN(Gate.FINAL_STATES),
+      descending, Gate.requested_on)
 
 
 QUERIABLE_FIELDS: dict[str, Property] = {

--- a/internals/search_queries_test.py
+++ b/internals/search_queries_test.py
@@ -18,8 +18,8 @@ import datetime
 from unittest import mock
 
 from internals import core_enums
-from internals import core_models
-from internals import review_models
+from internals.core_models import FeatureEntry, MilestoneSet, Stage
+from internals.review_models import Gate, Vote
 from internals import search
 from internals import search_queries
 
@@ -27,7 +27,7 @@ from internals import search_queries
 class SearchFeaturesTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = core_models.FeatureEntry(
+    self.feature_1 = FeatureEntry(
         name='feature a', summary='sum',
         category=1, impl_status_chrome=3)
     self.feature_1.owner_emails = ['owner@example.com']
@@ -36,68 +36,68 @@ class SearchFeaturesTest(testing_config.CustomTestCase):
     self.feature_1.put()
     self.feature_1_id = self.feature_1.key.integer_id()
 
-    self.stage_1_ship = core_models.Stage(
+    self.stage_1_ship = Stage(
         feature_id=self.feature_1_id,
         stage_type=core_enums.STAGE_BLINK_SHIPPING,
-        milestones=core_models.MilestoneSet(desktop_first=99))
+        milestones=MilestoneSet(desktop_first=99))
     self.stage_1_ship.put()
 
-    self.feature_2 = core_models.FeatureEntry(
+    self.feature_2 = FeatureEntry(
         name='feature b', summary='sum', owner_emails=['owner@example.com'],
         category=1, impl_status_chrome=3)
     self.feature_2.put()
     self.feature_2_id = self.feature_2.key.integer_id()
 
-    self.feature_3 = core_models.FeatureEntry(
+    self.feature_3 = FeatureEntry(
         name='feature c', summary='sum', owner_emails=['random@example.com'],
         category=1, impl_status_chrome=4)
     self.feature_3.put()
     self.feature_3_id = self.feature_3.key.integer_id()
 
-    self.gate_1 = review_models.Gate(
+    self.gate_1 = Gate(
         feature_id=self.feature_1_id, stage_id=1,
-        gate_type=core_models.GATE_API_PROTOTYPE,
-        state=review_models.Vote.APPROVED,
+        gate_type=core_enums.GATE_API_PROTOTYPE,
+        state=Vote.APPROVED,
         requested_on=datetime.datetime(2022, 7, 1))
     self.gate_1.put()
     self.gate_1_id = self.gate_1.key.integer_id()
 
-    self.vote_1_1 = review_models.Vote(
-        feature_id=self.feature_1_id, gate_type=core_models.GATE_API_PROTOTYPE,
+    self.vote_1_1 = Vote(
+        feature_id=self.feature_1_id, gate_type=core_enums.GATE_API_PROTOTYPE,
         gate_id=self.gate_1_id,
-        state=review_models.Vote.REVIEW_REQUESTED,
+        state=Vote.REVIEW_REQUESTED,
         set_on=datetime.datetime(2022, 7, 1),
         set_by='feature_owner@example.com')
     self.vote_1_1.put()
 
-    self.vote_1_2 = review_models.Vote(
-        feature_id=self.feature_1_id, gate_type=core_models.GATE_API_PROTOTYPE,
+    self.vote_1_2 = Vote(
+        feature_id=self.feature_1_id, gate_type=core_enums.GATE_API_PROTOTYPE,
         gate_id=self.gate_1_id,
-        state=review_models.Vote.APPROVED,
+        state=Vote.APPROVED,
         set_on=datetime.datetime(2022, 7, 2),
         set_by='reviewer@example.com')
     self.vote_1_2.put()
 
-    self.gate_2 = review_models.Gate(
+    self.gate_2 = Gate(
         feature_id=self.feature_2_id, stage_id=1,
         gate_type=core_enums.GATE_API_SHIP,
-        state=review_models.Vote.REVIEW_REQUESTED,
+        state=Vote.REVIEW_REQUESTED,
         requested_on=datetime.datetime(2022, 8, 1))
     self.gate_2.put()
     self.gate_2_id = self.gate_2.key.integer_id()
 
-    self.vote_2_1 = review_models.Vote(
+    self.vote_2_1 = Vote(
         feature_id=self.feature_2_id, gate_type=core_enums.GATE_API_SHIP,
         gate_id=self.gate_2_id,
-        state=review_models.Vote.REVIEW_REQUESTED,
+        state=Vote.REVIEW_REQUESTED,
         set_on=datetime.datetime(2022, 8, 1),
         set_by='feature_owner@example.com')
     self.vote_2_1.put()
 
-    self.vote_2_2 = review_models.Vote(
+    self.vote_2_2 = Vote(
         feature_id=self.feature_2_id, gate_type=core_enums.GATE_API_SHIP,
         gate_id=self.gate_2_id,
-        state=review_models.Vote.APPROVED,
+        state=Vote.APPROVED,
         set_on=datetime.datetime(2022, 8, 2),
         set_by='reviewer@example.com')
     self.vote_2_2.put()
@@ -107,9 +107,9 @@ class SearchFeaturesTest(testing_config.CustomTestCase):
     self.feature_2.key.delete()
     self.feature_3.key.delete()
     self.stage_1_ship.key.delete()
-    for gate in review_models.Gate.query():
+    for gate in Gate.query():
       gate.key.delete()
-    for vote in review_models.Vote.query():
+    for vote in Vote.query():
       vote.key.delete()
 
   def test_single_field_query_async__normal(self):

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -20,8 +20,8 @@ from unittest import mock
 from internals import core_enums
 from internals.core_models import FeatureEntry
 from internals.legacy_models import Feature
+from internals.review_models import Gate, Vote
 from internals import notifier
-from internals import review_models
 from internals import search
 
 
@@ -162,7 +162,7 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     self.featureentry_2.key.delete()
     self.featureentry_3.key.delete()
     self.featureentry_4.key.delete()
-    for gate in review_models.Gate.query():
+    for gate in Gate.query():
       gate.key.delete()
 
   @mock.patch('internals.approval_defs.fields_approvable_by')
@@ -185,9 +185,9 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     testing_config.sign_in('visitor@example.com', 111)
     now = datetime.datetime.now()
     mock_approvable_by.return_value = set()
-    review_models.Gate(
+    Gate(
         feature_id=self.feature_1.key.integer_id(), stage_id=1,
-        gate_type=1, state=review_models.Vote.REVIEW_REQUESTED,
+        gate_type=1, state=Vote.REVIEW_REQUESTED,
         requested_on=now).put()
 
     future = search.process_pending_approval_me_query()
@@ -203,13 +203,13 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     time_1 = datetime.datetime.now() - datetime.timedelta(days=4)
     time_2 = datetime.datetime.now()
     mock_approvable_by.return_value = set([1, 2, 3])
-    review_models.Gate(
+    Gate(
         feature_id=self.feature_2.key.integer_id(), stage_id=1,
-        gate_type=1, state=review_models.Vote.REVIEW_REQUESTED,
+        gate_type=1, state=Vote.REVIEW_REQUESTED,
         requested_on=time_1).put()
-    review_models.Gate(
+    Gate(
         feature_id=self.feature_1.key.integer_id(), stage_id=1,
-        gate_type=1, state=review_models.Vote.REVIEW_REQUESTED,
+        gate_type=1, state=Vote.REVIEW_REQUESTED,
         requested_on=time_2).put()
 
     future = search.process_pending_approval_me_query()
@@ -229,13 +229,13 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     time_1 = datetime.datetime.now() - datetime.timedelta(days=4)
     time_2 = datetime.datetime.now()
     mock_approvable_by.return_value = set([1, 2, 3])
-    review_models.Gate(
+    Gate(
         feature_id=self.feature_2.key.integer_id(), stage_id=1,
-        gate_type=1, state=review_models.Vote.REVIEW_REQUESTED,
+        gate_type=1, state=Vote.REVIEW_REQUESTED,
         requested_on=time_1).put()
-    review_models.Gate(
+    Gate(
         feature_id=self.feature_1.key.integer_id(), stage_id=1,
-        gate_type=1, state=review_models.Vote.APPROVED,
+        gate_type=1, state=Vote.APPROVED,
         requested_on=time_2).put()
 
     future = search.process_pending_approval_me_query()
@@ -283,13 +283,13 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     mock_approvable_by.return_value = set({1, 2, 3})
     time_1 = datetime.datetime.now() - datetime.timedelta(days=4)
     time_2 = datetime.datetime.now()
-    review_models.Gate(
+    Gate(
         feature_id=self.feature_1.key.integer_id(), stage_id=1,
-        gate_type=1, state=review_models.Vote.NA,
+        gate_type=1, state=Vote.NA,
         requested_on=time_2).put()
-    review_models.Gate(
+    Gate(
         feature_id=self.feature_2.key.integer_id(), stage_id=1,
-        gate_type=1, state=review_models.Vote.APPROVED,
+        gate_type=1, state=Vote.APPROVED,
         requested_on=time_1).put()
 
     future = search.process_recent_reviews_query()


### PR DESCRIPTION
Part of https://github.com/GoogleChrome/chromium-dashboard/issues/2797

This change moves legacy review models into a new legacy_models.py and updates all references of the legacy review models to use this location. This new file will soon house all of the old schema models.