### PR TITLE
Add hide obsolete support

### DIFF
--- a/client-src/elements/chromedash-stack-rank-page.js
+++ b/client-src/elements/chromedash-stack-rank-page.js
@@ -67,6 +67,7 @@ export class ChromedashStackRankPage extends LitElement {
     fetch(endpoint, options).then((res) => res.json()).then((props) => {
       for (let i = 0, item; item = props[i]; ++i) {
         item.percentage = (item.day_percentage * 100).toFixed(6);
+        item.obsolete = item.property_name && item.property_name.startsWith('OBSOLETE_');
       }
       const viewList = props.filter((item) => {
         return !['ERROR', 'PageVisits', 'PageDestruction'].includes(item.property_name);

--- a/client-src/elements/chromedash-stack-rank.js
+++ b/client-src/elements/chromedash-stack-rank.js
@@ -14,6 +14,7 @@ class ChromedashStackRank extends LitElement {
       sortType: {type: String},
       sortReverse: {type: Boolean},
       tempList: {attribute: false},
+      shouldHideObsolete: {state: true, attribute: false},
     };
   }
 
@@ -25,6 +26,8 @@ class ChromedashStackRank extends LitElement {
     this.maxPercentage = 100;
     this.sortType = 'percentage';
     this.sortReverse = false;
+    this.shouldHideObsolete = true;
+    this.obsoleteCount = 0;
   }
 
 
@@ -80,6 +83,10 @@ class ChromedashStackRank extends LitElement {
 
       .stack-rank-item {
         border-top: var(--table-divider)
+      }
+
+      .stack-rank-item-hidden {
+        display: none;
       }
 
       .stack-rank-item-name {
@@ -151,6 +158,8 @@ class ChromedashStackRank extends LitElement {
     setTimeout(() => {
       this.scrollToPosition();
     }, 300);
+
+    this.obsoleteCount = this.viewList.filter((item) => item.obsolete).length;
   }
 
   scrollToPosition(e) {
@@ -178,10 +187,19 @@ class ChromedashStackRank extends LitElement {
     this.viewList = sortBy_(this.sortType, this.sortReverse, newViewList);
   }
 
+  handleChangeHideObsolete(e) {
+    this.shouldHideObsolete = e.target.checked;
+  }
+
   renderSubHeader() {
     return html`
       <div id="subheader">
-        <p class="title-text">Showing <span>${this.viewList.length}</span> properties</p>
+        <p class="title-text">Showing <span>${this.viewList.length - (
+          this.shouldHideObsolete ? this.obsoleteCount : 0
+        )}</span> properties</p>
+        <sl-checkbox ?checked=${this.shouldHideObsolete} @input=${this.handleChangeHideObsolete} >
+          Hide obsolete
+        </sl-checkbox>
         <div id="dropdown-selection">
           <sl-dropdown>
             <sl-button slot="trigger" variant="text" ?disabled=${!this.viewList.length}>
@@ -219,7 +237,9 @@ class ChromedashStackRank extends LitElement {
   renderStackRank(displayedList) {
     return html`
       ${displayedList.map((item) => html`
-        <li class="stack-rank-item" id="${item.property_name}">
+        <li class="stack-rank-item" id="${item.property_name}" class="${
+          (this.shouldHideObsolete && item.obsolete) ? 'stack-rank-item-hidden' : ''
+        }">
           <div title="${item.property_name}. Click to deep link to this property.">
             <a class="stack-rank-item-name" href="#${item.property_name}" @click=${this.scrollToPosition}>
               <iron-icon class="hash-link" icon="chromestatus:link"></iron-icon>

--- a/client-src/elements/chromedash-stack-rank.js
+++ b/client-src/elements/chromedash-stack-rank.js
@@ -237,9 +237,8 @@ class ChromedashStackRank extends LitElement {
   renderStackRank(displayedList) {
     return html`
       ${displayedList.map((item) => html`
-        <li class="stack-rank-item" id="${item.property_name}" class="${
-          (this.shouldHideObsolete && item.obsolete) ? 'stack-rank-item-hidden' : ''
-        }">
+        <li class="stack-rank-item${(this.shouldHideObsolete && item.obsolete) ? ' stack-rank-item-hidden' : ''}"
+          id="${item.property_name}">
           <div title="${item.property_name}. Click to deep link to this property.">
             <a class="stack-rank-item-name" href="#${item.property_name}" @click=${this.scrollToPosition}>
               <iron-icon class="hash-link" icon="chromestatus:link"></iron-icon>

--- a/client-src/elements/chromedash-stack-rank.js
+++ b/client-src/elements/chromedash-stack-rank.js
@@ -237,7 +237,7 @@ class ChromedashStackRank extends LitElement {
   renderStackRank(displayedList) {
     return html`
       ${displayedList.map((item) => html`
-        <li class="stack-rank-item${(this.shouldHideObsolete && item.obsolete) ? ' stack-rank-item-hidden' : ''}"
+        <li class="stack-rank-item ${(this.shouldHideObsolete && item.obsolete) ? 'stack-rank-item-hidden' : ''}"
           id="${item.property_name}">
           <div title="${item.property_name}. Click to deep link to this property.">
             <a class="stack-rank-item-name" href="#${item.property_name}" @click=${this.scrollToPosition}>


### PR DESCRIPTION
Close #2565

<img width="655" alt="CleanShot 2023-05-21 at 12 15 31@2x" src="https://github.com/GoogleChrome/chromium-dashboard/assets/5123601/b98b5333-647d-4479-84f0-bd5966ca31a3">

- Hide property entries using `display: none`. Rather than mutating `viewList` or `tempList` with sorting logic. CSS is easier to implement and performance wise.
- Update total counts accordingly.