### PR TITLE
Implement script to backfill gate.responded_on.

### DIFF
--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -179,7 +179,6 @@ def decode_raw_owner_content(raw_content) -> list[str]:
   owners = []
   decoded = base64.b64decode(raw_content).decode()
   for line in decoded.split('\n'):
-    logging.info('got line: '  + line[:settings.MAX_LOG_LINE])
     if '#' in line:
       line = line[:line.index('#')]
     line = line.strip()

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -190,6 +190,9 @@ def decode_raw_owner_content(raw_content) -> list[str]:
 
 def get_approvers(field_id) -> list[str]:
   """Return a list of email addresses of users allowed to approve."""
+  if field_id not in APPROVAL_FIELDS_BY_ID:
+    return []
+
   afd = APPROVAL_FIELDS_BY_ID[field_id]
 
   # afd.approvers can be either a hard-coded list of approver emails

--- a/main.py
+++ b/main.py
@@ -238,11 +238,13 @@ internals_routes: list[Route] = [
 
   # Maintenance scripts.
   Route('/scripts/evaluate_gate_status',
-      maintenance_scripts.EvaluateGateStatus),
+        maintenance_scripts.EvaluateGateStatus),
   Route('/scripts/write_missing_gates',
-      maintenance_scripts.WriteMissingGates),
+        maintenance_scripts.WriteMissingGates),
   Route('/scripts/migrate_gecko_views',
-      maintenance_scripts.MigrateGeckoViews),
+        maintenance_scripts.MigrateGeckoViews),
+  Route('/scripts/backfill_responded_on',
+        maintenance_scripts.BackfillRespondedOn),
 ]
 
 dev_routes: list[Route] = []


### PR DESCRIPTION
This should finish the last part of issue #3022.

This PR implements a script to backfill values for gate.responded_on based on existing vote and activity entities.  It chooses the earliest vote or comment by an approver that came after the review was requested.  Backfilling this data is needed to avoid existing completed reviews from being displayed as overdue.

In this PR:
* Add a new maintenance script to main.py
* In the maintenance script, copy the previously used pattern for updating entities in batches of 100 so that we make progress even if the request times out
* For each gate with a requested_on but no responded_on, check if there is a vote or activity that counts as a response
* Add logging for this script and remove some old unneeded logging from approvals_defs.py