### PR TITLE
Feature links rendering

### DIFF
--- a/client-src/components.js
+++ b/client-src/components.js
@@ -25,6 +25,7 @@ import '@shoelace-style/shoelace/dist/components/skeleton/skeleton.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/textarea/textarea.js';
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
+import '@shoelace-style/shoelace/dist/components/tag/tag.js';
 import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
 import {setBasePath} from '@shoelace-style/shoelace/dist/utilities/base-path.js';
 

--- a/client-src/css/shared-css.js
+++ b/client-src/css/shared-css.js
@@ -152,6 +152,7 @@ export const SHARED_STYLES = [
     height: 16px;
     padding: 4px;
     border-width: 0;
+    text-transform: capitalize;
   }
 
   .feature-link .tag::part(base) {

--- a/client-src/css/shared-css.js
+++ b/client-src/css/shared-css.js
@@ -161,7 +161,8 @@ export const SHARED_STYLES = [
     background-color: rgb(232,234,237);
     color: var(--default-font-color);
     font-weight: 400;
-    border-width: 0;
+    border-left-width 0px;
+    border-right-width 0px;
     border-radius: 8px;
     display: inline-flex;
     align-items: center;

--- a/client-src/css/shared-css.js
+++ b/client-src/css/shared-css.js
@@ -141,10 +141,40 @@ export const SHARED_STYLES = [
     display: inline;
     white-space: normal;
     line-break: anywhere;
+    color: var(--default-font-color);
   }
 
-  .feature-link .badge {
-    height: 18px;
+  .feature-link:hover {
+    text-decoration: none;
+  }
+
+  .feature-link .badge::part(base) {
+    height: 16px;
+    padding: 4px;
+    border-width: 0;
+  }
+
+  .feature-link .tag::part(base) {
+    vertical-align: middle;
+    height: 22px;
+    background-color: rgb(232,234,237);
+    color: var(--default-font-color);
+    font-weight: 400;
+    border-width: 0;
+    border-radius: 8px;
+    display: inline-flex;
+    align-items: center;
+    column-gap: 0.3em;
+  }
+
+  .feature-link .tag::part(base):hover {
+    background-color: rgb(209,211,213);
+  }
+
+  .feature-link .icon {
+    display: block;
+    width: 12px;
+    height: 12px;
   }
 
   .feature-link-tooltip {

--- a/client-src/elements/feature-link.js
+++ b/client-src/elements/feature-link.js
@@ -20,6 +20,11 @@ function enhanceChromeStatusLink(featureLink, text) {
   // const ccRefs = information.ccRefs;
   const openedTimestamp = information.openedTimestamp;
   const closedTimestamp = information.closedTimestamp;
+
+  if (!text) {
+    text = summary;
+  }
+
   function renderTooltipContent() {
     return html`<div class="feature-link-tooltip">
     ${summary && html`
@@ -54,15 +59,16 @@ function enhanceChromeStatusLink(featureLink, text) {
     `}
     </div>`;
   }
-  return html`<div class="feature-link">
-    <sl-badge class="badge" pill variant="${statusRef.meansOpen ? 'success' : 'neutral'}">${statusRef.status}</sl-badge>
+  return html`<a class="feature-link" href="${featureLink.url}" target="_blank" rel="noopener noreferrer">
     <sl-tooltip style="--sl-tooltip-arrow-size: 0;--max-width: 50vw;">
         <div slot="content">${renderTooltipContent()}</div>
-        <a href="${featureLink.url}" target="_blank" rel="noopener noreferrer">
-        ${text}
-        </a>
+        <sl-badge class="tag">
+          <sl-tag size="small" class="badge" variant="${statusRef.meansOpen ? 'success' : 'neutral'}">${statusRef.status}</sl-tag>
+          <img src="https://bugs.chromium.org/static/images/monorail.ico" alt="icon" class="icon" />
+          ${text}
+        </sl-badge>
     </sl-tooltip>
-  </div>`;
+  </a>`;
 }
 
 function _enhanceLink(featureLink, fallback, text) {
@@ -77,7 +83,7 @@ function _enhanceLink(featureLink, fallback, text) {
   }
   switch (featureLink.type) {
     case LINK_TYPE_CHROMIUM_BUG:
-      return enhanceChromeStatusLink(featureLink, text);
+      return enhanceChromeStatusLink(featureLink);
     default:
       return fallback;
   }

--- a/client-src/elements/feature-link.js
+++ b/client-src/elements/feature-link.js
@@ -4,6 +4,13 @@ const LINK_TYPE_CHROMIUM_BUG = 'chromium_bug';
 const LINK_TYPE_GITHUB_ISSUE = 'github_issue';
 const LINK_TYPE_GITHUB_MARKDOWN = 'github_markdown';
 
+function _formatLongText(text, maxLength = 50) {
+  if (text.length > maxLength) {
+    return text.substring(0, 35) + '...' + text.substring(text.length - 15, text.length);
+  }
+  return text;
+}
+
 function enhanceChromeStatusLink(featureLink, text) {
   function _formatTimestamp(timestamp) {
     const date = new Date(timestamp * 1000);
@@ -66,7 +73,7 @@ function enhanceChromeStatusLink(featureLink, text) {
         <sl-badge class="tag">
           <sl-tag size="small" class="badge" variant="${statusRef.meansOpen ? 'success' : 'neutral'}">${statusRef.status}</sl-tag>
           <img src="https://bugs.chromium.org/static/images/monorail.ico" alt="icon" class="icon" />
-          ${text}
+          ${_formatLongText(text)}
         </sl-badge>
     </sl-tooltip>
   </a>`;
@@ -140,7 +147,7 @@ function enhanceGithubIssueLink(featureLink, text) {
         <sl-badge class="tag">
           <sl-tag size="small" class="badge" variant="${state === 'open' ? 'success' : 'neutral'}">${state}</sl-tag>
           <img src="https://docs.github.com/assets/cb-600/images/site/favicon.png" alt="icon" class="icon" />
-          ${`#${number} ` + text}
+          ${_formatLongText(`#${number} ` + text)}
         </sl-badge>
     </sl-tooltip>
   </a>`;
@@ -177,7 +184,7 @@ function enhanceGithubMarkdownLink(featureLink, text) {
         <div slot="content">${renderTooltipContent()}</div>
         <sl-badge class="tag">
           <img src="https://docs.github.com/assets/cb-600/images/site/favicon.png" alt="icon" class="icon" />
-          ${'Markdown: ' + text}
+          ${_formatLongText('Markdown: ' + text)}
         </sl-badge>
     </sl-tooltip>
   </a>`;

--- a/client-src/elements/feature-link.js
+++ b/client-src/elements/feature-link.js
@@ -71,6 +71,7 @@ function enhanceChromeStatusLink(featureLink, text) {
     </sl-tooltip>
   </a>`;
 }
+
 function enhanceGithubIssueLink(featureLink, text) {
   function _formatISOTime(dateString) {
     const date = new Date(dateString);
@@ -181,6 +182,7 @@ function enhanceGithubMarkdownLink(featureLink, text) {
     </sl-tooltip>
   </a>`;
 }
+
 function _enhanceLink(featureLink, fallback, text) {
   if (!fallback) {
     throw new Error('fallback html is required');

--- a/client-src/elements/feature-link.js
+++ b/client-src/elements/feature-link.js
@@ -78,6 +78,10 @@ function _enhanceLink(featureLink, fallback, text) {
   if (!featureLink) {
     return fallback;
   }
+  if (!featureLink.information) {
+    // TODO: render 403/404 link empty information
+    return fallback;
+  }
   if (!text) {
     text = featureLink.url;
   }
@@ -89,6 +93,7 @@ function _enhanceLink(featureLink, fallback, text) {
         return fallback;
     }
   } catch (e) {
+    console.log('feature link render error:', e);
     return fallback;
   }
 }

--- a/client-src/elements/feature-link.js
+++ b/client-src/elements/feature-link.js
@@ -1,7 +1,7 @@
 import {html} from 'lit';
 // LINK_TYPES should be consistent with the server link_helpers.py
 const LINK_TYPE_CHROMIUM_BUG = 'chromium_bug';
-
+const LINK_TYPE_GITHUB_ISSUE = 'github_issue';
 
 function enhanceChromeStatusLink(featureLink, text) {
   function _formatTimestamp(timestamp) {
@@ -70,7 +70,79 @@ function enhanceChromeStatusLink(featureLink, text) {
     </sl-tooltip>
   </a>`;
 }
+function enhanceGithubIssueLink(featureLink, text) {
+  function _formatISOTime(dateString) {
+    const date = new Date(dateString);
+    const formatOptions = {
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+      hour: 'numeric', minute: 'numeric'}; // No seconds
+    return date.toLocaleString('en-US', formatOptions);
+  }
+  const information = featureLink.information;
+  const assignee = information.assignee_login;
+  const createdAt = information.created_at;
+  const closedAt = information.closed_at;
+  const updatedAt = information.updated_at;
+  const state = information.state;
+  // const stateReason = information.state_reason;
+  const title = information.title;
+  const owner = information.user_login;
+  const number = information.number;
+  if (!text) {
+    text = title;
+  }
 
+  function renderTooltipContent() {
+    return html`<div class="feature-link-tooltip">
+    ${title && html`
+    <div>
+      <strong>Title:</strong>
+      <span>${title}</span>
+    </div>
+  `}
+    ${createdAt && html`
+      <div>
+        <strong>Opened:</strong>
+        <span>${_formatISOTime(createdAt)}</span>
+      </div>
+    `}
+    ${updatedAt && html`
+    <div>
+      <strong>Updated:</strong>
+      <span>${_formatISOTime(updatedAt)}</span>
+    </div>
+    `}
+    ${closedAt && html`
+      <div>
+        <strong>Closed:</strong>
+        <span>${_formatISOTime(closedAt)}</span>
+      </div>
+    `}
+    ${assignee && html`
+      <div>
+        <strong>Assignee:</strong>
+        <span>${assignee}</span>
+      </div>
+    `}
+    ${owner && html`
+        <div>
+          <strong>Owner:</strong>
+          <span>${owner}</span>
+        </div>
+    `}
+    </div>`;
+  }
+  return html`<a class="feature-link" href="${featureLink.url}" target="_blank" rel="noopener noreferrer">
+    <sl-tooltip style="--sl-tooltip-arrow-size: 0;--max-width: 50vw;">
+        <div slot="content">${renderTooltipContent()}</div>
+        <sl-badge class="tag">
+          <sl-tag size="small" class="badge" variant="${state === 'open' ? 'success' : 'neutral'}">${state}</sl-tag>
+          <img src="https://docs.github.com/assets/cb-600/images/site/favicon.png" alt="icon" class="icon" />
+          ${`#${number} ` + text}
+        </sl-badge>
+    </sl-tooltip>
+  </a>`;
+}
 function _enhanceLink(featureLink, fallback, text) {
   if (!fallback) {
     throw new Error('fallback html is required');
@@ -89,6 +161,8 @@ function _enhanceLink(featureLink, fallback, text) {
     switch (featureLink.type) {
       case LINK_TYPE_CHROMIUM_BUG:
         return enhanceChromeStatusLink(featureLink);
+      case LINK_TYPE_GITHUB_ISSUE:
+        return enhanceGithubIssueLink(featureLink);
       default:
         return fallback;
     }

--- a/client-src/elements/feature-link.js
+++ b/client-src/elements/feature-link.js
@@ -2,6 +2,7 @@ import {html} from 'lit';
 // LINK_TYPES should be consistent with the server link_helpers.py
 const LINK_TYPE_CHROMIUM_BUG = 'chromium_bug';
 const LINK_TYPE_GITHUB_ISSUE = 'github_issue';
+const LINK_TYPE_GITHUB_MARKDOWN = 'github_markdown';
 
 function enhanceChromeStatusLink(featureLink, text) {
   function _formatTimestamp(timestamp) {
@@ -143,6 +144,43 @@ function enhanceGithubIssueLink(featureLink, text) {
     </sl-tooltip>
   </a>`;
 }
+
+function enhanceGithubMarkdownLink(featureLink, text) {
+  const information = featureLink.information;
+  const path = information.path;
+  const title = information._parsed_title;
+  const size = information.size;
+  const readableSize = (size / 1024).toFixed(2) + ' KB';
+  if (!text) {
+    text = title;
+  }
+
+  function renderTooltipContent() {
+    return html`<div class="feature-link-tooltip">
+    ${path && html`
+      <div>
+        <strong>File:</strong>
+        <span>${path}</span>
+      </div>
+    `}
+    ${size && html`
+    <div>
+      <strong>Size:</strong>
+      <span>${readableSize}</span>
+    </div>
+    `}
+    </div>`;
+  }
+  return html`<a class="feature-link" href="${featureLink.url}" target="_blank" rel="noopener noreferrer">
+    <sl-tooltip style="--sl-tooltip-arrow-size: 0;--max-width: 50vw;">
+        <div slot="content">${renderTooltipContent()}</div>
+        <sl-badge class="tag">
+          <img src="https://docs.github.com/assets/cb-600/images/site/favicon.png" alt="icon" class="icon" />
+          ${'Markdown: ' + text}
+        </sl-badge>
+    </sl-tooltip>
+  </a>`;
+}
 function _enhanceLink(featureLink, fallback, text) {
   if (!fallback) {
     throw new Error('fallback html is required');
@@ -163,6 +201,8 @@ function _enhanceLink(featureLink, fallback, text) {
         return enhanceChromeStatusLink(featureLink);
       case LINK_TYPE_GITHUB_ISSUE:
         return enhanceGithubIssueLink(featureLink);
+      case LINK_TYPE_GITHUB_MARKDOWN:
+        return enhanceGithubMarkdownLink(featureLink);
       default:
         return fallback;
     }

--- a/client-src/elements/feature-link.js
+++ b/client-src/elements/feature-link.js
@@ -81,11 +81,15 @@ function _enhanceLink(featureLink, fallback, text) {
   if (!text) {
     text = featureLink.url;
   }
-  switch (featureLink.type) {
-    case LINK_TYPE_CHROMIUM_BUG:
-      return enhanceChromeStatusLink(featureLink);
-    default:
-      return fallback;
+  try {
+    switch (featureLink.type) {
+      case LINK_TYPE_CHROMIUM_BUG:
+        return enhanceChromeStatusLink(featureLink);
+      default:
+        return fallback;
+    }
+  } catch (e) {
+    return fallback;
   }
 }
 


### PR DESCRIPTION
In this PR:

- Render all feature links similar to Google Docs style by default
- Support rendering `LINK_TYPE_GITHUB_ISSUE` and `LINK_TYPE_GITHUB_MARKDOWN`
- Fallback if feature link is invalid

<img width="850" alt="截屏2023-07-02 21 11 27" src="https://github.com/GoogleChrome/chromium-dashboard/assets/5123601/72848e60-3383-45ff-a4de-010bc6162c9b">
<img width="802" alt="截屏2023-07-02 23 53 07" src="https://github.com/GoogleChrome/chromium-dashboard/assets/5123601/c086f6a6-ba08-4a7d-b159-8dcf5cfa6ef2">
