### PR TITLE
Fix bug when a page has no form

### DIFF
--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -215,19 +215,20 @@ class ChromedashApp extends LitElement {
 
     // Loading new page.
     this.pageComponent = document.createElement(componentName);
-    this.setChangesMade(false);
-    this.addBeforeUnloadHandler();
-
-    // Remember if anything has changed since the page was loaded.
-    this.pageComponent.addEventListener('sl-change', () => {
-      this.setChangesMade(true);
-    });
 
     window.setTimeout(() => {
       // Timeout required since the form may not be created yet.
       // Allow form submit to proceed without warning.
       const form = this.pageComponent.shadowRoot.querySelector('form');
       if (form) {
+        this.setChangesMade(false);
+        this.addBeforeUnloadHandler();
+
+        // Remember if anything has changed since the page was loaded.
+        this.pageComponent.addEventListener('sl-change', () => {
+          this.setChangesMade(true);
+        });
+
         form.addEventListener('submit', () => {
           this.handleFormSubmit();
         });


### PR DESCRIPTION
This PR changes how page transitions set up the beforeunload handler, which is now only done when the page has a form element.