### PR TITLE
Set API Owners SLO to 5 days.

### DIFF
--- a/api/reviews_api_test.py
+++ b/api/reviews_api_test.py
@@ -328,7 +328,7 @@ class GatesAPITest(testing_config.CustomTestCase):
                 "owners": [],
                 "next_action": None,
                 "additional_review": False,
-                'slo_initial_response': 7,
+                'slo_initial_response': 5,
                 'slo_initial_response_took': None,
                 'slo_initial_response_remaining': None,
             },

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -58,7 +58,7 @@ TESTING_APPROVERS = [
 ]
 
 DEFAULT_SLO_LIMIT = 2  # Two weekdays in the Pacific timezone.
-LONGER_SLO_LIMIT = 7  # Seven weekdays in the Pacific timezone.
+LONGER_SLO_LIMIT = 5  # Five weekdays in the Pacific timezone.
 
 @dataclass(eq=True, frozen=True)
 class ApprovalFieldDef:


### PR DESCRIPTION
Dharani asked to limit this to 5 days to more tightly match a weekly review cadence.