### PR TITLE
Allow mock login to test accounts.

### DIFF
--- a/api/login_api.py
+++ b/api/login_api.py
@@ -48,3 +48,23 @@ class LoginAPI(basehandlers.APIHandler):
       message = "Invalid token"
 
     return {'message': message}
+
+
+TESTING_ACCOUNTS = ['example@chromium.org']
+
+
+class MockLogin(basehandlers.APIHandler):
+  """Create a session using a testing account."""
+
+  def do_post(self, **kwargs):
+    if not settings.DEV_MODE and not settings.UNIT_TEST_MODE:
+      self.abort(status=403,
+          msg="This can only be used in a development environment.")
+
+    email = self.get_param('email', default=TESTING_ACCOUNTS[0])
+    if email not in TESTING_ACCOUNTS:
+      self.abort(status=403,
+          msg="This can only be used with specific testing accounts.")
+
+    users.add_signed_user_info_to_session(email)
+    return {'message': f'Signed in as {email}'}

--- a/main.py
+++ b/main.py
@@ -259,7 +259,8 @@ if settings.DEV_MODE:
     ## These routes can be uncommented for local environment use. ##
 
     # Route('/dev/clear_entities', dev_api.ClearEntities),
-    # Route('/dev/write_dev_data', dev_api.WriteDevData)
+    # Route('/dev/write_dev_data', dev_api.WriteDevData),
+    Route('/dev/mock_login', login_api.MockLogin),
   ]
 # All requests to the app-py3 GAE service are handled by this Flask app.
 app = basehandlers.FlaskApplication(


### PR DESCRIPTION
This should allow logging in for system tests when running in dev mode, but not on our production or staging servers.  The set of accounts allowed is strictly limited.