### PR TITLE
Squeeze out whitespace from sl-relative-time.

### DIFF
--- a/client-src/css/shared-css.js
+++ b/client-src/css/shared-css.js
@@ -204,6 +204,10 @@ export const SHARED_STYLES = [
     --sheen-color: #ccc;
   }
 
+  sl-relative-time {
+    margin: 0 -3px;  // Mitigate spacing from unknown cause.
+  }
+
   @media only screen and (max-width: 700px) {
     h1 {
       font-size: 24px;


### PR DESCRIPTION
We have been using `<sl-relative-time>' to display how long ago something happened, e.g., "2 weeks ago".   However, the element has some annoying padding so it always ends up looking like `( 2 weeks ago )` rather than what people would normally write: `(2 weeks ago)`.

The annoying padding is not `padding` or `margin` on the `sl-relative-time` element.  And there is no easy way for us to style the `:host` inside that element.  So, as a work-around, I just used some negative margin on the element.