### PR TITLE
Implement PATCH request for Features API

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, TypedDict
+from datetime import datetime
 
 from api import converters
 from framework import basehandlers
@@ -84,6 +84,36 @@ class FeaturesAPI(basehandlers.APIHandler):
   # TODO(jrobbins): do_post
 
   # TODO(jrobbins): do_patch
+  def do_patch(self, **kwargs):
+    """Handle PATCH requests to update fields in a single feature."""
+    feature_id = kwargs['feature_id']
+    body = self.get_json_param_dict()
+
+    # update_fields represents which fields will be updated by this request.
+    fields_to_update = body.get('update_fields', [])
+    feature: FeatureEntry | None = FeatureEntry.get_by_id(feature_id)
+    if feature is None:
+      self.abort(404, msg=f'Feature {feature_id} not found')
+
+    # Validate the user has edit permissions and redirect if needed.
+    redirect_resp = permissions.validate_feature_edit_permission(
+        self, feature_id)
+    if redirect_resp:
+      return redirect_resp
+
+    # Update each field specified in the field mask.
+    for field in fields_to_update:
+      # Each field specified should be a valid field that exists on the entity.
+      if not hasattr(feature, field):
+        self.abort(500, msg=f'FeatureEntry has no attribute {field}')
+      if field in FeatureEntry.FIELDS_IMMUTABLE_BY_USER:
+        self.abort(500, f'FeatureEntry field {field} is immutable.')
+      setattr(feature, field, body[field])
+
+    feature.updater_email = self.get_current_user().email()
+    feature.updated = datetime.now()
+    feature.put()
+    return {'message': f'Feature {feature_id} updated.'}
 
   @permissions.require_admin_site
   def do_delete(self, **kwargs) -> dict[str, str]:
@@ -98,7 +128,7 @@ class FeaturesAPI(basehandlers.APIHandler):
     rediscache.delete_keys_with_prefix(FeatureEntry.feature_cache_prefix())
 
     # Write for new FeatureEntry entity.
-    feature_entry: Optional[FeatureEntry] = (
+    feature_entry: FeatureEntry | None = (
         FeatureEntry.get_by_id(feature_id))
     if feature_entry:
       feature_entry.deleted = True

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -83,7 +83,6 @@ class FeaturesAPI(basehandlers.APIHandler):
 
   # TODO(jrobbins): do_post
 
-  # TODO(jrobbins): do_patch
   def do_patch(self, **kwargs):
     """Handle PATCH requests to update fields in a single feature."""
     feature_id = kwargs['feature_id']
@@ -105,10 +104,10 @@ class FeaturesAPI(basehandlers.APIHandler):
     for field in fields_to_update:
       # Each field specified should be a valid field that exists on the entity.
       if not hasattr(feature, field):
-        self.abort(500, msg=f'FeatureEntry has no attribute {field}')
+        self.abort(400, msg=f'FeatureEntry has no attribute {field}.')
       if field in FeatureEntry.FIELDS_IMMUTABLE_BY_USER:
-        self.abort(500, f'FeatureEntry field {field} is immutable.')
-      setattr(feature, field, body[field])
+        self.abort(400, f'FeatureEntry field {field} is immutable.')
+      setattr(feature, field, body.get(field, None))
 
     feature.updater_email = self.get_current_user().email()
     feature.updated = datetime.now()

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -420,7 +420,7 @@ class FeaturesAPITest(testing_config.CustomTestCase):
         self.handler.do_patch(feature_id=self.feature_1_id)
 
   def test_patch__invalid_fields(self):
-    """PATCH request fails with 500 when supplying invalid fields."""
+    """PATCH request fails with 400 when supplying invalid fields."""
     # Signed-in user with permissions
     testing_config.sign_in('admin@example.com', 123567890)
 
@@ -433,11 +433,11 @@ class FeaturesAPITest(testing_config.CustomTestCase):
     }
     request_path = f'{self.request_path}/{self.feature_1_id}'
     with test_app.test_request_context(request_path, json=invalid_request_body):
-      with self.assertRaises(werkzeug.exceptions.InternalServerError):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_patch(feature_id=self.feature_1_id)
   
   def test_patch__immutable_fields(self):
-    """PATCH request fails with 500 when immutable field change is attempted."""
+    """PATCH request fails with 400 when immutable field change is attempted."""
     # Signed-in user with permissions
     testing_config.sign_in('admin@example.com', 123567890)
 
@@ -448,5 +448,5 @@ class FeaturesAPITest(testing_config.CustomTestCase):
     }
     request_path = f'{self.request_path}/{self.feature_1_id}'
     with test_app.test_request_context(request_path, json=invalid_request_body):
-      with self.assertRaises(werkzeug.exceptions.InternalServerError):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_patch(feature_id=self.feature_1_id)

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -43,6 +43,9 @@ class FeaturesAPITestDelete(testing_config.CustomTestCase):
     self.app_admin.is_admin = True
     self.app_admin.put()
 
+    self.random_user = user_models.AppUser(email='someuser@example.com')
+    self.random_user.put()
+
   def tearDown(self):
     cache_key = '%s|%s' % (
         FeatureEntry.DEFAULT_CACHE_KEY, self.feature_1.key.integer_id())
@@ -96,30 +99,39 @@ class FeaturesAPITestDelete(testing_config.CustomTestCase):
     self.assertFalse(revised_feature.deleted)
 
 
-class FeaturesAPITestGet_NewSchema(testing_config.CustomTestCase):
+class FeaturesAPITest(testing_config.CustomTestCase):
 
   def setUp(self):
     self.feature_1 = FeatureEntry(
-        name='feature one', summary='sum Z',
+        name='feature one', summary='sum Z', feature_type=0,
         owner_emails=['feature_owner@example.com'], category=1,
         intent_stage=core_enums.INTENT_IMPLEMENT)
     self.feature_1.put()
     self.feature_1_id = self.feature_1.key.integer_id()
+    self.ship_stage_1 = Stage(feature_id=self.feature_1_id,
+        stage_type=160, milestones=MilestoneSet(desktop_first=1))
+    self.ship_stage_1.put()
 
     self.feature_2 = FeatureEntry(
-        name='feature two', summary='sum K',
+        name='feature two', summary='sum K', feature_type=1,
         owner_emails=['other_owner@example.com'], category=1,
         intent_stage=core_enums.INTENT_IMPLEMENT)
     self.feature_2.put()
     self.feature_2_id = self.feature_2.key.integer_id()
+    self.ship_stage_2 = Stage(feature_id=self.feature_2_id,
+        stage_type=260, milestones=MilestoneSet(desktop_first=2))
+    self.ship_stage_2.put()
 
     self.feature_3 = FeatureEntry(
-        name='feature three', summary='sum A',
+        name='feature three', summary='sum A', feature_type=2,
         owner_emails=['other_owner@example.com'], category=1,
         intent_stage=core_enums.INTENT_IMPLEMENT,
         unlisted=True)
     self.feature_3.put()
     self.feature_3_id = self.feature_3.key.integer_id()
+    self.ship_stage_3 = Stage(feature_id=self.feature_3_id,
+        stage_type=360, milestones=MilestoneSet(desktop_first=2))
+    self.ship_stage_3.put()
 
     self.request_path = '/api/v0/features'
     self.handler = features_api.FeaturesAPI()
@@ -129,7 +141,7 @@ class FeaturesAPITestGet_NewSchema(testing_config.CustomTestCase):
     self.app_admin.put()
 
   def tearDown(self):
-    for kind in [FeatureEntry, user_models.AppUser]:
+    for kind in [FeatureEntry, Stage, user_models.AppUser]:
       for entity in kind.query():
         entity.key.delete()
 
@@ -292,54 +304,6 @@ class FeaturesAPITestGet_NewSchema(testing_config.CustomTestCase):
     self.assertEqual('sum K', actual['features'][1]['summary'])
     self.assertEqual('sum A', actual['features'][2]['summary'])
 
-
-# TODO(jrobbins): Merge with class above when everything uses FeatureEntries.
-class FeaturesAPITestGet_OldSchema(testing_config.CustomTestCase):
-
-  def setUp(self):
-    self.feature_1 = FeatureEntry(
-        name='feature one', summary='sum Z',
-        owner_emails=['feature_owner@example.com'], category=1,
-        intent_stage=core_enums.INTENT_IMPLEMENT, feature_type=0)
-    self.feature_1.put()
-    self.feature_1_id = self.feature_1.key.integer_id()
-    self.ship_stage_1 = Stage(feature_id=self.feature_1_id,
-        stage_type=160, milestones=MilestoneSet(desktop_first=1))
-    self.ship_stage_1.put()
-    self.feature_2 = FeatureEntry(
-        name='feature two', summary='sum K',
-        owner_emails=['other_owner@example.com'], category=1,
-        intent_stage=core_enums.INTENT_IMPLEMENT, feature_type=1)
-    self.feature_2.put()
-    self.feature_2_id = self.feature_2.key.integer_id()
-    self.ship_stage_2 = Stage(feature_id=self.feature_1_id,
-        stage_type=260, milestones=MilestoneSet(desktop_first=2))
-
-    self.feature_3 = FeatureEntry(
-        name='feature three', summary='sum A',
-        owner_emails=['other_owner@example.com'], category=1,
-        intent_stage=core_enums.INTENT_IMPLEMENT, feature_type=2,
-        unlisted=True)
-    self.feature_3.put()
-    self.feature_3_id = self.feature_3.key.integer_id()
-    self.ship_stage_3 = Stage(feature_id=self.feature_1_id,
-        stage_type=360, milestones=MilestoneSet(desktop_first=2))
-
-    self.request_path = '/api/v0/features'
-    self.handler = features_api.FeaturesAPI()
-
-    self.app_admin = user_models.AppUser(email='admin@example.com')
-    self.app_admin.is_admin = True
-    self.app_admin.put()
-
-  def tearDown(self):
-    for kind in [FeatureEntry, Stage, user_models.AppUser]:
-      for entity in kind.query():
-        entity.key.delete()
-    testing_config.sign_out()
-    rediscache.delete_keys_with_prefix('features|*')
-    rediscache.delete_keys_with_prefix('FeatureEntries|*')
-
   def test_get__in_milestone_listed(self):
     """Get all features in a specific milestone that are listed."""
     # Atleast one feature is present in milestone
@@ -422,3 +386,67 @@ class FeaturesAPITestGet_OldSchema(testing_config.CustomTestCase):
     with test_app.test_request_context(request_path):
       with self.assertRaises(werkzeug.exceptions.NotFound):
         self.handler.do_get(feature_id=999)
+  
+  def test_patch__valid(self):
+    """PATCH request successful with valid input from user with permissions."""
+    # Signed-in user with permissions
+    testing_config.sign_in('admin@example.com', 123567890)
+
+    new_summary = 'a different summary'
+    new_owner_emails = ['test@example.com']
+    valid_request_body = {
+      'update_fields': ['summary', 'owner_emails'],
+      'summary': new_summary,
+      'owner_emails': new_owner_emails,
+    }
+    request_path = f'{self.request_path}/{self.feature_1_id}'
+    with test_app.test_request_context(request_path, json=valid_request_body):
+      response = self.handler.do_patch(feature_id=self.feature_1_id)
+    # Success response should be returned
+    self.assertEqual({'message': f'Feature {self.feature_1_id} updated.'}, response)
+    # Assert that changes were made.
+    self.assertEqual(self.feature_1.summary, new_summary)
+    self.assertEqual(self.feature_1.owner_emails, new_owner_emails)
+    # Updater email field should be changed
+    self.assertEqual(self.feature_1.updater_email, 'admin@example.com')
+
+  def test_patch__no_permissions(self):
+    """We give 403 if the user does not have feature edit access."""
+    testing_config.sign_in('someuser@example.com', 123567890)
+
+    request_path = f'{self.request_path}/{self.feature_1_id}'
+    with test_app.test_request_context(request_path, json={}):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
+        self.handler.do_patch(feature_id=self.feature_1_id)
+
+  def test_patch__invalid_fields(self):
+    """PATCH request fails with 500 when supplying invalid fields."""
+    # Signed-in user with permissions
+    testing_config.sign_in('admin@example.com', 123567890)
+
+    bad_param = 'Not a real field'
+    new_owner_emails = ['test@example.com']
+    invalid_request_body = {
+      'update_fields': ['bad_param', 'owner_emails'],
+      'bad_param': bad_param,
+      'owner_emails': new_owner_emails,
+    }
+    request_path = f'{self.request_path}/{self.feature_1_id}'
+    with test_app.test_request_context(request_path, json=invalid_request_body):
+      with self.assertRaises(werkzeug.exceptions.InternalServerError):
+        self.handler.do_patch(feature_id=self.feature_1_id)
+  
+  def test_patch__immutable_fields(self):
+    """PATCH request fails with 500 when immutable field change is attempted."""
+    # Signed-in user with permissions
+    testing_config.sign_in('admin@example.com', 123567890)
+
+    new_creator = 'differentuser@example.com'
+    invalid_request_body = {
+      'update_fields': ['creator_email'],
+      'creator_email': new_creator,
+    }
+    request_path = f'{self.request_path}/{self.feature_1_id}'
+    with test_app.test_request_context(request_path, json=invalid_request_body):
+      with self.assertRaises(werkzeug.exceptions.InternalServerError):
+        self.handler.do_patch(feature_id=self.feature_1_id)

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -29,6 +29,17 @@ import settings
 class FeatureEntry(ndb.Model):  # Copy from Feature
   """This is the main representation of a feature that we are tracking."""
 
+  # Fields that should not be mutated by user edit requests.
+  FIELDS_IMMUTABLE_BY_USER = frozenset([
+    'id',
+    'created',
+    'creator_email',
+    'outstanding_notifications',
+    'deleted',
+    'star_count',
+    'feature_type',
+  ])
+
   # Metadata: Creation and updates.
   created = ndb.DateTimeProperty(auto_now_add=True)
   updated = ndb.DateTimeProperty(auto_now_add=True)


### PR DESCRIPTION
Part of #2872

This change adds PATCH request support to the Features API, which allows specific fields to be edited on FeatureEntry entities. This will not currently be used by any client aspects, but will be a necessary change for phasing out or old approach to feature edits (guide.py).
This request will only make changes if:
- the user has edit permission for the feature.
- the feature exists.
- the fields provided can be mutated by normal users.

List of changes by file:
- api/features_api.py: Add a new PATCH request function. This request will require providing a list of fields that should be changed on the FeatureEntry entity, as well as their values.
-  internals/core_models.py: Adds a new list of fields that normal users should not have access to mutate.