### PR TITLE
Add fields for finch flag name and non-finch justification.

### DIFF
--- a/api/api_specs.py
+++ b/api/api_specs.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Data type for lists defining field data type information.
-FIELD_INFO_DATA_TYPE = list[tuple[str, str]]  
+FIELD_INFO_DATA_TYPE = list[tuple[str, str]]
 
 # List with fields that can be edited on feature create/update
 # and their data types.
@@ -47,6 +47,8 @@ FEATURE_FIELD_DATA_TYPES: FIELD_INFO_DATA_TYPE = [
   ('ff_views_link', 'str'),
   ('ff_views_notes', 'str'),
   ('flag_name', 'str'),
+  ('finch_name', 'str'),
+  ('non_finch_justification', 'str'),
   ('impl_status_chrome', 'int'),
   ('initial_public_proposal_url', 'str'),
   ('intent_stage', 'int'),

--- a/api/converters.py
+++ b/api/converters.py
@@ -273,6 +273,8 @@ def feature_entry_to_json_verbose(
     'screenshot_links': fe.screenshot_links or [],
     'breaking_change': fe.breaking_change,
     'flag_name': fe.flag_name,
+    'finch_name': fe.finch_name,
+    'non_finch_justification': fe.non_finch_justification,
     'ongoing_constraints': fe.ongoing_constraints,
     'motivation': fe.motivation,
     'devtrial_instructions': fe.devtrial_instructions,

--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -351,6 +351,8 @@ class FeatureConvertersTest(testing_config.CustomTestCase):
       'feature_notes': 'notes',
       'ff_views': 5,
       'flag_name': None,
+      'finch_name': None,
+      'non_finch_justification': None,
       'initial_public_proposal_url': None,
       'interop_compat_risks': None,
       'measurement': None,

--- a/client-src/elements/chromedash-feature-filter.js
+++ b/client-src/elements/chromedash-feature-filter.js
@@ -95,6 +95,8 @@ const QUERIABLE_FIELDS = [
   // 'requires_embedder_support': Feature.requires_embedder_support,
 
   {name: 'browsers.chrome.flag_name', display: 'Flag name', type: TEXT_TYPE},
+  {name: 'browsers.chrome.finch_name', display: 'Finch name', type: TEXT_TYPE},
+  // 'browsers.chrome.non_finch_justification': Feature.non_finch_justification,
   // 'all_platforms': Feature.all_platforms,
   // 'all_platforms_descr': Feature.all_platforms_descr,
   // 'wpt': Feature.wpt,

--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -262,6 +262,8 @@ const FLAT_DEV_TRIAL_FIELDS = {
       name: 'Implementation in Chromium',
       fields: [
         'flag_name',
+        'finch_name',
+        'non_finch_justification',
         'dt_milestone_desktop_start',
         'dt_milestone_android_start',
         'dt_milestone_ios_start',
@@ -493,6 +495,8 @@ const DEPRECATION_DEV_TRIAL_FIELDS = {
       name: 'Implementation in Chromium',
       fields: [
         'flag_name',
+        'finch_name',
+        'non_finch_justification',
         'dt_milestone_desktop_start',
         'dt_milestone_android_start',
         'dt_milestone_ios_start',

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -1261,7 +1261,34 @@ export const ALL_FIELDS = {
     required: false,
     label: 'Flag name',
     help_text: html`
-      Name of the flag on chrome://flags that enables this feature.`,
+      Name of the flag on chrome://flags that allows a web developer to
+      enable this feature in their own browser to try it out.
+      E.g., "storage-buckets".  These are defined in <a target="_blank"
+      href="https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/about_flags.cc">about_flags.cc</a>.`,
+  },
+
+  'finch_name': {
+    type: 'input',
+    attrs: TEXT_FIELD_ATTRS,
+    required: false,
+    label: 'Finch feature name',
+    help_text: html`
+      String name of the <code>base::Feature</code> defined via the
+      <code>BASE_FEATURE</code> macro in your feature implementation
+      code. E.g., "StoragBuckets".  These names are used
+      in <a target="_blank"
+      href="https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/renderer/platform/runtime_enabled_features.json5"
+      >runtime_enabled_features.json5</a> and finch GCL files`,
+  },
+
+  'non_finch_justification': {
+    type: 'textarea',
+    required: false,
+    label: 'Non-finch justification',
+    help_text: html`
+      The <a target="_blank"
+      href="https://chromium.googlesource.com/chromium/src/+/main/docs/flag_guarding_guidelines.md">Flag Guarding Guidelines</a> require new features to have
+       a finch flag.  If your feature does not have a finch flag, explain why.`,
   },
 
   'prefixed': {

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -93,6 +93,8 @@ class FeatureEntry(ndb.Model):  # Copy from Feature
   # Implementation in Chrome
   impl_status_chrome = ndb.IntegerProperty(required=True, default=NO_ACTIVE_DEV)
   flag_name = ndb.StringProperty()
+  finch_name = ndb.StringProperty()
+  non_finch_justification = ndb.TextProperty()
   ongoing_constraints = ndb.TextProperty()
 
   # Topic: Adoption (reviewed by API Owners.  Auto-approved gate later?)

--- a/internals/data_types.py
+++ b/internals/data_types.py
@@ -32,13 +32,13 @@ class StageDict(TypedDict):
   # Dev trial specific fields.
   announcement_url: str | None
 
-  
+
   # Origin trial specific fields.
   experiment_goals: str | None
   experiment_risks: str | None
   extensions: list[StageDict]  # type: ignore
   origin_trial_feedback_url: str | None
-  
+
   # Trial extension specific fields.
   ot_stage_id: int | None
   experiment_extension_reason: str | None
@@ -191,6 +191,8 @@ class VerboseFeatureDict(TypedDict):
 
   # Implementation in Chrome
   flag_name: str | None
+  finch_name: str | None
+  non_finch_justification: str | None
   ongoing_constraints: str | None
 
   # Topic: Adoption

--- a/internals/search_fulltext.py
+++ b/internals/search_fulltext.py
@@ -64,6 +64,8 @@ def get_strings(fe : FeatureEntry) -> list[str]:
 
   # TODO: impl_status_Chrome
   strings.append(fe.flag_name)
+  strings.append(fe.finch_name)
+  strings.append(fe.non_finch_justification)
   strings.append(fe.ongoing_constraints)
 
   strings.append(fe.motivation)

--- a/internals/search_queries.py
+++ b/internals/search_queries.py
@@ -225,6 +225,9 @@ QUERIABLE_FIELDS: dict[str, Property] = {
 
     'browsers.chrome.status': FeatureEntry.impl_status_chrome,
     'browsers.chrome.flag_name': FeatureEntry.flag_name,
+    'browsers.chrome.finch_name': FeatureEntry.finch_name,
+    'browsers.chrome.non_finch_justification':
+        FeatureEntry.non_finch_justification,
     'ongoing_constraints': FeatureEntry.ongoing_constraints,
 
     'motivation': FeatureEntry.motivation,

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -178,6 +178,8 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       ('requires_embedder_support', 'bool'),
       ('devtrial_instructions', 'link'),
       ('flag_name', 'str'),
+      ('finch_name', 'str'),
+      ('non_finch_justification', 'str'),
       ('owner', 'emails'),
       ('editors', 'emails'),
       ('cc_recipients', 'emails'),

--- a/pages/testdata/intentpreview_test/test_html_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_rendering.html
@@ -246,8 +246,20 @@ No
 
 
 
-<br><br><h4>Flag name</h4>
+<br><br><h4>Flag name on chrome://flags</h4>
 None
+
+<br><br><h4>Finch feature name</h4>
+None
+
+
+  
+    <br><br><h4>Non-finch justification</h4>
+    None
+  
+
+
+
 
 <br><br><h4>Requires code in //chrome?</h4>
 False

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -195,8 +195,23 @@
      >{{feature.devtrial_instructions}}</a>
 {% endif %}
 
-<br><br><h4>Flag name</h4>
+<br><br><h4>Flag name on chrome://flags</h4>
 {{feature.flag_name}}
+
+<br><br><h4>Finch feature name</h4>
+{{feature.finch_name}}
+
+{% if feature.non_finch_justification %}
+  <br><br><h4>Non-finch justification</h4>
+  <p class="preformatted">{{feature.non_finch_justification|urlize}}</p>
+{% else %}
+  {% if not feature.finch_name %}
+    <br><br><h4>Non-finch justification</h4>
+    None
+  {% endif %}
+{% endif %}
+
+
 
 <br><br><h4>Requires code in //chrome?</h4>
 {{feature.requires_embedder_support}}


### PR DESCRIPTION
This implements most of issue #2928.

In this PR:
* Add FeatureEntry fields for finch_name and non_finch_justification.
* Add field specs for those in various places in the code, and add them to the dev trial forms.  Also, add more detail to the existing flag_name field-level docs.
* Display those values in the intent emails.  The non_finch_justification is shown if it has a value, otherwise "None" is shown if there is no finch_name.
* Make the finch_name searchable.  The non_finch_justification could be searchable in the future.