### PR TITLE
Use CSS outline rather than border to highlight selected gate chip.

### DIFF
--- a/client-src/elements/chromedash-gate-chip.js
+++ b/client-src/elements/chromedash-gate-chip.js
@@ -58,7 +58,7 @@ class ChromedashGateChip extends LitElement {
      }
 
      sl-button.selected::part(base) {
-       border: 2px solid var(--dark-spot-color);
+       outline: 2px solid var(--dark-spot-color);
      }
 
      sl-button::part(base):hover {


### PR DESCRIPTION
While working on adding support for "INT" and "N/A" text in gate chips, I noticed that the text baseline was getting messed up whenever I selected a gate chip: The text for the selected chip moves down about 3 pixels.   Apparently, shoelace calculates the line-height using a formula that includes the border width.   To avoid that, let's highlight the selected gate chip using the `outline` property rather than `border`.