### PR TITLE
Sign in user for Features API Test

### DIFF
--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -151,6 +151,7 @@ class FeaturesAPITest(testing_config.CustomTestCase):
 
   def test_get__all_listed(self):
     """Get all features that are listed."""
+    testing_config.sign_in('test@example.com', 111)
     with test_app.test_request_context(self.request_path):
       actual = self.handler.do_get()
 


### PR DESCRIPTION
Similar to #2966, running this test fails:

```
$ python3.10 -m unittest api/features_api_test.py 
E......................
======================================================================
ERROR: test_get__all_listed (api.features_api_test.FeaturesAPITest)
Get all features that are listed.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspaces/chromium-dashboard/api/features_api_test.py", line 155, in test_get__all_listed
    actual = self.handler.do_get()
  File "/workspaces/chromium-dashboard/api/features_api.py", line 82, in do_get
    return self.do_search()
  File "/workspaces/chromium-dashboard/api/features_api.py", line 40, in do_search
    user = users.get_current_user()
  File "/workspaces/chromium-dashboard/framework/users.py", line 193, in get_current_user
    if os.environ['USER_EMAIL']!= '':
  File "/usr/local/lib/python3.10/os.py", line 680, in __getitem__
    raise KeyError(key) from None
KeyError: 'USER_EMAIL'

----------------------------------------------------------------------
Ran 23 tests in 1.047s

FAILED (errors=1)
```

It seems that this particular subtest (unlike the rest) needs to have a user signed in first.