### PR TITLE
Update email templates to use new schema

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -57,6 +57,7 @@ def _determine_milestone_string(ship_stages: list[Stage]) -> str:
                 if mstone is None else min(ms.android_first, mstone))
       has_android_mstone = True
   
+  # Add the android suffix if there were only android milestones.
   milestone_str = str(mstone)
   if not has_desktop_mstone and has_android_mstone:
     milestone_str = f'{milestone_str} (android)'

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -43,25 +43,22 @@ from internals.user_models import (
 
 def _determine_milestone_string(ship_stages: list[Stage]) -> str:
   """Determine the shipping milestone string to display in the template."""
-  has_desktop_mstone = False
-  has_android_mstone = False
-  mstone: int | None = None
-  for stage in ship_stages:
-    ms: MilestoneSet = stage.milestones or MilestoneSet()
-    if ms.desktop_first:
-      mstone = (ms.desktop_first
-                if mstone is None else min(ms.desktop_first, mstone))
-      has_desktop_mstone = True
-    elif not has_desktop_mstone and ms.android_first:
-      mstone = (ms.android_first
-                if mstone is None else min(ms.android_first, mstone))
-      has_android_mstone = True
-  
-  # Add the android suffix if there were only android milestones.
-  milestone_str = str(mstone)
-  if not has_desktop_mstone and has_android_mstone:
-    milestone_str = f'{milestone_str} (android)'
-  
+  # Get the earliest desktop and android milestones.
+  first_desktop = min(
+      (stage.milestones.desktop_first for stage in ship_stages
+        if stage.milestones and stage.milestones.desktop_first),
+    default=None)
+  first_android = min(
+      (stage.milestones.android_first for stage in ship_stages
+        if stage.milestones and stage.milestones.android_first),
+    default=None)
+
+  # Use the desktop milestone by default if it's available.
+  milestone_str = str(first_desktop)
+  # Use the android milestone with the android suffix if there are no
+  # desktop milestones.
+  if not first_desktop and first_android:
+    milestone_str = f'{first_android} (android)'
   return milestone_str
 
 

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -100,12 +100,14 @@ class EmailFormattingTest(testing_config.CustomTestCase):
         editor_emails=['feature_editor@example.com', 'owner_1@example.com'],
         category=1, creator_email='creator_template@example.com',
         updater_email='editor_template@example.com',
-        blink_components=['Blink'])
+        blink_components=['Blink'], feature_type=0)
     self.template_ship_stage = Stage(feature_id=123, stage_type=160,
         milestones=MilestoneSet(desktop_first=100))
+    self.template_ship_stage_2 = Stage(feature_id=123, stage_type=160,
+        milestones=MilestoneSet(desktop_first=103))
     self.template_fe.put()
     self.template_ship_stage.put()
-    self.template_stages = stage_helpers.get_feature_stages(123)
+    self.template_ship_stage_2.put()
     self.template_fe.key = ndb.Key('FeatureEntry', 123)
     self.template_fe.put()
 
@@ -122,7 +124,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     """We generate an email body for new features."""
     with test_app.app_context():
       body_html = notifier.format_email_body(
-          False, self.template_fe, self.template_stages, [])
+          False, self.template_fe, [])
     # TESTDATA.make_golden(body_html, 'test_format_email_body__new.html')
     self.assertEqual(body_html,
       TESTDATA['test_format_email_body__new.html'])
@@ -131,7 +133,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     """We don't crash if the change list is emtpy."""
     with test_app.app_context():
       body_html = notifier.format_email_body(
-          True, self.template_fe, self.template_stages, [])
+          True, self.template_fe, [])
     # TESTDATA.make_golden(body_html, 'test_format_email_body__update_no_changes.html')
     self.assertEqual(body_html,
       TESTDATA['test_format_email_body__update_no_changes.html'])
@@ -140,7 +142,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     """We generate an email body for an updated feature."""
     with test_app.app_context():
       body_html = notifier.format_email_body(
-          True, self.template_fe, self.template_stages, self.changes)
+          True, self.template_fe, self.changes)
     # TESTDATA.make_golden(body_html, 'test_format_email_body__update_with_changes.html')
     self.assertEqual(body_html,
       TESTDATA['test_format_email_body__update_with_changes.html'])
@@ -150,7 +152,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.fe_1.doc_links = ['https://developer.mozilla.org/look-here']
     with test_app.app_context():
       body_html = notifier.format_email_body(
-          True, self.template_fe, self.template_stages, self.changes)
+          True, self.template_fe, self.changes)
     # TESTDATA.make_golden(body_html, 'test_format_email_body__mozdev_links_mozilla.html')
     self.assertEqual(body_html,
       TESTDATA['test_format_email_body__mozdev_links_mozilla.html'])
@@ -159,7 +161,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
         'https://hacker-site.org/developer.mozilla.org/look-here']
     with test_app.app_context():
       body_html = notifier.format_email_body(
-          True, self.template_fe, self.template_stages, self.changes)
+          True, self.template_fe, self.changes)
     # TESTDATA.make_golden(body_html, 'test_format_email_body__mozdev_links_non_mozilla.html')
     self.assertEqual(body_html,
       TESTDATA['test_format_email_body__mozdev_links_non_mozilla.html'])
@@ -235,7 +237,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     changes = [{'prop_name': 'shipped_android_milestone'}]
 
     actual = notifier.apply_subscription_rules(
-        self.fe_1, self.fe_1_stages, changes)
+        self.fe_1, changes)
 
     self.assertEqual(
         {notifier.WEBVIEW_RULE_REASON: notifier.WEBVIEW_RULE_ADDRS},
@@ -248,7 +250,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     changes = [{'prop_name': 'some_other_field'}]  # irrelevant changesa
 
     actual = notifier.apply_subscription_rules(
-        self.fe_1, self.fe_1_stages, changes)
+        self.fe_1, changes)
 
     self.assertEqual({}, actual)
 
@@ -258,14 +260,14 @@ class EmailFormattingTest(testing_config.CustomTestCase):
 
     # No milestones of any kind set.
     actual = notifier.apply_subscription_rules(
-        self.fe_1, self.fe_1_stages, changes)
+        self.fe_1, changes)
     self.assertEqual({}, actual)
 
     # Webview is also set
     self.ship_stage.milestones.android_first = 88
     self.ship_stage.milestones.webview_first = 89
     actual = notifier.apply_subscription_rules(
-        self.fe_1, self.fe_1_stages, changes)
+        self.fe_1, changes)
     self.assertEqual({}, actual)
 
   @mock.patch('internals.notifier.format_email_body')
@@ -323,7 +325,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.assertEqual('watcher_1@example.com', watcher_task['to'])
 
     mock_f_e_b.assert_called_once_with(
-        False, self.fe_1, self.fe_1_stages, [])
+        False, self.fe_1, [])
 
   @mock.patch('internals.notifier.format_email_body')
   def test_make_feature_changes_email__update(self, mock_f_e_b):
@@ -384,7 +386,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.assertEqual('watcher_1@example.com', watcher_task['to'])
 
     mock_f_e_b.assert_called_once_with(
-        True, self.fe_1, self.fe_1_stages, self.changes)
+        True, self.fe_1, self.changes)
 
   @mock.patch('internals.notifier.format_email_body')
   @mock.patch('internals.approval_defs.get_approvers')
@@ -415,7 +417,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.assertEqual('approver2@example.com', review_task_2['to'])
 
     mock_f_e_b.assert_called_once_with(
-        True, self.fe_1, self.fe_1_stages, self.changes)
+        True, self.fe_1, self.changes)
     mock_get_approvers.assert_called_once_with(1)
 
   @mock.patch('internals.notifier.format_email_body')
@@ -486,7 +488,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.assertEqual('watcher_1@example.com', watcher_task['to'])
 
     mock_f_e_b.assert_called_once_with(
-        True, self.fe_1, self.fe_1_stages, self.changes)
+        True, self.fe_1, self.changes)
 
 
   @mock.patch('internals.notifier.format_email_body')
@@ -510,7 +512,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.assertEqual('owner_1@example.com', component_owner_task['to'])
     self.assertEqual('watcher_1@example.com', watcher_task['to'])
     mock_f_e_b.assert_called_once_with(
-        True, self.fe_2, self.fe_2_stages, self.changes)
+        True, self.fe_2, self.changes)
 
 
 class FeatureStarTest(testing_config.CustomTestCase):

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -192,6 +192,8 @@ class FeatureAccuracyHandler(AbstractReminderHandler):
   """Periodically remind owners to verify the accuracy of their entries."""
 
   ACCURACY_GRACE_PERIOD = timedelta(weeks=4)
+  ALLOW_ESCALATION = True  # Outstanding notifications will be escalated.
+  ESCALATION_CHECK = lambda self, f: f.outstanding_notifications >= 2
   SUBJECT_FORMAT = '[Action requested] Update %s'
   EMAIL_TEMPLATE_PATH = 'accuracy_notice_email.html'
   FUTURE_MILESTONES_TO_CONSIDER = 2

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -192,7 +192,8 @@ class FeatureAccuracyHandler(AbstractReminderHandler):
   """Periodically remind owners to verify the accuracy of their entries."""
 
   ACCURACY_GRACE_PERIOD = timedelta(weeks=4)
-  ALLOW_ESCALATION = True  # Outstanding notifications will be escalated.
+  ALLOW_ESCALATION = True 
+  # Notifications after the 2nd with no acknowledgement will be escalated.
   ESCALATION_CHECK = lambda self, f: f.outstanding_notifications >= 2
   SUBJECT_FORMAT = '[Action requested] Update %s'
   EMAIL_TEMPLATE_PATH = 'accuracy_notice_email.html'

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -202,9 +202,6 @@ class FeatureAccuracyHandler(AbstractReminderHandler):
   """Periodically remind owners to verify the accuracy of their entries."""
 
   ACCURACY_GRACE_PERIOD = timedelta(weeks=4)
-  ALLOW_ESCALATION = True 
-  # Notifications after the 2nd with no acknowledgement will be escalated.
-  ESCALATION_CHECK = lambda self, f: f.outstanding_notifications >= 2
   SUBJECT_FORMAT = '[Action requested] Update %s'
   EMAIL_TEMPLATE_PATH = 'accuracy_notice_email.html'
   FUTURE_MILESTONES_TO_CONSIDER = 2

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -22,7 +22,7 @@ from google.cloud import ndb  # type: ignore
 from flask import render_template
 
 from framework import basehandlers
-from internals.core_models import FeatureEntry
+from internals.core_models import FeatureEntry, MilestoneSet
 from internals import notifier
 from internals import stage_helpers
 from internals.core_enums import (

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -15,17 +15,18 @@
 from datetime import datetime, timedelta
 import json
 import logging
+from typing import Any, Callable
 import requests
 
 from google.cloud import ndb  # type: ignore
 from flask import render_template
 
 from framework import basehandlers
-from internals.core_models import FeatureEntry, MilestoneSet
-from internals.legacy_models import Feature
+from internals.core_models import FeatureEntry
 from internals import notifier
 from internals import stage_helpers
-from internals.core_enums import STAGE_TYPES_BY_FIELD_MAPPING
+from internals.core_enums import (
+    STAGE_TYPES_BY_FIELD_MAPPING)
 import settings
 
 
@@ -61,21 +62,27 @@ def choose_email_recipients(
   
 
 def build_email_tasks(
-    features_to_notify, subject_format, body_template_path,
-    current_milestone_info, escalation_check):
-  email_tasks = []
+    features_to_notify: list[tuple[FeatureEntry, int]],
+    subject_format: str,
+    body_template_path: str,
+    current_milestone_info: dict,
+    escalation_check: Callable
+    ) -> list[dict[str, Any]]:
+  email_tasks: list[dict[str, Any]] = []
   beta_date = datetime.fromisoformat(current_milestone_info['earliest_beta'])
   beta_date_str = beta_date.strftime('%Y-%m-%d')
   for fe, mstone in features_to_notify:
-    # TODO(danielrsmith): the estimated-milestones-template.html is reliant
-    # on old Feature entity milestone fields and will need to be refactored
-    # to use Stage entity fields before removing this Feature use.
-    feature = Feature.get_by_id(fe.key.integer_id())
     # Check if this notification should be escalated.
     is_escalated = escalation_check(fe)
+
+    # Get stage information needed to display the template.
+    stage_info = stage_helpers.get_stage_info_for_templates(fe)
+
     body_data = {
       'id': fe.key.integer_id(),
-      'feature': feature,
+      'feature': fe,
+      'stage_info': stage_info,
+      'should_render_mstone_table': stage_info['should_render_mstone_table'],
       'site_url': settings.SITE_URL,
       'milestone': mstone,
       'beta_date_str': beta_date_str,
@@ -167,7 +174,10 @@ class AbstractReminderHandler(basehandlers.FlaskHandler):
 
     return result
 
-  def determine_features_to_notify(self, current_milestone_info):
+  def determine_features_to_notify(
+      self,
+      current_milestone_info: dict
+      ) -> list[tuple[FeatureEntry, int]]:
     """Get all features filter them by class-specific and milestone criteria."""
     features = FeatureEntry.query(
         FeatureEntry.deleted == False).fetch()

--- a/internals/stage_helpers.py
+++ b/internals/stage_helpers.py
@@ -14,8 +14,7 @@
 # limitations under the License.
 
 from collections import defaultdict
-
-from google.cloud import ndb  # type: ignore
+from typing import TypedDict
 
 from api import converters
 from internals.core_enums import (
@@ -27,6 +26,17 @@ from internals.core_enums import (
     STAGE_TYPES_EXTEND_ORIGIN_TRIAL,
     STAGE_TYPES_SHIPPING)
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
+
+
+# Type return value of get_stage_info_for_templates()
+class StageTemplateInfo(TypedDict):
+  proto_stages: list[Stage]
+  dt_stages: list[Stage]
+  ot_stages: list[Stage]
+  extension_stages: list[Stage]
+  ship_stages: list[Stage]
+  should_render_mstone_table: bool
+  should_render_intents: bool
 
 
 def get_feature_stages(feature_id: int) -> dict[int, list[Stage]]:
@@ -74,7 +84,7 @@ def get_ot_stage_extensions(ot_stage_id: int):
 
 
 def get_stage_info_for_templates(
-    fe: FeatureEntry) -> dict[str, list[Stage] | bool]:
+    fe: FeatureEntry) -> StageTemplateInfo:
   """Gather the information needed to display the estimated milestones table."""
   # Only milestones from DevTrial, OT, or shipping stages are displayed.
   id = fe.key.integer_id()
@@ -85,7 +95,8 @@ def get_stage_info_for_templates(
   extension_stage_type = STAGE_TYPES_EXTEND_ORIGIN_TRIAL[f_type]
   ship_stage_type = STAGE_TYPES_SHIPPING[f_type]
 
-  stage_info: dict[str, list[Stage] | bool] = {
+
+  stage_info: StageTemplateInfo = {
     'proto_stages': [],
     'dt_stages': [],
     'ot_stages': [],
@@ -140,7 +151,7 @@ def get_stage_info_for_templates(
         stage_info['should_render_mstone_table'] = True
     
     if s.stage_type == extension_stage_type:
-      stage_info['extension_stages'].append(s)
+     stage_info['extension_stages'].append(s)
       # Extension stages are not rendered
       # in the milestones table; only for intents.
 

--- a/internals/stage_helpers.py
+++ b/internals/stage_helpers.py
@@ -95,7 +95,6 @@ def get_stage_info_for_templates(
   extension_stage_type = STAGE_TYPES_EXTEND_ORIGIN_TRIAL[f_type]
   ship_stage_type = STAGE_TYPES_SHIPPING[f_type]
 
-
   stage_info: StageTemplateInfo = {
     'proto_stages': [],
     'dt_stages': [],
@@ -107,12 +106,11 @@ def get_stage_info_for_templates(
     'should_render_mstone_table': False,
     # Note if any intent URLs are seen while organizing.
     # This is used to check if rendering the table is needed.
-    'should_render_intents': False
+    'should_render_intents': False,
   }
 
   for s in Stage.query(Stage.feature_id == id):
-    # Stage info is not needed if it's not the correct stage type
-    # or has no milestones specified.
+    # Stage info is not needed if it's not the correct stage type.
     if (s.stage_type != proto_stage_type and
         s.stage_type != dt_stage_type and
         s.stage_type != ot_stage_type and
@@ -122,9 +120,8 @@ def get_stage_info_for_templates(
 
     # If an intent thread is present in any stage,
     # we should render the intents template.
-    stage_info['should_render_intents'] = (
-        stage_info['should_render_intents'] or
-        s.intent_thread_url is not None)
+    if s.intent_thread_url is not None:
+      stage_info['should_render_intents'] = True
 
     # Add stages to their respective lists.
     if s.stage_type == proto_stage_type: 
@@ -137,9 +134,8 @@ def get_stage_info_for_templates(
     m: MilestoneSet = s.milestones
     if s.stage_type == dt_stage_type:
       # Dev trial's announcement URL is rendered in templates like an intent.
-      stage_info['should_render_intents'] = (
-          stage_info['should_render_intents'] or
-          s.announcement_url is not None)
+      if s.announcement_url is not None:
+        stage_info['should_render_intents'] = True
       stage_info['dt_stages'].append(s)
       if m.desktop_first or m.android_first or m.ios_first:
         stage_info['should_render_mstone_table'] = True

--- a/internals/testdata/notifier_test/test_format_email_body__mozdev_links_mozilla.html
+++ b/internals/testdata/notifier_test/test_format_email_body__mozdev_links_mozilla.html
@@ -12,7 +12,45 @@
 <p><b>Estimated milestones</b>:
   
 
-  <p>No milestones specified</p>
+  <table>
+
+    
+      <tr><td>Shipping on desktop</td>
+      <td>100</td></tr>
+
+    
+      <tr><td>Shipping on desktop</td>
+      <td>103</td></tr>
+
+    
+    
+    
+
+  </table>
+
+  <table>
+
+    
+    
+    
+
+  </table>
+
+
+  <table>
+
+    
+    
+
+  </table>
+
+
+  <table>
+
+    
+    
+
+  </table>
 
 
 </p>

--- a/internals/testdata/notifier_test/test_format_email_body__mozdev_links_non_mozilla.html
+++ b/internals/testdata/notifier_test/test_format_email_body__mozdev_links_non_mozilla.html
@@ -12,7 +12,45 @@
 <p><b>Estimated milestones</b>:
   
 
-  <p>No milestones specified</p>
+  <table>
+
+    
+      <tr><td>Shipping on desktop</td>
+      <td>100</td></tr>
+
+    
+      <tr><td>Shipping on desktop</td>
+      <td>103</td></tr>
+
+    
+    
+    
+
+  </table>
+
+  <table>
+
+    
+    
+    
+
+  </table>
+
+
+  <table>
+
+    
+    
+
+  </table>
+
+
+  <table>
+
+    
+    
+
+  </table>
 
 
 </p>

--- a/internals/testdata/notifier_test/test_format_email_body__new.html
+++ b/internals/testdata/notifier_test/test_format_email_body__new.html
@@ -10,7 +10,45 @@
 <p><b>Estimated milestones</b>:
   
 
-  <p>No milestones specified</p>
+  <table>
+
+    
+      <tr><td>Shipping on desktop</td>
+      <td>100</td></tr>
+
+    
+      <tr><td>Shipping on desktop</td>
+      <td>103</td></tr>
+
+    
+    
+    
+
+  </table>
+
+  <table>
+
+    
+    
+    
+
+  </table>
+
+
+  <table>
+
+    
+    
+
+  </table>
+
+
+  <table>
+
+    
+    
+
+  </table>
 
 
 </p>

--- a/internals/testdata/notifier_test/test_format_email_body__update_no_changes.html
+++ b/internals/testdata/notifier_test/test_format_email_body__update_no_changes.html
@@ -12,7 +12,45 @@
 <p><b>Estimated milestones</b>:
   
 
-  <p>No milestones specified</p>
+  <table>
+
+    
+      <tr><td>Shipping on desktop</td>
+      <td>100</td></tr>
+
+    
+      <tr><td>Shipping on desktop</td>
+      <td>103</td></tr>
+
+    
+    
+    
+
+  </table>
+
+  <table>
+
+    
+    
+    
+
+  </table>
+
+
+  <table>
+
+    
+    
+
+  </table>
+
+
+  <table>
+
+    
+    
+
+  </table>
 
 
 </p>

--- a/internals/testdata/notifier_test/test_format_email_body__update_with_changes.html
+++ b/internals/testdata/notifier_test/test_format_email_body__update_with_changes.html
@@ -12,7 +12,45 @@
 <p><b>Estimated milestones</b>:
   
 
-  <p>No milestones specified</p>
+  <table>
+
+    
+      <tr><td>Shipping on desktop</td>
+      <td>100</td></tr>
+
+    
+      <tr><td>Shipping on desktop</td>
+      <td>103</td></tr>
+
+    
+    
+    
+
+  </table>
+
+  <table>
+
+    
+    
+    
+
+  </table>
+
+
+  <table>
+
+    
+    
+
+  </table>
+
+
+  <table>
+
+    
+    
+
+  </table>
 
 
 </p>

--- a/internals/testdata/reminders_test/test_build_email_tasks_escalated_feature_accuracy.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_escalated_feature_accuracy.html
@@ -22,14 +22,11 @@
   <table>
 
     
-
-    
-
     
       <tr><td>OriginTrial desktop first</td>
       <td>100</td></tr>
-    
 
+    
     
 
   </table>
@@ -37,11 +34,7 @@
   <table>
 
     
-
     
-
-    
-
     
 
   </table>
@@ -50,9 +43,6 @@
   <table>
 
     
-
-    
-
     
 
   </table>
@@ -61,7 +51,6 @@
   <table>
 
     
-
     
 
   </table>

--- a/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy.html
@@ -18,14 +18,11 @@
   <table>
 
     
-
-    
-
     
       <tr><td>OriginTrial desktop first</td>
       <td>100</td></tr>
-    
 
+    
     
 
   </table>
@@ -33,11 +30,7 @@
   <table>
 
     
-
     
-
-    
-
     
 
   </table>
@@ -46,9 +39,6 @@
   <table>
 
     
-
-    
-
     
 
   </table>
@@ -57,7 +47,6 @@
   <table>
 
     
-
     
 
   </table>

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -199,7 +199,7 @@ class FeatureEditHandlerTest(testing_config.CustomTestCase):
     # rollout_platforms is not part of this form
     with test_app.test_request_context(
         'path', data={'form_fields': 'other,fields'}):
-      self.assertFalse(self.handler.touched('rollout_platforms', ['other, fields']))
+      self.assertFalse(self.handler.touched('rollout_platforms', ['other', 'fields']))
 
   def test_post__anon(self):
     """Anon cannot edit features, gets a 403."""

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -199,7 +199,7 @@ class FeatureEditHandlerTest(testing_config.CustomTestCase):
     # rollout_platforms is not part of this form
     with test_app.test_request_context(
         'path', data={'form_fields': 'other,fields'}):
-      self.assertFalse(self.handler.touched('rollout_platforms', ['other', 'fields']))
+      self.assertFalse(self.handler.touched('rollout_platforms'))
 
   def test_post__anon(self):
     """Anon cannot edit features, gets a 403."""

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -199,7 +199,7 @@ class FeatureEditHandlerTest(testing_config.CustomTestCase):
     # rollout_platforms is not part of this form
     with test_app.test_request_context(
         'path', data={'form_fields': 'other,fields'}):
-      self.assertFalse(self.handler.touched('rollout_platforms'))
+      self.assertFalse(self.handler.touched('rollout_platforms', ['other', 'fields']))
 
   def test_post__anon(self):
     """Anon cannot edit features, gets a 403."""

--- a/pages/intentpreview.py
+++ b/pages/intentpreview.py
@@ -16,10 +16,11 @@
 # from google.appengine.api import users
 from api.converters import feature_entry_to_json_verbose
 
-from internals import core_enums, stage_helpers
+from internals import core_enums
+from internals import processes
+from internals import stage_helpers
 from framework import basehandlers
 from framework import permissions
-from internals import processes
 
 INTENT_PARAM = 'intent'
 LAUNCH_PARAM = 'launch'

--- a/pages/intentpreview.py
+++ b/pages/intentpreview.py
@@ -16,7 +16,7 @@
 # from google.appengine.api import users
 from api.converters import feature_entry_to_json_verbose
 
-from internals import core_enums
+from internals import core_enums, stage_helpers
 from framework import basehandlers
 from framework import permissions
 from internals import processes
@@ -49,9 +49,13 @@ class IntentEmailPreviewHandler(basehandlers.FlaskHandler):
 
   def get_page_data(self, feature_id, f, intent_stage):
     """Return a dictionary of data used to render the page."""
+    stage_info = stage_helpers.get_stage_info_for_templates(f)
     page_data = {
         'subject_prefix': self.compute_subject_prefix(f, intent_stage),
         'feature': feature_entry_to_json_verbose(f),
+        'stage_info': stage_info,
+        'should_render_mstone_table': stage_info['should_render_mstone_table'],
+        'should_render_intents': stage_info['should_render_intents'],
         'sections_to_show': processes.INTENT_EMAIL_SECTIONS.get(
             intent_stage, []),
         'intent_stage': intent_stage,

--- a/pages/testdata/intentpreview_test/test_html_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_rendering.html
@@ -198,7 +198,6 @@ limitations under the License.
   
 
   
-
   <br><br><h4>Risks</h4>
   <div style="margin-left: 4em;">
     <br><br><h4>Interoperability and Compatibility</h4>

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -82,11 +82,13 @@
     {{feature.tag_review_status}}
   {% endif %}
 
-  {% if feature.origin_trial_feedback_url %}
-    <br><br><h4>Link to origin trial feedback summary</h4>
-    {{feature.origin_trial_feedback_url}}
-  {% endif %}
+  {% for stage in stage_info.ot_stages %}
+    {% if stage.origin_trial_feedback_url %}
+      <br><br><h4>Link to origin trial feedback summary</h4>
+      {{stage.origin_trial_feedback_url}}
 
+    {% endif %}
+  {% endfor %}
   <br><br><h4>Risks</h4>
   <div style="margin-left: 4em;">
     <br><br><h4>Interoperability and Compatibility</h4>
@@ -156,8 +158,12 @@
   {% endif %}
 
   {% if 'extension_reason' in sections_to_show %}
-    <br><br><h4>Reason this experiment is being extended</h4>
-    <p class="preformatted">{{feature.experiment_extension_reason|urlize}}</p>
+    {% for stage in stage_info.extension_stages %}
+      {% if stage.experiment_extension_reason %}
+        <br><br><h4>Reason this experiment is being extended</h4>
+        <p class="preformatted">{{stage.experiment_extension_reason|urlize}}</p>
+      {% endif %}
+    {% endfor %}
   {% endif %}
 
   <br><br><h4>Ongoing technical constraints</h4>
@@ -266,33 +272,34 @@
 <a href="{{default_url}}">{{default_url}}</a>
 
 
-{% if feature.intent_to_implement_url or feature.ready_for_trial_url or feature.intent_to_experiment_url or feature.intent_to_extend_experiment_url or feature.intent_to_ship_url %}
+{% if should_render_intents %}
   <br><br><h4>Links to previous Intent discussions</h4>
 
-  {% if feature.intent_to_implement_url %}
-    Intent to prototype: {{feature.intent_to_implement_url|urlize}}
-    <br>
-  {% endif %}
+  {% for stage in stage_info.proto_stages %}{% if stage.intent_thread_url %}
+      Intent to prototype: {{stage.intent_thread_url|urlize}}
 
-  {% if feature.ready_for_trial_url %}
-    Ready for Trial: {{feature.ready_for_trial_url|urlize}}
-    <br>
-  {% endif %}
+  {% endif %}{% endfor %}
+  {% for stage in stage_info.dt_stages %}{% if stage.announcement_url %}
+      Ready for Trial: {{stage.announcement_url|urlize}}
+      <br>
 
-  {% if feature.intent_to_experiment_url %}
-    Intent to Experiment: {{feature.intent_to_experiment_url|urlize}}
-    <br>
-  {% endif %}
+  {% endif %}{% endfor %}
+  {% for stage in stage_info.ot_stages %}{% if stage.intent_thread_url %}
+      Intent to Experiment: {{stage.intent_thread_url|urlize}}
+      <br>
 
-  {% if feature.intent_to_extend_experiment_url %}
-    Intent to Extend Experiment: {{feature.intent_to_extend_experiment_url|urlize}}
-    <br>
-  {% endif %}
+  {% endif %}{% endfor %}
+  {% for stage in stage_info.extension_stages %}
+    {% if stage.intent_thread_url %}
+      Intent to Extend Experiment: {{stage.intent_thread_url|urlize}}
+      <br>
 
-  {% if feature.intent_to_ship_url %}
-    Intent to Ship: {{feature.intent_to_ship_url|urlize}}
-    <br>
-  {% endif %}
+  {% endif %}{% endfor %}
+  {% for stage in stage_info.extension_stages %}{% if stage.intent_thread_url %}
+      Intent to Ship: {{stage.intent_thread_url|urlize}}
+      <br>
+
+  {% endif %}{% endfor %}
 {% endif %}
 
 

--- a/templates/estimated-milestones-table.html
+++ b/templates/estimated-milestones-table.html
@@ -1,85 +1,86 @@
-{% if feature.shipped_milestone or feature.ot_milestone_desktop_end or feature.ot_milestone_desktop_start or feature.dt_milestone_desktop_start or feature.shipped_android_milestone or feature.ot_milestone_android_end or feature.ot_milestone_android_start or feature.dt_milestone_android_start or feature.shipped_ios_milestone or feature.dt_milestone_ios_start or feature.shipped_webview_milestone or feature.ot_milestone_webview_end or feature.ot_milestone_webview_start %}
+{% if should_render_mstone_table %}
 
   <table>
 
-    {% if feature.shipped_milestone %}
+    {% for stage in stage_info.ship_stages %}{% if stage.milestones.desktop_first %}
       <tr><td>Shipping on desktop</td>
-      <td>{{feature.shipped_milestone}}</td></tr>
-    {% endif %}
+      <td>{{stage.milestones.desktop_first}}</td></tr>
 
-    {% if feature.ot_milestone_desktop_end %}
+    {% endif %}{% endfor %}
+    {% for stage in stage_info.ot_stages %}{% if stage.milestones.desktop_last %}
       <tr><td>OriginTrial desktop last</td>
-      <td>{{feature.ot_milestone_desktop_end}}</td></tr>
-    {% endif %}
+      <td>{{stage.milestones.desktop_last}}</td></tr>
 
-    {% if feature.ot_milestone_desktop_start %}
+      {% endif %}{% if stage.milestones.desktop_first %}
       <tr><td>OriginTrial desktop first</td>
-      <td>{{feature.ot_milestone_desktop_start}}</td></tr>
-    {% endif %}
+      <td>{{stage.milestones.desktop_first}}</td></tr>
 
-    {% if feature.dt_milestone_desktop_start %}
+    {% endif %}{% endfor %}
+    {% for stage in stage_info.dt_stages %}{% if stage.milestones.desktop_first %}
       <tr><td>DevTrial on desktop</td>
-      <td>{{feature.dt_milestone_desktop_start}}</td></tr>
-    {% endif %}
+      <td>{{stage.milestones.desktop_first}}</td></tr>
+
+    {% endif %}{% endfor %}
 
   </table>
 
   <table>
 
-    {% if feature.shipped_android_milestone %}
-      <tr><td>Shipping on Android</td>
-      <td>{{feature.shipped_android_milestone}}</td></tr>
-    {% endif %}
+    {% for stage in stage_info.ship_stages %}{% if stage.milestones.android_first %}
+        <tr><td>Shipping on Android</td>
+        <td>{{stage.milestones.android_first}}</td></tr>
 
-    {% if feature.ot_milestone_android_end %}
-      <tr><td>OriginTrial Android last</td>
-      <td>{{feature.ot_milestone_android_end}}</td></tr>
-    {% endif %}
+    {% endif %}{% endfor %}
+    {% for stage in stage_info.ot_stages %}{% if stage.milestones.android_last %}
+        <tr><td>OriginTrial Android last</td>
+        <td>{{stage.milestones.android_last}}</td></tr>
 
-    {% if feature.ot_milestone_android_start %}
-      <tr><td>OriginTrial Android first</td>
-      <td>{{feature.ot_milestone_android_start}}</td></tr>
-    {% endif %}
+      {% endif %}{% if stage.milestones.android_first %}
+        <tr><td>OriginTrial Android first</td>
+        <td>{{stage.milestones.android_first}}</td></tr>
 
-    {% if feature.dt_milestone_android_start %}
-      <tr><td>DevTrial on Android</td>
-      <td>{{feature.dt_milestone_android_start}}</td></tr>
-    {% endif %}
+    {% endif %}{% endfor %}
+    {% for stage in stage_info.dt_stages %}{% if stage.milestones.android_first %}
+        <tr><td>DevTrial on Android</td>
+        <td>{{stage.milestones.android_first}}</td></tr>
+
+    {% endif %}{% endfor %}
 
   </table>
 
 
   <table>
 
-    {% if feature.shipped_webview_milestone %}
+    {% for stage in stage_info.ship_stages %}{% if stage.milestones.webview_first %}
       <tr><td>Shipping on WebView</td>
-      <td>{{feature.shipped_webview_milestone}}</td></tr>
-    {% endif %}
+      <td>{{stage.milestones.webview_first}}</td></tr>
 
-    {% if feature.ot_milestone_webview_end %}
-      <tr><td>OriginTrial webView last</td>
-      <td>{{feature.ot_milestone_webview_end}}</td></tr>
-    {% endif %}
+    {% endif %}{% endfor %}
+    {% for stage in stage_info.ot_stages %}{% if stage.milestones.webview_last %}
+        <tr><td>OriginTrial webView last</td>
+        <td>{{stage.milestones.webview_last}}</td></tr>
 
-    {% if feature.ot_milestone_webview_start %}
-      <tr><td>OriginTrial webView first</td>
-      <td>{{feature.ot_milestone_webview_start}}</td></tr>
-    {% endif %}
+      {% endif %}{% if stage.milestones.webview_first %}
+        <tr><td>OriginTrial webView first</td>
+        <td>{{stage.milestones.webview_first}}</td></tr>
+
+    {% endif %}{% endfor %}
 
   </table>
 
 
   <table>
 
-    {% if feature.shipped_ios_milestone %}
-      <tr><td>Shipping on iOS</td>
-      <td>{{feature.shipped_ios_milestone}}</td></tr>
-    {% endif %}
+    {% for stage in stage_info.ship_stages %}{% if stage.milestones.ios_first %}
+        <tr><td>Shipping on WebView</td>
+        <td>{{stage.milestones.ios_first}}</td></tr>
 
-    {% if feature.dt_milestone_ios_start %}
-      <tr><td>DevTrial on iOS</td>
-      <td>{{feature.dt_milestone_ios_start}}</td></tr>
-    {% endif %}
+      {% endif %}{% endfor %}
+    {% for stage in stage_info.dt_stages %}{% if stage.milestones.ios_first %}
+        <tr><td>DevTrial on iOS</td>
+        <td>{{stage.milestones.ios_first}}</td></tr>
+
+      {% endif %}{% endfor %}
 
   </table>
 


### PR DESCRIPTION
Part of the schema migration and tangentially related to #2820 

This PR updates the email templates that were previously using fields from the old schema to use the new schema and support multiple stages and fields of the same type.


Explanation of changes by file:
- internals/stage_helpers.py: create a new function `get_stage_info_for_templates()` which aggregates Stage entities associated with the feature that are needed to render information on the email templates. The function determines whether it is needed to display the milestone table in an email, which is represented by the `should_render_mstone_table` attribute in the returned dictionary.
- internals/notifier.py: Updates the `format_email_body()` function to use the new `get_stage_info_for_templates()` helper function. Also adds a helper function`_determine_milestone_string()` that moves existing logic into a separate function for clarity.
- internals/reminders.py: Updates `build_email_tasks()` function to to use the new `get_stage_info_for_templates()` helper function.
- pages/intentpreview.py:  Updates `get_page_data()` function to to use the new `get_stage_info_for_templates()` helper function.
- templates/blink/intent_to_implement.html: Updates the email template to loop through stages to print all relevant data for each field that was previously represented by a single field on the Feature entity.
- templates/estimated-milestones-table.html: Updates the email template to loop through stages to print all relevant data for each field that was previously represented by a single field on the Feature entity.