### PR TITLE
Fix #2859. Display milestones in the right order

### DIFF
--- a/templates/estimated-milestones-table.html
+++ b/templates/estimated-milestones-table.html
@@ -7,13 +7,15 @@
       <td>{{stage.milestones.desktop_first}}</td></tr>
 
     {% endif %}{% endfor %}
-    {% for stage in stage_info.ot_stages %}{% if stage.milestones.desktop_last %}
-      <tr><td>OriginTrial desktop last</td>
-      <td>{{stage.milestones.desktop_last}}</td></tr>
-
-      {% endif %}{% if stage.milestones.desktop_first %}
+    {% for stage in stage_info.ot_stages %}{% if stage.milestones.desktop_first %}
       <tr><td>OriginTrial desktop first</td>
       <td>{{stage.milestones.desktop_first}}</td></tr>
+
+      {% endif %}{% if stage.milestones.desktop_last %}
+      <tr>
+        <td>OriginTrial desktop last</td>
+        <td>{{stage.milestones.desktop_last}}</td>
+      </tr>
 
     {% endif %}{% endfor %}
     {% for stage in stage_info.dt_stages %}{% if stage.milestones.desktop_first %}


### PR DESCRIPTION
This PR fixes https://github.com/GoogleChrome/chromium-dashboard/issues/2859

I changed the order in which OriginTrial milestones are shown (now the start milestones show before the end)