### PR TITLE
Improve the test coverage of basehandlers.py.

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -223,6 +223,8 @@ class APIHandler(BaseHandler):
     valid_methods = ['GET']
     if self.do_post.__code__ is not APIHandler.do_post.__code__:
       valid_methods.append('POST')
+    if self.do_put.__code__ is not APIHandler.do_put.__code__:
+      valid_methods.append('PUT')
     if self.do_patch.__code__ is not APIHandler.do_patch.__code__:
       valid_methods.append('PATCH')
     if self.do_delete.__code__ is not APIHandler.do_delete.__code__:
@@ -271,8 +273,6 @@ class APIHandler(BaseHandler):
   def require_signed_in_and_xsrf_token(self):
     """Every API POST, PUT, or DELETE must be signed in with an XSRF token."""
     user = self.get_current_user(required=True)
-    if not user:
-      self.abort(403, msg='Sign in required')
     token = self.request.headers.get('X-Xsrf-Token')
     if not token:
       try:


### PR DESCRIPTION
Improve our code health by adding some python unit tests.

Also, have more consistent handling of the HTTP PUT method.

And, remove one 'Sign in required' response that was unreachable because the line above it has required=True which will itself cause the request to abort.