### PR TITLE
Fix to the beforeunload handling especially for the metadata form

### DIFF
--- a/client-src/elements/chromedash-guide-metadata.js
+++ b/client-src/elements/chromedash-guide-metadata.js
@@ -73,6 +73,10 @@ export class ChromedashGuideMetadata extends LitElement {
   async registerFormSubmitHandler(el) {
     if (!el) return;
 
+    // Call the app.handleFormSbubmit, which manages beforeunload events.
+    const app = document.querySelector('chromedash-app');
+    app.handleFormSubmit();
+
     await el.updateComplete;
     const hiddenTokenField = this.shadowRoot.querySelector('input[name=token]');
     hiddenTokenField.form.addEventListener('submit', (event) => {

--- a/client-src/elements/chromedash-guide-metadata.js
+++ b/client-src/elements/chromedash-guide-metadata.js
@@ -73,10 +73,6 @@ export class ChromedashGuideMetadata extends LitElement {
   async registerFormSubmitHandler(el) {
     if (!el) return;
 
-    // Call the app.handleFormSbubmit, which manages beforeunload events.
-    const app = document.querySelector('chromedash-app');
-    app.handleFormSubmit();
-
     await el.updateComplete;
     const hiddenTokenField = this.shadowRoot.querySelector('input[name=token]');
     hiddenTokenField.form.addEventListener('submit', (event) => {
@@ -86,6 +82,10 @@ export class ChromedashGuideMetadata extends LitElement {
 
   handleFormSubmit(event, hiddenTokenField) {
     event.preventDefault();
+
+    // Call the app.handleFormSbubmit, which manages beforeunload events.
+    const app = document.querySelector('chromedash-app');
+    app.handleFormSubmit();
 
     // get the XSRF token and update it if it's expired before submission
     window.csClient.ensureTokenIsValid().then(() => {


### PR DESCRIPTION
This PR is mostly a refactoring of the chromedash-app methods to enable the chromedash-guide-metadata to call the form "submit" handler.  This special handling is required since that form does not have its own "page" but instead it is part of the guide feature overview page.  

Note that the Cancel button does not warn about unsaved changes, and furthermore, the unsaved changes will trigger a confirm dialog on the overview page when leaving it.  Rather than fixing this, we will refactor the metadata form page to  be a proper page.