### PR TITLE
Replace "Comments & Activity" with a link to comment page

### DIFF
--- a/client-src/elements/chromedash-activity-page.js
+++ b/client-src/elements/chromedash-activity-page.js
@@ -17,8 +17,16 @@ export class ChromedashActivityPage extends LitElement {
        .instructions {
          padding: var(--content-padding-half);
          margin-bottom: var(--content-padding-large);
+         margin-left: 3px;
        }
 
+       #comment_area {
+        margin: 0 var(--content-padding);
+       }
+       #header {
+          margin-bottom: 10px;
+          margin-left: 5px;
+       }
        #controls {
          padding: var(--content-padding);
          text-align: right;
@@ -147,7 +155,14 @@ export class ChromedashActivityPage extends LitElement {
   renderComments() {
     // TODO(jrobbins): Include relevant activities too.
     return html`
-      <h2>Comments</h2>
+      <div id="header">
+        <h2 id="breadcrumbs">
+          <a href="/feature/${this.featureId}">
+            <iron-icon icon="chromestatus:arrow-back"></iron-icon>
+            Comments
+          </a>
+        </h2>
+      </div>
       ${this.renderControls()}
       <chromedash-activity-log
         .user=${this.user}

--- a/client-src/elements/chromedash-activity-page.js
+++ b/client-src/elements/chromedash-activity-page.js
@@ -17,7 +17,7 @@ export class ChromedashActivityPage extends LitElement {
        .instructions {
          padding: var(--content-padding-half);
          margin-bottom: var(--content-padding-large);
-         margin-left: 3px;
+         margin-left: 10px;
        }
 
        #comment_area {
@@ -25,7 +25,7 @@ export class ChromedashActivityPage extends LitElement {
        }
        #header {
           margin-bottom: 10px;
-          margin-left: 5px;
+          margin-left: 15px;
        }
        #controls {
          padding: var(--content-padding);

--- a/client-src/elements/chromedash-approvals-dialog.js
+++ b/client-src/elements/chromedash-approvals-dialog.js
@@ -56,7 +56,6 @@ class ChromedashApprovalsDialog extends LitElement {
     this.user = {};
     this.feature = {};
     this.votes = [];
-    this.comments = [];
     this.configs = [];
     this.gates = [];
     this.subsetPending = false;
@@ -158,10 +157,9 @@ class ChromedashApprovalsDialog extends LitElement {
     const featureId = this.feature.id;
     Promise.all([
       window.csClient.getVotes(featureId, null),
-      window.csClient.getComments(featureId),
       window.csClient.getApprovalConfigs(featureId),
       window.csClient.getGates(featureId),
-    ]).then(([votesRes, commentRes, configRes, gatesRes]) => {
+    ]).then(([votesRes, configRes, gatesRes]) => {
       this.votes = votesRes.votes;
       this.gates = gatesRes.gates;
 
@@ -187,9 +185,6 @@ class ChromedashApprovalsDialog extends LitElement {
       this.showAllIntents = numPending == 0;
       this.changedApprovalsByGate = new Map();
       this.needsSave = false;
-
-      this.comments = commentRes.comments;
-
       this.configs = configRes.configs;
       this.showConfigs = new Set(this.configs.map(c => c.field_id));
       this.changedConfigsByField = new Map();
@@ -378,14 +373,9 @@ class ChromedashApprovalsDialog extends LitElement {
 
   renderAllComments() {
     return html`
-      <h3>Comments</h3>
-      <div class="comment_section">
-        <chromedash-activity-log
-          .user=${this.user}
-          .featureId=${this.feature.id}
-          .comments=${this.comments}>
-        </chromedash-activity-log>
-      </div>
+      <a href="/feature/${this.feature.id}/activity">
+        <h3>Comments</h3>
+      </a>
     `;
   }
 

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -613,15 +613,11 @@ class ChromedashFeatureDetail extends LitElement {
   renderActivitySection() {
     const summary = 'Comments & Activity';
     const content = html`
-        <div style="padding-top: var(--content-padding)">
-          <chromedash-activity-log
-            .user=${this.user}
-            .featureId=${this.feature.id}
-            .comments=${this.comments}
-          ></chromedash-activity-log>
-        </div>
+      <a href="/feature/${this.feature.id}/activity">
+        <sl-details summary=${summary}></sl-details>
+      </a>
     `;
-    return this.renderSection(summary, content);
+    return content;
   }
 
   renderAddStageButton() {


### PR DESCRIPTION
Fix #2831. 

- Add a backarrow icon to the featuredetail page from the comment page
- Replace the "Comments & Activity" section with a link to comment page

Comment page
<img width="1170" alt="Screenshot 2023-04-25 at 4 16 51 PM" src="https://user-images.githubusercontent.com/8611520/234428513-c5333b92-2d40-4d41-a57e-d2e741d34107.png">

Featuredetail page, on hover

<img width="946" alt="Screenshot 2023-04-25 at 4 18 50 PM" src="https://user-images.githubusercontent.com/8611520/234428556-584a1b10-13f2-4d10-a485-f5add6eaa7be.png">
