### PR TITLE
Relabel "ready for trial" emails to "ready for developer testing"

### DIFF
--- a/api/processes_api_test.py
+++ b/api/processes_api_test.py
@@ -208,7 +208,7 @@ class ProgressAPITest(testing_config.CustomTestCase):
       'Final target milestone': 'True',
       'Intent to Prototype email': 'https://example.com/prototype',
       'Intent to Experiment email': 'https://example.com/ot',
-      'Ready for Trial email': 'https://example.com/ready_for_trial',
+      'Ready for Developer Testing email': 'https://example.com/ready_for_trial',
       'Intent to Ship email': 'https://example.com/ship',
       'Spec link': 'fake spec link',
       'Updated target milestone': 'True',

--- a/client-src/elements/chromedash-guide-edit-page_test.js
+++ b/client-src/elements/chromedash-guide-edit-page_test.js
@@ -67,7 +67,7 @@ describe('chromedash-guide-edit-page', () => {
     'Estimated target milestone': 'True',
     'Final target milestone': 'True',
     'Intent to Experiment email': 'fake intent to experiment url',
-    'Ready for Trial email': 'fake ready for trial url',
+    'Ready for Developer Testing email': 'fake ready for dev test url',
     'Spec link': 'fake spec link',
     'Web developer signals': 'True',
   });

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -633,9 +633,9 @@ export const ALL_FIELDS = {
     type: 'input',
     attrs: URL_FIELD_ATTRS,
     required: false,
-    label: 'Ready for Trial link',
-    help_text: html`After you have started the "Ready for Trial" discussion
-                thread, link to it here.`,
+    label: 'Ready for Develper Testing link',
+    help_text: html`After you have started the "Ready for Developer Testing"
+                 discussion thread, link to it here.`,
   },
 
   'intent_to_experiment_url': {
@@ -1002,7 +1002,7 @@ export const ALL_FIELDS = {
     help_text: html`
       If your feature was available as an origin trial, link to a summary
       of usage and developer feedback. If not, leave this empty. DO NOT
-      USE FEEDBACK VERBATIM without prior consultation with the Origin 
+      USE FEEDBACK VERBATIM without prior consultation with the Origin
       Trials team.`,
   },
 

--- a/internals/processes.py
+++ b/internals/processes.py
@@ -99,7 +99,8 @@ PI_SEC_REVIEW = ProgressItem('Security review issues addressed')
 PI_PRI_REVIEW = ProgressItem('Privacy review issues addressed')
 # TODO(jrobbins): needs detector.
 PI_EXTERNAL_REVIEWS = ProgressItem('External reviews')
-PI_R4DT_EMAIL = ProgressItem('Ready for Trial email', 'announcement_url')
+PI_R4DT_EMAIL = ProgressItem(
+    'Ready for Developer Testing email', 'announcement_url')
 
 PI_TAG_REQUESTED = ProgressItem('TAG review requested', 'tag_review')
 PI_VENDOR_SIGNALS = ProgressItem('Vendor signals', 'safari_views')
@@ -223,7 +224,7 @@ BLINK_PROCESS_STAGES = [
        PI_EXTERNAL_REVIEWS,
        PI_R4DT_EMAIL,
       ],
-      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL,
+      [Action('Draft Ready for Developer Testing email', INTENT_EMAIL_URL,
               [PI_INITIAL_PUBLIC_PROPOSAL.name, PI_MOTIVATION.name,
                PI_EXPLAINER.name, PI_SPEC_LINK.name])],
       [],
@@ -330,7 +331,7 @@ BLINK_FAST_TRACK_STAGES = [
        PI_VENDOR_SIGNALS,
        PI_EST_TARGET_MILESTONE,
       ],
-      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL,
+      [Action('Draft Ready for Developer Testing email', INTENT_EMAIL_URL,
               [PI_SPEC_LINK.name, PI_EST_TARGET_MILESTONE.name])],
       [],
       core_enums.INTENT_IMPLEMENT, core_enums.INTENT_EXPERIMENT,
@@ -409,7 +410,7 @@ PSA_ONLY_STAGES = [
        PI_VENDOR_SIGNALS,
        PI_EST_TARGET_MILESTONE,
       ],
-      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL,
+      [Action('Draft Ready for Developer Testing email', INTENT_EMAIL_URL,
               [PI_SPEC_LINK.name, PI_EST_TARGET_MILESTONE.name])],
       [],
       core_enums.INTENT_IMPLEMENT, core_enums.INTENT_EXPERIMENT,
@@ -473,7 +474,7 @@ DEPRECATION_STAGES = [
        PI_VENDOR_SIGNALS,
        PI_EST_TARGET_MILESTONE,
       ],
-      [Action('Draft Ready for Trial email', INTENT_EMAIL_URL,
+      [Action('Draft Ready for Developer Testing email', INTENT_EMAIL_URL,
               [PI_MOTIVATION.name, PI_VENDOR_SIGNALS.name,
                PI_EST_TARGET_MILESTONE.name])],
       [],
@@ -623,7 +624,7 @@ PROGRESS_DETECTORS = {
     lambda f, stages: (core_enums.STAGE_TYPES_SHIPPING[f.feature_type] and
         stages[core_enums.STAGE_TYPES_SHIPPING[f.feature_type]][0].intent_thread_url),
 
-    'Ready for Trial email':
+    'Ready for Developer Testing email':
     lambda f, stages: (core_enums.STAGE_TYPES_DEV_TRIAL[f.feature_type] and
         stages[core_enums.STAGE_TYPES_DEV_TRIAL[f.feature_type]][0].announcement_url),
 

--- a/internals/processes_test.py
+++ b/internals/processes_test.py
@@ -206,7 +206,7 @@ class ProgressDetectorsTest(testing_config.CustomTestCase):
     self.assertTrue(detector(self.feature_1, self.stages_dict))
 
   def test_ready_for_trial_email(self):
-    detector = processes.PROGRESS_DETECTORS['Ready for Trial email']
+    detector = processes.PROGRESS_DETECTORS['Ready for Developer Testing email']
     self.assertFalse(detector(self.feature_1, self.stages_dict))
     self.stages_dict[130][0].announcement_url = 'http://example.com/trial_ready'
     self.assertTrue(detector(self.feature_1, self.stages_dict))

--- a/pages/intentpreview.py
+++ b/pages/intentpreview.py
@@ -81,7 +81,7 @@ class IntentEmailPreviewHandler(basehandlers.FlaskHandler):
     elif intent_stage == core_enums.INTENT_IMPLEMENT:
       return 'Intent to Prototype'
     elif intent_stage == core_enums.INTENT_EXPERIMENT:
-      return 'Ready for Trial'
+      return 'Ready for Developer Testing'
     elif intent_stage == core_enums.INTENT_EXTEND_TRIAL:
       if feature.feature_type == core_enums.FEATURE_TYPE_DEPRECATION_ID:
         return 'Request for Deprecation Trial'

--- a/pages/intentpreview_test.py
+++ b/pages/intentpreview_test.py
@@ -153,7 +153,7 @@ class IntentEmailPreviewHandlerTest(testing_config.CustomTestCase):
             self.feature_1, core_enums.INTENT_IMPLEMENT))
 
     self.assertEqual(
-        'Ready for Trial',
+        'Ready for Developer Testing',
         self.handler.compute_subject_prefix(
             self.feature_1, core_enums.INTENT_EXPERIMENT))
 


### PR DESCRIPTION
Relabel the email subject line for announcing a dev trial from "Ready for Trial" to "Ready for Developer Testing".
This was suggested by Chris H to avoid confusion with origin trial threads.