### PR TITLE
Fix ordering of new steps added on the edit all page

### DIFF
--- a/client-src/elements/chromedash-guide-editall-page.js
+++ b/client-src/elements/chromedash-guide-editall-page.js
@@ -319,13 +319,20 @@ export class ChromedashGuideEditallPage extends LitElement {
     </sl-button>`;
   }
 
-  AddNewStageToCreate(stageType) {
-    this.feature.stages.push({
-      ...stageType,
-      to_create: true,
-      id: ++this.nextStageToCreateId});
-    this.feature.stages = this.feature.stages
-      .sort((a, b) => a.stage_type_int - b.stage_type_int);
+  AddNewStageToCreate(newStage) {
+    const lastIndexOfType = this.feature.stages
+      .findLastIndex((stage) => stage.stage_type === newStage.stage_type);
+    if (lastIndexOfType === -1) {
+      this.feature.stages.push({
+        ...newStage,
+        to_create: true,
+        id: ++this.nextStageToCreateId});
+    } else {
+      this.feature.stages.splice(lastIndexOfType + 1, 0, {
+        ...newStage,
+        to_create: true,
+        id: ++this.nextStageToCreateId});
+    }
     this.feature = {...this.feature};
   }
 

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -338,6 +338,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     elif field_type == 'str':
       return self.form.get(field)
     elif field_type == 'split_str':
+      val = self.split_input(field, delim=',')
       if 'rollout_platforms' in field or field == 'enterprise_feature_categories':
         val = self.form.getlist(field)
         # Occasionally, input will give an empty string as the first element.
@@ -347,7 +348,6 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
         return val
       elif field == 'blink_components' and len(val) == 0:
         return [settings.DEFAULT_COMPONENT]
-      val = self.split_input(field, delim=',')
       return val
     raise ValueError(f'Unknown field data type: {field_type}')
 


### PR DESCRIPTION
Instead of sorting the stages after adding a new stage, we simply add it at the right place