### PR TITLE
POST request functionality for Features API

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -15,7 +15,6 @@
 
 from datetime import datetime
 from typing import Any
-from google.cloud import ndb
 
 from api import converters
 from framework import basehandlers
@@ -102,10 +101,15 @@ class FeaturesAPI(basehandlers.APIHandler):
 
   def _abort_invalid_data_type(
       self, field: str, field_type: str, value: Any) -> None:
+    """Abort the process if an invalid data type is given."""
     self.abort(400, msg=(
         f'Bad value for field {field} of type {field_type}: {value}'))
 
-  def _format_field_val(self, field: str, value: Any) -> Any:
+  def _format_field_val(
+      self,
+      field: str,
+      value: Any
+    ) -> str | int | bool | list | None:
     """Format the given feature value based on the field type."""
     # Only fields with defined data types are allowed.
     if field not in self.FIELD_DATA_TYPES_CREATE:
@@ -128,11 +132,8 @@ class FeaturesAPI(basehandlers.APIHandler):
       except ValueError:
         self._abort_invalid_data_type(field, field_type, value)
     elif field_type == 'bool':
-      try:
-        return bool(value)
-      except ValueError:
-        self._abort_invalid_data_type(field, field_type, value)
-    return value
+      return bool(value)
+    return str(value)
 
   def get_one_feature(self, feature_id: int) -> VerboseFeatureDict:
     feature = FeatureEntry.get_by_id(feature_id)

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from datetime import datetime
+from typing import Any
 from google.cloud import ndb
 
 from api import converters
@@ -26,10 +27,112 @@ from internals.core_models import FeatureEntry
 from internals.data_types import VerboseFeatureDict
 from internals import feature_helpers
 from internals import search
-
+import settings
 
 class FeaturesAPI(basehandlers.APIHandler):
   """Features are the the main records that we track."""
+
+  # Dictionary with fields that can be edited on feature creation
+  # and their data types.
+  # Field name, data type
+  FIELD_DATA_TYPES_CREATE: dict[str, str] = {
+    'activation_risks': 'str',
+    'adoption_expectation': 'str',
+    'adoption_plan': 'str',
+    'all_platforms': 'bool',
+    'all_platforms_descr': 'str',
+    'anticipated_spec_changes': 'str',
+    'api_spec': 'bool',
+    'availability_expectation': 'str',
+    'blink_components': 'list',
+    'breaking_change': 'bool',
+    'bug_url': 'str',
+    'category': 'int',
+    'cc_emails': 'list',
+    'comments': 'str',
+    'debuggability': 'str',
+    'devrel': 'list',
+    'devtrial_instructions': 'str',
+    'doc_links': 'list',
+    'editors_emails': 'list',
+    'enterprise_feature_categories': 'list',
+    'ergonomics_risks': 'str',
+    'explainer_links': 'list',
+    'feature_type': 'int',
+    'ff_views': 'int',
+    'ff_views_link': 'str',
+    'ff_views_notes': 'str',
+    'flag_name': 'str',
+    'impl_status_chrome': 'int',
+    'initial_public_proposal_url': 'str',
+    'intent_stage': 'int',
+    'interop_compat_risks': 'str',
+    'launch_bug_url': 'str',
+    'measurement': 'str',
+    'motivation': 'str',
+    'name': 'str',
+    'non_oss_deps': 'str',
+    'ongoing_constraints': 'str',
+    'other_views_notes': 'str',
+    'owner_emails': 'list',
+    'prefixed': 'bool',
+    'privacy_review_status': 'int',
+    'requires_embedder_support': 'bool',
+    'safari_views': 'int',
+    'safari_views_link': 'str',
+    'safari_views_notes': 'str',
+    'sample_links': 'list',
+    'search_tags': 'list',
+    'security_review_status': 'int',
+    'security_risks': 'str',
+    'spec_link': 'str',
+    'spec_mentors': 'list',
+    'standard_maturity': 'int',
+    'summary': 'str',
+    'tag_review': 'str',
+    'tag_review_status': 'int',
+    'unlisted': 'bool',
+    'web_dev_views': 'int',
+    'web_dev_views_link': 'str',
+    'web_dev_views_notes': 'str',
+    'webview_risks': 'str',
+    'wpt': 'bool',
+    'wpt_descr': 'str',
+  }
+
+  def _abort_invalid_data_type(
+      self, field: str, field_type: str, value: Any) -> None:
+    self.abort(400, msg=(
+        f'Bad value for field {field} of type {field_type}: {value}'))
+
+  def _format_field_val(self, field: str, value: Any) -> Any:
+    """Format the given feature value based on the field type."""
+    # Only fields with defined data types are allowed.
+    if field not in self.FIELD_DATA_TYPES_CREATE:
+      self.abort(400, msg=f'Field "{field}" data format not found.')
+    
+    field_type = self.FIELD_DATA_TYPES_CREATE[field]
+
+    # If the field is empty, no need to format.
+    if value is None:
+      return None
+
+    # TODO(DanielRyanSmith): Write checks to ensure enum values are valid.
+    if (field_type == 'list'):
+      if field == 'blink_components' and len(value) == 0:
+        return [settings.DEFAULT_COMPONENT]
+      return value
+    elif field_type == 'int':
+      try:
+        return int(value)
+      except ValueError:
+        self._abort_invalid_data_type(field, field_type, value)
+    elif field_type == 'bool':
+      try:
+        return bool(value)
+      except ValueError:
+        self._abort_invalid_data_type(field, field_type, value)
+    return value
 
   def get_one_feature(self, feature_id: int) -> VerboseFeatureDict:
     feature = FeatureEntry.get_by_id(feature_id)
@@ -91,20 +194,12 @@ class FeaturesAPI(basehandlers.APIHandler):
     for field in FeatureEntry.REQUIRED_FIELDS:
       if field not in body:
         self.abort(400, msg=f'Required field "{field}" not provided.')
-    
-    # A feature creation request should not change fields that user
-    # cannot change.
-    for field in FeatureEntry.FIELDS_IMMUTABLE_BY_USER:
-      # Feature type cannot be changed after creation,
-      # but is required to be created. Don't check for it as an immutable field.
-      if field == 'feature_type':
-        continue
-      if field in body:
-        self.abort(400, msg=f'Immutable field "{field}" provided')
 
+    fields_dict = {field: self._format_field_val(field, value)
+                   for field, value in body.items()}
     # Try to create the feature using the provided data.
     try:
-      feature = FeatureEntry(**body,
+      feature = FeatureEntry(**fields_dict,
                              creator_email=self.get_current_user().email())
       feature.put()
     except Exception as e:

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -467,6 +467,7 @@ class FeaturesAPITest(testing_config.CustomTestCase):
       'ff_views': 1,
       'safari_views': 1,
       'web_dev_views': 1,
+      'wpt': True,
     }
 
     request_path = f'{self.request_path}/create'
@@ -501,11 +502,11 @@ class FeaturesAPITest(testing_config.CustomTestCase):
     testing_config.sign_in('admin@example.com', 123567890)
 
     invalid_request_body = {
-      'bad_param': 'Not a real field',
+      'bad_param': 'Not a real field',  # Bad field.
 
       'name': 'A name',
       'summary': 'A summary',
-      'owner_emails': ['summary', 'owner_emails'],
+      'owner_emails': ['user@example.com', 'user2@example.com'],
       'category': 1,
       'feature_type': 1,
       'impl_status_chrome': 1,
@@ -529,7 +530,7 @@ class FeaturesAPITest(testing_config.CustomTestCase):
 
       'name': 'A name',
       'summary': 'A summary',
-      'owner_emails': ['summary', 'owner_emails'],
+      'owner_emails': ['user@example.com', 'user2@example.com'],
       'category': 1,
       'feature_type': 1,
       'impl_status_chrome': 1,
@@ -551,30 +552,8 @@ class FeaturesAPITest(testing_config.CustomTestCase):
     invalid_request_body = {
       'name': 'A name',
       'summary': 'A summary',
-      'owner_emails': ['summary', 'owner_emails'],
+      'owner_emails': ['user@example.com', 'user2@example.com'],
       'category': 'THIS SHOULD BE AN INTEGER',  # Bad data type.
-      'feature_type': 1,
-      'impl_status_chrome': 1,
-      'standard_maturity': 1,
-      'ff_views': 1,
-      'safari_views': 1,
-      'web_dev_views': 1,
-    }
-    request_path = f'{self.request_path}/create'
-    with test_app.test_request_context(request_path, json=invalid_request_body):
-      with self.assertRaises(werkzeug.exceptions.BadRequest):
-        self.handler.do_post()
-
-  def test_post__bad_data_type_str(self):
-    """POST request fails with 400 when a bad str data type is provided."""
-    # Signed-in user with permissions
-    testing_config.sign_in('admin@example.com', 123567890)
-
-    invalid_request_body = {
-      'name': 1, # Bad data type.
-      'summary': 'A summary',
-      'owner_emails': ['summary', 'owner_emails'],
-      'category': 1,
       'feature_type': 1,
       'impl_status_chrome': 1,
       'standard_maturity': 1,

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -450,3 +450,117 @@ class FeaturesAPITest(testing_config.CustomTestCase):
     with test_app.test_request_context(request_path, json=invalid_request_body):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
         self.handler.do_patch(feature_id=self.feature_1_id)
+
+  def test_post__valid(self):
+    """POST request successful with valid input from user with permissions."""
+    # Signed-in user with permissions
+    testing_config.sign_in('admin@example.com', 123567890)
+
+    valid_request_body = {
+      'name': 'A name',
+      'summary': 'A summary',
+      'owner_emails': ['summary', 'owner_emails'],
+      'category': 2,
+      'feature_type': 1,
+      'impl_status_chrome': 3,
+      'standard_maturity': 2,
+      'ff_views': 1,
+      'safari_views': 1,
+      'web_dev_views': 1,
+    }
+
+    request_path = f'{self.request_path}/create'
+    with test_app.test_request_context(request_path, json=valid_request_body):
+      response = self.handler.do_post()
+    # A new feature ID should be returned.
+    self.assertIsNotNone(response['feature_id'])
+    self.assertTrue(type(response['feature_id']) == int)
+    # New feature should exist.
+    new_feature: FeatureEntry | None = (
+        FeatureEntry.get_by_id(response['feature_id']))
+    self.assertIsNotNone(new_feature)
+
+    # New feature's values should match fields in JSON body. 
+    for field, value in valid_request_body.items():
+      self.assertEqual(getattr(new_feature, field), value)
+    # User's email should match creator_email field.
+    self.assertEqual(new_feature.creator_email, 'admin@example.com')
+
+  def test_post__no_permissions(self):
+    """403 Forbidden if the user does not have feature create access."""
+    testing_config.sign_in('someuser@example.com', 123567890)
+
+    request_path = f'{self.request_path}/create'
+    with test_app.test_request_context(request_path, json={}):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
+        self.handler.do_post()
+
+  def test_post__invalid_fields(self):
+    """POST request fails with 400 when supplying invalid fields."""
+    # Signed-in user with permissions
+    testing_config.sign_in('admin@example.com', 123567890)
+
+    invalid_request_body = {
+      'bad_param': 'Not a real field',
+
+      'name': 'A name',
+      'summary': 'A summary',
+      'owner_emails': ['summary', 'owner_emails'],
+      'category': 1,
+      'feature_type': 1,
+      'impl_status_chrome': 1,
+      'standard_maturity': 1,
+      'ff_views': 1,
+      'safari_views': 1,
+      'web_dev_views': 1,
+    }
+    request_path = f'{self.request_path}/create'
+    with test_app.test_request_context(request_path, json=invalid_request_body):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post()
+  
+  def test_post__immutable_fields(self):
+    """POST request fails with 400 when immutable field is provided."""
+    # Signed-in user with permissions
+    testing_config.sign_in('admin@example.com', 123567890)
+
+    invalid_request_body = {
+      'creator_email': 'differentuser@example.com',
+
+      'name': 'A name',
+      'summary': 'A summary',
+      'owner_emails': ['summary', 'owner_emails'],
+      'category': 1,
+      'feature_type': 1,
+      'impl_status_chrome': 1,
+      'standard_maturity': 1,
+      'ff_views': 1,
+      'safari_views': 1,
+      'web_dev_views': 1,
+    }
+    request_path = f'{self.request_path}/create'
+    with test_app.test_request_context(request_path, json=invalid_request_body):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post()
+
+  def test_post__missing_required_field(self):
+    """POST request fails with 400 when missing required fields."""
+    # Signed-in user with permissions
+    testing_config.sign_in('admin@example.com', 123567890)
+
+    invalid_request_body = {
+      # No 'name' field.
+      'summary': 'A summary',
+      'owner_emails': ['summary', 'owner_emails'],
+      'category': 1,
+      'feature_type': 1,
+      'impl_status_chrome': 1,
+      'standard_maturity': 1,
+      'ff_views': 1,
+      'safari_views': 1,
+      'web_dev_views': 1,
+    }
+    request_path = f'{self.request_path}/create'
+    with test_app.test_request_context(request_path, json=invalid_request_body):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post()

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -525,11 +525,77 @@ class FeaturesAPITest(testing_config.CustomTestCase):
     testing_config.sign_in('admin@example.com', 123567890)
 
     invalid_request_body = {
-      'creator_email': 'differentuser@example.com',
+      'creator_email': 'differentuser@example.com',  # Immutable.
 
       'name': 'A name',
       'summary': 'A summary',
       'owner_emails': ['summary', 'owner_emails'],
+      'category': 1,
+      'feature_type': 1,
+      'impl_status_chrome': 1,
+      'standard_maturity': 1,
+      'ff_views': 1,
+      'safari_views': 1,
+      'web_dev_views': 1,
+    }
+    request_path = f'{self.request_path}/create'
+    with test_app.test_request_context(request_path, json=invalid_request_body):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post()
+
+  def test_post__bad_data_type_int(self):
+    """POST request fails with 400 when a bad int data type is provided."""
+    # Signed-in user with permissions
+    testing_config.sign_in('admin@example.com', 123567890)
+
+    invalid_request_body = {
+      'name': 'A name',
+      'summary': 'A summary',
+      'owner_emails': ['summary', 'owner_emails'],
+      'category': 'THIS SHOULD BE AN INTEGER',  # Bad data type.
+      'feature_type': 1,
+      'impl_status_chrome': 1,
+      'standard_maturity': 1,
+      'ff_views': 1,
+      'safari_views': 1,
+      'web_dev_views': 1,
+    }
+    request_path = f'{self.request_path}/create'
+    with test_app.test_request_context(request_path, json=invalid_request_body):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post()
+
+  def test_post__bad_data_type_str(self):
+    """POST request fails with 400 when a bad str data type is provided."""
+    # Signed-in user with permissions
+    testing_config.sign_in('admin@example.com', 123567890)
+
+    invalid_request_body = {
+      'name': 1, # Bad data type.
+      'summary': 'A summary',
+      'owner_emails': ['summary', 'owner_emails'],
+      'category': 1,
+      'feature_type': 1,
+      'impl_status_chrome': 1,
+      'standard_maturity': 1,
+      'ff_views': 1,
+      'safari_views': 1,
+      'web_dev_views': 1,
+    }
+    request_path = f'{self.request_path}/create'
+    with test_app.test_request_context(request_path, json=invalid_request_body):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler.do_post()
+
+  def test_post__bad_data_type_list(self):
+    """POST request fails with 400 when a bad list data type is provided."""
+    # Signed-in user with permissions
+    testing_config.sign_in('admin@example.com', 123567890)
+
+    invalid_request_body = {
+      'name': 'A name',
+      'summary': 'A summary',
+      'owner_emails': 'summary,owner_emails', # Bad data type.
       'category': 1,
       'feature_type': 1,
       'impl_status_chrome': 1,

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -43,6 +43,19 @@ class FeatureEntry(ndb.Model):  # Copy from Feature
     'feature_type',
   ])
 
+  # All required fields needed upon feature creation.
+  REQUIRED_FIELDS = frozenset([
+    'name',
+    'summary',
+    'category',
+    'feature_type',
+    'impl_status_chrome',
+    'standard_maturity',
+    'ff_views',
+    'safari_views',
+    'web_dev_views',
+  ])
+
   # Metadata: Creation and updates.
   created = ndb.DateTimeProperty(auto_now_add=True)
   updated = ndb.DateTimeProperty(auto_now_add=True)

--- a/main.py
+++ b/main.py
@@ -98,6 +98,7 @@ API_BASE = '/api/v0'
 api_routes: list[Route] = [
     Route(f'{API_BASE}/features', features_api.FeaturesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>', features_api.FeaturesAPI),
+    Route(f'{API_BASE}/features/create', features_api.FeaturesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/votes',
         reviews_api.VotesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/votes/<int:gate_id>',

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -57,9 +57,6 @@ class FeatureCreateHandler(basehandlers.FlaskHandler):
     # TODO(jrobbins): Validate input, even though it is done on client.
 
     feature_type = int(self.form.get('feature_type', 0))
-    signed_in_user = ndb.User(
-        email=self.get_current_user().email(),
-        _auth_domain='gmail.com')
 
     # Write for new FeatureEntry entity.
     feature_entry = FeatureEntry(
@@ -71,8 +68,8 @@ class FeatureCreateHandler(basehandlers.FlaskHandler):
         editor_emails=editors,
         cc_emails=cc_emails,
         devrel_emails=[DEVREL_EMAIL],
-        creator_email=signed_in_user.email(),
-        updater_email=signed_in_user.email(),
+        creator_email=self.get_current_user().email(),
+        updater_email=self.get_current_user().email(),
         accurate_as_of=datetime.now(),
         unlisted=self.form.get('unlisted') == 'on',
         breaking_change=self.form.get('breaking_change') == 'on',


### PR DESCRIPTION
Part of #2872.

This change adds POST request functionality for the Features API, which allows the creation of new features.

A small unrelated refactor is also present in `pages/guide.py`.