### PR TITLE
Avoid cluttering test output with expected error logging.

### DIFF
--- a/internals/feature_links_test.py
+++ b/internals/feature_links_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import testing_config
+from unittest import mock
 from internals.core_models import FeatureEntry
 from internals.feature_links import FeatureLinks, update_feature_links
 from internals.link_helpers import LINK_TYPE_CHROMIUM_BUG
@@ -84,7 +85,8 @@ class LinkTest(testing_config.CustomTestCase):
     link = query.get()
     self.assertIsNone(link)
 
-  def test_feature_changed_invalid_url(self):
+  @mock.patch('logging.error')
+  def test_feature_changed_invalid_url(self, mock_error):
     url = "https://bugs.chromium.org/p/chromium/issues/detail?id=100000000000"
     query = FeatureLinks.query(FeatureLinks.url == url)
     changed_fields = [

--- a/internals/link_helpers_test.py
+++ b/internals/link_helpers_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import testing_config
+from unittest import mock
 from internals.link_helpers import Link, LINK_TYPE_CHROMIUM_BUG
 
 
@@ -32,7 +33,8 @@ class LinkHelperTest(testing_config.CustomTestCase):
     self.assertEqual(info["statusRef"]["status"], "Fixed")
     self.assertEqual(info["ownerRef"]["displayName"], "backer@chromium.org")
 
-  def test_parse_chromium_tracker_fail_wrong_id(self):
+  @mock.patch('logging.error')
+  def test_parse_chromium_tracker_fail_wrong_id(self, mock_error):
     link = Link(
         "https://bugs.chromium.org/p/chromium/issues/detail?id=100000000000000"
     )
@@ -42,7 +44,8 @@ class LinkHelperTest(testing_config.CustomTestCase):
     self.assertEqual(link.is_error, True)
     self.assertEqual(link.information, None)
 
-  def test_parse_chromium_tracker_fail_no_permission(self):
+  @mock.patch('logging.error')
+  def test_parse_chromium_tracker_fail_no_permission(self, mock_error):
     link = Link("https://bugs.chromium.org/p/chromium/issues/detail?id=1")
     link.parse()
     self.assertEqual(link.type, LINK_TYPE_CHROMIUM_BUG)


### PR DESCRIPTION
This PR cleans up the unit test output.  It should not change the tests themselves.

When testing a case that is expected to log an error, we should mock `logging.error` so that any error logging output does not clutter the output of `npm test`.  I always like to see the output look like `................................... OK`.