### PR TITLE
Bug fix: enums display as their expanded versions on feature detail page

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -337,7 +337,7 @@ class ChromedashFeatureDetail extends LitElement {
       web_dev_views_notes: 'browsers.webdev.view.notes',
       other_views_notes: 'browsers.other.view.notes',
     };
-    if (!value && fieldNameMapping[fieldName]) {
+    if (fieldNameMapping[fieldName]) {
       value = this.feature;
       for (const step of fieldNameMapping[fieldName].split('.')) {
         if (value) {

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -518,7 +518,7 @@ VENDOR_VIEWS_COMMON = {
   SHIPPED: 'Shipped/Shipping',
   IN_DEV: 'In development',
   PUBLIC_SUPPORT: 'Positive',
-  NO_PUBLIC_SIGNALS: 'No signals',
+  NO_PUBLIC_SIGNALS: 'No signal',
   OPPOSED: 'Negative',
   NEUTRAL: 'Neutral',
   SIGNALS_NA: 'N/A',

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -518,7 +518,7 @@ VENDOR_VIEWS_COMMON = {
   SHIPPED: 'Shipped/Shipping',
   IN_DEV: 'In development',
   PUBLIC_SUPPORT: 'Positive',
-  NO_PUBLIC_SIGNALS: 'No signal',
+  NO_PUBLIC_SIGNALS: 'No signals',
   OPPOSED: 'Negative',
   NEUTRAL: 'Neutral',
   SIGNALS_NA: 'N/A',


### PR DESCRIPTION
This change updates the logic that previously would not expand enum values for the feature detail page if the int value could be referenced successfully from the FeatureEntry JSON.

~~Additionally, this contains a fix to normalize the `web_views` field text to display as plural, which correlates with the text for `ff_views` and `safari_views`.~~ Edit: Not making this change, as it might be intended.