### PR TITLE
Use "N/A" and "INT" instead of icons.

### DIFF
--- a/client-src/elements/chromedash-gate-chip.js
+++ b/client-src/elements/chromedash-gate-chip.js
@@ -68,7 +68,7 @@ class ChromedashGateChip extends LitElement {
        border: 2px solid var(--dark-spot-color);
      }
 
-     sl-button::part(base):hover {
+     sl-button:hover .teamname {
        text-decoration: underline;
      }
 
@@ -128,14 +128,9 @@ class ChromedashGateChip extends LitElement {
        align-items: baseline;
      }
 
-
      .abbrev {
        padding-left: var(--content-padding-quarter);
-       text-decoration: none;
        font-weight: 900;
-     }
-     sl-button::part(base):hover sl-button::part(prefix) {
-       text-decoration: none;
      }
     `];
   }
@@ -190,7 +185,7 @@ class ChromedashGateChip extends LitElement {
         title="${teamName}: ${gateName}: ${stateName}"
         @click=${this.openApprovalsDialog}
         >
-        ${icon} ${teamName}
+        ${icon} <span class="teamname">${teamName}</span>
       </sl-button>
     `;
   }

--- a/client-src/elements/chromedash-gate-chip.js
+++ b/client-src/elements/chromedash-gate-chip.js
@@ -11,17 +11,24 @@ const GATE_STATE_TO_NAME = {
   5: 'Approved', // APPROVED
   6: 'Denied', // DENIED
   // TODO(jrobbins): COMPLETE for auto-approved.
+  8: 'Internal review', // INTERNAL_REVIEW
 };
 
 const GATE_STATE_TO_ICON = {
   0: 'arrow_circle_right_20px', // PREPARING
-  1: 'visibility_20px', //  NA
+  //  NA has no icon.
   2: 'pending_20px', // REVIEW_REQUESTED
   3: 'pending_20px', // REVIEW_STARTED
   4: 'autorenew_20px', // NEEDS_WORK
   5: 'check_circle_filled_20px', // APPROVED
   6: 'block_20px', // DENIED
   // TODO(jrobbins): COMPLETE for auto-approved also check_circle_filled_20px.
+  // INTERNAL_REVIEW has no icon.
+};
+
+const GATE_STATE_TO_ABBREV = {
+  1: 'N/A', //  NA
+  8: 'INT', // INTERNAL_REVIEW
 };
 
 
@@ -69,8 +76,8 @@ class ChromedashGateChip extends LitElement {
        background: var(--gate-fyi-background);
        color: var(--gate-fyi-color);
      }
-     .fyi sl-icon {
-       color: var(--gate-fyi-icon-color);
+     sl-button.fyi::part(prefix) {
+       align-items: baseline;
      }
 
      sl-button.preparing::part(base) {
@@ -112,6 +119,24 @@ class ChromedashGateChip extends LitElement {
      .denied sl-icon {
        color: var(--gate-denied-icon-color);
      }
+
+     sl-button.internal_review::part(base) {
+       background: var(--gate-fyi-background);
+       color: var(--gate-fyi-color);
+     }
+     sl-button.internal_review::part(prefix) {
+       align-items: baseline;
+     }
+
+
+     .abbrev {
+       padding-left: var(--content-padding-quarter);
+       text-decoration: none;
+       font-weight: 900;
+     }
+     sl-button::part(base):hover sl-button::part(prefix) {
+       text-decoration: none;
+     }
     `];
   }
 
@@ -149,15 +174,23 @@ class ChromedashGateChip extends LitElement {
     const gateName = this.gate.name;
     const stateName = GATE_STATE_TO_NAME[this.gate.state];
     const className = stateName.toLowerCase().replaceAll(' ', '_');
-    const iconName = GATE_STATE_TO_ICON[this.gate.state];
     const selected = (this.gate.id == this.selectedGateId) ? 'selected' : '';
+
+    const iconName = GATE_STATE_TO_ICON[this.gate.state];
+    const abbrev = GATE_STATE_TO_ABBREV[this.gate.state] || gateName;
+    let icon = html`<b class="abbrev" slot="prefix">${abbrev}</b>`;
+    if (iconName) {
+      icon = html`
+        <sl-icon slot="prefix" library="material" name=${iconName}></sl-icon>
+      `;
+    }
+
     return html`
       <sl-button pill size="small" class="${className} ${selected}"
         title="${teamName}: ${gateName}: ${stateName}"
         @click=${this.openApprovalsDialog}
         >
-        <sl-icon slot="prefix" library="material" name=${iconName}></sl-icon>
-        ${teamName}
+        ${icon} ${teamName}
       </sl-button>
     `;
   }

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -308,14 +308,14 @@ def _calc_gate_state(votes: list[Vote], rule: str) -> int:
       return Vote.APPROVED
 
   # Return the most recent of any REVIEW_REQUESTED, NEEDS_WORK,
-  # REVIEW_STARTED, or DENIED.  This could allow a feature owner to
-  # re-request a review after addressing feedback and have the gate
-  # show up as REVIEW_STARTED again.  However, we will not offer
-  # "re-review" in the UI yet.
+  # REVIEW_STARTED, INTERNAL_REVIEW, or DENIED.  This could allow a
+  # feature owner to re-request a review after addressing feedback and
+  # have the gate show up as REVIEW_STARTED again.  However, we will
+  # not offer "re-review" in the UI yet.
   for vote in sorted(votes, reverse=True, key=lambda v: v.set_on):
     if vote.state in (
         Vote.NEEDS_WORK, Vote.REVIEW_STARTED, Vote.REVIEW_REQUESTED,
-        Vote.DENIED):
+        Vote.DENIED, Vote.INTERNAL_REVIEW):
       return vote.state
 
   # The feature owner has not requested review yet, or the request was

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -216,6 +216,7 @@ DN = Vote.DENIED
 NW = Vote.NEEDS_WORK
 RS = Vote.REVIEW_STARTED
 NA = Vote.NA
+IR = Vote.INTERNAL_REVIEW
 GATE_VALUES= Vote.VOTE_VALUES.copy()
 GATE_VALUES.update({Gate.PREPARING: 'preparing'})
 
@@ -258,6 +259,15 @@ class CalcGateStateTest(testing_config.CustomTestCase):
                      self.do_calc(RR, RS, NW))
     self.assertEqual(('needs_work', 'needs_work'),
                      self.do_calc(RR, NW, NW))
+
+  def test_request_internal_review(self):
+    """Owner requested a review and a reviewer opts for internal review."""
+    self.assertEqual(('internal_review', 'internal_review'),
+                     self.do_calc(RR, IR))
+    self.assertEqual(('internal_review', 'internal_review'),
+                     self.do_calc(RR, RS, IR))
+    self.assertEqual(('internal_review', 'internal_review'),
+                     self.do_calc(RR, NW, IR))
 
   def test_request_disagreement(self):
     """Reviewers may have different opinions, needed LGTMs counted."""


### PR DESCRIPTION
Finish adding support for the internal_review vote value.  Also, there is no intuitive icon for the concept of a "N/A" or "Internal review" vote, so instead of trying to use icons, use short textual abbreviations. 

In this PR:
* approval_defs.py: compute the gate state when there is a vote with value INTERNAL_REVIEW.
* chromedash-gate-chip.js:  allow either an icon or a textual abbreviation that is shown in very bold letters