### PR TITLE
Reflect selected milestone in query params for the release notes page

### DIFF
--- a/client-src/elements/chromedash-enterprise-release-notes-page_test.js
+++ b/client-src/elements/chromedash-enterprise-release-notes-page_test.js
@@ -1,6 +1,7 @@
 import {html} from 'lit';
 import {assert, fixture, nextFrame} from '@open-wc/testing';
 import {ChromedashEnterpriseReleaseNotesPage} from './chromedash-enterprise-release-notes-page';
+import {parseRawQuery, clearURLParams} from './utils.js';
 import './chromedash-toast';
 import '../js-src/cs-client';
 import sinon from 'sinon';
@@ -143,6 +144,25 @@ describe('chromedash-feature-page', () => {
   afterEach(() => {
     window.csClient.searchFeatures.restore();
     window.csClient.getChannels.restore();
+    clearURLParams('milestone');
+  });
+
+  it('reflects the milestone in the query params', async () => {
+    const component = await fixture(html`
+      <chromedash-enterprise-release-notes-page></chromedash-enterprise-release-notes-page>`);
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashEnterpriseReleaseNotesPage);
+    assert.equal(parseRawQuery(window.location.search).milestone, 100);
+
+    // Select a future milestone
+    component.selectedMilestone = 110;
+    await nextFrame();
+    assert.equal(parseRawQuery(window.location.search).milestone, 110);
+
+    // Select a previous milestone
+    component.selectedMilestone = 90;
+    await nextFrame();
+    assert.equal(parseRawQuery(window.location.search).milestone, 90);
   });
 
   it('renders with no data', async () => {

--- a/client-src/elements/utils.js
+++ b/client-src/elements/utils.js
@@ -152,3 +152,89 @@ export function renderRelativeDate(dateStr) {
          </sl-relative-time>)
       </span>`;
 }
+
+
+/**
+ * Parses URL query strings into a dict.
+ * @param {string} rawQuery a raw URL query string, e.g. q=abc&num=1;
+ * @return {Object} A key-value pair dictionary for the query string.
+ */
+export function parseRawQuery(rawQuery) {
+  const params = new URLSearchParams(rawQuery);
+  const result = {};
+  for (const param of params.keys()) {
+    const values = params.getAll(param);
+    if (!values.length) {
+      continue;
+    }
+    // Assume there is only one value.
+    result[param] = values[0];
+  }
+  return result;
+}
+
+
+/**
+ * Create a new URL using params and a location.
+ * @param {string} params is the new param object.
+ * @param {Object} location is an URL location.
+ * @return {Object} the new URL.
+ */
+export function getNewLocation(params, location) {
+  const url = new URL(location);
+  url.search = '';
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      // Skip if the value is empty.
+      if (!v) {
+        continue;
+      }
+      url.searchParams.append(k, v);
+    }
+  }
+  return url;
+}
+
+
+/**
+ * Update window.location with new query params.
+ * @param {string} key is the key of the query param.
+ * @param {string} val is the unencoded value of the query param.
+ */
+export function updateURLParams(key, val) {
+  // Update the query param object.
+  const rawQuery = parseRawQuery(window.location.search);
+  rawQuery[key] = encodeURIComponent(val);
+
+  // Assemble the new URL.
+  const newURL = getNewLocation(rawQuery, window.location);
+  newURL.hash = '';
+  if (newURL.toString() === window.location.toString()) {
+    return;
+  }
+  // Update URL without refreshing the page. {path:} is needed for
+  // an issue in page.js:
+  // https://github.com/visionmedia/page.js/issues/293#issuecomment-456906679
+  window.history.pushState({path: newURL.toString()}, '', newURL);
+}
+
+/**
+ * Update window.location with new query params.
+ * @param {string} key is the key of the query param to delete.
+ */
+export function clearURLParams(key) {
+  // Update the query param object.
+  const rawQuery = parseRawQuery(window.location.search);
+  delete rawQuery[key];
+
+  // Assemble the new URL.
+  const newURL = getNewLocation(rawQuery, window.location);
+  newURL.hash = '';
+  if (newURL.toString() === window.location.toString()) {
+    return;
+  }
+  // Update URL without refreshing the page. {path:} is needed for
+  // an issue in page.js:
+  // https://github.com/visionmedia/page.js/issues/293#issuecomment-456906679
+  window.history.pushState({path: newURL.toString()}, '', newURL);
+}

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -335,25 +335,6 @@ class ChromeStatusClient {
   getSpecifiedChannels(start, end) {
     return this.doGet(`/channels?start=${start}&end=${end}`);
   }
-
-  /**
-   * Parses URL query strings into a dict.
-   * @param {string} rawQuery a raw URL query string, e.g. q=abc&num=1;
-   * @return {Object} A key-value pair dictionary for the query string.
-   */
-  parseRawQuery(rawQuery) {
-    const params = new URLSearchParams(rawQuery);
-    const result = {};
-    for (const param of params.keys()) {
-      const values = params.getAll(param);
-      if (!values.length) {
-        continue;
-      }
-      // Assume there is only one value.
-      result[param] = values[0];
-    }
-    return result;
-  }
 };
 
 exports.ChromeStatusClient = ChromeStatusClient;


### PR DESCRIPTION
This includes a moving the functions parseRawQuery, getNewLocation and updateURLParams from cs-client.js to utils.js to make them more accessible.

It also adds a clearQueryParam which deletes a query parameter from the url and is mostly used for testing now.