### PR TITLE
Ensure that newly created stages have an id that keeps increasing in the database

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -211,8 +211,6 @@ def stage_to_json_dict(
     'webview_last': milestones.webview_last,
   }
 
-  print(d['created'])
-
   return d
 
 

--- a/api/converters.py
+++ b/api/converters.py
@@ -115,11 +115,9 @@ def _prep_stage_info(
 
   # Get all stages associated with the feature, sorted by stage type.
   if prefetched_stages is not None:
-    prefetched_stages.sort(key=lambda s: s.stage_type)
     stages = prefetched_stages
   else:
-    stages = Stage.query(
-        Stage.feature_id == fe.key.integer_id()).order(Stage.stage_type)
+    stages = Stage.query(Stage.feature_id == fe.key.integer_id())
 
   stage_info: StagePrepResponse = {
       'proto': None,
@@ -160,6 +158,7 @@ def _prep_stage_info(
       stage_info['rollout'] = s
     stage_info['all_stages'].append(stage_dict)
 
+  stage_info['all_stages'].sort(key=lambda s: (s['stage_type'], s['created']))
   return stage_info
 
 
@@ -174,6 +173,7 @@ def stage_to_json_dict(
 
   d: StageDict = {
     'id': stage.key.integer_id(),
+    'created': str(stage.created),
     'feature_id': stage.feature_id,
     'stage_type': stage.stage_type,
     'display_name': stage.display_name,
@@ -210,6 +210,8 @@ def stage_to_json_dict(
     'ios_last': milestones.ios_last,
     'webview_last': milestones.webview_last,
   }
+
+  print(d['created'])
 
   return d
 

--- a/api/stages_api_test.py
+++ b/api/stages_api_test.py
@@ -16,6 +16,7 @@
 import testing_config  # Must be imported before the module under test.
 
 import flask
+from datetime import datetime
 from unittest import mock
 from google.cloud import ndb  # type: ignore
 import werkzeug.exceptions
@@ -30,6 +31,7 @@ test_app = flask.Flask(__name__)
 class StagesAPITest(testing_config.CustomTestCase):
 
   def setUp(self):
+    self.now = datetime.now()
     self.feature_owner = AppUser(email='feature_owner@example.com')
     self.feature_owner.put()
 
@@ -45,24 +47,27 @@ class StagesAPITest(testing_config.CustomTestCase):
         ux_emails=['ux_person@example.com'],
         intent_thread_url='https://example.com/intent',
         milestones=MilestoneSet(desktop_first=100),
-        experiment_goals='To be the very best.')
+        experiment_goals='To be the very best.',
+        created=self.now)
     self.stage_1.put()
     # Shipping stage.
-    self.stage_2 = Stage(id=11, feature_id=1, stage_type=160)
+    self.stage_2 = Stage(id=11, feature_id=1, stage_type=160, created=self.now)
     self.stage_2.put()
 
     self.stage_3 = Stage(id=30, feature_id=99, stage_type=150, browser='Chrome',
         ux_emails=['ux_person@example.com'],
         intent_thread_url='https://example.com/intent',
         milestones=MilestoneSet(desktop_first=100),
-        experiment_goals='To be the very best.')
+        experiment_goals='To be the very best.',
+        created=self.now)
     self.stage_3.put()
 
     self.stage_4 = Stage(id=40, feature_id=1, stage_type=150, browser='Chrome',
         ux_emails=['ux_person@example.com'],
         intent_thread_url='https://example.com/intent',
         milestones=MilestoneSet(desktop_first=100),
-        experiment_goals='To be the very best.')
+        experiment_goals='To be the very best.',
+        created=self.now)
     self.stage_4.put()
 
     self.stage_5 = Stage(id=50, feature_id=1, stage_type=150, browser='Chrome',
@@ -70,13 +75,15 @@ class StagesAPITest(testing_config.CustomTestCase):
         ux_emails=['ux_person@example.com'],
         intent_thread_url='https://example.com/intent',
         milestones=MilestoneSet(desktop_first=100),
-        experiment_goals='To be the very best.')
+        experiment_goals='To be the very best.',
+        created=self.now)
     self.stage_5.put()
 
     self.expected_stage_1 = {
         'android_first': None,
         'android_last': None,
         'announcement_url': None,
+        'created': str(self.now),
         'desktop_first': 100,
         'desktop_last': None,
         'display_name': None,
@@ -147,6 +154,7 @@ class StagesAPITest(testing_config.CustomTestCase):
     """Returns stage data with extension if requesting a valid stage ID."""
     extension = {
         'id': 50,
+        'created': str(self.now),
         'feature_id': 1,
         'stage_type': 150,
         'intent_stage': 3,
@@ -181,6 +189,7 @@ class StagesAPITest(testing_config.CustomTestCase):
 
     expect = {
         'id': 40,
+        'created': str(self.now),
         'feature_id': 1,
         'stage_type': 150,
         'intent_stage': 3,

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -17,6 +17,7 @@
 # https://stackoverflow.com/a/33533514
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from google.cloud import ndb  # type: ignore
@@ -287,3 +288,4 @@ class Stage(ndb.Model):
   enterprise_policies = ndb.StringProperty(repeated=True)
 
   archived = ndb.BooleanProperty(default=False)
+  created = ndb.DateTimeProperty(auto_now_add=True, default=datetime.min, required=True)

--- a/internals/data_types.py
+++ b/internals/data_types.py
@@ -23,6 +23,7 @@ from typing import TypedDict
 # JSON representation of Stage entity data.
 class StageDict(TypedDict):
   id: int
+  created: str
   feature_id: int
   stage_type: int
   display_name: str

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -567,6 +567,12 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
         setattr(stage_to_update, field, new_val)
       if old_val != new_val:
         changed_fields.append((old_field_name, old_val, new_val))
+    
+    if stage_to_update.created == datetime.min:
+      feature: FeatureEntry = FeatureEntry.get_by_id(stage_to_update.feature_id)
+      if feature is None:
+        self.abort(404, msg='Feature not found')
+      setattr(stage_to_update, 'created', feature.created)
     stage_to_update.put()
 
   def update_stages_editall(
@@ -655,7 +661,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
         if old_val != new_val:
           changed_fields.append((field, old_val, new_val))
 
-      # Update the created date only when editing all so that ordering of the stages stays
+      # Update the created date when editing so that ordering of the stages stays
       # consistent.
       if stage.created == datetime.min:
         setattr(stage, 'created', feature.created)


### PR DESCRIPTION
It seems that having the same parameter for every place we create a new stage ensures that the ID keeps increasing while having multiple parameters seems to give random ID. The ID is used to sort the stages when we  fetch them, so they should be sorted in the order they were created.