### PR TITLE
Ensure that the google charts library is loaded before calling it.

### DIFF
--- a/client-src/elements/chromedash-timeline-page_test.js
+++ b/client-src/elements/chromedash-timeline-page_test.js
@@ -12,7 +12,10 @@ describe('chromedash-timeline-page', () => {
     await fixture(html`<chromedash-toast></chromedash-toast>`);
     sinon.stub(window, 'fetch');
     // hacky way to stub out google chart load method
-    window.google = {charts: {load: () => {}}};
+    window.google = {charts: {
+      load: () => {},
+      setOnLoadCallback: (f) => f(),
+    }};
   });
 
   afterEach(() => {

--- a/client-src/elements/chromedash-timeline.js
+++ b/client-src/elements/chromedash-timeline.js
@@ -100,7 +100,7 @@ class ChromedashTimeline extends LitElement {
   }
 
   updated() {
-    this._updateTimeline();
+    window.google.charts.setOnLoadCallback(this._updateTimeline.bind(this));
   }
 
   updateSelectedBucketId(e) {


### PR DESCRIPTION
This should resolve a bug I hit just now while testing the prod and staging sites.
When doing a hard-refresh of a metrics timeline, I was getting the error:
`chromedash-timeline.js:125 Uncaught (in promise) TypeError: google.visualization.DataTable is not a constructor`
I saw this in Chrome but not Safari.  And, it did not occur when navigation to a metrics page after a previous SPA page had loaded.
My theory was that it was a race condition because the charts / visualization library takes some time to load.

The fix is to add a callback for when that library is loaded.
And, that line of code also needs to be stubbed out for unit tests.