### PR TITLE
After creating WP feature, redirect to feature detail page.

### DIFF
--- a/pages/guide.py
+++ b/pages/guide.py
@@ -84,9 +84,7 @@ class FeatureCreateHandler(basehandlers.FlaskHandler):
     # Remove all feature-related cache.
     rediscache.delete_keys_with_prefix(FeatureEntry.feature_cache_prefix())
 
-    # TODO(jrobbins): Make this be /feature/ID after ability to edit
-    # from the feature detail page is complete.
-    redirect_url = '/guide/edit/' + str(key.integer_id())
+    redirect_url = '/feature/' + str(key.integer_id())
     return self.redirect(redirect_url)
 
   def write_gates_and_stages_for_feature(
@@ -150,8 +148,6 @@ class EnterpriseFeatureCreateHandler(FeatureCreateHandler):
     # Remove all feature-related cache.
     rediscache.delete_keys_with_prefix(FeatureEntry.feature_cache_prefix())
 
-    # TODO(jrobbins): Make this be /feature/ID after ability to edit
-    # from the feature detail page is complete.
     redirect_url = '/guide/editall/' + str(key.integer_id()) + '#rollout1'
     return self.redirect(redirect_url)
 

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -82,7 +82,7 @@ class FeatureCreateTest(testing_config.CustomTestCase):
 
     self.assertEqual('302 FOUND', actual_response.status)
     location = actual_response.headers['location']
-    self.assertTrue(location.startswith('/guide/edit/'))
+    self.assertTrue(location.startswith('/feature/'))
     new_feature_id = int(location.split('/')[-1])
 
     # Ensure FeatureEntry entity was created.


### PR DESCRIPTION
Now that we have had "Edit fields" buttons on the feature detail page for a while, shift the users toward using them and away from the old Guide UX by changing the redirect after feature creation.