### PR TITLE
Implement a simple JSON report about overdue review gates.

### DIFF
--- a/main.py
+++ b/main.py
@@ -191,6 +191,7 @@ spa_page_routes = [
     defaults={'require_signin': True, 'is_enterprise_page': True}),
   # Admin pages
   Route('/admin/blink', defaults={'require_admin_site': True, 'require_signin': True}),
+  Route('/admin/slo_report', reminders.SLOReportHandler),
 ]
 
 mpa_page_routes: list[Route] = [


### PR DESCRIPTION
This is a first step toward resolving #3027.  But, before we start sending SLO reminder emails to users, I want to get a feel for how many gates are overdue.  By looking at this report, we might decide to adjust the SLO limits or make some other change.

In this PR:
* Implement a new handler, but this one just returns JSON rather than displaying an HTML page.
* Generate a list of overdue review gates in a way that does not require any new ndb index.
* Reorganize that list into a dictionary keyed by recipient.