### PR TITLE
Fix display of feature updated-on and refactor date rendering.

### DIFF
--- a/client-src/elements/chromedash-activity-log.js
+++ b/client-src/elements/chromedash-activity-log.js
@@ -1,5 +1,6 @@
 import {LitElement, css, html, nothing} from 'lit';
-import {autolink} from './utils.js';
+import {autolink, renderAbsoluteDate, renderRelativeDate,
+} from './utils.js';
 import '@polymer/iron-icon';
 
 import {SHARED_STYLES} from '../sass/shared-css.js';
@@ -136,10 +137,6 @@ export class ChromedashActivity extends LitElement {
       `];
   }
 
-  formatDate(dateStr) {
-    return dateStr.split('.')[0]; // Ignore microseconds.
-  }
-
   // Returns a boolean representing whether the given activity can be edited.
   isEditable() {
     if (!this.user) {
@@ -204,22 +201,6 @@ export class ChromedashActivity extends LitElement {
       </div>`;
   }
 
-  // Display how long ago the comment was created compared to now.
-  formatRelativeDate() {
-    // Format date to "YYYY-MM-DDTHH:mm:ss.sssZ" to represent UTC.
-    let dateStr = this.activity.created || '';
-    dateStr = this.activity.created.replace(' ', 'T');
-    const activityDate = new Date(`${dateStr}Z`);
-    if (isNaN(activityDate)) {
-      return nothing;
-    }
-    return html`
-      <span class="relative_date">
-        (<sl-relative-time date="${activityDate.toISOString()}">
-        </sl-relative-time>)
-      </span>`;
-  }
-
   render() {
     if (!this.activity) {
       return nothing;
@@ -231,8 +212,9 @@ export class ChromedashActivity extends LitElement {
            ${this.formatEditMenu()}
            <span class="author">${this.activity.author}</span>
            <span class="preposition">on</span>
-           <span class="date">${this.formatDate(this.activity.created)}
-             ${this.formatRelativeDate()}
+           <span class="date">
+             ${renderAbsoluteDate(this.activity.created, true)}
+             ${renderRelativeDate(this.activity.created)}
            </span>
         </div>
         <div id="amendments">

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -2,7 +2,9 @@ import {LitElement, css, html, nothing} from 'lit';
 import './chromedash-feature-detail';
 import './chromedash-gantt';
 import {openApprovalsDialog} from './chromedash-approvals-dialog';
-import {autolink, renderHTMLIf, showToastMessage} from './utils.js';
+import {autolink, renderHTMLIf, showToastMessage,
+  renderAbsoluteDate, renderRelativeDate,
+} from './utils.js';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
 const INACTIVE_STATES = [
@@ -40,6 +42,12 @@ export class ChromedashFeaturePage extends LitElement {
         section label {
           font-weight: 500;
           margin-right: 5px;
+        }
+
+        #updated {
+          color: var(--unimportant-text-color);
+          border-top: var(--default-border);
+          padding: var(--content-padding-quarter) 0 0 var(--content-padding);
         }
 
         li {
@@ -383,10 +391,7 @@ export class ChromedashFeaturePage extends LitElement {
         </ul>
       </section>
     `: nothing}
-
-    <section id="updated">
-      <p><span>Last updated on ${this.feature.updated_display}</span></p>
-    </section>`;
+    `;
   }
 
 
@@ -477,9 +482,15 @@ export class ChromedashFeaturePage extends LitElement {
             `)}
         </section>
       `: nothing}
+    `;
+  }
 
+  renderUpdated() {
+    return html`
       <section id="updated">
-        <p><span>Last updated on ${this.feature.updated_display}</span></p>
+          Last updated on
+          ${renderAbsoluteDate(this.feature.updated?.when, true)}
+          ${renderRelativeDate(this.feature.updated?.when)}
       </section>
     `;
   }
@@ -522,6 +533,7 @@ export class ChromedashFeaturePage extends LitElement {
         ${this.feature.is_enterprise_feature ?
             this.renderEnterpriseFeatureStatus() :
             this.renderFeatureStatus()}
+        ${this.renderUpdated()}
       </div>
       ${this.renderFeatureDetails()}
     `;

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -5,7 +5,9 @@ import {
   openPreflightDialog,
   somePendingPrereqs,
 } from './chromedash-preflight-dialog';
-import {autolink, showToastMessage, findProcessStage} from './utils.js';
+import {autolink, showToastMessage, findProcessStage,
+  renderAbsoluteDate, renderRelativeDate,
+} from './utils.js';
 import {GATE_QUESTIONNAIRES} from './form-definition.js';
 
 import {SHARED_STYLES} from '../sass/shared-css.js';
@@ -321,25 +323,6 @@ export class ChromedashGateColumn extends LitElement {
       });
   }
 
-  formatDate(dateStr) {
-    return dateStr.split(' ')[0]; // Ignore time of day
-  }
-
-  formatRelativeDate(dateStr) {
-    // Format date to "YYYY-MM-DDTHH:mm:ss.sssZ" to represent UTC.
-    dateStr = dateStr || '';
-    dateStr = dateStr.replace(' ', 'T');
-    const dateObj = new Date(`${dateStr}Z`);
-    if (isNaN(dateObj)) {
-      return nothing;
-    }
-    return html`
-      <span class="relative_date">
-        (<sl-relative-time date="${dateObj.toISOString()}">
-        </sl-relative-time>)
-      </span>`;
-  }
-
   /* A user that can edit the current feature can request a review. */
   userCanRequestReview() {
     return (this.user &&
@@ -397,8 +380,9 @@ export class ChromedashGateColumn extends LitElement {
 
   renderReviewStatusActive() {
     return html`
-      Review requested on ${this.formatDate(this.gate.requested_on)}
-      ${this.formatRelativeDate(this.gate.requested_on)}
+      Review requested on
+      ${renderAbsoluteDate(this.gate.requested_on)}
+      ${renderRelativeDate(this.gate.requested_on)}
     `;
   }
 

--- a/client-src/elements/utils.js
+++ b/client-src/elements/utils.js
@@ -1,7 +1,7 @@
 // This file contains helper functions for our elements.
 
 import {markupAutolinks} from './autolink.js';
-import {nothing} from 'lit';
+import {nothing, html} from 'lit';
 
 let toastEl;
 
@@ -110,4 +110,39 @@ export function setupScrollToHash(pageElement) {
 /* Returns a html template if the condition is true, otherwise returns an empty html */
 export function renderHTMLIf(condition, originalHTML) {
   return condition ? originalHTML : nothing;
+}
+
+
+function _parseDateStr(dateStr) {
+  // Format date to "YYYY-MM-DDTHH:mm:ss.sssZ" to represent UTC.
+  dateStr = dateStr || '';
+  dateStr = dateStr.replace(' ', 'T');
+  const dateObj = new Date(`${dateStr}Z`);
+  if (isNaN(dateObj)) {
+    return null;
+  }
+  return dateObj;
+}
+
+
+export function renderAbsoluteDate(dateStr, includeTime=false) {
+  if (!dateStr) {
+    return '';
+  }
+  if (includeTime) {
+    return dateStr.split('.')[0]; // Ignore microseconds.
+  } else {
+    return dateStr.split(' ')[0]; // Ignore time.
+  }
+}
+
+
+export function renderRelativeDate(dateStr) {
+  const dateObj = _parseDateStr(dateStr);
+  if (!dateObj) return nothing;
+  return html`
+      <span class="relative_date">
+        (<sl-relative-time date="${dateObj.toISOString()}">
+         </sl-relative-time>)
+      </span>`;
 }

--- a/client-src/sass/shared-css.js
+++ b/client-src/sass/shared-css.js
@@ -137,16 +137,6 @@ export const SHARED_STYLES = [
     white-space: pre-wrap;
   }
 
-  #updated {
-    padding-top: var(--content-padding);
-  }
-
-  #updated span {
-    color: var(--unimportant-text-color);
-    border-top: var(--default-border);
-    padding: var(--content-padding-quarter) var(--content-padding) 0 0;
-  }
-
   #breadcrumbs a {
     text-decoration: none;
     color: inherit;


### PR DESCRIPTION
This fixes a problem that I noticed while testing on staging today.  The "Last updated on" line on the feature detail page was not showing any date.  This is because the JSON for the feature is a little different than it used to be: we are doing less UI-centric string formatting on the backend because it should be done on the frontend.

In this PR:
* Create some new util.js functions to render dates.
* Update existing spots where we render dates to call the new functions.