### PR TITLE
Clarify requirements for OT feedback summary

### DIFF
--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -996,7 +996,9 @@ export const ALL_FIELDS = {
     label: 'Origin trial feedback summary',
     help_text: html`
       If your feature was available as an origin trial, link to a summary
-      of usage and developer feedback. If not, leave this empty.`,
+      of usage and developer feedback. If not, leave this empty. DO NOT
+      USE FEEDBACK VERBATIM without prior consultation with the Origin 
+      Trials team.`,
   },
 
   'anticipated_spec_changes': {


### PR DESCRIPTION
The trial feedback summary field is expected to summarize participant feedback, not include feedback copied (or linked to) verbatim. When in doubt, feature teams should consult with the Origin Trials team on how to proceed.