### PR TITLE
Validate search parameter types.

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -63,8 +63,8 @@ class FeaturesAPI(basehandlers.APIHandler):
       features_on_page, total_count = search.process_query(
           user_query, sort_spec=sort_spec, show_unlisted=show_unlisted_features,
           show_enterprise=show_enterprise, start=start, num=num)
-    except ValueError:
-      self.abort(400, msg=str(ValueError))
+    except ValueError as err:
+      self.abort(400, msg=str(err))
 
     return {
         'total_count': total_count,

--- a/internals/search_queries.py
+++ b/internals/search_queries.py
@@ -62,6 +62,14 @@ def single_field_query_async(
     return []
 
   # TODO(jrobbins): Handle ":" operator as substrings for text fields.
+
+  try:
+    # If the field can be set to val, then it can be compared to val.
+    field._validate(val)
+  except ndb.exceptions.BadValueError:
+    logging.info('Wrong type of value for %r: %r' % (field, val))
+    raise ValueError('Query value does not match field type')
+
   if (operator == '='):
     val_list = str(val).split(',')
     if len(val_list) > 1:

--- a/internals/search_queries.py
+++ b/internals/search_queries.py
@@ -62,6 +62,7 @@ def single_field_query_async(
     return []
 
   # TODO(jrobbins): Handle ":" operator as substrings for text fields.
+  # TODO(jrobbins): Implement quick-OR for integer fields, e.g., x=2,3,4.
 
   try:
     # If the field can be set to val, then it can be compared to val.

--- a/internals/search_queries_test.py
+++ b/internals/search_queries_test.py
@@ -140,6 +140,27 @@ class SearchFeaturesTest(testing_config.CustomTestCase):
         [self.feature_1_id, self.feature_2_id, self.feature_3_id],
         [key.integer_id() for key in actual])
 
+  def check_wrong_type(self, field_name, bad_value):
+    with self.assertRaises(ValueError) as cm:
+      search_queries.single_field_query_async(
+          field_name, '=', bad_value)
+    self.assertEqual(
+        cm.exception.args[0], 'Query value does not match field type')
+
+  def test_single_field_query_async__wrong_types(self):
+    """We reject requests with values that parse to the wrong type."""
+    # Feature entry fields
+    self.check_wrong_type('owner', True)
+    self.check_wrong_type('owner', 123)
+    self.check_wrong_type('deleted', 'not a boolean')
+    self.check_wrong_type('star_count', 'not an integer')
+    self.check_wrong_type('created.when', 'not a date')
+
+    # Stage fields
+    self.check_wrong_type('browsers.chrome.android', 'not an integer')
+    self.check_wrong_type('finch_url', 123)
+    self.check_wrong_type('finch_url', True)
+
   def test_single_field_query_async__normal_stage_field(self):
     """We can find a FeatureEntry based on values in an associated Stage."""
     actual_promise = search_queries.single_field_query_async(


### PR DESCRIPTION
This improves our handling of bad requests, such as an attempted SQL-injection attack.

In this PR:
* Check if the query value would be accepted as a field value for that field, if not, raise a ValueError
* Improve the text of the 400 response when such a request is rejected
* Add unit tests