### PR TITLE
Bump fakeredis to 1.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ google-cloud-logging==3.0.0
 google-auth==1.31.0
 requests==2.27.1
 redis==4.3.4
-fakeredis==1.9.0
+fakeredis==1.10.1
 Flask==2.1.2
 flask-cors==3.0.10
 funcsigs==1.0.2


### PR DESCRIPTION
Right now, redis can't be upgraded.

https://github.com/GoogleChrome/chromium-dashboard/actions/runs/4576646737/jobs/8081053938?pr=2884#step:6:167

```
The conflict is caused by:
170    The user requested redis==4.4.4
171    google-cloud-ndb 1.11.1 depends on redis
172    fakeredis 1.9.0 depends on redis<4.4
```

This PR fixes that. After this PR is merged, rebase https://github.com/GoogleChrome/chromium-dashboard/pull/2884