### PR TITLE
Add screenshot links to enterprise features

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -269,6 +269,7 @@ def feature_entry_to_json_verbose(
     'bug_url': fe.bug_url,
     'launch_bug_url': fe.launch_bug_url,
     'new_crbug_url': None,
+    'screenshot_links': fe.screenshot_links or [],
     'breaking_change': fe.breaking_change,
     'flag_name': fe.flag_name,
     'ongoing_constraints': fe.ongoing_constraints,

--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -48,7 +48,8 @@ class FeatureConvertersTest(testing_config.CustomTestCase):
         editor_emails=['feature_editor@example.com', 'owner_1@example.com'],
         impl_status_chrome=5, blink_components=['Blink'],
         spec_link='https://example.com/spec',
-        sample_links=['https://example.com/samples'], standard_maturity=1,
+        sample_links=['https://example.com/samples'],
+        screenshot_links=['https://example.com/screenshot'], standard_maturity=1,
         ff_views=5, ff_views_link='https://example.com/ff_views',
         ff_views_notes='ff notes', safari_views=1,
         bug_url='https://example.com/bug',
@@ -303,6 +304,7 @@ class FeatureConvertersTest(testing_config.CustomTestCase):
       'requires_embedder_support': False,
       'spec_link': 'https://example.com/spec',
       'sample_links': ['https://example.com/samples'],
+      'screenshot_links': ['https://example.com/screenshot'],
       'created': {
         'by': 'creator@example.com',
         'when': str(self.date)

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -69,6 +69,7 @@ class FeaturesAPI(basehandlers.APIHandler):
     'intent_stage': 'int',
     'interop_compat_risks': 'str',
     'launch_bug_url': 'str',
+    'screenshot_links': 'list',
     'measurement': 'str',
     'motivation': 'str',
     'name': 'str',

--- a/client-src/elements/chromedash-enterprise-release-notes-page.js
+++ b/client-src/elements/chromedash-enterprise-release-notes-page.js
@@ -103,6 +103,19 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
   
       td:not(:first-child), th:not(:first-child) {
         text-align: center;
+      }
+      
+      .screenshots {
+        display: flex;
+      }
+
+      .screenshots img {
+        margin-top: 1rem;
+        max-width: 50%;
+      }
+
+      .screenshots img + img {
+        margin-inline-start: 1rem;
       }`,
     ];
   }
@@ -162,11 +175,11 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
                              stages.some(s => s.rollout_milestone > this.selectedMilestone))
       .sort((a, b) => {
         const minA = Math.min(a.stages
-          .filter(s => s.rollout_milestone > this.selectedMilestone)
-          .map(s => s.rollout_milestone));
+          .filter(s => (s.rollout_milestone || 0) > this.selectedMilestone)
+          .map(s => s.rollout_milestone)) || 0;
         const minB = Math.min(b.stages
-          .filter(s => s.rollout_milestone > this.selectedMilestone)
-          .map(s => s.rollout_milestone));
+          .filter(s => (s.rollout_milestone || 0) > this.selectedMilestone)
+          .map(s => s.rollout_milestone)) || 0;
         return minA - minB;
       });
   }
@@ -291,6 +304,9 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
             ${s.rollout_details || 'Missing details' }
           </li>`)}
         </ul>
+        <div class="screenshots">
+          ${f.screenshot_links.map((url, i) => html`<img src="${url}" alt="Feature screenshot ${i + 1}">`)}
+        </div>
       </section>`)}
     </div>`;
   }

--- a/client-src/elements/chromedash-enterprise-release-notes-page_test.js
+++ b/client-src/elements/chromedash-enterprise-release-notes-page_test.js
@@ -25,6 +25,7 @@ describe('chromedash-feature-page', () => {
           updated: {
             when: 'feature1 updated',
           },
+          screenshot_links: [],
         },
         {
           id: 2,
@@ -50,6 +51,7 @@ describe('chromedash-feature-page', () => {
           updated: {
             when: 'updated when',
           },
+          screenshot_links: [],
         },
         {
           id: 3,
@@ -79,6 +81,7 @@ describe('chromedash-feature-page', () => {
           updated: {
             when: 'updated when',
           },
+          screenshot_links: ['https://example.com/screenshot1'],
         },
         {
           id: 4,
@@ -112,6 +115,7 @@ describe('chromedash-feature-page', () => {
           updated: {
             when: 'feature 4 updated',
           },
+          screenshot_links: ['https://example.com/screenshot1', 'https://example.com/screenshot2'],
         },
         {
           id: 5,
@@ -145,6 +149,7 @@ describe('chromedash-feature-page', () => {
           updated: {
             when: 'updated when',
           },
+          screenshot_links: ['https://example.com/screenshot1'],
         },
         {
           id: 6,
@@ -170,6 +175,7 @@ describe('chromedash-feature-page', () => {
           updated: {
             when: 'updated when',
           },
+          screenshot_links: [],
         },
       ],
     });
@@ -306,6 +312,13 @@ describe('chromedash-feature-page', () => {
         assert.include(stages[0].textContent, 'fake rollout details 100');
         assert.include(stages[1].textContent, 'Chrome 101: ');
         assert.include(stages[1].textContent, 'fake rollout details 101');
+
+        const screenshots = [...features[0].querySelectorAll('.screenshots img')];
+        assert.lengthOf(screenshots, 2)
+        assert.equal(screenshots[0].src, 'https://example.com/screenshot1')
+        assert.equal(screenshots[0].alt, `Feature screenshot 1`)
+        assert.equal(screenshots[1].src, 'https://example.com/screenshot2')
+        assert.equal(screenshots[1].alt, `Feature screenshot 2`)
       }
 
       // Test feature 2
@@ -323,6 +336,11 @@ describe('chromedash-feature-page', () => {
         assert.equal(1, stages.length);
         assert.include(stages[0].textContent, 'Chrome 100: ');
         assert.include(stages[0].textContent, 'fake rollout details 100');
+
+        const screenshots = [...features[1].querySelectorAll('.screenshots img')];
+        assert.lengthOf(screenshots, 1)
+        assert.equal(screenshots[0].src, 'https://example.com/screenshot1')
+        assert.equal(screenshots[0].alt, `Feature screenshot 1`)
       }
     }
 
@@ -348,6 +366,9 @@ describe('chromedash-feature-page', () => {
         assert.equal(1, stages.length);
         assert.include(stages[0].textContent, 'Chrome 999: ');
         assert.include(stages[0].textContent, 'fake rollout details 999');
+
+        const screenshots = [...features[0].querySelectorAll('.screenshots img')];
+        assert.isEmpty(screenshots);
       }
 
       // Test feature 2
@@ -367,6 +388,11 @@ describe('chromedash-feature-page', () => {
         assert.include(stages[0].textContent, 'fake rollout details 1');
         assert.include(stages[1].textContent, 'Chrome 1000: ');
         assert.include(stages[1].textContent, 'fake rollout details 1000');
+
+        const screenshots = [...features[1].querySelectorAll('.screenshots img')];
+        assert.lengthOf(screenshots, 1)
+        assert.equal(screenshots[0].src, 'https://example.com/screenshot1')
+        assert.equal(screenshots[0].alt, `Feature screenshot 1`)
       }
     }
   });

--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -17,6 +17,7 @@ const LINE_SEPARATED_FIELDS = [
   'explainer_links',
   'doc_links',
   'sample_links',
+  'screenshot_links',
 ];
 
 /* Convert the format of feature object fetched from API into those for edit.
@@ -175,6 +176,7 @@ export const FLAT_ENTERPRISE_METADATA_FIELDS = {
         'owner',
         'editors',
         'enterprise_feature_categories',
+        'screenshot_links',
       ],
     },
   ],

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -314,6 +314,14 @@ export const ALL_FIELDS = {
             href="https://launch.corp.google.com/">
           Create a launch</a>.`,
   },
+  'screenshot_links': {
+    type: 'textarea',
+    attrs: MULTI_URL_FIELD_ATTRS,
+    required: false,
+    label: 'Screenshots link(s)',
+    help_text: html`
+        Link to screenshots showcasing this feature (one URL per line).`,
+  },
 
   'motivation': {
     type: 'textarea',

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -87,6 +87,7 @@ class FeatureEntry(ndb.Model):  # Copy from Feature
   active_stage_id = ndb.IntegerProperty()
   bug_url = ndb.StringProperty()  # Tracking bug
   launch_bug_url = ndb.StringProperty()  # FLT or go/launch
+  screenshot_links = ndb.StringProperty(repeated=True)
   breaking_change = ndb.BooleanProperty(default=False)
 
   # Implementation in Chrome

--- a/internals/data_types.py
+++ b/internals/data_types.py
@@ -186,6 +186,7 @@ class VerboseFeatureDict(TypedDict):
   active_stage_id: int | None
   bug_url: str | None
   launch_bug_url: str | None
+  screenshot_links: list[str]
   breaking_change: bool
 
   # Implementation in Chrome

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -172,6 +172,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       ('explainer_links', 'links'),
       ('bug_url', 'link'),
       ('launch_bug_url', 'link'),
+      ('screenshot_links', 'links'),
       ('anticipated_spec_changes', 'str'),
       ('requires_embedder_support', 'bool'),
       ('devtrial_instructions', 'link'),


### PR DESCRIPTION
Allow users to add/edit/remove multiple screenshots per feature.

Show the screenshots on the enterprise release notes page