### PR TITLE
Remove Feature from tests (except guide_tests.py)

### DIFF
--- a/api/dev_api.py
+++ b/api/dev_api.py
@@ -74,13 +74,8 @@ class WriteDevData(APIHandler):
 
         fe = FeatureEntry(id=f_id, created=created, updated=updated,
             accurate_as_of=accurate_as_of)
-        # Also write the old Feature entity.
-        feature = Feature(id=f_id, created=created, updated=updated,
-            accurate_as_of=accurate_as_of)
         for field, value in d.items():
           setattr(fe, field, value)
-          setattr(feature, self.RENAMED_FIELD_MAPPING.get(field, field), value)
-        feature.put()
         fe.put()
       features_created = len(info['feature_entries'])
 

--- a/api/dev_api_test.py
+++ b/api/dev_api_test.py
@@ -19,13 +19,12 @@ from google.cloud import ndb  # type: ignore
 from api import dev_api
 from internals import stage_helpers
 from internals.core_models import FeatureEntry, Stage
-from internals.legacy_models import Feature
 from internals.review_models import Gate
 
 class DevAPITest(testing_config.CustomTestCase):
 
   def tearDown(self):
-    for kind in [Feature, FeatureEntry, Stage, Gate]:
+    for kind in [FeatureEntry, Stage, Gate]:
       for entity in kind.query():
         entity.key.delete()
 
@@ -51,13 +50,10 @@ class DevAPITest(testing_config.CustomTestCase):
 
   def test_clear_entities(self):
     """Script successfully deletes most major entities."""
-    f_1 = Feature(id=1, name='feature one', summary='summary',
-        category=1, impl_status_chrome=1)
     fe_1 = FeatureEntry(id=1, name='feature one', summary='summary',
         category=1, impl_status_chrome=1)
     stage = Stage(id=2, feature_id=1, stage_type=160)
     gate = Gate(id=3, feature_id=1, stage_id=2, gate_type=4, state=1)
-    f_1.put()
     fe_1.put()
     stage.put()
     gate.put()
@@ -65,6 +61,6 @@ class DevAPITest(testing_config.CustomTestCase):
     handler_class = dev_api.ClearEntities()
     handler_class.do_get()
 
-    kinds: list[ndb.Model] = [Feature, FeatureEntry, Stage, Gate]
+    kinds: list[ndb.Model] = [FeatureEntry, Stage, Gate]
     for kind in kinds:
       self.assertTrue(len(kind.query().fetch()) == 0)

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -122,29 +122,6 @@ class FeaturesAPITestGet_NewSchema(testing_config.CustomTestCase):
     self.feature_3.put()
     self.feature_3_id = self.feature_3.key.integer_id()
 
-    # Feature entities for testing legacy functions.
-    self.legacy_feature_1 = Feature(
-        name='feature one', summary='sum Z',
-        owner=['feature_owner@example.com'], category=1,
-        intent_stage=core_enums.INTENT_IMPLEMENT)
-    self.legacy_feature_1.put()
-    self.legacy_feature_1_id = self.feature_1.key.integer_id()
-
-    self.legacy_feature_2 = Feature(
-        name='feature two', summary='sum K',
-        owner=['other_owner@example.com'], category=1,
-        intent_stage=core_enums.INTENT_IMPLEMENT)
-    self.legacy_feature_2.put()
-    self.legacy_feature_2_id = self.feature_2.key.integer_id()
-
-    self.legacy_feature_3 = Feature(
-        name='feature three', summary='sum A',
-        owner=['other_owner@example.com'], category=1,
-        intent_stage=core_enums.INTENT_IMPLEMENT,
-        unlisted=True)
-    self.legacy_feature_3.put()
-    self.legacy_feature_3_id = self.feature_3.key.integer_id()
-
     self.request_path = '/api/v0/features'
     self.handler = features_api.FeaturesAPI()
 
@@ -348,31 +325,6 @@ class FeaturesAPITestGet_OldSchema(testing_config.CustomTestCase):
     self.feature_3_id = self.feature_3.key.integer_id()
     self.ship_stage_3 = Stage(feature_id=self.feature_1_id,
         stage_type=360, milestones=MilestoneSet(desktop_first=2))
-
-    # Feature entities for testing legacy functions.
-    self.legacy_feature_1 = Feature(
-        name='feature one', summary='sum Z',
-        owner=['feature_owner@example.com'], category=1,
-        intent_stage=core_enums.INTENT_IMPLEMENT,
-        shipped_milestone=1)
-    self.legacy_feature_1.put()
-    self.legacy_feature_1_id = self.feature_1.key.integer_id()
-
-    self.legacy_feature_2 = Feature(
-        name='feature two', summary='sum K',
-        owner=['other_owner@example.com'], category=1,
-        intent_stage=core_enums.INTENT_IMPLEMENT,
-        shipped_milestone=2)
-    self.legacy_feature_2.put()
-    self.legacy_feature_2_id = self.feature_2.key.integer_id()
-
-    self.legacy_feature_3 = Feature(
-        name='feature three', summary='sum A',
-        owner=['other_owner@example.com'], category=1,
-        intent_stage=core_enums.INTENT_IMPLEMENT,
-        shipped_milestone=2, unlisted=True)
-    self.legacy_feature_3.put()
-    self.legacy_feature_3_id = self.feature_3.key.integer_id()
 
     self.request_path = '/api/v0/features'
     self.handler = features_api.FeaturesAPI()

--- a/internals/feature_helpers_test.py
+++ b/internals/feature_helpers_test.py
@@ -20,7 +20,6 @@ from framework import rediscache
 from internals.core_enums import *
 from internals import feature_helpers
 from internals import stage_helpers
-from internals.legacy_models import Feature
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
 
 
@@ -81,29 +80,8 @@ class FeatureHelpersTest(testing_config.CustomTestCase):
     self.fe_4_stages_dict = stage_helpers.get_feature_stages(
         self.feature_4.key.integer_id())
 
-    # Legacy entities for testing legacy functions.
-    self.legacy_feature_2 = Feature(
-        name='feature b', summary='sum',
-        owner=['feature_owner@example.com'], category=1)
-    self.legacy_feature_2.put()
-
-    self.legacy_feature_1 = Feature(
-        name='feature a', summary='sum', impl_status_chrome=3,
-        owner=['feature_owner@example.com'], category=1)
-    self.legacy_feature_1.put()
-
-    self.legacy_feature_4 = Feature(
-        name='feature d', summary='sum', category=1, impl_status_chrome=2,
-        owner=['feature_owner@example.com'])
-    self.legacy_feature_4.put()
-
-    self.legacy_feature_3 = Feature(
-        name='feature c', summary='sum', category=1, impl_status_chrome=2,
-        owner=['feature_owner@example.com'])
-    self.legacy_feature_3.put()
-
   def tearDown(self):
-    for kind in [Feature, FeatureEntry, Stage]:
+    for kind in [FeatureEntry, Stage]:
       for entity in kind.query():
         entity.key.delete()
 

--- a/internals/reminders_test.py
+++ b/internals/reminders_test.py
@@ -85,10 +85,6 @@ class FunctionTest(testing_config.CustomTestCase):
     self.current_milestone_info = {
         'earliest_beta': '2022-09-21T12:34:56',
     }
-
-    self.old_feature_template = Feature(id=123,
-        name='feature one', summary='sum', owner=['feature_owner@example.com'],
-        category=1, feature_type=0, ot_milestone_desktop_start=100)
     self.feature_template = FeatureEntry(id=123,
       name='feature one', summary='sum',
       creator_email='creator@example.com',
@@ -103,7 +99,6 @@ class FunctionTest(testing_config.CustomTestCase):
         stage.milestones = MilestoneSet(desktop_first=100)
       stage.put()
 
-    self.old_feature_template.put()
     self.feature_template.put()
 
     self.maxDiff = None

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -16,14 +16,15 @@ import testing_config  # Must be imported before the module under test.
 
 import datetime
 
-from internals.legacy_models import Approval, Feature 
+from internals.legacy_models import Approval
+from internals.core_models import FeatureEntry
 from internals.review_models import Activity, Gate, OwnersFile, Vote
 
 
 class ApprovalTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = Feature(
+    self.feature_1 = FeatureEntry(
         name='feature a', summary='sum', category=1, impl_status_chrome=3)
     self.feature_1.put()
     self.feature_1_id = self.feature_1.key.integer_id()
@@ -111,8 +112,9 @@ class ApprovalTest(testing_config.CustomTestCase):
 class CommentTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.feature_1 = Feature(
-        name='feature a', summary='sum',  owner=['feature_owner@example.com'],
+    self.feature_1 = FeatureEntry(
+        name='feature a', summary='sum',
+        owner_emails=['feature_owner@example.com'],
         category=1, impl_status_chrome=3)
     self.feature_1.put()
     self.feature_1_id = self.feature_1.key.integer_id()
@@ -132,8 +134,9 @@ class CommentTest(testing_config.CustomTestCase):
         content='random')
     self.act_1_3.put()
 
-    self.feature_2 = Feature(
-        name='feature b', summary='sum', owner=['feature_owner@example.com'],
+    self.feature_2 = FeatureEntry(
+        name='feature b', summary='sum',
+        owner_emails=['feature_owner@example.com'],
         category=1, impl_status_chrome=3)
     self.feature_2.put()
     self.feature_2_id = self.feature_2.key.integer_id()

--- a/pages/featurelist_test.py
+++ b/pages/featurelist_test.py
@@ -48,18 +48,12 @@ class TestWithFeature(testing_config.CustomTestCase):
     self.app_admin.is_admin = True
     self.app_admin.put()
 
-    self.feature_1 = Feature(
-        name='feature one', summary='detailed sum', owner=['owner@example.com'],
-        category=1, intent_stage=core_enums.INTENT_IMPLEMENT)
-    self.feature_1.put()
-    self.feature_id = self.feature_1.key.integer_id()
-
     self.fe_1 = FeatureEntry(
         name='feature one', summary='detailed sum',
         owner_emails=['owner@example.com'],
         category=1, intent_stage=core_enums.INTENT_IMPLEMENT)
     self.fe_1.put()
-    self.fe_id = self.fe_1.key.integer_id()
+    self.feature_id = self.fe_1.key.integer_id()
 
     self.request_path = (self.REQUEST_PATH_FORMAT %
         {'feature_id': self.feature_id} if self.REQUEST_PATH_FORMAT else '')
@@ -67,7 +61,6 @@ class TestWithFeature(testing_config.CustomTestCase):
       self.handler = self.HANDLER_CLASS()
 
   def tearDown(self):
-    self.feature_1.key.delete()
     self.fe_1.key.delete()
     self.app_user.delete()
     self.app_admin.delete()
@@ -90,8 +83,6 @@ class FeaturesJsonHandlerTest(TestWithFeature):
 
   def test_get_template_data__unlisted_no_perms(self):
     """JSON feed does not include unlisted features for users who can't edit."""
-    self.feature_1.unlisted = True
-    self.feature_1.put()
     self.fe_1.unlisted = True
     self.fe_1.put()
 
@@ -107,8 +98,6 @@ class FeaturesJsonHandlerTest(TestWithFeature):
 
   def test_get_template_data__unlisted_can_edit(self):
     """JSON feed includes unlisted features for site editors and admins."""
-    self.feature_1.unlisted = True
-    self.feature_1.put()
 
     testing_config.sign_in('admin@example.com', 111)
     with test_app.test_request_context(self.request_path):


### PR DESCRIPTION
Part of #2797

This change removes any uses of the old Feature kind from Python tests, with the exception of `guide_test.py`, which will come in a later PR since it also includes some double-write functionality that needs to be removed.