### PR TITLE
Revert "npm: bump lit from 2.7.2 to 2.7.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10016,9 +10016,9 @@
       "dev": true
     },
     "node_modules/lit": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.3.tgz",
-      "integrity": "sha512-0a+u+vVbmgSfPu+fyvqjMPBX0Kwbyj9QOv9MbQFZhWGlV2cyk3lEwgfUQgYN+i/lx++1Z3wZknSIp3QCKxHLyg==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.2.tgz",
+      "integrity": "sha512-9QnZmG5mIKPRja96cpndMclLSi0Qrz2BXD6EbqNqCKMMjOWVm/BwAeXufFk2jqFsNmY07HOzU8X+8aTSVt3yrA==",
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
         "lit-element": "^3.3.0",
@@ -22715,9 +22715,9 @@
       }
     },
     "lit": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.3.tgz",
-      "integrity": "sha512-0a+u+vVbmgSfPu+fyvqjMPBX0Kwbyj9QOv9MbQFZhWGlV2cyk3lEwgfUQgYN+i/lx++1Z3wZknSIp3QCKxHLyg==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.2.tgz",
+      "integrity": "sha512-9QnZmG5mIKPRja96cpndMclLSi0Qrz2BXD6EbqNqCKMMjOWVm/BwAeXufFk2jqFsNmY07HOzU8X+8aTSVt3yrA==",
       "requires": {
         "@lit/reactive-element": "^1.6.0",
         "lit-element": "^3.3.0",


### PR DESCRIPTION
Reverts GoogleChrome/chromium-dashboard#2955
This may have caused #2957 to fail. 