### PR TITLE
Fix yet another bug with beforeunload

### DIFF
--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -215,13 +215,14 @@ class ChromedashApp extends LitElement {
 
     // Loading new page.
     this.pageComponent = document.createElement(componentName);
+    this.setChangesMade(false);
+    this.removeBeforeUnloadHandler();
 
     window.setTimeout(() => {
       // Timeout required since the form may not be created yet.
       // Allow form submit to proceed without warning.
       const form = this.pageComponent.shadowRoot.querySelector('form');
       if (form) {
-        this.setChangesMade(false);
         this.addBeforeUnloadHandler();
 
         // Remember if anything has changed since the page was loaded.


### PR DESCRIPTION
This PR always resets the changed status, and removes any beforeunload handler, as the first part of setting up a new SPA page, regardless whether there is a form.