### PR TITLE
Set detected intent_thread_url even if it was an empty string.

### DIFF
--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -437,6 +437,12 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
     self.assertEqual(
         self.stages_dict[160][0].intent_thread_url, self.thread_url)
 
+  def test_process_post_data__new_thread_already_empty_str(self):
+    """We still set intent_thread_url if it was previously an empty string."""
+    self.stages_dict[160][0].intent_thread_url = ''
+    self.stages_dict[160][0].put()
+    self.test_process_post_data__new_thread()
+
   def test_process_post_data__new_thread_just_FYI(self):
     """When we detect a new thread, it might not require a review."""
     self.review_json_data['subject'] = 'Intent to Prototype: featurename'


### PR DESCRIPTION
Fix a problem that Yoav spotted: recent features with requested reviews don't have the intent_thread_url filled in.

I believe that the cause was that when users edit the fields for that stage, the intent_thread_url is set to an empty string when they leave that field blank.  That is fine.  But, in detect_intent the code would only set intent_thread_url if it was previously None.

In this PR:
* Change the condition to look for a value that is falsey, allowing either `None` or `''`.
* Add a unit test
* Add a bunch of logging as an example of doing more logging.
* Split the originally condition so that we can log two cases separately.