### PR TITLE
Add roadmap check to prepub reminder email.

### DIFF
--- a/internals/reminders_test.py
+++ b/internals/reminders_test.py
@@ -102,12 +102,12 @@ class FunctionTest(testing_config.CustomTestCase):
       if stage_type == 150:
         stage.milestones = MilestoneSet(desktop_first=100)
       stage.put()
-    
+
     self.old_feature_template.put()
     self.feature_template.put()
 
     self.maxDiff = None
-  
+
   def tearDown(self) -> None:
     kinds: list[ndb.Model] = [Feature, FeatureEntry, Stage]
     for kind in kinds:
@@ -240,7 +240,7 @@ class FeatureAccuracyHandlerTest(testing_config.CustomTestCase):
       self, mock_get):
     self.feature_1.outstanding_notifications = 2
     self.feature_2.outstanding_notifications = 1
-    
+
     mock_return = MockResponse(
         text=('{"mstones":[{"mstone": "148", '
               '"earliest_beta": "2024-02-03T01:23:45"}]}'))

--- a/internals/testdata/reminders_test/test_build_email_tasks_prepublication.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_prepublication.html
@@ -7,6 +7,20 @@ notes) to announce this new milestone.  These posts are widely read by
 web developers and IT admins, and they are sometimes used as the basis
 for popular press articles.</p>
 
+<h2>1. Locate your releases on the roadmap.</h2>
+<p>Please check where your feature appears on the
+<a href="https://chromestatus.com/roadmap">roadmap page</a>.
+If your feature does not appear, you may need to fill in
+milestone values or update the feature's implementation status.
+Be sure that you have gotten all needed approvals.</p>
+
+<p>Features can appear multiple times in different milestones or
+different sections depending on how they are released.  Check that
+the sequence of releases for your feature makes sense from the
+perspective of a web developer.  For example, dev trials should come
+before the feature is enabled by default.</p>
+
+<h2>2. Refine your feature summary.</h2>
 <p>Please take a look at
   <a href="https://developer.chrome.com/tags/beta/"
      >past blog posts</a> and
@@ -60,3 +74,14 @@ publication.</p>
   side-channel attacks where one site can detect resources in another
   site's cache.
 </p>
+
+
+<h2>3. Reach out if needed.</h2>
+
+<p>If you have questions about approvals, reach out to the specific
+  approving teams or to the API Owners on blink-dev@chromium.org.</p>
+
+<p>If you have questions about chromestatus.com,
+  <a href="https://github.com/GoogleChrome/chromium-dashboard/issues"
+     >file an issue</a>
+  or email us at webstatus@google.com.</p>

--- a/internals/testdata/reminders_test/test_build_email_tasks_prepublication.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_prepublication.html
@@ -9,7 +9,7 @@ for popular press articles.</p>
 
 <h2>1. Locate your releases on the roadmap.</h2>
 <p>Please check where your feature appears on the
-<a href="https://chromestatus.com/roadmap">roadmap page</a>.
+<a href="http://127.0.0.1:8888/roadmap">roadmap page</a>.
 If your feature does not appear, you may need to fill in
 milestone values or update the feature's implementation status.
 Be sure that you have gotten all needed approvals.</p>

--- a/templates/prepublication-notice-email.html
+++ b/templates/prepublication-notice-email.html
@@ -7,6 +7,20 @@ notes) to announce this new milestone.  These posts are widely read by
 web developers and IT admins, and they are sometimes used as the basis
 for popular press articles.</p>
 
+<h2>1. Locate your releases on the roadmap.</h2>
+<p>Please check where your feature appears on the
+<a href="https://chromestatus.com/roadmap">roadmap page</a>.
+If your feature does not appear, you may need to fill in
+milestone values or update the feature's implementation status.
+Be sure that you have gotten all needed approvals.</p>
+
+<p>Features can appear multiple times in different milestones or
+different sections depending on how they are released.  Check that
+the sequence of releases for your feature makes sense from the
+perspective of a web developer.  For example, dev trials should come
+before the feature is enabled by default.</p>
+
+<h2>2. Refine your feature summary.</h2>
 <p>Please take a look at
   <a href="https://developer.chrome.com/tags/beta/"
      >past blog posts</a> and
@@ -60,3 +74,14 @@ publication.</p>
   side-channel attacks where one site can detect resources in another
   site's cache.
 </p>
+
+
+<h2>3. Reach out if needed.</h2>
+
+<p>If you have questions about approvals, reach out to the specific
+  approving teams or to the API Owners on blink-dev@chromium.org.</p>
+
+<p>If you have questions about chromestatus.com,
+  <a href="https://github.com/GoogleChrome/chromium-dashboard/issues"
+     >file an issue</a>
+  or email us at webstatus@google.com.</p>

--- a/templates/prepublication-notice-email.html
+++ b/templates/prepublication-notice-email.html
@@ -9,7 +9,7 @@ for popular press articles.</p>
 
 <h2>1. Locate your releases on the roadmap.</h2>
 <p>Please check where your feature appears on the
-<a href="https://chromestatus.com/roadmap">roadmap page</a>.
+<a href="{{site_url}}roadmap">roadmap page</a>.
 If your feature does not appear, you may need to fill in
 milestone values or update the feature's implementation status.
 Be sure that you have gotten all needed approvals.</p>


### PR DESCRIPTION
This is inspired by our discussion today with Rachel about preparing beta blog posts.  I am adding two steps to the prepublication email that is sent to feature owners 2 weeks before a feature is released on the beta channel.

In this PR:
* Ask feature owners to check where their feature appears on the roadmap page.
* Ask feature owners to reach out for help or feedback.
* Organize the email into 3 numbered steps with headings.