### PR TITLE
Feature accuracy verification handles multiple stages of the same type

### DIFF
--- a/client-src/elements/chromedash-guide-editall-page.js
+++ b/client-src/elements/chromedash-guide-editall-page.js
@@ -42,6 +42,7 @@ export class ChromedashGuideEditallPage extends LitElement {
     this.loading = true;
     this.appTitle = '';
     this.nextPage = '';
+    this.previousStageTypeRendered = 0;
     this.sameTypeRendered = 0;
   }
 

--- a/client-src/elements/chromedash-guide-verify-accuracy-page.js
+++ b/client-src/elements/chromedash-guide-verify-accuracy-page.js
@@ -38,6 +38,8 @@ export class ChromedashGuideVerifyAccuracyPage extends LitElement {
     this.feature = {};
     this.loading = true;
     this.appTitle = '';
+    this.previousStageTypeRendered = 0;
+    this.sameTypeRendered = 0;
   }
 
   connectedCallback() {

--- a/client-src/elements/chromedash-guide-verify-accuracy-page.js
+++ b/client-src/elements/chromedash-guide-verify-accuracy-page.js
@@ -1,9 +1,15 @@
 import {LitElement, css, html} from 'lit';
 import {ref} from 'lit/directives/ref.js';
-import {showToastMessage} from './utils.js';
+import {flattenSections, showToastMessage} from './utils.js';
 import './chromedash-form-field';
 import './chromedash-form-table';
-import {formatFeatureForEdit, VERIFY_ACCURACY_FORM_FIELDS} from './form-definition';
+import {formatFeatureForEdit,
+  STAGE_SHORT_NAMES,
+  VERIFY_ACCURACY_CONFIRMATION_FIELD,
+  VERIFY_ACCURACY_FORMS_BY_STAGE_TYPE,
+  VERIFY_ACCURACY_METADATA_FIELDS,
+  VERIFY_ACCURACY_TRIAL_EXTENSION_FIELDS} from './form-definition';
+import {STAGE_SPECIFIC_FIELDS} from './form-field-enums.js';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 import {FORM_STYLES} from '../sass/forms-css.js';
 
@@ -115,28 +121,135 @@ export class ChromedashGuideVerifyAccuracyPage extends LitElement {
     `;
   }
 
+  getStageForm(stageType) {
+    return VERIFY_ACCURACY_FORMS_BY_STAGE_TYPE[stageType] || null;
+  }
+
+  renderStageSection(formattedFeature, name, feStage, stageFields) {
+    if (!stageFields) return nothing;
+
+    // Add a number differentiation if this stage type is the same as another stage.
+    let numberDifferentiation = '';
+    if (this.previousStageTypeRendered && this.previousStageTypeRendered === feStage.stage_type) {
+      this.sameTypeRendered += 1;
+      numberDifferentiation = ` (${this.sameTypeRendered})`;
+    } else {
+      this.previousStageTypeRendered = feStage.stage_type;
+      this.sameTypeRendered = 1;
+    }
+    const sectionName = `${name}${numberDifferentiation}`;
+
+    const formFieldEls = stageFields.map(field => {
+      let value = formattedFeature[field];
+      if (STAGE_SPECIFIC_FIELDS.has(field)) {
+        value = feStage[field];
+      } else if (this.sameTypeRendered > 1) {
+        // Don't render fields that are not stage-specific if this is
+        // a stage type that is already being rendered.
+        // This is to avoid repeated fields on the edit-all page.
+        return nothing;
+      }
+      return html`
+        <chromedash-form-field
+          name=${field}
+          stageId=${feStage.id}
+          value=${value}>
+        </chromedash-form-field>
+      `;
+    });
+    const id = `${STAGE_SHORT_NAMES[feStage.stage_type] || 'metadata'}${this.sameTypeRendered}`
+      .toLowerCase();
+    return html`
+    <h3 id="${id}">${sectionName}</h3>
+    <section class="flat_form">
+      ${formFieldEls}
+    </section>
+    `;
+  }
+
+  /**
+   * Builds the HTML elements for rendering the form sections.
+   * @param {Object} formattedFeature Object describing the feature.
+   * @param {Array} feStages List of stages associated with the feature.
+   *
+   * @return {Array} allFormFields, an array of strings representing all the field
+   *   names that will exist on the page.
+   * @return {Array} formsToRender, All HTML elements to render in the form.
+   */
+  getForms(formattedFeature, feStages) {
+    // All features display the metadata section.
+    let fieldsOnly = flattenSections(VERIFY_ACCURACY_METADATA_FIELDS);
+    const formsToRender = [
+      this.renderStageSection(
+        formattedFeature, VERIFY_ACCURACY_METADATA_FIELDS.name, {}, fieldsOnly)];
+
+    // Generate a single array with the name of every field that is displayed.
+    let allFormFields = [...fieldsOnly];
+
+
+    for (const feStage of feStages) {
+      const stageForm = this.getStageForm(feStage.stage_type);
+      if (!stageForm) {
+        continue;
+      }
+
+      fieldsOnly = flattenSections(stageForm);
+      formsToRender.push(this.renderStageSection(
+        formattedFeature, stageForm.name, feStage, fieldsOnly));
+      allFormFields = [...allFormFields, ...fieldsOnly];
+
+      // If extension stages are associated with this stage,
+      // render them in a separate section as well.
+      const extensions = feStage.extensions || [];
+      extensions.forEach(extensionStage => {
+        fieldsOnly = flattenSections(VERIFY_ACCURACY_TRIAL_EXTENSION_FIELDS);
+        formsToRender.push(this.renderStageSection(
+          formattedFeature,
+          `${VERIFY_ACCURACY_TRIAL_EXTENSION_FIELDS.name}`,
+          extensionStage,
+          fieldsOnly));
+        allFormFields = [...allFormFields, ...fieldsOnly];
+      });
+    }
+
+    // Add the verify accuracy checkbox at the end of all forms.
+    fieldsOnly = flattenSections(VERIFY_ACCURACY_CONFIRMATION_FIELD);
+    formsToRender.push(this.renderStageSection(
+      formattedFeature, `${VERIFY_ACCURACY_CONFIRMATION_FIELD.name}`, {}, fieldsOnly));
+    allFormFields = [...allFormFields, ...fieldsOnly];
+
+    return [allFormFields, formsToRender];
+  }
+
+  getAllStageIds() {
+    const stageIds = [];
+    this.feature.stages.forEach(feStage => {
+      stageIds.push(feStage.id);
+      // Check if any trial extension exist, and collect their IDs as well.
+      const extensions = feStage.extensions || [];
+      extensions.forEach(extensionStage => stageIds.push(extensionStage.id));
+    });
+    return stageIds.join(',');
+  }
+
   renderForm() {
+    const formattedFeature = formatFeatureForEdit(this.feature);
+    const stageIds = this.getAllStageIds();
+    const [allFormFields, formsToRender] = this.getForms(formattedFeature, this.feature.stages);
+
     const title = this.feature.accurate_as_of ?
       `Accuracy last verified ${this.feature.accurate_as_of.split(' ')[0]}.` :
       'Accuracy last verified at time of creation.';
-    const formattedFeature = formatFeatureForEdit(this.feature);
 
     return html`
       <form name="feature_form" method="POST" action="/guide/verify_accuracy/${this.featureId}">
+        <input type="hidden" name="stages" value="${stageIds}">
         <input type="hidden" name="token">
-        <input type="hidden" name="form_fields" value=${VERIFY_ACCURACY_FORM_FIELDS.join()}>
-
+        <input type="hidden" name="form_fields" value=${allFormFields.join(',')}>
         <h3>${title}</h3>
-        <section class="flat_form">
-          <chromedash-form-table ${ref(this.registerFormSubmitHandler)}>
-          ${VERIFY_ACCURACY_FORM_FIELDS.map((field) => html`
-            <chromedash-form-field
-              name=${field}
-              value=${formattedFeature[field]}>
-            </chromedash-form-field>
-          `)}
-          </chromedash-form-table>
-        </section>
+        <chromedash-form-table ${ref(this.registerFormSubmitHandler)}>
+          ${formsToRender}
+        </chromedash-form-table>
 
         <section class="final_buttons">
           <input class="button" type="submit" value="Submit">

--- a/client-src/elements/chromedash-guide-verify-accuracy-page_test.js
+++ b/client-src/elements/chromedash-guide-verify-accuracy-page_test.js
@@ -1,7 +1,6 @@
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashGuideVerifyAccuracyPage} from './chromedash-guide-verify-accuracy-page';
-import {VERIFY_ACCURACY_FORM_FIELDS} from './form-definition';
 import './chromedash-toast';
 import '../js-src/cs-client';
 import sinon from 'sinon';
@@ -15,6 +14,37 @@ describe('chromedash-guide-verify-accuracy-page', () => {
     feature_type: 'fake feature type',
     intent_stage: 'fake intent stage',
     new_crbug_url: 'fake crbug link',
+    browsers: {
+      chrome: {
+        blink_components: ['Blink'],
+        owners: ['fake chrome owner one', 'fake chrome owner two'],
+        status: {
+          milestone_str: 'No active development',
+          text: 'No active development',
+          val: 1},
+      },
+      ff: {view: {text: 'No signal', val: 5}},
+      safari: {view: {text: 'No signal', val: 5}},
+      webdev: {view: {text: 'No signal', val: 4}},
+      other: {view: {}},
+    },
+    stages: [
+      {
+        id: 1,
+        stage_type: 110,
+        intent_stage: 1,
+      },
+      {
+        id: 2,
+        stage_type: 160,
+        intent_stage: 2,
+      },
+      {
+        id: 3,
+        stage_type: 160,
+        intent_stage: 2,
+      },
+    ],
     browsers: {
       chrome: {
         blink_components: ['Blink'],
@@ -94,8 +124,6 @@ describe('chromedash-guide-verify-accuracy-page', () => {
     const featureForm = component.shadowRoot.querySelector('form[name="feature_form"]');
     assert.exists(featureForm);
     assert.include(featureForm.innerHTML, '<input type="hidden" name="token">');
-    assert.include(featureForm.innerHTML,
-      `<input type="hidden" name="form_fields" value="${VERIFY_ACCURACY_FORM_FIELDS.join()}">`);
     assert.include(featureForm.innerHTML, '<section class="final_buttons">');
   });
 });

--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -132,29 +132,6 @@ export const ENTERPRISE_NEW_FEATURE_FORM_FIELDS = [
   'breaking_change',
 ];
 
-// The fields shown to the user when verifying the accuracy of a feature.
-export const VERIFY_ACCURACY_FORM_FIELDS = [
-  'summary',
-  'owner',
-  'editors',
-  'cc_recipients',
-  'impl_status_chrome',
-  'dt_milestone_android_start',
-  'dt_milestone_desktop_start',
-  'dt_milestone_ios_start',
-  'ot_milestone_android_start',
-  'ot_milestone_android_end',
-  'ot_milestone_desktop_start',
-  'ot_milestone_desktop_end',
-  'ot_milestone_webview_start',
-  'ot_milestone_webview_end',
-  'shipped_android_milestone',
-  'shipped_ios_milestone',
-  'shipped_milestone',
-  'shipped_webview_milestone',
-  'accurate_as_of',
-];
-
 // The fields that are available to every feature.
 export const FLAT_METADATA_FIELDS = {
   name: 'Feature metadata',
@@ -599,6 +576,101 @@ const DEPRECATION_PREPARE_TO_SHIP_FIELDS = {
   ],
 };
 
+// ****************************
+// ** Verify Accuracy fields **
+// ****************************
+// The fields shown to the user when verifying the accuracy of a feature.
+// Only one stage can be used for each definition object, so
+// multiple definitions exist for each stage that might be updated.
+export const VERIFY_ACCURACY_METADATA_FIELDS = {
+  name: 'Feature Metadata',
+  sections: [
+    {
+      name: 'Feature Metadata',
+      fields: [
+        'summary',
+        'owner',
+        'editors',
+        'cc_recipients',
+        'impl_status_chrome',
+      ],
+    },
+  ],
+};
+
+const VERIFY_ACCURACY_DEV_TRIAL_FIELDS = {
+  name: 'Dev trials and iterate on design',
+  sections: [
+    {
+      name: 'Dev trials milestones',
+      fields: [
+        'dt_milestone_android_start',
+        'dt_milestone_desktop_start',
+        'dt_milestone_ios_start',
+      ],
+    },
+  ],
+};
+
+const VERIFY_ACCURACY_ORIGIN_TRIAL_FIELDS = {
+  name: 'Origin trial',
+  sections: [
+    {
+      name: 'Origin trial milestones',
+      fields: [
+        'ot_milestone_android_start',
+        'ot_milestone_android_end',
+        'ot_milestone_desktop_start',
+        'ot_milestone_desktop_end',
+        'ot_milestone_webview_start',
+        'ot_milestone_webview_end',
+      ],
+    },
+  ],
+};
+
+export const VERIFY_ACCURACY_TRIAL_EXTENSION_FIELDS = {
+  name: 'Trial extension',
+  sections: [
+    {
+      name: 'Trial extension milestones',
+      fields: [
+        'extension_desktop_last',
+        'extension_android_last',
+        'extension_webview_last',
+      ],
+    },
+  ],
+};
+
+const VERIFY_ACCURACY_PREPARE_TO_SHIP_FIELDS = {
+  name: 'Prepare to ship',
+  sections: [
+    {
+      name: 'Shipping milestones',
+      fields: [
+        'shipped_android_milestone',
+        'shipped_ios_milestone',
+        'shipped_milestone',
+        'shipped_webview_milestone',
+      ],
+    },
+  ],
+};
+
+// A single form to display the checkbox for verifying accuracy at the end.
+export const VERIFY_ACCURACY_CONFIRMATION_FIELD = {
+  name: 'Verify Accuracy',
+  sections: [
+    {
+      name: 'Verify Accuracy',
+      fields: [
+        'accurate_as_of',
+      ],
+    },
+  ],
+};
+
 
 // Stage_type values for each process.  Even though some of the stages
 // in these processes are similar to each other, they have distinct enum
@@ -690,6 +762,25 @@ export const CREATEABLE_STAGES = {
   [FEATURE_TYPES.FEATURE_TYPE_ENTERPRISE_ID[0]]: [
     STAGE_ENT_ROLLOUT,
   ],
+};
+
+export const VERIFY_ACCURACY_FORMS_BY_STAGE_TYPE = {
+  [STAGE_BLINK_DEV_TRIAL]: VERIFY_ACCURACY_DEV_TRIAL_FIELDS,
+  [STAGE_BLINK_ORIGIN_TRIAL]: VERIFY_ACCURACY_ORIGIN_TRIAL_FIELDS,
+  [STAGE_BLINK_SHIPPING]: VERIFY_ACCURACY_PREPARE_TO_SHIP_FIELDS,
+
+  [STAGE_FAST_DEV_TRIAL]: VERIFY_ACCURACY_DEV_TRIAL_FIELDS,
+  [STAGE_FAST_ORIGIN_TRIAL]: VERIFY_ACCURACY_ORIGIN_TRIAL_FIELDS,
+  [STAGE_FAST_SHIPPING]: VERIFY_ACCURACY_PREPARE_TO_SHIP_FIELDS,
+
+  [STAGE_PSA_DEV_TRIAL]: VERIFY_ACCURACY_DEV_TRIAL_FIELDS,
+  [STAGE_PSA_SHIPPING]: VERIFY_ACCURACY_PREPARE_TO_SHIP_FIELDS,
+
+  [STAGE_DEP_DEV_TRIAL]: VERIFY_ACCURACY_DEV_TRIAL_FIELDS,
+  [STAGE_DEP_DEPRECATION_TRIAL]: VERIFY_ACCURACY_ORIGIN_TRIAL_FIELDS,
+  [STAGE_DEP_SHIPPING]: VERIFY_ACCURACY_PREPARE_TO_SHIP_FIELDS,
+
+  [STAGE_ENT_SHIPPED]: VERIFY_ACCURACY_PREPARE_TO_SHIP_FIELDS,
 };
 
 // key: Origin trial stage types,

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -277,7 +277,6 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
   STAGE_FIELDS: list[tuple[str, str]] = [
       ('ready_for_trial_url', 'link'),
       ('origin_trial_feedback_url', 'link'),
-      ('intent_to_extend_experiment_url', 'link'),
       ('experiment_extension_reason', 'str'),
       ('finch_url', 'link'),
       ('experiment_goals', 'str'),
@@ -336,30 +335,22 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
 
   MULTI_SELECT_FIELDS: frozenset[str] = frozenset(['rollout_platforms', 'enterprise_feature_categories'])
 
-  def touched(self, param_name: str) -> bool:
+  def touched(self, param_name: str, form_fields: list[str]) -> bool:
     """Return True if the user edited the specified field."""
     # TODO(jrobbins): for now we just consider everything on the current form
     # to have been touched.  Later we will add javascript to populate a
     # hidden form field named "touched" that lists the names of all fields
     # actually touched by the user.
 
-    # For now, checkboxes and multi-selects are always considered "touched",
-    # if they are present on the form.
-    if (param_name in self.CHECKBOX_FIELDS or
-        param_name in self.MULTI_SELECT_FIELDS):
-      form_fields_str = self.form.get('form_fields')
-      if form_fields_str:
-        form_fields = [field_name.strip()
-                       for field_name in form_fields_str.split(',')]
-        return param_name in form_fields
-      else:
-        return True
 
     # For now, selects are considered "touched", if they are
     # present on the form and are not empty strings.
     if param_name in self.SELECT_FIELDS:
       return bool(self.form.get(param_name))
-
+    # For now, checkboxes and multi-selects are always considered "touched",
+    # if they are present on the form.
+    if param_name in form_fields:
+      return True
     # See TODO at top of this method.
     return param_name in self.form
 
@@ -422,8 +413,14 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     stage_update_items: list[tuple[str, Any]] = []
     changed_fields: list[tuple[str, Any, Any]] = []
 
+    form_fields_str = self.form.get('form_fields')
+    form_fields: list[str] = []
+    if form_fields_str:
+      form_fields = [
+          field_name.strip() for field_name in form_fields_str.split(',')]
+
     for field, field_type in self.EXISTING_FIELDS:
-      if self.touched(field):
+      if self.touched(field, form_fields):
         field_val = self._get_field_val(field, field_type)
         new_field = self.RENAMED_FIELD_MAPPING.get(field, field)
         self._add_changed_field(fe, new_field, field_val, changed_fields)
@@ -433,7 +430,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     # impl_status_chrome and intent_stage
     # can be be set either by <select> or a checkbox.
     impl_status_val: Optional[int] = None
-    if self.touched('impl_status_chrome'):
+    if self.touched('impl_status_chrome', form_fields):
       impl_status_val = self._get_field_val('impl_status_chrome', 'int')
     elif self._get_field_val('set_impl_status', 'bool'):
       impl_status_val = self._get_field_val('impl_status_offered', 'int')
@@ -462,35 +459,29 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     if stage_ids:
       stage_ids_list = [int(id) for id in stage_ids.split(',')]
       self.update_stages_editall(
-          feature, fe.feature_type, stage_ids_list, changed_fields)
-    else:
+          feature, fe.feature_type, stage_ids_list, changed_fields, form_fields)
+    # If a stage_id is supplied, we make changes to only that specific stage.
+    elif stage_id:
       for field, field_type in self.STAGE_FIELDS:
-        if self.touched(field):
+        if self.touched(field, form_fields):
           field_val = self._get_field_val(field, field_type)
           setattr(feature, field, field_val)
           stage_update_items.append((field, field_val))
 
       for field in MilestoneSet.MILESTONE_FIELD_MAPPING.keys():
-        if self.touched(field):
+        if self.touched(field, form_fields):
           # TODO(jrobbins): Consider supporting milestones that are not ints.
           field_val = self._get_field_val(field, 'int')
           setattr(feature, field, field_val)
           stage_update_items.append((field, field_val))
-
-    # If a stage_id is supplied, we make changes to only that specific stage.
-    if stage_id:
       self.update_single_stage(
           stage_id, fe.feature_type, stage_update_items, changed_fields)
-    # Otherwise, we find the associated stages and make changes (edit-all).
-    else:
-      self.update_multiple_stages(feature_id, feature.feature_type,
-          stage_update_items, changed_fields)
 
     extension_stage_ids = self.form.get('extension_stage_ids')
     if extension_stage_ids:
       stage_ids_list = [int(id) for id in extension_stage_ids.split(',')]
       self.update_stages_editall(
-          feature, fe.feature_type, stage_ids_list, changed_fields)
+          feature, fe.feature_type, stage_ids_list, changed_fields, form_fields)
     # Update metadata fields.
     now = datetime.now()
     if self.form.get('accurate_as_of'):
@@ -621,26 +612,32 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
         changed_fields.append((old_field_name, old_val, new_val))
     stage_to_update.put()
 
-  def update_stages_editall(self, feature: Feature, feature_type: int,
-      stage_ids: list[int], changed_fields: list[tuple[str, Any, Any]]) -> None:
+  def update_stages_editall(
+      self,
+      feature: Feature, feature_type: int,
+      stage_ids: list[int],
+      changed_fields: list[tuple[str, Any, Any]],
+      form_fields: list[str]) -> None:
     """Handle the updates for stages on the edit-all page."""
     for id in stage_ids:
       stage = Stage.get_by_id(id)
       if not stage:
         self.abort(404, msg=f'No stage {id} found')
-
       # Update the stage-specific fields.
       for field, field_type in self.STAGE_FIELDS:
         # To differentiate stages that have the same fields, the stage ID
         # is appended to the field name with 2 underscores.
         field_with_id = f'{field}__{id}'
+        if not self.touched(field, form_fields):
+          continue
         new_field_name = self.RENAMED_FIELD_MAPPING.get(field, field)
         old_val = getattr(stage, new_field_name)
         new_val = self._get_field_val(field_with_id, field_type)
         setattr(stage, new_field_name, new_val)
-        changed_fields.append((field, old_val, new_val))
+        if old_val != new_val:
+          changed_fields.append((field, old_val, new_val))
 
-      intent_thread_field= None
+      intent_thread_field = None
       milestone_fields = []
       # Determine if the stage type is one with specific milestone fields.
       if stage.stage_type == core_enums.STAGE_TYPES_PROTOTYPE[feature_type]:
@@ -659,7 +656,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
         milestone_fields = self.SHIPPING_MILESTONE_FIELDS
 
       # Determine if 'intent_thread_url' field needs to be changed.
-      if intent_thread_field:
+      if intent_thread_field and self.touched(intent_thread_field, form_fields):
         old_val = stage.intent_thread_url
         new_val = self._get_field_val(f'{intent_thread_field}__{id}', 'link')
         if old_val != new_val:
@@ -667,6 +664,8 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
         setattr(stage, 'intent_thread_url', new_val)
 
       for field, milestone_field in milestone_fields:
+        if not self.touched(field, form_fields):
+          continue
         field_with_id = f'{field}__{id}'
         old_val = None
         new_val = self._get_field_val(field_with_id, 'int')
@@ -679,5 +678,6 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
           old_val = getattr(milestoneset_entity, milestone_field)
         setattr(milestoneset_entity, milestone_field, new_val)
         stage.milestones = milestoneset_entity
-        changed_fields.append((field, old_val, new_val))
+        if old_val != new_val:
+          changed_fields.append((field, old_val, new_val))
       stage.put()


### PR DESCRIPTION
Part of #2820

This change updates the feature accuracy verification page to handle and reference data from multiples of the same stage type. Additionally, it adds a fix to `guide.py` that marked some fields as changed despite not being edited.

Explanation of changed by file:
- client-src/elements/chromedash-guide-verify-accuracy-page.js: Changes the page to function similarly to the editall page, which displays a sections of fields from stages that exist as part of the feature.
- client-src/elements/form-definition.js: Write a new set of form definitions that are only used on the accuracy verification page. These are the most important pieces of stage data for the feature owner to verify (mostly milestone fields).
- pages/guide.py: Fixes a bug in which the editall stage updates were not using the `touched()` method check to see if the fields exist on the page. This has not been an issue on the editall page yet because every editable field that exists in the stage entity is displayed on the editall page. With the new feature accuracy changes, this bug appeared and would delete values on stage entities that were not displayed on the page. This is now fixed.
Additionally, the `touched()` method has been slightly refactored to have the `form_fields` list passed into it as an argument, which avoids creating the list from the form fields string in multiple invocations of the method.