### PR TITLE
Change arguments passed to new format_email_body implementation

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -265,7 +265,7 @@ def make_new_comments_email(fe: FeatureEntry, gate_type: int, changes: Optional[
   if changes is None:
     changes = []
   fe_stages = stage_helpers.get_feature_stages(fe.key.integer_id())
-  email_html = format_email_body(True, fe, fe_stages, changes)
+  email_html = format_email_body(True, fe, changes)
 
   subject = 'New comments for feature: %s' % fe.name
   triggering_user_email = fe.updater_email

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -476,8 +476,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
       feature_editor_task_2['html'])
     self.assertEqual('owner_1@example.com', feature_editor_task_2['to'])
 
-    mock_f_e_b.assert_called_once_with(
-        True, self.fe_1, self.fe_1_stages, self.changes)
+    mock_f_e_b.assert_called_once_with(True, self.fe_1, self.changes)
     mock_get_approvers.assert_called_once_with(1)
 
   @mock.patch('internals.notifier.format_email_body')


### PR DESCRIPTION
This change fixes a call to the `format_email_body()` function that has not been updated for the new implementation.