### PR TITLE
Notify subscribers of a new comment

### DIFF
--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -18,7 +18,7 @@ from typing import Any
 from framework import basehandlers
 from framework import permissions
 from internals.review_models import Activity, Amendment
-from internals import notifier
+from internals import notifier, notifier_helpers
 
 
 def amendment_to_json_dict(amendment: Amendment) -> dict[str, Any]:
@@ -90,6 +90,12 @@ class CommentsAPI(basehandlers.APIHandler):
       comment_activity = Activity(feature_id=feature_id, gate_id=gate_id,
           author=user.email(), content=comment_content)
       comment_activity.put()
+
+    # Notify subscribers of new comments when user posts a comment
+    # via the gate column.
+    if gate_id:
+      notifier_helpers.notify_subscribers_of_new_comments(
+          feature, gate_id, user.email(), comment_content)
 
     # We can only be certain which intent thread we want to post to with
     # a relevant gate ID in order to get the intent_thread_url field from

--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from framework import basehandlers
 from framework import permissions
-from internals.review_models import Activity, Amendment
+from internals.review_models import Activity, Amendment, Gate
 from internals import notifier, notifier_helpers
 
 
@@ -94,8 +94,11 @@ class CommentsAPI(basehandlers.APIHandler):
     # Notify subscribers of new comments when user posts a comment
     # via the gate column.
     if gate_id:
+      gate = Gate.get_by_id(gate_id)
+      if not gate:
+        self.abort(404, msg='Gate not found; notifications abort.')
       notifier_helpers.notify_subscribers_of_new_comments(
-          feature, gate_id, user.email(), comment_content)
+          feature, gate, user.email(), comment_content)
 
     # We can only be certain which intent thread we want to post to with
     # a relevant gate ID in order to get the intent_thread_url field from

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -254,8 +254,9 @@ class CommentsAPITest(testing_config.CustomTestCase):
     self.assertIsNotNone(activity)
     self.assertIsNone(activity.deleted_by)
 
+  @mock.patch('internals.notifier_helpers.notify_subscribers_of_new_comments')
   @mock.patch('internals.approval_defs.get_approvers')
-  def test_post__comment_only(self, mock_get_approvers):
+  def test_post__comment_only(self, mock_get_approvers, mock_notifier):
     """Handler adds a comment only, does not require approval permission."""
     mock_get_approvers.return_value = []
     testing_config.sign_in('user2@chromium.org', 123567890)

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -13,7 +13,7 @@ dispatch:
 - url: "*/tasks/email-reviewers"
   service: notifier
 
-- url: "*/tasks/email-new-comments"
+- url: "*/tasks/email-comments"
   service: notifier
 
 - url: "*/*"

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -13,5 +13,8 @@ dispatch:
 - url: "*/tasks/email-reviewers"
   service: notifier
 
+- url: "*/tasks/email-new-comments"
+  service: notifier
+
 - url: "*/*"
   service: default

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -134,3 +134,25 @@ def notify_subscribers_of_vote_changes(fe: 'FeatureEntry', gate: Gate,
 
   # Create task to email subscribers.
   cloud_tasks_helpers.enqueue_task('/tasks/email-subscribers', params)
+
+
+def notify_subscribers_of_new_comments(fe: 'FeatureEntry', gate_id: int,
+    email: str, comment: str) -> None:
+  """Notify subscribers of a new comment."""
+  gate_url = 'https://chromestatus.com/feature/%s?gate=%s' % (
+      fe.key.integer_id(), gate_id)
+  changed_props = {
+      'prop_name': '%s posted a new comment in %s' % (email, gate_url),
+      'old_val': 'na',
+      'new_val': comment,
+  }
+
+  params = {
+    'changes': [changed_props],
+    # Subscribers are only notified on feature update.
+    'is_update': True,
+    'feature': converters.feature_entry_to_json_verbose(fe)
+  }
+
+  # Create task to email subscribers.
+  cloud_tasks_helpers.enqueue_task('/tasks/email-subscribers', params)

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -136,9 +136,10 @@ def notify_subscribers_of_vote_changes(fe: 'FeatureEntry', gate: Gate,
   cloud_tasks_helpers.enqueue_task('/tasks/email-subscribers', params)
 
 
-def notify_subscribers_of_new_comments(fe: 'FeatureEntry', gate_id: int,
+def notify_subscribers_of_new_comments(fe: 'FeatureEntry', gate: Gate,
     email: str, comment: str) -> None:
   """Notify subscribers of a new comment."""
+  gate_id = gate.key.integer_id()
   gate_url = 'https://chromestatus.com/feature/%s?gate=%s' % (
       fe.key.integer_id(), gate_id)
   changed_props = {
@@ -149,10 +150,8 @@ def notify_subscribers_of_new_comments(fe: 'FeatureEntry', gate_id: int,
 
   params = {
     'changes': [changed_props],
-    # Subscribers are only notified on feature update.
-    'is_update': True,
+    'gate_type': gate.gate_type,
     'feature': converters.feature_entry_to_json_verbose(fe)
   }
 
-  # Create task to email subscribers.
-  cloud_tasks_helpers.enqueue_task('/tasks/email-subscribers', params)
+  cloud_tasks_helpers.enqueue_task('/tasks/email-comments', params)

--- a/internals/notifier_helpers_test.py
+++ b/internals/notifier_helpers_test.py
@@ -85,7 +85,7 @@ class ActivityTest(testing_config.CustomTestCase):
     changed_fields = [('editor_emails', None, [])]
     notifier_helpers.notify_subscribers_and_save_amendments(
         self.feature_1, changed_fields)
-    
+
     activities = Activity.get_activities(self.feature_1.key.integer_id())
     # No activity entity created.
     self.assertTrue(len(activities) == 0)
@@ -103,5 +103,12 @@ class ActivityTest(testing_config.CustomTestCase):
     self.assertEqual(activities[0].gate_id, self.gate_1_id)
     self.assertEqual(activities[0].author, 'abc@example.com')
     self.assertEqual(activities[0].content, expected_content)
+
+    mock_task_helpers.assert_called_once()
+
+  @mock.patch('framework.cloud_tasks_helpers.enqueue_task')
+  def test_notify_subscribers_of_new_comments(self, mock_task_helpers):
+    notifier_helpers.notify_subscribers_of_new_comments(
+        self.feature_1, 123, 'abc@example.com', 'fake comments')
 
     mock_task_helpers.assert_called_once()

--- a/internals/notifier_helpers_test.py
+++ b/internals/notifier_helpers_test.py
@@ -109,6 +109,6 @@ class ActivityTest(testing_config.CustomTestCase):
   @mock.patch('framework.cloud_tasks_helpers.enqueue_task')
   def test_notify_subscribers_of_new_comments(self, mock_task_helpers):
     notifier_helpers.notify_subscribers_of_new_comments(
-        self.feature_1, 123, 'abc@example.com', 'fake comments')
+        self.feature_1, self.gate_1, 'abc@example.com', 'fake comments')
 
     mock_task_helpers.assert_called_once()

--- a/main.py
+++ b/main.py
@@ -240,6 +240,7 @@ internals_routes: list[Route] = [
   Route('/tasks/email-subscribers', notifier.FeatureChangeHandler),
   Route('/tasks/detect-intent', detect_intent.IntentEmailHandler),
   Route('/tasks/email-reviewers', notifier.FeatureReviewHandler),
+  Route('/tasks/email-comments', notifier.FeatureCommentHandler),
 
   Route('/admin/schema_migration_delete_entities',
       schema_migration.DeleteNewEntities),

--- a/notifier.staging.yaml
+++ b/notifier.staging.yaml
@@ -14,6 +14,10 @@ handlers:
   script: auto
   # Header checks prevent raw access to this handler.  Tasks have headers.
 
+- url: /tasks/email-comments
+  script: auto
+  # Header checks prevent raw access to this handler.  Tasks have headers.
+
 app_engine_apis: true
 
 # Set up VPC Access Connector for Redis.

--- a/notifier.yaml
+++ b/notifier.yaml
@@ -14,6 +14,10 @@ handlers:
   script: auto
   # Header checks prevent raw access to this handler.  Tasks have headers.
 
+- url: /tasks/email-comments
+  script: auto
+  # Header checks prevent raw access to this handler.  Tasks have headers.
+
 app_engine_apis: true
 
 # Set up VPC Access Connector for Redis in prod.


### PR DESCRIPTION
Fix #1170. Notify subscribers of a new comment when it is commented through the gate column.  Add a /tasks/email-comments endpoint to only notify feature owners, editors, and CCs, devrel contact and gate reviewers.

### TODO
Staging tests