### PR TITLE
Explicitly list enterprise approvers.

### DIFF
--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -40,7 +40,9 @@ SECURITY_APPROVERS: list[str] = [
   # TBD
 ]
 ENTERPRISE_APPROVERS = [
-    'cbe-launch-approvers@google.com',
+    'mhoste@google.com',
+    'angelaweber@google.com',
+    'davidayad@google.com',
     'bheenan@google.com',
 ]
 DEBUGGABILITY_APPROVERS = [


### PR DESCRIPTION
List individual enterprise reviewers because our app cannot access mailing list membership lists.