### PR TITLE
Make gate status update script more robust.

### DIFF
--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -324,8 +324,10 @@ def _calc_gate_state(votes: list[Vote], rule: str) -> int:
 def update_gate_approval_state(gate: Gate) -> int:
   """Change the Gate state in RAM based on its votes. Return True if changed."""
   votes = Vote.get_votes(gate_id=gate.key.integer_id())
-  afd = APPROVAL_FIELDS_BY_ID[gate.gate_type]
-  new_state = _calc_gate_state(votes, afd.rule)
+  afd = APPROVAL_FIELDS_BY_ID.get(gate.gate_type)
+  # Assume any gate of a type that is not currently supported is ONE_LGTM.
+  rule = afd.rule if afd else ONE_LGTM
+  new_state = _calc_gate_state(votes, rule)
   if new_state == gate.state:
     return False
   gate.state = new_state

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -368,7 +368,7 @@ class UpdateTest(testing_config.CustomTestCase):
 
   def test_update_approval_stage__needs_update(self):
     """Gate's approval state will be updated based on votes."""
-    # Gate 1 should evaluate to not approved after updating.
+    # Gate 1 should evaluate to approved after updating.
     self.assertTrue(
         approval_defs.update_gate_approval_state(self.gate_1))
     self.assertEqual(self.gate_1.state, Vote.APPROVED)
@@ -379,3 +379,11 @@ class UpdateTest(testing_config.CustomTestCase):
     self.assertFalse(
         approval_defs.update_gate_approval_state(self.gate_2))
     self.assertEqual(self.gate_2.state, Vote.APPROVED)
+
+  def test_update_approval_state__unsupported_gate_type(self):
+    """If we don't recognize the gate type, assume rule ONE_LGTM."""
+    self.gate_1.gate_type = 999
+    # Gate 1 should evaluate to approved after updating.
+    self.assertTrue(
+        approval_defs.update_gate_approval_state(self.gate_1))
+    self.assertEqual(self.gate_1.state, Vote.APPROVED)


### PR DESCRIPTION
On staging, we had enabled gates for privacy and security, created data with gates of those types, and then commented out those gate types until we are ready to launch them.  That causes some KeyErrors when we try to process those gates.  So, I made this script more robust by assuming that any gate with an unrecognized gate type has rule ONE_LGTM.