### PR TITLE
Restrict access to deleted feature entries.

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -117,7 +117,7 @@ class FeaturesAPI(basehandlers.APIHandler):
     # Only fields with defined data types are allowed.
     if field not in self.FIELD_DATA_TYPES_CREATE:
       self.abort(400, msg=f'Field "{field}" data format not found.')
-    
+
     field_type = self.FIELD_DATA_TYPES_CREATE[field]
 
     # If the field is empty, no need to format.
@@ -141,6 +141,9 @@ class FeaturesAPI(basehandlers.APIHandler):
   def get_one_feature(self, feature_id: int) -> VerboseFeatureDict:
     feature = FeatureEntry.get_by_id(feature_id)
     if not feature:
+      self.abort(404, msg='Feature %r not found' % feature_id)
+    user = users.get_current_user()
+    if feature.deleted and not permissions.can_edit_feature(user, feature_id):
       self.abort(404, msg='Feature %r not found' % feature_id)
     return converters.feature_entry_to_json_verbose(feature)
 

--- a/client-src/css/shared-css.js
+++ b/client-src/css/shared-css.js
@@ -137,6 +137,13 @@ export const SHARED_STYLES = [
     white-space: pre-wrap;
   }
 
+  .warning {
+    margin: var(--content-padding);
+    padding: var(--content-padding);
+    background: var(--warning-background);
+    color: var(--warning-color);
+  }
+
   #breadcrumbs a {
     text-decoration: none;
     color: inherit;

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -309,6 +309,26 @@ export class ChromedashFeaturePage extends LitElement {
     `;
   }
 
+  renderWarnings() {
+    if (this.feature.deleted) {
+      return html`
+        <div id="deleted" class="warning">
+          This feature is marked as deleted.  It does not appear in
+          feature lists and is only viewable by users who can edit it.
+        </div>
+      `;
+    }
+    if (this.feature.unlisted) {
+      return html`
+        <div id="access" class="warning">
+          This feature is only shown in the feature list
+          to users with access to edit this feature.
+        </div>
+      `;
+    }
+    return nothing;
+  }
+
   renderEnterpriseFeatureContent() {
     return html`
       ${this.feature.summary ? html`
@@ -321,13 +341,6 @@ export class ChromedashFeaturePage extends LitElement {
 
   renderFeatureContent() {
     return html`
-      ${this.feature.unlisted ? html`
-        <section id="access">
-        <p><b>This feature is only shown in the feature list
-        to users with access to edit this feature.</b></p>
-        </section>
-      `: nothing}
-
       ${this.feature.summary ? html`
         <section id="summary">
           <p class="preformatted">${autolink(this.feature.summary)}</p>
@@ -393,7 +406,6 @@ export class ChromedashFeaturePage extends LitElement {
     `: nothing}
     `;
   }
-
 
   renderFeatureStatus() {
     return html`
@@ -535,6 +547,7 @@ export class ChromedashFeaturePage extends LitElement {
     // At this point, the feature has loaded successfully, render the components.
     return html`
       ${this.renderSubHeader()}
+      ${this.renderWarnings()}
       <sl-details summary="Overview"
         ?open=${true}
       >

--- a/client-src/elements/chromedash-guide-metadata.js
+++ b/client-src/elements/chromedash-guide-metadata.js
@@ -158,6 +158,26 @@ export class ChromedashGuideMetadata extends LitElement {
     `;
   }
 
+  renderWarnings() {
+    if (this.feature.deleted) {
+      return html`
+        <div id="deleted" class="warning">
+          This feature is marked as deleted.  It does not appear in
+          feature lists and is only viewable by users who can edit it.
+        </div>
+      `;
+    }
+    if (this.feature.unlisted) {
+      return html`
+        <div id="access" class="warning">
+          This feature is only shown in the feature list
+          to users with access to edit this feature.
+        </div>
+      `;
+    }
+    return nothing;
+  }
+
   renderReadOnlyTable() {
     return html`
       <div id="metadata-readonly">
@@ -173,13 +193,6 @@ export class ChromedashGuideMetadata extends LitElement {
           </div>
           <div>${autolink(this.feature.summary)}</div>
         </div>
-
-        ${this.feature.unlisted ? html`
-          <div style="padding: 8px">
-            This feature is only shown in the feature list
-            to users with access to edit this feature.
-          </div>
-        `: nothing}
 
         <div class="flex-cols">
           <table class="property-sheet">
@@ -333,6 +346,7 @@ export class ChromedashGuideMetadata extends LitElement {
 
   render() {
     return html`
+      ${this.renderWarnings()}
       <section id="metadata">
         ${this.editing ?
           this.renderEditForm() :this.feature.is_enterprise_feature ?


### PR DESCRIPTION
Today I was asked to delete an unneeded feature entry, which I did.  But then I realized that we still serve the feature detail page and guide page for deleted features with not indication that they are marked deleted.    I do want to continue to serve these pages to users who can edit the feature, so that it could be undeleted in the future.

In this PR:
* The GET handler for the features_api returns 404 when the feature has been marked deleted and the user does not have permission to edit it.  This will cause the client-side to show "Feature not found".
* For users who still see these pages for deleted features, add a warning banner to top.  And, move the existing unlisted warning to the top.
* Add a shared style for warnings.

Note that the code for renderWarnings() appears in two places, but we expect to delete the guide metadata page fairly soon.