### PR TITLE
Make script to update gate states more scalable.

### DIFF
--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -304,7 +304,8 @@ class CalcGateStateTest(testing_config.CustomTestCase):
 class UpdateTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.gate_1 = Gate(feature_id=1, stage_id=1, gate_type=2, state=Vote.APPROVED)
+    self.gate_1 = Gate(
+        id=1001, feature_id=1, stage_id=1, gate_type=2, state=Gate.PREPARING)
     self.gate_1.put()
     gate_id = self.gate_1.key.integer_id()
     self.votes = []
@@ -324,8 +325,8 @@ class UpdateTest(testing_config.CustomTestCase):
         state=Vote.REVIEW_REQUESTED, set_on=datetime.datetime(2020, 1, 2),
         set_by='user5@example.com'))
 
-    self.gate_2 = Gate(feature_id=2, stage_id=2, gate_type=2,
-        state=Vote.APPROVED)
+    self.gate_2 = Gate(
+        id=1002, feature_id=2, stage_id=2, gate_type=2, state=Vote.APPROVED)
     self.gate_2.put()
     gate_id = self.gate_2.key.integer_id()
     self.votes.append(Vote(feature_id=1, gate_id=gate_id,
@@ -368,13 +369,13 @@ class UpdateTest(testing_config.CustomTestCase):
   def test_update_approval_stage__needs_update(self):
     """Gate's approval state will be updated based on votes."""
     # Gate 1 should evaluate to not approved after updating.
-    self.assertEqual(
-        approval_defs.update_gate_approval_state(self.gate_1), Vote.APPROVED)
+    self.assertTrue(
+        approval_defs.update_gate_approval_state(self.gate_1))
     self.assertEqual(self.gate_1.state, Vote.APPROVED)
 
   def test_update_approval_state__no_change(self):
     """Gate's approval state does not change unless it needs to."""
     # Gate 2 is already marked as approved and should not change.
-    self.assertEqual(
-        approval_defs.update_gate_approval_state(self.gate_2), Vote.APPROVED)
+    self.assertFalse(
+        approval_defs.update_gate_approval_state(self.gate_2))
     self.assertEqual(self.gate_2.state, Vote.APPROVED)

--- a/internals/schema_migration.py
+++ b/internals/schema_migration.py
@@ -31,11 +31,18 @@ class EvaluateGateStatus(FlaskHandler):
 
     gates: ndb.Query = Gate.query()
     count = 0
+    batch = []
+    BATCH_SIZE = 100
     for gate in gates:
-      approval_defs.update_gate_approval_state(gate)
-      count += 1
+      if approval_defs.update_gate_approval_state(gate):
+        batch.append(gate)
+        count += 1
+        if len(batch) > BATCH_SIZE:
+          ndb.put_multi(batch)
+          batch = []
 
-    return f'{count} Gate entities reevaluated.'
+    ndb.put_multi(batch)
+    return f'{count} Gate entities updated.'
 
 
 class WriteMissingGates(FlaskHandler):


### PR DESCRIPTION
I noticed that some of the gates on prod have state == NA when they have no votes.
I think that was left over from some earlier data migration stage, but I don't see current source code that could have done it.
I tried running /admin/schema_migration_gate_status and it timed out after 10 minutes.
So, this should be faster because:
* It only writes gates that changed, allowing the script to make additional progress when re-run.
* It writes in batches of 100.