### PR TITLE
Fix hash link scrolling and focus for guide pages

### DIFF
--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -138,6 +138,17 @@ class ChromedashApp extends LitElement {
   setUpRoutes() {
     page.strict(true); // Be precise about trailing slashes in routes.
 
+    const scrollIfHash = (ctx) => {
+      // If current page is ctx.path and only the hash changes, don't create a new element
+      // but instead just scroll to the element identified by the hash.
+      if (this.currentPage == ctx.path && ctx.hash) {
+        if (window.scrollToElement) {
+          window.scrollToElement(`#${ctx.hash}`);
+        }
+        return true;
+      }
+    };
+
     // SPA routing rules.  Note that rules are considered in order.
     // And :var can match any string (including a slash) if there is no slash after it.
     page('/', () => page.redirect('/roadmap'));
@@ -198,13 +209,7 @@ class ChromedashApp extends LitElement {
       this.hideSidebar();
     });
     page('/guide/editall/:featureId(\\d+)', (ctx) => {
-      // if already on this page and only the hash changes, don't create a new element
-      if (this.currentPage == ctx.path && ctx.hash) {
-        if (window.jumpToLink) {
-          window.jumpToLink(`#${ctx.hash}`);
-        }
-        return;
-      }
+      if (scrollIfHash(ctx)) return;
       this.pageComponent = document.createElement('chromedash-guide-editall-page');
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.appTitle = this.appTitle;
@@ -219,20 +224,24 @@ class ChromedashApp extends LitElement {
       this.hideSidebar();
     });
     page('/guide/stage/:featureId(\\d+)/:intentStage(\\d+)', (ctx) => {
+      if (scrollIfHash(ctx)) return;
       this.pageComponent = document.createElement('chromedash-guide-stage-page');
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.intentStage = parseInt(ctx.params.intentStage);
       this.pageComponent.nextPage = this.currentPage;
       this.pageComponent.appTitle = this.appTitle;
+      this.currentPage = ctx.path;
       this.hideSidebar();
     });
     page('/guide/stage/:featureId(\\d+)/:intentStage(\\d+)/:stageId(\\d+)', (ctx) => {
+      if (scrollIfHash(ctx)) return;
       this.pageComponent = document.createElement('chromedash-guide-stage-page');
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.stageId = parseInt(ctx.params.stageId);
       this.pageComponent.intentStage = parseInt(ctx.params.intentStage);
       this.pageComponent.nextPage = this.currentPage;
       this.pageComponent.appTitle = this.appTitle;
+      this.currentPage = ctx.path;
       this.hideSidebar();
     });
     page('/guide/stage/:featureId(\\d+)/metadata', (ctx) => {

--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -198,10 +198,18 @@ class ChromedashApp extends LitElement {
       this.hideSidebar();
     });
     page('/guide/editall/:featureId(\\d+)', (ctx) => {
+      // if already on this page and only the hash changes, don't create a new element
+      if (this.currentPage == ctx.path && ctx.hash) {
+        if (window.jumpToLink) {
+          window.jumpToLink(`#${ctx.hash}`);
+        }
+        return;
+      }
       this.pageComponent = document.createElement('chromedash-guide-editall-page');
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.appTitle = this.appTitle;
       this.pageComponent.nextPage = this.currentPage;
+      this.currentPage = ctx.path;
       this.hideSidebar();
     });
     page('/guide/verify_accuracy/:featureId(\\d+)', (ctx) => {

--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -191,17 +191,22 @@ class ChromedashApp extends LitElement {
       }
     });
     page('/guide/new', () => {
+      if (scrollIfHash(ctx)) return;
       this.pageComponent = document.createElement('chromedash-guide-new-page');
       this.pageComponent.userEmail = this.user.email;
+      this.currentPage = ctx.path;
       this.hideSidebar();
     });
     page('/guide/enterprise/new', () => {
+      if (scrollIfHash(ctx)) return;
       this.pageComponent = document.createElement('chromedash-guide-new-page');
       this.pageComponent.userEmail = this.user.email;
       this.pageComponent.isEnterpriseFeature = true;
+      this.currentPage = ctx.path;
       this.hideSidebar();
     });
     page('/guide/edit/:featureId(\\d+)', (ctx) => {
+      if (scrollIfHash(ctx)) return;
       this.pageComponent = document.createElement('chromedash-guide-edit-page');
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.appTitle = this.appTitle;
@@ -245,10 +250,12 @@ class ChromedashApp extends LitElement {
       this.hideSidebar();
     });
     page('/guide/stage/:featureId(\\d+)/metadata', (ctx) => {
+      if (scrollIfHash(ctx)) return;
       this.pageComponent = document.createElement('chromedash-guide-metadata-page');
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.nextPage = this.currentPage;
       this.pageComponent.appTitle = this.appTitle;
+      this.currentPage = ctx.path;
       this.hideSidebar();
     });
     page('/settings', (ctx) => {

--- a/client-src/elements/chromedash-guide-editall-page.js
+++ b/client-src/elements/chromedash-guide-editall-page.js
@@ -1,6 +1,6 @@
 import {LitElement, css, html, nothing} from 'lit';
 import {ref} from 'lit/directives/ref.js';
-import {showToastMessage, flattenSections} from './utils.js';
+import {showToastMessage, flattenSections, setupScrollToHash} from './utils.js';
 import './chromedash-form-table';
 import './chromedash-form-field';
 import {
@@ -74,20 +74,12 @@ export class ChromedashGuideEditallPage extends LitElement {
     if (!el) return;
     await el.updateComplete;
 
-    window.addEventListener('beforeunload', (event) => {
-      // Having an event listener for beforeunload causes the browser to
-      // check for unsaved changes. But the event handler seems to be otherwise ignored.
-
-      event.preventDefault();
-      return event.returnValue = '';
-    });
-
     const hiddenTokenField = this.shadowRoot.querySelector('input[name=token]');
     hiddenTokenField.form.addEventListener('submit', (event) => {
       this.handleFormSubmit(event, hiddenTokenField);
     });
 
-    this.setupScrollToHash();
+    setupScrollToHash(this);
   }
 
   handleFormSubmit(event, hiddenTokenField) {
@@ -102,44 +94,6 @@ export class ChromedashGuideEditallPage extends LitElement {
 
   handleCancelClick() {
     window.location.href = `/guide/edit/${this.featureId}`;
-  }
-
-  setupScrollToHash() {
-    const scrollToElement = (hash) => {
-      if (hash) {
-        const el = this.shadowRoot.querySelector(hash);
-        if (el) {
-          // Find the header element for the form field.
-          const headerSelector = `chromedash-form-field[name="${el.name}"] tr th b`;
-          const header = this.shadowRoot.querySelector(headerSelector);
-          if (header) {
-            header.scrollIntoView({
-              block: 'start', inline: 'nearest', behavior: 'smooth',
-            });
-            // Focus on the corresponding form field.
-            if (el.input) {
-              // el.focus() calls el.input.focus();
-              el.focus();
-            } else {
-              // Not ready yet, so try after a timeout.  TODO: Avoid the timeout.
-              setTimeout(() => {
-                el.focus();
-              }, 0);
-            }
-          }
-        }
-      }
-    };
-
-    if (location.hash) {
-      const hash = decodeURIComponent(location.hash);
-      scrollToElement(hash);
-    }
-
-    // Add global function to jump to form field.
-    window.scrollToElement = (hash) => {
-      scrollToElement(hash);
-    };
   }
 
   renderSkeletons() {

--- a/client-src/elements/chromedash-guide-metadata-page.js
+++ b/client-src/elements/chromedash-guide-metadata-page.js
@@ -1,6 +1,6 @@
 import {LitElement, css, html} from 'lit';
 import {ref} from 'lit/directives/ref.js';
-import {showToastMessage} from './utils.js';
+import {showToastMessage, setupScrollToHash} from './utils.js';
 import './chromedash-form-table';
 import './chromedash-form-field';
 import {
@@ -76,7 +76,7 @@ export class ChromedashGuideMetadataPage extends LitElement {
     });
 
     this.addMiscEventListeners();
-    this.scrollToPosition();
+    setupScrollToHash(this);
   }
 
   handleFormSubmit(event, hiddenTokenField) {
@@ -95,16 +95,6 @@ export class ChromedashGuideMetadataPage extends LitElement {
       fields[i].addEventListener('input', (e) => {
         e.target.classList.add('interacted');
       });
-    }
-  }
-
-  scrollToPosition() {
-    if (location.hash) {
-      const hash = decodeURIComponent(location.hash);
-      if (hash) {
-        const el = this.shadowRoot.querySelector(hash);
-        el.scrollIntoView(true, {behavior: 'smooth'});
-      }
     }
   }
 

--- a/client-src/elements/chromedash-guide-new-page.js
+++ b/client-src/elements/chromedash-guide-new-page.js
@@ -8,6 +8,7 @@ import {
 } from './form-definition';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 import {FORM_STYLES} from '../sass/forms-css.js';
+import {setupScrollToHash} from './utils';
 
 
 export class ChromedashGuideNewPage extends LitElement {
@@ -49,7 +50,7 @@ export class ChromedashGuideNewPage extends LitElement {
 
   /* Add the form's event listener after Shoelace event listeners are attached
    * see more at https://github.com/GoogleChrome/chromium-dashboard/issues/2014 */
-  async registerFormSubmitHandler(el) {
+  async registerHandlers(el) {
     if (!el) return;
 
     await el.updateComplete;
@@ -57,6 +58,8 @@ export class ChromedashGuideNewPage extends LitElement {
     hiddenTokenField.form.addEventListener('submit', (event) => {
       this.handleFormSubmit(event, hiddenTokenField);
     });
+
+    setupScrollToHash(this);
   }
 
   handleFormSubmit(event, hiddenTokenField) {
@@ -91,7 +94,7 @@ export class ChromedashGuideNewPage extends LitElement {
       <section id="stage_form">
         <form name="overview_form" method="POST" action=${postAction}>
           <input type="hidden" name="token">
-          <chromedash-form-table ${ref(this.registerFormSubmitHandler)}>
+          <chromedash-form-table ${ref(this.registerHandlers)}>
 
             <span>
               Please see the

--- a/client-src/elements/chromedash-guide-stage-page.js
+++ b/client-src/elements/chromedash-guide-stage-page.js
@@ -1,6 +1,6 @@
 import {LitElement, css, html, nothing} from 'lit';
 import {ref} from 'lit/directives/ref.js';
-import {showToastMessage} from './utils.js';
+import {showToastMessage, setupScrollToHash} from './utils.js';
 import './chromedash-form-table';
 import './chromedash-form-field';
 import {
@@ -94,13 +94,6 @@ export class ChromedashGuideStagePage extends LitElement {
   async registerHandlers(el) {
     if (!el) return;
 
-    window.addEventListener('beforeunload', (event) => {
-      // Having an event listener for beforeunload causes the browser to
-      // check for unsaved changes. But the event handler seems to be otherwise ignored.
-      event.preventDefault();
-      return event.returnValue = '';
-    });
-
     /* Add the form's event listener after Shoelace event listeners are attached
     * see more at https://github.com/GoogleChrome/chromium-dashboard/issues/2014 */
     await el.updateComplete;
@@ -110,7 +103,7 @@ export class ChromedashGuideStagePage extends LitElement {
     });
 
     this.addMiscEventListeners();
-    this.setupScrollToHash();
+    setupScrollToHash(this);
   }
 
   handleFormSubmit(event, hiddenTokenField) {
@@ -162,44 +155,6 @@ export class ChromedashGuideStagePage extends LitElement {
         });
       }
     }
-  }
-
-  setupScrollToHash() {
-    const scrollToElement = (hash) => {
-      if (hash) {
-        const el = this.shadowRoot.querySelector(hash);
-        if (el) {
-          // Find the header element for the form field.
-          const headerSelector = `chromedash-form-field[name="${el.name}"] tr th b`;
-          const header = this.shadowRoot.querySelector(headerSelector);
-          if (header) {
-            header.scrollIntoView({
-              block: 'start', inline: 'nearest', behavior: 'smooth',
-            });
-            // Focus on the corresponding form field.
-            if (el.input) {
-              // el.focus() calls el.input.focus();
-              el.focus();
-            } else {
-              // Not ready yet, so try after a timeout.  TODO: Avoid the timeout.
-              setTimeout(() => {
-                el.focus();
-              }, 0);
-            }
-          }
-        }
-      }
-    };
-
-    if (location.hash) {
-      const hash = decodeURIComponent(location.hash);
-      scrollToElement(hash);
-    }
-
-    // Add global function to jump to form field.
-    window.scrollToElement = (hash) => {
-      scrollToElement(hash);
-    };
   }
 
   handleCancelClick() {

--- a/client-src/elements/chromedash-guide-stage-page.js
+++ b/client-src/elements/chromedash-guide-stage-page.js
@@ -94,6 +94,13 @@ export class ChromedashGuideStagePage extends LitElement {
   async registerHandlers(el) {
     if (!el) return;
 
+    window.addEventListener('beforeunload', (event) => {
+      // Having an event listener for beforeunload causes the browser to
+      // check for unsaved changes. But the event handler seems to be otherwise ignored.
+      event.preventDefault();
+      return event.returnValue = '';
+    });
+
     /* Add the form's event listener after Shoelace event listeners are attached
     * see more at https://github.com/GoogleChrome/chromium-dashboard/issues/2014 */
     await el.updateComplete;
@@ -103,7 +110,7 @@ export class ChromedashGuideStagePage extends LitElement {
     });
 
     this.addMiscEventListeners();
-    this.scrollToPosition();
+    this.setupScrollToHash();
   }
 
   handleFormSubmit(event, hiddenTokenField) {
@@ -157,16 +164,42 @@ export class ChromedashGuideStagePage extends LitElement {
     }
   }
 
-  scrollToPosition() {
-    if (location.hash) {
-      const hash = decodeURIComponent(location.hash);
+  setupScrollToHash() {
+    const scrollToElement = (hash) => {
       if (hash) {
         const el = this.shadowRoot.querySelector(hash);
         if (el) {
-          this.shadowRoot.querySelector(`chromedash-form-field[name="${el.name}"] tr th b`).scrollIntoView(true, {behavior: 'smooth'});
+          // Find the header element for the form field.
+          const headerSelector = `chromedash-form-field[name="${el.name}"] tr th b`;
+          const header = this.shadowRoot.querySelector(headerSelector);
+          if (header) {
+            header.scrollIntoView({
+              block: 'start', inline: 'nearest', behavior: 'smooth',
+            });
+            // Focus on the corresponding form field.
+            if (el.input) {
+              // el.focus() calls el.input.focus();
+              el.focus();
+            } else {
+              // Not ready yet, so try after a timeout.  TODO: Avoid the timeout.
+              setTimeout(() => {
+                el.focus();
+              }, 0);
+            }
+          }
         }
       }
+    };
+
+    if (location.hash) {
+      const hash = decodeURIComponent(location.hash);
+      scrollToElement(hash);
     }
+
+    // Add global function to jump to form field.
+    window.scrollToElement = (hash) => {
+      scrollToElement(hash);
+    };
   }
 
   handleCancelClick() {

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -356,7 +356,8 @@ export const ALL_FIELDS = {
         Link to the first public proposal to create this feature.`,
     extra_help: html`
         If there isn't another obvious place to propose your feature, create a
-        <a href="https://github.com/WICG/proposals#what-does-a-proposal-look-like">
+        <a target="_blank"
+           href="https://github.com/WICG/proposals#what-does-a-proposal-look-like">
         WICG proposal</a>.
         You can use your proposal document to help you socialize the problem with other vendors
         and developers.`,
@@ -375,7 +376,8 @@ export const ALL_FIELDS = {
         standards bodies, or other interested parties.`,
     extra_help: html`
         <p>
-        See the TAG guide to writing <a href="https://tag.w3.org/explainers/">Explainers</a>
+        See the TAG guide to writing <a target="_blank"
+           href="https://tag.w3.org/explainers/">Explainers</a>
         for several examples of good explainers and tips for effective explainers.
         </p>
         <p>
@@ -390,7 +392,8 @@ export const ALL_FIELDS = {
         can help you.
         </p>
         <p>
-        If you want help, ask for a <a href="https://sites.google.com/a/chromium.org/dev/blink/spec-mentors">specification mentor</a>.
+        If you want help, ask for a <a target="_blank"
+           href="https://sites.google.com/a/chromium.org/dev/blink/spec-mentors">specification mentor</a>.
         </p>`,
   },
 
@@ -950,7 +953,8 @@ export const ALL_FIELDS = {
     label: 'Finch experiment',
     help_text: html`
       If your feature will roll out gradually via a
-      <a href="http://go/finch" targe="_blank">Finch experiment</a>,
+      <a target="_blank"
+           href="http://go/finch">Finch experiment</a>,
       link to it here.`,
   },
 
@@ -1031,16 +1035,20 @@ export const ALL_FIELDS = {
     required: false,
     label: 'Web Platform Tests Description',
     help_text: html`
-      Please link to the <a href="https://wpt.fyi/results">results on
+      Please link to the <a target="_blank"
+           href="https://wpt.fyi/results">results on
       wpt.fyi</a>. If any part of the feature is not tested by
       web-platform-tests, please include links to issues, e.g. a
       web-platform-tests issue with the "infra" label explaining why a
       certain thing cannot be tested
-      (<a href="https://github.com/w3c/web-platform-tests/issues/3867">example</a>),
+      (<a target="_blank"
+           href="https://github.com/w3c/web-platform-tests/issues/3867">example</a>),
       a spec issue for some change that would make it possible to test.
-      (<a href="https://github.com/whatwg/fullscreen/issues/70">example</a>),
+      (<a target="_blank"
+           href="https://github.com/whatwg/fullscreen/issues/70">example</a>),
       or a Chromium issue to upstream some existing tests
-      (<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=695486">example</a>).`,
+      (<a target="_blank"
+           href="https://bugs.chromium.org/p/chromium/issues/detail?id=695486">example</a>).`,
   },
 
   'sample_links': {

--- a/client-src/elements/utils.js
+++ b/client-src/elements/utils.js
@@ -62,3 +62,42 @@ export function findFirstFeatureStage(intentStage, currentStage, fe) {
 export function flattenSections(stage) {
   return stage.sections.reduce((combined, section) => [...combined, ...section.fields], []);
 }
+
+/* Set up scrolling to a hash url (e.g. #id_explainer_links). */
+export function setupScrollToHash(pageElement) {
+  const scrollToElement = (hash) => {
+    if (hash) {
+      const el = pageElement.shadowRoot.querySelector(hash);
+      if (el) {
+        // Find the form field element.
+        const fieldRowSelector = `chromedash-form-field[name="${el.name}"] tr + tr`;
+        const fieldRow = pageElement.shadowRoot.querySelector(fieldRowSelector);
+        if (fieldRow) {
+          if (el.input) {
+            // el.focus() calls el.input.focus();
+            el.focus();
+          } else {
+            // Not ready yet, so try after delay.  TODO: Avoid the timeout.
+            setTimeout(() => {
+              el.focus();
+            }, 100);
+          }
+          fieldRow.scrollIntoView({
+            block: 'center', behavior: 'smooth',
+          });
+        }
+      }
+    }
+  };
+
+  // Add global function to jump to form field.
+  window.scrollToElement = (hash) => {
+    scrollToElement(hash);
+  };
+
+  // Check now as well, used when first rendering a page.
+  if (location.hash) {
+    const hash = decodeURIComponent(location.hash);
+    scrollToElement(hash);
+  }
+}

--- a/developer-documentation.md
+++ b/developer-documentation.md
@@ -22,12 +22,12 @@ HISTORY:-
 ## Front end
 
 - Our client side is implemented in [Lit](https://lit.dev).
-- It is largely a SPA (single-page application) with routing done via `page.js`.
+- It is largely a SPA (single-page application) with routing done via `page.js` (see [visionmedia/page.js: Micro client-side router inspired by the Express router](http://github.copm/visionmedia/page.js)), configured in `setUpRoutes` of `chromedash-app.js`.
 - It communicates with the server via code in `cs-client.js`.
 - We use [Shoelace widgets](https://shoelace.style).
 
 
-### Main site page renderring
+### Main site page rendering
 
 All the pages are rendered in a combination of Jinja2 template (`/templates`) and front-end components (`/client-src/elements`).
 


### PR DESCRIPTION
This PR fixes the problem described in #2584 by adding a general global scrollIfHash function to utils.js.  The chromedash-app.js page.js configuration checks if scrolling should be done instead of a page refresh.  This is done for the  four types of pages that have help_text content: guide-editall, -metadata, -new, and -stage.

This PR also focuses on the form field that is being scrolled to.  So far, the assumption is that the #hash goes to a form field, but the hash text must be of the form "id_<form-field-name>".

To do the scrolling with smooth animation in combination with focusing on the form field, it is essential that the focus is done first, otherwise, as soon as focus() is called, it interrupts the scrolling animation, which will possibly leave the form field not scrolled into view.

This PR also fixes several links in help text that did not include target="_blank".   