### PR TITLE
Restrict release note page access, add help text to enterprise rollout stages

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -1,5 +1,5 @@
 import {LitElement, css, html, nothing} from 'lit';
-import {getStageValue} from './utils';
+import {getStageValue, renderHTMLIf} from './utils';
 import {openAddStageDialog} from './chromedash-add-stage-dialog';
 import {makeDisplaySpecs} from './form-field-specs';
 import {
@@ -173,6 +173,11 @@ class ChromedashFeatureDetail extends LitElement {
         box-shadow: var(--spot-card-box-shadow);
       }
 
+      .enterprise-help-text > *, .enterprise-help-text li {
+        margin: revert;
+        padding: revert;
+        list-style: revert;
+      }
     `];
   }
 
@@ -634,6 +639,23 @@ class ChromedashFeatureDetail extends LitElement {
         <span>Development stages</span>
         ${this.renderControls()}
       </h2>
+      ${renderHTMLIf(this.feature.is_enterprise_feature, html`
+        <section class="enterprise-help-text">
+          <p>The enterprise release notes focus on changes to the stable channel.
+          Please add a stage for each milestone where something is changing on the stable channel.
+          For finch rollouts, use the milestone where the rollout starts.
+          </p>
+          <p>
+            For example, you may only have a single stage where you roll out to 100% of users on milestone N.
+          </p>
+          <p>A more complex example might look like this:</p>
+          <ul>
+            <li>On milestone N-1, you introduce a flag for early testing of an upcoming change, or start a deprecation origin trial</li>
+            <li>On milestone N, you start a finch rollout of a feature at 1% and introduce an enterprise policy for it</li>
+            <li>On milestone N+3, you remove the enterprise policy</li>
+          </ul>
+        </section>
+      `)}
       ${this.feature.stages.map(feStage => this.renderProcessStage(feStage))}
       ${this.renderAddStageButton()}
     `;

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -588,6 +588,14 @@ def get_spa_template_data(handler_obj, defaults):
     if not user or not permissions.can_admin_site(user):
       handler_obj.abort(403, msg='Cannot perform admin actions')
 
+  # Validate the user has a google or chromium account and redirect if needed.
+  if defaults.get('require_google_or_chromium_account'):
+    user = handler_obj.get_current_user()
+    # Should have already done the require_signin check.
+    # If for reason, we don't let's treat it as the main 403 case.
+    if not user or not permissions.is_google_or_chromium_account(user):
+      handler_obj.abort(403, msg='You cannot access this page')
+
   return {} # no handler_data needed to be returned
 
 

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -38,7 +38,9 @@ def can_admin_site(user: User) -> bool:
 def is_google_or_chromium_account(user: User) -> bool:
   """Return True if the current uses a @chromium.org or @google.com email."""
   # A user is an admin if they have an AppUser entity that has is_admin set.
-  return user and user.email().endswith(('@chromium.org', '@google.com'))
+  if user:
+    return user.email().endswith(('@chromium.org', '@google.com'))
+  return False
 
 def can_view_feature(unused_user, unused_feature) -> bool:
   """Return True if the user is allowed to view the given feature."""

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -35,6 +35,10 @@ def can_admin_site(user: User) -> bool:
 
   return False
 
+def is_google_or_chromium_account(user: User) -> bool:
+  """Return True if the current uses a @chromium.org or @google.com email."""
+  # A user is an admin if they have an AppUser entity that has is_admin set.
+  return user and user.email().endswith(('@chromium.org', '@google.com'))
 
 def can_view_feature(unused_user, unused_feature) -> bool:
   """Return True if the user is allowed to view the given feature."""

--- a/framework/permissions_test.py
+++ b/framework/permissions_test.py
@@ -239,6 +239,18 @@ class PermissionFunctionTests(testing_config.CustomTestCase):
         unregistered=False, registered=True,
         special=False, site_editor=False, admin=True, anon=False)
 
+  def test_can_view_enterprise_release_notes(self):
+    # Test non google or chromium user
+    testing_config.sign_in('user@example.com', 123)
+    self.assertEqual(False, permissions.is_google_or_chromium_account(users.get_current_user()))
+
+    # Test google user
+    testing_config.sign_in('user@google.com', 123)
+    self.assertEqual(True, permissions.is_google_or_chromium_account(users.get_current_user()))
+
+    # Test chromium user
+    testing_config.sign_in('user@chromium.org', 123)
+    self.assertEqual(True, permissions.is_google_or_chromium_account(users.get_current_user()))
 
 class RequireAdminSiteTests(testing_config.CustomTestCase):
 

--- a/main.py
+++ b/main.py
@@ -186,7 +186,9 @@ spa_page_routes = [
   Route('/metrics/feature/timeline/popularity/<int:bucket_id>'),
   Route('/settings', defaults={'require_signin': True}),
   Route('/enterprise'),
-  Route('/enterprise/releasenotes'),
+  Route(
+    '/enterprise/releasenotes',
+    defaults={'require_signin': True, 'require_google_or_chromium_account': True,}),
   # Admin pages
   Route('/admin/blink', defaults={'require_admin_site': True, 'require_signin': True}),
 ]


### PR DESCRIPTION
* /enterprise/releasenotes is now restricted to @google.com and @chromium.org accounts
* A new help text has been added at the rollout stage for enterprise features