### PR TITLE
Reorganize feature page to clearify stage sections.

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -28,6 +28,29 @@ import './chromedash-gate-chip';
 import {autolink, findProcessStage, flattenSections} from './utils.js';
 import {SHARED_STYLES} from '../sass/shared-css.js';
 
+export const DETAILS_STYLES = [css`
+      sl-details {
+        border: var(--card-border);
+        box-shadow: var(--card-box-shadow);
+        margin: var(--content-padding-half);
+        border-radius: 4px;
+        background: var(--card-background);
+      }
+      sl-details::part(base),
+      sl-details::part(header) {
+        background: transparent;
+      }
+      sl-details::part(header) {
+        padding-bottom: 8px;
+      }
+
+      .card {
+        background: var(--card-background);
+        max-width: var(--max-content-width);
+        padding: 16px;
+      }
+`];
+
 const LONG_TEXT = 60;
 
 class ChromedashFeatureDetail extends LitElement {
@@ -69,6 +92,7 @@ class ChromedashFeatureDetail extends LitElement {
 
     return [
       ...SHARED_STYLES,
+      ...DETAILS_STYLES,
       css`
       :host {
         display: block;
@@ -80,29 +104,11 @@ class ChromedashFeatureDetail extends LitElement {
       }
 
       h2 {
+        margin-top: var(--content-padding);
         display: flex;
       }
       h2 span {
         flex: 1;
-      }
-
-      sl-details {
-        border: var(--card-border);
-        box-shadow: var(--card-box-shadow);
-        margin: var(--content-padding-half);
-        border-radius: 4px;
-      }
-
-      sl-details {
-        background: var(--card-background);
-      }
-
-      sl-details::part(base),
-      sl-details::part(header) {
-        background: transparent;
-      }
-      sl-details::part(header) {
-        padding-bottom: 8px;
       }
 
       .description,
@@ -113,12 +119,6 @@ class ChromedashFeatureDetail extends LitElement {
       sl-details sl-button::part(base) {
         color: var(--sl-color-primary-600);
         border: 1px solid var(--sl-color-primary-600);
-      }
-
-      .card {
-        background: var(--card-background);
-        max-width: var(--max-content-width);
-        padding: 16px;
       }
 
       ol {
@@ -220,8 +220,8 @@ class ChromedashFeatureDetail extends LitElement {
   }
 
   isAnyCollapsed() {
-    const sections = this.shadowRoot.querySelectorAll('sl-details');
-    const open = this.shadowRoot.querySelectorAll('sl-details[open]');
+    const sections = this.shadowRoot.querySelectorAll('.stage');
+    const open = this.shadowRoot.querySelectorAll('.stage[open]');
     return open.length < sections.length;
   }
 
@@ -231,7 +231,7 @@ class ChromedashFeatureDetail extends LitElement {
 
   toggleAll() {
     const shouldOpen = this.anyCollapsed;
-    this.shadowRoot.querySelectorAll('sl-details').forEach((el) => {
+    this.shadowRoot.querySelectorAll('.stage').forEach((el) => {
       el.open = shouldOpen;
     });
   }
@@ -457,7 +457,8 @@ class ChromedashFeatureDetail extends LitElement {
     }
   }
 
-  renderSection(summary, content, isActive=false, defaultOpen=false) {
+  renderSection(
+    summary, content, isActive=false, defaultOpen=false, isStage=true) {
     if (isActive) {
       summary += ' - Active';
     }
@@ -466,7 +467,7 @@ class ChromedashFeatureDetail extends LitElement {
         @sl-after-show=${this.updateCollapsed}
         @sl-after-hide=${this.updateCollapsed}
         ?open=${isActive || defaultOpen}
-        class=${isActive ? 'active' : ''}
+        class="${isActive ? 'active' : ''} ${isStage ? 'stage' : ''}"
       >
         ${content}
       </sl-details>
@@ -504,7 +505,9 @@ class ChromedashFeatureDetail extends LitElement {
       'Metadata',
       content,
       /* isActive=*/false,
-      /* defaultOpen=*/this.feature.is_enterprise_feature);
+      /* defaultOpen=*/this.feature.is_enterprise_feature,
+      /* isStage=*/false,
+    );
   }
 
   renderGateChip(feStage, gate) {
@@ -612,16 +615,6 @@ class ChromedashFeatureDetail extends LitElement {
     return this.renderSection(name, content, isActive, defaultOpen);
   }
 
-  renderActivitySection() {
-    const summary = 'Comments & Activity';
-    const content = html`
-      <a href="/feature/${this.feature.id}/activity">
-        <sl-details summary=${summary}></sl-details>
-      </a>
-    `;
-    return content;
-  }
-
   renderAddStageButton() {
     if (!this.canEdit) {
       return nothing;
@@ -636,13 +629,12 @@ class ChromedashFeatureDetail extends LitElement {
 
   render() {
     return html`
+      ${this.renderMetadataSection()}
       <h2>
         <span>Development stages</span>
         ${this.renderControls()}
       </h2>
-      ${this.renderMetadataSection()}
       ${this.feature.stages.map(feStage => this.renderProcessStage(feStage))}
-      ${this.renderActivitySection()}
       ${this.renderAddStageButton()}
     `;
   }

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -6,6 +6,7 @@ import {autolink, renderHTMLIf, showToastMessage,
   renderAbsoluteDate, renderRelativeDate,
 } from './utils.js';
 import {SHARED_STYLES} from '../sass/shared-css.js';
+import {DETAILS_STYLES} from './chromedash-feature-detail';
 
 const INACTIVE_STATES = [
   'No longer pursuing',
@@ -17,6 +18,7 @@ export class ChromedashFeaturePage extends LitElement {
   static get styles() {
     return [
       ...SHARED_STYLES,
+      ...DETAILS_STYLES,
       css`
         #feature {
           background: var(--card-background);
@@ -42,12 +44,6 @@ export class ChromedashFeaturePage extends LitElement {
         section label {
           font-weight: 500;
           margin-right: 5px;
-        }
-
-        #updated {
-          color: var(--unimportant-text-color);
-          border-top: var(--default-border);
-          padding: var(--content-padding-quarter) 0 0 var(--content-padding);
         }
 
         li {
@@ -485,12 +481,20 @@ export class ChromedashFeaturePage extends LitElement {
     `;
   }
 
-  renderUpdated() {
+  renderHistory() {
     return html`
-      <section id="updated">
-          Last updated on
+      <section id="history">
+          <h3>History</h3>
+          <p>Entry created on
+          ${renderAbsoluteDate(this.feature.created?.when, true)}
+          ${renderRelativeDate(this.feature.created?.when)}</p>
+          <p>Last updated on
           ${renderAbsoluteDate(this.feature.updated?.when, true)}
-          ${renderRelativeDate(this.feature.updated?.when)}
+          ${renderRelativeDate(this.feature.updated?.when)}</p>
+
+          <p><a href="/feature/${this.feature.id}/activity">
+            All comments &amp; activity
+          </a></p>
       </section>
     `;
   }
@@ -528,13 +532,17 @@ export class ChromedashFeaturePage extends LitElement {
     // At this point, the feature has loaded successfully, render the components.
     return html`
       ${this.renderSubHeader()}
-      <div id="feature">
-        ${this.renderFeatureContent()}
-        ${this.feature.is_enterprise_feature ?
-            this.renderEnterpriseFeatureStatus() :
-            this.renderFeatureStatus()}
-        ${this.renderUpdated()}
-      </div>
+      <sl-details summary="Overview"
+        ?open=${true}
+      >
+        <section class="card">
+          ${this.renderFeatureContent()}
+          ${this.feature.is_enterprise_feature ?
+              this.renderEnterpriseFeatureStatus() :
+              this.renderFeatureStatus()}
+          ${this.renderHistory()}
+        </section>
+      </sl-details>
       ${this.renderFeatureDetails()}
     `;
   }

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -57,6 +57,10 @@ export class ChromedashFeaturePage extends LitElement {
           width: 125px;
         }
 
+        #history p {
+          margin-top: var(--content-padding-half);
+        }
+
         sl-skeleton {
           margin-bottom: 1em;
           width: 60%;


### PR DESCRIPTION
This should resolve #2969.

In this PR:
* Define a set of CSS styles that is shared between chromedash-feature-page and chromedash-feature-detail.
* Move the metadata section just above the heading "Development stages".
* Add a "stage" CSS class and change the CSS selector used find the stage accordion sections to look for that class.  This makes the expand-all / collapse-all link work for just the stage sections.
* Create a new "History" heading in the overview box:
    * add an entry created date
    * move the link to the comments & activity page here