### PR TITLE
New accounts are not warned/removed as inactive

### DIFF
--- a/internals/inactive_users_test.py
+++ b/internals/inactive_users_test.py
@@ -15,57 +15,63 @@
 import testing_config  # Must be imported before the module under test.
 from datetime import datetime
 
-from internals import user_models
+from internals.user_models import AppUser
 from internals.inactive_users import RemoveInactiveUsersHandler
 
 class RemoveInactiveUsersHandlerTest(testing_config.CustomTestCase):
 
   def setUp(self):
-    self.users = []
-    active_user = user_models.AppUser(
+    active_user = AppUser(
+      created=datetime(2020, 10, 1),
       email="active_user@example.com", is_admin=False, is_site_editor=False,
       last_visit=datetime(2023, 8, 30))
     active_user.put()
-    self.users.append(active_user)
 
-    inactive_user = user_models.AppUser(
+    inactive_user = AppUser(
+      created=datetime(2020, 10, 1),
       email="inactive_user@example.com", is_admin=False, is_site_editor=False,
       last_visit=datetime(2023, 2, 20))
     inactive_user.put()
-    self.users.append(inactive_user)
+    
+    # User who has recently been given access by an admin,
+    # but has not yet visited the site. They should not be considered inactive.
+    newly_created_user = AppUser(
+      created=datetime(2023, 8, 1),
+      email="new_user@example.com", is_admin=False, is_site_editor=False)
+    newly_created_user.put()
 
-    really_inactive_user = user_models.AppUser(
+    really_inactive_user = AppUser(
+      created=datetime(2020, 10, 1),
       email="really_inactive_user@example.com", is_admin=False,
       is_site_editor=False, last_visit=datetime(2022, 10, 1))
     really_inactive_user.put()
-    self.users.append(really_inactive_user)
 
-    active_admin = user_models.AppUser(
+    active_admin = AppUser(
+      created=datetime(2020, 10, 1),
       email="active_admin@example.com", is_admin=True, is_site_editor=True,
       last_visit=datetime(2023, 9, 30))
     active_admin.put()
-    self.users.append(active_admin)
 
-    inactive_admin = user_models.AppUser(
+    inactive_admin = AppUser(
+      created=datetime(2020, 10, 1),
       email="inactive_admin@example.com", is_admin=True, is_site_editor=True,
       last_visit=datetime(2023, 3, 1))
     inactive_admin.put()
-    self.users.append(inactive_admin)
 
-    active_site_editor = user_models.AppUser(
+    active_site_editor = AppUser(
+      created=datetime(2020, 10, 1),
       email="active_site_editor@example.com", is_admin=False,
       is_site_editor=True, last_visit=datetime(2023, 7, 30))
     active_site_editor.put()
-    self.users.append(active_site_editor)
 
-    inactive_site_editor = user_models.AppUser(
+    inactive_site_editor = AppUser(
+      created=datetime(2020, 10, 1),
       email="inactive_site_editor@example.com", is_admin=False,
       is_site_editor=True, last_visit=datetime(2023, 2, 9))
     inactive_site_editor.put()
-    self.users.append(inactive_site_editor)
 
   def tearDown(self):
-    for user in self.users:
+    for user in AppUser.query():
       user.key.delete()
 
   def test_remove_inactive_users(self):

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -377,7 +377,7 @@ class NotifyInactiveUsersHandler(basehandlers.FlaskHandler):
       now = datetime.now()
 
     q = AppUser.query()
-    users = q.fetch()
+    users: list[AppUser] = q.fetch()
     inactive_users = []
     inactive_cutoff = now - timedelta(days=self.INACTIVE_WARN_DAYS)
 
@@ -388,8 +388,11 @@ class NotifyInactiveUsersHandler(basehandlers.FlaskHandler):
         continue
 
       # If the user does not have a last visit, it is assumed the last visit
-      # is roughly the date the last_visit field was added.
+      # is either the account's creation date or the date the last_visit
+      # field was created on the model - whatever is latest.
       last_visit = user.last_visit or self.DEFAULT_LAST_VISIT
+      if user.created > last_visit:
+        last_visit = user.created
       # Notify the user of inactivity if they haven't already been notified.
       if (last_visit < inactive_cutoff):
         inactive_users.append(user.email)


### PR DESCRIPTION
This PR fixes a logic error where new accounts created by admins are considered inactive if the user has not yet logged in once. Instead of just comparing the `last_visit` date when checking for inactivity, both `last_visit` date and `created` date are both checked, and the most recent value is used.