### PR TITLE
Use default empty string for USER_EMAIL in UNIT_TEST_MODE

### DIFF
--- a/api/metricsdata_test.py
+++ b/api/metricsdata_test.py
@@ -134,6 +134,7 @@ class CSSPopularityHandlerTests(testing_config.CustomTestCase):
     self.prop_4 = metrics_models.FeatureObserverHistogram(
         bucket_id=4, property_name='a feat')
     self.prop_4.put()
+    testing_config.sign_in('test@example.com', 111)
 
   def tearDown(self):
     self.datapoint.key.delete()
@@ -142,6 +143,7 @@ class CSSPopularityHandlerTests(testing_config.CustomTestCase):
     self.prop_3.key.delete()
     self.prop_4.key.delete()
     rediscache.flushall()
+    testing_config.sign_out()
 
   def test_get_top_num_cache_key(self):
     actual = self.handler.get_top_num_cache_key(30)

--- a/api/metricsdata_test.py
+++ b/api/metricsdata_test.py
@@ -134,7 +134,6 @@ class CSSPopularityHandlerTests(testing_config.CustomTestCase):
     self.prop_4 = metrics_models.FeatureObserverHistogram(
         bucket_id=4, property_name='a feat')
     self.prop_4.put()
-    testing_config.sign_in('test@example.com', 111)
 
   def tearDown(self):
     self.datapoint.key.delete()
@@ -143,7 +142,6 @@ class CSSPopularityHandlerTests(testing_config.CustomTestCase):
     self.prop_3.key.delete()
     self.prop_4.key.delete()
     rediscache.flushall()
-    testing_config.sign_out()
 
   def test_get_top_num_cache_key(self):
     actual = self.handler.get_top_num_cache_key(30)

--- a/framework/users.py
+++ b/framework/users.py
@@ -190,7 +190,7 @@ class User(object):
 def get_current_user():
     if settings.UNIT_TEST_MODE:
       user_via_env = None
-      if os.environ['USER_EMAIL']!= '':
+      if os.environ.get('USER_EMAIL', '') != '':
         user_via_env = User(email=os.environ['USER_EMAIL'])
       return user_via_env
 


### PR DESCRIPTION
### Bug:
If a developer runs:

```
python3.10 -m unittest api/metricsdata_test.py
```

It will fail. The error is:

```
Traceback (most recent call last):
  File "/workspaces/chromium-dashboard/api/metricsdata_test.py", line 153, in test_get_template_data
    actual_datapoints = self.handler.get_template_data()
  File "/workspaces/chromium-dashboard/api/metricsdata.py", line 216, in get_template_data
    return super(CSSPopularityHandler, self).get_template_data()
  File "/workspaces/chromium-dashboard/api/metricsdata.py", line 184, in get_template_data
    return _datapoints_to_json_dicts(properties)
  File "/workspaces/chromium-dashboard/api/metricsdata.py", line 37, in _datapoints_to_json_dicts
    user = users.get_current_user()
  File "/workspaces/chromium-dashboard/framework/users.py", line 193, in get_current_user
    if os.environ['USER_EMAIL']!= '':
  File "/usr/local/lib/python3.10/os.py", line 680, in __getitem__
    raise KeyError(key) from None
KeyError: 'USER_EMAIL'
```

### Troubleshooting:

The test passes if you run npm run test / npm run do-tests though. Added a print statement and it turns out when running npm run test, os.environ['USER_EMAIL'] is equal to ''. That is why it is not caught in the regular CI test.

That means there's some test somewhere that runs beforehand that resets os.environ['USER_EMAIL'] to '' during the full suite (most likely the sign_out from testing_config.py which is used in tests).

### This change:

This suggestion: https://github.com/GoogleChrome/chromium-dashboard/pull/2966#issuecomment-1532310761



### Alternatives considered:

1. At the beginning of testing_config.py, set os.environ['USER_EMAIL'] to ''. Open to that too. Not sure if there are unintended consequences though.
2. ~Add a sign in on setup and signout on teardown. This will solve when a developer runs a one-off of that test file. It will work.~ This was originally tried out but upon discussion it does not make sense because this page does not need users to be  signed in