### PR TITLE
Show "Pending my review" box to users who can approve any gate.

### DIFF
--- a/api/permissions_api.py
+++ b/api/permissions_api.py
@@ -36,7 +36,7 @@ class PermissionsAPI(basehandlers.APIHandler):
       approvers = approval_defs.get_approvers(field_id)
       user_data = {
         'can_create_feature': permissions.can_create_feature(user),
-        # TODO(jrobbins): phase out can_approve and use approvable_gate_types
+        # TODO(jrobbins): delete unused can_approve in an upcoming release.
         'can_approve': permissions.can_approve_feature(
             user, None, approvers),
         'approvable_gate_types': sorted(

--- a/client-src/elements/chromedash-activity-log_test.js
+++ b/client-src/elements/chromedash-activity-log_test.js
@@ -5,7 +5,6 @@ import '../js-src/cs-client';
 import sinon from 'sinon';
 
 const nonAdminUser = {
-  can_approve: false,
   can_create_feature: true,
   can_edit_all: true,
   is_admin: false,

--- a/client-src/elements/chromedash-all-features-page_test.js
+++ b/client-src/elements/chromedash-all-features-page_test.js
@@ -67,7 +67,6 @@ describe('chromedash-all-features-page', () => {
       }],
     });
     const user = {
-      can_approve: false,
       can_create_feature: true,
       can_edit_all: true,
       is_admin: false,

--- a/client-src/elements/chromedash-approvals-dialog.js
+++ b/client-src/elements/chromedash-approvals-dialog.js
@@ -216,11 +216,16 @@ class ChromedashApprovalsDialog extends LitElement {
     return `State ${state}`;
   }
 
+  userCanApprove() {
+    return this.user && (
+      this.user.is_admin || this.user.approvable_gate_types?.length > 0);
+  }
+
   renderApprovalValue(voteValue) {
     const selectedValue = (
       this.changedApprovalsByGate.get(voteValue.gate_id) ||
       voteValue.state);
-    const canVote = (this.user?.can_approve &&
+    const canVote = (this.userCanApprove() &&
                      voteValue.set_by == this.user?.email);
     // hoist is needed when <sl-select> is in overflow:hidden context.
     return html`
@@ -248,7 +253,7 @@ class ChromedashApprovalsDialog extends LitElement {
   }
 
   renderMyPendingApproval(gateInfo) {
-    if (!this.user || !this.user.can_approve) return nothing;
+    if (!this.userCanApprove()) return nothing;
     const existingApprovalByMe = this.votes.some((a) =>
       a.gate_id === gateInfo.id && a.set_by == this.user.email);
     // There shoud be only one approval entry for now, until we have

--- a/client-src/elements/chromedash-enterprise-page.js
+++ b/client-src/elements/chromedash-enterprise-page.js
@@ -9,7 +9,6 @@ export class ChromedashEnterprisePage extends ChromedashAllFeaturesPage {
         query=${query}
         ?signedIn=${Boolean(this.user)}
         ?canEdit=${this.user && this.user.can_edit_all}
-        ?canApprove=${this.user && this.user.can_approve}
         .starredFeatures=${this.starredFeatures}
         @star-toggle-event=${this.handleStarToggle}
         @open-approvals-event=${this.handleOpenApprovals}

--- a/client-src/elements/chromedash-enterprise-page_test.js
+++ b/client-src/elements/chromedash-enterprise-page_test.js
@@ -46,7 +46,6 @@ describe('chromedash-enterprise-page', () => {
       }],
     });
     const user = {
-      can_approve: false,
       can_create_feature: true,
       can_edit_all: true,
       is_admin: false,

--- a/client-src/elements/chromedash-feature-page_test.js
+++ b/client-src/elements/chromedash-feature-page_test.js
@@ -7,14 +7,12 @@ import sinon from 'sinon';
 
 describe('chromedash-feature-page', () => {
   const user = {
-    can_approve: false,
     can_create_feature: true,
     can_edit_all: true,
     is_admin: false,
     email: 'example@google.com',
   };
   const editor = {
-    can_approve: false,
     can_create_feature: false,
     can_edit_all: false,
     editable_features: [123456],
@@ -22,7 +20,6 @@ describe('chromedash-feature-page', () => {
     email: 'editor@example.com',
   };
   const visitor = {
-    can_approve: false,
     can_create_feature: false,
     can_edit_all: false,
     editable_features: [],

--- a/client-src/elements/chromedash-feature-row.js
+++ b/client-src/elements/chromedash-feature-row.js
@@ -13,7 +13,6 @@ class ChromedashFeatureRow extends LitElement {
       columns: {type: String},
       signedIn: {type: Boolean},
       canEdit: {type: Boolean},
-      canApprove: {type: Boolean},
       starredFeatures: {type: Object},
       approvals: {type: Object},
       gates: {type: Object},
@@ -26,7 +25,6 @@ class ChromedashFeatureRow extends LitElement {
     this.starredFeatures = new Set();
     this.feature = null;
     this.canEdit = false;
-    this.canApprove = false;
     this.approvals = {};
     this.gates = {};
     this.selectedGateId = 0;

--- a/client-src/elements/chromedash-feature-table.js
+++ b/client-src/elements/chromedash-feature-table.js
@@ -20,7 +20,6 @@ class ChromedashFeatureTable extends LitElement {
       columns: {type: String},
       signedIn: {type: Boolean},
       canEdit: {type: Boolean},
-      canApprove: {type: Boolean},
       starredFeatures: {type: Object},
       noResultsMessage: {type: String},
       gates: {type: Object},
@@ -42,7 +41,6 @@ class ChromedashFeatureTable extends LitElement {
     this.alwaysOfferPagination = false;
     this.noResultsMessage = 'No results';
     this.canEdit = false;
-    this.canApprove = false;
     this.gates = {};
     this.selectedGateId = 0;
   }
@@ -238,7 +236,6 @@ class ChromedashFeatureTable extends LitElement {
          columns=${this.columns}
          ?signedIn=${this.signedIn}
          ?canEdit=${this.canEdit}
-         ?canApprove=${this.canApprove}
          .starredFeatures=${this.starredFeatures}
          .gates=${this.gates}
          selectedGateId=${this.selectedGateId}

--- a/client-src/elements/chromedash-guide-edit-page_test.js
+++ b/client-src/elements/chromedash-guide-edit-page_test.js
@@ -7,7 +7,6 @@ import sinon from 'sinon';
 
 describe('chromedash-guide-edit-page', () => {
   const permissionsPromise = Promise.resolve({
-    can_approve: false,
     can_create_feature: true,
     can_edit_all: true,
     is_admin: false,

--- a/client-src/elements/chromedash-header_test.js
+++ b/client-src/elements/chromedash-header_test.js
@@ -68,7 +68,6 @@ describe('chromedash-header', () => {
 
   it('user is signed in', async () => {
     window.csClient.getPermissions.returns(Promise.resolve({
-      can_approve: false,
       can_create_feature: true,
       can_edit: true,
       is_admin: false,

--- a/client-src/elements/chromedash-myfeatures-page.js
+++ b/client-src/elements/chromedash-myfeatures-page.js
@@ -72,6 +72,11 @@ export class ChromedashMyFeaturesPage extends LitElement {
     openApprovalsDialog(this.user, e.detail.feature);
   }
 
+  userCanApprove() {
+    return this.user && (
+      this.user.is_admin || this.user.approvable_gate_types?.length > 0);
+  }
+
   renderBox(title, query, columns, sortSpec='', opened=true) {
     return html`
       <sl-details
@@ -83,7 +88,6 @@ export class ChromedashMyFeaturesPage extends LitElement {
           sortSpec="${sortSpec}"
           ?signedIn=${Boolean(this.user)}
           ?canEdit=${this.user && this.user.can_edit_all}
-          ?canApprove=${this.user && this.user.can_approve}
           .starredFeatures=${this.starredFeatures}
           @star-toggle-event=${this.handleStarToggle}
           @open-approvals-event=${this.handleOpenApprovals}
@@ -119,7 +123,7 @@ export class ChromedashMyFeaturesPage extends LitElement {
       <div id="subheader">
         <h2>My features</h2>
       </div>
-      ${this.user && this.user.can_approve ? this.renderPendingAndRecentApprovals() : nothing}
+      ${this.userCanApprove() ? this.renderPendingAndRecentApprovals() : nothing}
       ${this.renderICanEdit()}
       ${this.renderIStarred()}
     `;

--- a/client-src/elements/chromedash-myfeatures-page_test.js
+++ b/client-src/elements/chromedash-myfeatures-page_test.js
@@ -33,7 +33,6 @@ describe('chromedash-myfeatures-page', () => {
 
   it('user has no approval permission', async () => {
     const user = {
-      can_approve: false,
       can_create_feature: true,
       can_edit_all: true,
       is_admin: false,
@@ -75,7 +74,7 @@ describe('chromedash-myfeatures-page', () => {
 
   it('user has approval permission', async () => {
     const user = {
-      can_approve: true,
+      approvable_gate_types: [54],
       can_create_feature: true,
       can_edit_all: true,
       is_admin: false,

--- a/client-src/elements/chromedash-roadmap-page_test.js
+++ b/client-src/elements/chromedash-roadmap-page_test.js
@@ -88,7 +88,6 @@ describe('chromedash-roadmap-page', () => {
 
   it('renders with fake data', async () => {
     const user = {
-      can_approve: false,
       can_create_feature: true,
       can_edit: true,
       is_admin: false,

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -42,6 +42,7 @@ SECURITY_APPROVERS: list[str] = [
 ENTERPRISE_APPROVERS = [
     'cbe-launch-approvers@google.com',
     'bheenan@google.com',
+    'jrobbins@gmail.com'
 ]
 DEBUGGABILITY_APPROVERS = [
     'bmeurer@google.com',

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -42,7 +42,6 @@ SECURITY_APPROVERS: list[str] = [
 ENTERPRISE_APPROVERS = [
     'cbe-launch-approvers@google.com',
     'bheenan@google.com',
-    'jrobbins@gmail.com'
 ]
 DEBUGGABILITY_APPROVERS = [
     'bmeurer@google.com',

--- a/internals/search.py
+++ b/internals/search.py
@@ -43,6 +43,7 @@ def process_pending_approval_me_query() -> list[int]:
 
   approvable_gate_types = approval_defs.fields_approvable_by(user)
   if not approvable_gate_types:
+    logging.info('User has no approvable_gate_types')
     return []
   query = Gate.query(
       Gate.state.IN(Gate.PENDING_STATES),
@@ -275,6 +276,8 @@ def create_future_operations_from_queries(terms):
     if textterm:
       future = search_fulltext.search_fulltext(textterm)
     elif is_predefined_query_term(field_name, op_str, val_str):
+      logging.info('Running predefined query term: %r %r %r',
+                   field_name, op_str, val_str)
       future = process_predefined_query_term(field_name, op_str, val_str)
     else:
       future = process_query_term(is_negation, field_name, op_str, val_str)


### PR DESCRIPTION
This should resolve a problem reported yesterday by bheenan, as well as taking care of a pending TODO comment.

Previously the only users doing approval were the API Owners, and the permission check to display the "Features pending my review" box on the My Features page checked specifically for ability to approve the API Owners gate.  That was wrong because it leaves out approvers on other teams.  I had written a TODO comment to check for specific approval permissions, but not resolved that TODO until now.

In this PR:
* Change chromedash-myfeatures-page to check `this.user.approvable_gate_types`.
    * Also change the approvals dialog, even though it will soon be deleted.
* Remove all other client-side references to `can_approve`
    * Most of them were passing info down to feature-row so that the stamp icon could be offered, but that icon was previously removed, so the canApprove property was no longer used.
