### PR TITLE
Migrate ff_views values.

### DIFF
--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -507,11 +507,11 @@ OPPOSED = 7
 NEUTRAL = 8
 SIGNALS_NA = 9
 GECKO_UNDER_CONSIDERATION = 10
-GECKO_IMPORTANT = 11
-GECKO_WORTH_PROTOTYPING = 12
-GECKO_NONHARMFUL = 13
+GECKO_IMPORTANT = 11  # Deprecated
+GECKO_WORTH_PROTOTYPING = 12  # Deprecated
+GECKO_NONHARMFUL = 13  # Deprecated
 GECKO_DEFER = 14
-GECKO_HARMFUL = 15
+GECKO_HARMFUL = 15  # Deprecated
 
 
 VENDOR_VIEWS_COMMON = {
@@ -524,15 +524,23 @@ VENDOR_VIEWS_COMMON = {
   SIGNALS_NA: 'N/A',
   }
 
-VENDOR_VIEWS_GECKO = VENDOR_VIEWS_COMMON.copy()
-VENDOR_VIEWS_GECKO.update({
+VENDOR_VIEWS_GECKO = {
+  NO_PUBLIC_SIGNALS: 'No signal',
+  SIGNALS_NA: 'N/A',
   GECKO_UNDER_CONSIDERATION: 'Under consideration',
+  GECKO_DEFER: 'Defer',
+  PUBLIC_SUPPORT: 'Positive',
+  OPPOSED: 'Negative',
+  NEUTRAL: 'Neutral',
+  SHIPPED: 'Shipped/Shipping',
+
+  # TODO(jrobbins): Delete these lines after migration script has been
+  # run in prod.
   GECKO_IMPORTANT: 'Important',
   GECKO_WORTH_PROTOTYPING: 'Worth prototyping',
   GECKO_NONHARMFUL: 'Non-harmful',
-  GECKO_DEFER: 'Defer',
   GECKO_HARMFUL: 'Harmful',
-  })
+  }
 
 # These vendors have no "custom" views values yet.
 VENDOR_VIEWS_EDGE = VENDOR_VIEWS_COMMON

--- a/main.py
+++ b/main.py
@@ -241,6 +241,8 @@ internals_routes: list[Route] = [
       maintenance_scripts.EvaluateGateStatus),
   Route('/scripts/write_missing_gates',
       maintenance_scripts.WriteMissingGates),
+  Route('/scripts/migrate_gecko_views',
+      maintenance_scripts.MigrateGeckoViews),
 ]
 
 dev_routes: list[Route] = []

--- a/pages/featurelist.py
+++ b/pages/featurelist.py
@@ -58,7 +58,7 @@ class FeatureListHandler(basehandlers.FlaskHandler):
       list(core_enums.IMPLEMENTATION_STATUS.items())])
     template_data['VENDOR_VIEWS'] = json.dumps([
       {'key': k, 'val': v} for k,v in
-      list(core_enums.VENDOR_VIEWS.items())])
+      sorted(core_enums.VENDOR_VIEWS.items())])
     template_data['WEB_DEV_VIEWS'] = json.dumps([
       {'key': k, 'val': v} for k,v in
       list(core_enums.WEB_DEV_VIEWS.items())])


### PR DESCRIPTION
This is the other PR needed to resolve #2909.

In this PR:
* Mark enum values deprecated on the server side, but keep them available until after the script is run in prod.
* Implement a data migration script and register it in main.py
* For the old feature list page, the list of possible enums needs to be sorted because it is built up from a dictionary that is no longer in numeric order.