### PR TITLE
Remove unused `console.log()` statements

### DIFF
--- a/client-src/elements/chromedash-enterprise-release-notes-page_test.js
+++ b/client-src/elements/chromedash-enterprise-release-notes-page_test.js
@@ -177,7 +177,6 @@ describe('chromedash-feature-page', () => {
     // invalid feature requests would trigger the toast to show message
     const toastEl = document.querySelector('chromedash-toast');
     const toastMsgSpan = toastEl.shadowRoot.querySelector('span#msg');
-    console.log(toastMsgSpan.innerHTML);
     assert.include(toastMsgSpan.innerHTML,
       'Some errors occurred. Please refresh the page or try again later.');
   });

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -416,8 +416,6 @@ export class ChromedashGateColumn extends LitElement {
     } else if (this.gate.state == STATE_NAMES.DENIED[0]) {
       return this.renderReviewStatusDenied();
     } else {
-      console.log('Unexpected gate state');
-      console.log(this.gate);
       return nothing;
     }
   }

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -97,7 +97,6 @@ class ChromeStatusClient {
     const rawResponseText = await response.text();
     const XSSIPrefix = ')]}\'\n';
     if (!rawResponseText.startsWith(XSSIPrefix)) {
-      console.log(rawResponseText);
       throw new Error(
           `Response does not start with XSSI prefix: ${XSSIPrefix}`);
     }


### PR DESCRIPTION
This change removes `console.log` statements that exist in the code but are unneeded for the most part. This also fixes an issue where logs are being generated when running `npm run webtest`.