### PR TITLE
Handle unsaved changes both with form submission and API save calls

### DIFF
--- a/client-src/elements/chromedash-settings-page.js
+++ b/client-src/elements/chromedash-settings-page.js
@@ -1,5 +1,5 @@
 import {LitElement, css, html, nothing} from 'lit';
-import {showToastMessage} from './utils';
+import {showToastMessage, handleSaveChangesResponse} from './utils';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {FORM_STYLES} from '../css/forms-css.js';
 
@@ -70,8 +70,10 @@ export class ChromedashSettingsPage extends LitElement {
     this.submitting = true;
     window.csClient.setSettings(this.notify_as_starrer).then(() => {
       showToastMessage('Settings saved.');
+      handleSaveChangesResponse('');
     }).catch(() => {
       showToastMessage('Unable to save the settings. Please try again.');
+      handleSaveChangesResponse('Unable to save the settings. Please try again.');
     }).finally(() => {
       this.submitting = false;
     });

--- a/client-src/elements/chromedash-settings-page_test.js
+++ b/client-src/elements/chromedash-settings-page_test.js
@@ -79,3 +79,7 @@ describe('chromedash-settings-page', () => {
     assert.notInclude(checkboxEl.outerHTML, 'checked');
   });
 });
+
+
+// When you get a chance, I'd like your insights into how to fix the "you have unsaved changes" logic for the user settings page.  Right now if the user changes then saves, then navigates away, they still get the warning.
+// It looks like the logic in chromedash-app that waits 1 sec then checks of the user is still on the same pageComponent (to detect a failed submission) is also being used here because the user settings component stays on the same component and just shows "settings save" as a toast.

--- a/client-src/elements/utils.js
+++ b/client-src/elements/utils.js
@@ -331,3 +331,14 @@ export function formatFeatureChanges(fieldValues, featureId) {
     hasChanges,
   };
 }
+
+/**
+ * Manage response to change submission.
+ * Required to manage beforeUnload handler.
+ * @param {string} response The error message to display,
+ *     or empty string if save was successful.
+ */
+export function handleSaveChangesResponse(response) {
+  const app = document.querySelector('chromedash-app');
+  app.setUnsavedChanges(response !== '');
+}


### PR DESCRIPTION
This PR generalizes the way form submission and API save calls are handled regarding unsaved changes.

* Rename the 'changesMade' vars to 'unsavedChanges'.
* Move the unsaved changes status to be a property of each page component.
* Add getter for unsaved changes status.
* Add utility method for interfacing between each API save call and the app method for handling unsaved changes.
* Fix the handling of the the API call on the user settings page, to fix #3004.