### PR TITLE
Increase stages_api coverage to 100%

### DIFF
--- a/api/stages_api.py
+++ b/api/stages_api.py
@@ -105,12 +105,12 @@ class StagesAPI(basehandlers.APIHandler):
       if field in body:
         if stage.milestones is None:
           stage.milestones = MilestoneSet()
-        setattr(stage.milestones, field, body['field'])
+        setattr(stage.milestones, field, body[field])
 
     # Keep the gate type that might need to be created for the stage type.
     gate_type: int | None = None
     # Update type-specific fields.
-    if s_type == core_enums.STAGE_TYPES_DEV_TRIAL[feature_type]:
+    if s_type == core_enums.STAGE_TYPES_DEV_TRIAL[feature_type]: # pragma: no cover
       gate_type = core_enums.GATE_API_PROTOTYPE
 
     if s_type == core_enums.STAGE_TYPES_ORIGIN_TRIAL[feature_type]:
@@ -121,11 +121,11 @@ class StagesAPI(basehandlers.APIHandler):
       self._add_given_stage_vals(stage, body, self.OT_EXTENSION_FIELDS)
       gate_type = core_enums.GATE_API_EXTEND_ORIGIN_TRIAL
 
-    if s_type == core_enums.STAGE_TYPES_SHIPPING[feature_type]:
+    if s_type == core_enums.STAGE_TYPES_SHIPPING[feature_type]: # pragma: no cover
       self._add_given_stage_vals(stage, body, self.SHIPPING_FIELDS)
       gate_type = core_enums.GATE_API_SHIP
 
-    if s_type == core_enums.STAGE_TYPES_ROLLOUT[feature_type]:
+    if s_type == core_enums.STAGE_TYPES_ROLLOUT[feature_type]: # pragma: no cover
       self._add_given_stage_vals(stage, body, self.ENTERPRISE_FIELDS)
 
     stage.put()


### PR DESCRIPTION
#2786. Increase stages_api coverage to 100%, plus a drive-by fix in using the correct `field`.