### PR TITLE
Fix rollout platforms only saving 1 platform on the edit all page

### DIFF
--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -81,9 +81,6 @@ export function formatFeatureForEdit(feature) {
 
     // from feature.browsers.other
     other_views_notes: feature.browsers.other.view.notes,
-
-    rollout_platforms: Array.from(new Set((feature.rollout_platforms || [])
-      .map(x => parseInt(x).toString()))),
   };
 
   COMMA_SEPARATED_FIELDS.map((field) => {

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -338,8 +338,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     elif field_type == 'str':
       return self.form.get(field)
     elif field_type == 'split_str':
-      val = self.split_input(field, delim=',')
-      if field == 'rollout_platforms' or field == 'enterprise_feature_categories':
+      if 'rollout_platforms' in field or field == 'enterprise_feature_categories':
         val = self.form.getlist(field)
         # Occasionally, input will give an empty string as the first element.
         # It needs to be removed.
@@ -348,6 +347,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
         return val
       elif field == 'blink_components' and len(val) == 0:
         return [settings.DEFAULT_COMPONENT]
+      val = self.split_input(field, delim=',')
       return val
     raise ValueError(f'Unknown field data type: {field_type}')
 


### PR DESCRIPTION
- In the backend, to save rollout platforms we omitted to account for the suffix added because it is a stage value. We now look to see if 'rollout_platforms' is in the field name.