### PR TITLE
Update stale feature links

### DIFF
--- a/api/feature_links_api.py
+++ b/api/feature_links_api.py
@@ -22,7 +22,7 @@ from internals import feature_links
 class FeatureLinksAPI(basehandlers.APIHandler):
   """FeatureLinksAPI will return the links and its information to the client."""
 
-  def get_feature_links(self, feature_id: int, update_stale_links: bool = False):
+  def get_feature_links(self, feature_id: int, update_stale_links: bool):
     feature = FeatureEntry.get_by_id(feature_id)
     if not feature:
       self.abort(404, msg='Feature not found')

--- a/api/feature_links_api.py
+++ b/api/feature_links_api.py
@@ -22,16 +22,22 @@ from internals import feature_links
 class FeatureLinksAPI(basehandlers.APIHandler):
   """FeatureLinksAPI will return the links and its information to the client."""
 
-  def get_feature_links(self, feature_id: int):
+  def get_feature_links(self, feature_id: int, update_stale_links: bool = False):
     feature = FeatureEntry.get_by_id(feature_id)
     if not feature:
       self.abort(404, msg='Feature not found')
-    return feature_links.get_by_feature_id(feature_id)
+    return feature_links.get_by_feature_id(feature_id, update_stale_links)
 
   def do_get(self, **kwargs):
 
     feature_id = self.get_int_arg('feature_id', None)
+    update_stale_links = self.get_bool_arg('update_stale_links', True)
     if feature_id:
-      return self.get_feature_links(feature_id)
+      data, has_stale_links = self.get_feature_links(
+          feature_id, update_stale_links)
+      return {
+          "data": data,
+          "has_stale_links": has_stale_links
+      }
     else:
       self.abort(400, msg='Missing feature_id')

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -175,9 +175,18 @@ export class ChromedashFeaturePage extends LitElement {
 
     window.csClient.getFeatureLinks(this.featureId).then(
       (featureLinks) => {
-        this.featureLinks = featureLinks;
+        this.featureLinks = featureLinks?.data || [];
+        if (featureLinks?.has_stale_links) {
+          // delay 2 seconds to fetch server to get latest link information
+          setTimeout(this.refetchFeatureLinks.bind(this), 2000);
+        }
       },
     );
+  }
+
+  async refetchFeatureLinks() {
+    featureLinks = await window.csClient.getFeatureLinks(this.featureId, false);
+    this.featureLinks = featureLinks?.data || [];
   }
 
   refetch() {

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -177,8 +177,8 @@ export class ChromedashFeaturePage extends LitElement {
       (featureLinks) => {
         this.featureLinks = featureLinks?.data || [];
         if (featureLinks?.has_stale_links) {
-          // delay 2 seconds to fetch server to get latest link information
-          setTimeout(this.refetchFeatureLinks.bind(this), 2000);
+          // delay 10 seconds to fetch server to get latest link information
+          setTimeout(this.refetchFeatureLinks.bind(this), 10000);
         }
       },
     );

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -304,8 +304,8 @@ class ChromeStatusClient {
 
   // FeatureLinks API
 
-  getFeatureLinks(featureId) {
-    return this.doGet(`/feature_links?feature_id=${featureId}`);
+  getFeatureLinks(featureId, updateStaleLinks=true) {
+    return this.doGet(`/feature_links?feature_id=${featureId}&update_stale_links=${updateStaleLinks}`);
   }
 
   // Stages API

--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -76,8 +76,8 @@ class Link():
     # decode the content from base64
     content_str = information.content
     content_decoded = base64.b64decode(content_str).decode('utf-8')
-    # get markdown title
-    title = content_decoded.split('\n')[0].replace('#', '').strip()
+    # get markdown title, remove beginning and trailing # but keep the rest
+    title = content_decoded.split('\n')[0].strip('#').strip()
     information['_parsed_title'] = title
 
     return information

--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -157,4 +157,5 @@ class Link():
       self.error = e
       self.is_error = True
       self.information = None
+      # TODO: store error information and show 404/403 error icon for the link
     self.is_parsed = True

--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -63,10 +63,13 @@ class Link():
     ref = path.split('/')[4]
     file_path = '/'.join(path.split('/')[5:])
     try:
+      # try to get the branch information, if it exists, update branch name
+      # this handles the case where the branch is renamed
       branch_information = github_api_client.repos.get_branch(
           owner=owner, repo=repo, branch=ref)
       ref = branch_information.name
     except HTTPError as e:
+      # if the branch does not exist, then it is probably a commit hash
       if e.code != 404:
         raise e
 

--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -19,6 +19,7 @@ import json
 import logging
 from typing import Any
 from ghapi.core import GhApi
+from urllib.error import HTTPError
 from urllib.parse import urlparse
 import base64
 
@@ -65,7 +66,7 @@ class Link():
       branch_information = github_api_client.repos.get_branch(
           owner=owner, repo=repo, branch=ref)
       ref = branch_information.name
-    except Exception as e:
+    except HTTPError as e:
       if e.code != 404:
         raise e
 

--- a/main.py
+++ b/main.py
@@ -40,6 +40,7 @@ from framework import csp
 from framework import sendemail
 from internals import detect_intent
 from internals import fetchmetrics
+from internals import feature_links
 from internals import maintenance_scripts
 from internals import notifier
 from internals import data_backup
@@ -238,6 +239,7 @@ internals_routes: list[Route] = [
   Route('/tasks/detect-intent', detect_intent.IntentEmailHandler),
   Route('/tasks/email-reviewers', notifier.FeatureReviewHandler),
   Route('/tasks/email-comments', notifier.FeatureCommentHandler),
+  Route('/tasks/update-feature-links', feature_links.FeatureLinksUpdateHandler),
 
   # Maintenance scripts.
   Route('/scripts/evaluate_gate_status',

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ MarkupSafe==2.1.1
 Werkzeug==2.3.3
 click==8.1.3
 itsdangerous==2.1.2
-
+ghapi==1.0.3
 # Work-around for failure to deploy
 # https://stackoverflow.com/questions/69936420/google-cloud-platform-app-deploy-failure-due-to-pyparsing
 pyparsing==2.4.7


### PR DESCRIPTION
In this PR:

## Feature links updates on the fly
- `feature_link` update time older than 30 minutes ago will be considered stale.
- server will update the link if `update_stale_links = True`
- if any links are stale, client will send a second request to get the latest information.

Possible improvements:

- `_index_feature_links` could get many links to update, we could improve its performance by updating/requests concurrently.
- if two or more users visit a feature at the same time, the updates could be triggered more than once (which is acceptable since any of them will still get the latest information). We could use a global cache (such as redis) to prevent the same feature's links from being updated multiple times.

## Parsing GitHub issues and markdown file

- Use https://github.com/fastai/ghapi as client
  - parse GitHub issues and get its information
  - parse markdown file and get its title on the first line
- improve url components parsing with `urllib.parse`

Possible improvements:
- Add an access_token to increase GitHub API rate limit, since
   

> For unauthenticated requests, the rate limit allows for up to 60 requests per hour. Unauthenticated requests are associated with the originating IP address, and not the person making requests.

https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-personal-accounts