### PR TITLE
Add index needed for detect_intent.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -374,6 +374,10 @@ indexes:
   - name: set_on
 - kind: Vote
   properties:
+  - name: gate_type
+  - name: set_on
+- kind: Vote
+  properties:
   - name: state
   - name: set_on
 - kind: Vote


### PR DESCRIPTION
Some of our detect_intent tasks were failing and showing up on the Error Reporting page.  
The error message suggested adding this index.  
Error location:
https://github.com/GoogleChrome/chromium-dashboard/blob/main/internals/detect_intent.py#L150

