### PR TITLE
Add unit tests to bring basehandlers near 100%.

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -537,6 +537,7 @@ class ConstHandler(FlaskHandler):
 
     return flask.jsonify(defaults)
 
+
 def ndb_wsgi_middleware(wsgi_app):
   """Create a new runtime context for cloud ndb for every request"""
   client = ndb.Client()


### PR DESCRIPTION
Add more unit tests to increase coverage.
And, rearrange test classes to be in the same order as the code with consistent names.