### PR TITLE
Add adoption fields to intent template.

### DIFF
--- a/pages/testdata/intentpreview_test/test_html_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_rendering.html
@@ -265,6 +265,12 @@ False
 
 
 
+
+
+
+
+
+
 <br><br><h4>Estimated milestones</h4>
 
 

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -210,6 +210,21 @@
   {{feature.measurement|urlize}}
 {% endif %}
 
+{% if feature.availability_expectation %}
+  <br><br><h4>Availability expectation</h4>
+  {{feature.availability_expectation|urlize}}
+{% endif %}
+
+{% if feature.adoption_expectation %}
+  <br><br><h4>Adoption expectation</h4>
+  {{feature.adoption_expectation|urlize}}
+{% endif %}
+
+{% if feature.adoption_plan %}
+  <br><br><h4>Adoption plan</h4>
+  {{feature.adoption_plan|urlize}}
+{% endif %}
+
 {% if feature.non_oss_deps %}
   <br><br><h4>Non-OSS dependencies</h4>
   <p style="font-style: italic">


### PR DESCRIPTION
Now that I have added some new fields for the adoption team, also add them to the intent email template so that API owners can review them as part of the intent thread.