### PR TITLE
Fix vote row for review requester.

### DIFF
--- a/api/permissions_api.py
+++ b/api/permissions_api.py
@@ -36,9 +36,6 @@ class PermissionsAPI(basehandlers.APIHandler):
       approvers = approval_defs.get_approvers(field_id)
       user_data = {
         'can_create_feature': permissions.can_create_feature(user),
-        # TODO(jrobbins): delete unused can_approve in an upcoming release.
-        'can_approve': permissions.can_approve_feature(
-            user, None, approvers),
         'approvable_gate_types': sorted(
             approval_defs.fields_approvable_by(user)),
         'can_comment': permissions.can_comment(user),

--- a/api/permissions_api_test.py
+++ b/api/permissions_api_test.py
@@ -47,7 +47,6 @@ class PermissionsAPITest(testing_config.CustomTestCase):
       'user': {
         'can_create_feature': False,
         'approvable_gate_types': [],
-        'can_approve': False,
         'can_comment': False,
         'can_edit_all': False,
         'is_admin': False,
@@ -65,7 +64,6 @@ class PermissionsAPITest(testing_config.CustomTestCase):
       'user': {
         'can_create_feature': True,
         'approvable_gate_types': [],
-        'can_approve': False,
         'can_comment': True,
         'can_edit_all': False,
         'is_admin': False,

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -465,12 +465,12 @@ export class ChromedashGateColumn extends LitElement {
     `;
   }
 
-  renderVoteRow(vote) {
+  renderVoteRow(vote, canVote) {
     const shortVoter = vote.set_by.split('@')[0] + '@';
     let saveButton = nothing;
     let voteCell = this.renderVoteReadOnly(vote);
 
-    if (vote.set_by == this.user?.email) {
+    if (canVote && vote.set_by == this.user?.email) {
       // If the current reviewer was the one who requested the review,
       // select "No response" in the menu because there is no
       // "Review requested" menu item now.
@@ -505,7 +505,7 @@ export class ChromedashGateColumn extends LitElement {
         this.user.approvable_gate_types.includes(this.gate.gate_type));
     const myVoteExists = this.votes.some((v) => v.set_by == this.user?.email);
     const addVoteRow = (canVote && !myVoteExists) ?
-      this.renderVoteRow({set_by: this.user?.email, state: 7}) :
+      this.renderVoteRow({set_by: this.user?.email, state: 7}, canVote) :
       nothing;
 
     if (!canVote && this.votes.length === 0) {
@@ -517,7 +517,7 @@ export class ChromedashGateColumn extends LitElement {
     return html`
       <table>
         <tr><th>Reviewer</th><th>Review status</th></tr>
-        ${this.votes.map((v) => this.renderVoteRow(v))}
+        ${this.votes.map((v) => this.renderVoteRow(v, canVote))}
         ${addVoteRow}
       </table>
     `;


### PR DESCRIPTION
This fixes a defect that was brought to my attention today by an internal user.
The problem was that a feature owner who requested a review was then offered a widget to vote on that same review.

The underlying cause was that there was logic to display a vote row for a user to change their existing vote.  However, that was triggered for the review requester because requesting a review is implemented as casting a REVIEW_REQUESTED vote.

The fix is to also check if the user has permission to vote before replacing the read-only vote row with a voting widget.

Also in this PR: Delete the `can_approve` boolean from the permissions_api.  The client side was previously updated to check for permission to vote on specific gates rather than a can-vote-on-anything boolean.  Removing this just finishes the change that was started a month ago in #2984.