### PR TITLE
Only store github issue info we need.

### DIFF
--- a/internals/feature_links.py
+++ b/internals/feature_links.py
@@ -27,7 +27,7 @@ LINK_STALE_MINUTES = 30
 
 
 class FeatureLinks(ndb.Model):
-  """Links that occur in the fields of the feature. 
+  """Links that occur in the fields of the feature.
   This helps show a preview of information of linked pages, saving users the trouble of clicking.
   """
   created = ndb.DateTimeProperty(auto_now_add=True)
@@ -77,6 +77,7 @@ def _index_link(link: Link, fe: FeatureEntry) -> None:
     link.parse()
     if link.information is None:
       logging.info(f'Could not parse link {link.url}')
+    logging.info('info is %r', link.information)
     feature_link = FeatureLinks(
         feature_ids=[feature_id],
         type=link.type,

--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -110,8 +110,22 @@ class Link():
     repo = path.split('/')[2]
     issue_id = path.split('/')[4]
 
-    information = github_api_client.issues.get(
+    resp = github_api_client.issues.get(
         owner=owner, repo=repo, issue_number=int(issue_id))
+    information = {
+        'url': resp.get('url'),
+        'number': resp.get('number'),
+        'title': resp.get('title'),
+        'user_login': (
+            resp.get('user').get('login') if resp.get('user') else None),
+        'state': resp.get('state'),
+        'state_reason': resp.get('state_reason'),
+        'assignee_login': (
+            resp.get('assignee').get('login') if resp.get('assignee') else None),
+        'created_at': resp.get('created_at'),
+        'updated_at': resp.get('updated_at'),
+        'closed_at': resp.get('closed_at'),
+        }
 
     return information
 


### PR DESCRIPTION
When testing links to GitHub issues I found that ndb raised an exception saying that some part of link.information was not JSON serializable.   Doing a json.dumps() call on it works fine, so I am not sure why ndb could not serialize it.

To work around that problem, I now only capture a subset of the response from GitHub that includes the fields that we are likely to actually display in our UI.  