### PR TITLE
Update HAR similar query SQL and give more space to table.

### DIFF
--- a/client-src/elements/chromedash-timeline.js
+++ b/client-src/elements/chromedash-timeline.js
@@ -49,7 +49,7 @@ class ChromedashTimeline extends LitElement {
       #http-archive-data {
         border: 0;
         width: 100%;
-        height: 775px;
+        height: 870px;
       }
 
       .header_title {
@@ -253,6 +253,7 @@ class ChromedashTimeline extends LitElement {
 SELECT yyyymmdd, client, pct_urls, sample_urls
 FROM \`httparchive.blink_features.usage\`
 WHERE feature = '${featureName}'
+AND yyyymmdd = (SELECT MAX(yyyymmdd) FROM \`httparchive.blink_features.usage\`)
 ORDER BY yyyymmdd DESC, client`;
     }
   }


### PR DESCRIPTION
This addresses the follow-up discussion on issue #2944.

In this PR:
* Give some more vertical space to the HTTP archive iframe so that the logo does not overlap the "next" icon
* Add an "AND" clause to the example BugQuery query.