### PR TITLE
Include enterprise features on "My features" page.

### DIFF
--- a/client-src/elements/chromedash-myfeatures-page.js
+++ b/client-src/elements/chromedash-myfeatures-page.js
@@ -94,22 +94,28 @@ export class ChromedashMyFeaturesPage extends LitElement {
 
   renderPendingAndRecentApprovals() {
     const pendingBox = this.renderBox(
-      'Features pending my approval', 'pending-approval-by:me', 'approvals',
-      'gate.requested_on');
+      'Features pending my approval',
+      'pending-approval-by:me feature_type>=0',
+      'approvals', 'gate.requested_on');
     const recentBox = this.renderBox(
-      'Recently reviewed features', 'is:recently-reviewed', 'normal',
-      '-gate.reviewed_on', false);
+      'Recently reviewed features',
+      'is:recently-reviewed feature_type>=0',
+      'normal', '-gate.reviewed_on', false);
     return [pendingBox, recentBox];
   }
 
   renderIStarred() {
     return this.renderBox(
-      'Features I starred', 'starred-by:me', 'normal');
+      'Features I starred',
+      'starred-by:me feature_type>=0',
+      'normal');
   }
 
   renderICanEdit() {
     return this.renderBox(
-      'Features I can edit', 'can_edit:me', 'normal');
+      'Features I can edit',
+      'can_edit:me feature_type>=0',
+      'normal');
   }
 
   render() {

--- a/client-src/elements/chromedash-myfeatures-page.js
+++ b/client-src/elements/chromedash-myfeatures-page.js
@@ -93,6 +93,7 @@ export class ChromedashMyFeaturesPage extends LitElement {
   }
 
   renderPendingAndRecentApprovals() {
+    // Use feature_type>=0 to include all types, even enterprise.
     const pendingBox = this.renderBox(
       'Features pending my approval',
       'pending-approval-by:me feature_type>=0',

--- a/client-src/elements/chromedash-myfeatures-page_test.js
+++ b/client-src/elements/chromedash-myfeatures-page_test.js
@@ -65,11 +65,13 @@ describe('chromedash-myfeatures-page', () => {
 
     // "Features I can edit" sl-details exists and has a correct query
     assert.exists(featureICanEdit);
-    assert.include(featureICanEdit.innerHTML, 'query="can_edit:me"');
+    assert.include(
+      featureICanEdit.innerHTML, 'query="can_edit:me feature_type>=0"');
 
     // Features I starred sl-details exists and has a correct query
     assert.exists(featureIStarred);
-    assert.include(featureIStarred.innerHTML, 'query="starred-by:me"');
+    assert.include(
+      featureIStarred.innerHTML, 'query="starred-by:me feature_type>=0"');
   });
 
   it('user has approval permission', async () => {
@@ -103,18 +105,24 @@ describe('chromedash-myfeatures-page', () => {
 
     // "Recently reviewed features" exists and has a correct query
     assert.exists(pendingReview);
-    assert.include(pendingReview.innerHTML, 'query="pending-approval-by:me"');
+    assert.include(
+      pendingReview.innerHTML,
+      'query="pending-approval-by:me feature_type>=0"');
 
     // "Features pending my approval" exists and has a correct query
     assert.exists(recentReview);
-    assert.include(recentReview.innerHTML, 'query="is:recently-reviewed"');
+    assert.include(
+      recentReview.innerHTML,
+      'query="is:recently-reviewed feature_type>=0"');
 
     // "Features I can edit" sl-details exists and has a correct query
     assert.exists(featureICanEdit);
-    assert.include(featureICanEdit.innerHTML, 'query="can_edit:me"');
+    assert.include(
+      featureICanEdit.innerHTML, 'query="can_edit:me feature_type>=0"');
 
     // "Features I starred" sl-details exists and has a correct query
     assert.exists(featureIStarred);
-    assert.include(featureIStarred.innerHTML, 'query="starred-by:me"');
+    assert.include(
+      featureIStarred.innerHTML, 'query="starred-by:me feature_type>=0"');
   });
 });


### PR DESCRIPTION
This makes enterprise features show up in each box on the "My features" page by adding a term that basically says "and check for any type of feature", which disables the server-side default of excluding enterprise features.