### PR TITLE
Fix syntax error in refetchFeatureLinks

### DIFF
--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -185,7 +185,7 @@ export class ChromedashFeaturePage extends LitElement {
   }
 
   async refetchFeatureLinks() {
-    featureLinks = await window.csClient.getFeatureLinks(this.featureId, false);
+    const featureLinks = await window.csClient.getFeatureLinks(this.featureId, false);
     this.featureLinks = featureLinks?.data || [];
   }
 


### PR DESCRIPTION
I just realized this syntax error introduced in https://github.com/GoogleChrome/chromium-dashboard/pull/3098/files#diff-5e5ac0d33f4baf7a4776ec61355e4bb4083a3dfb77f2997004d76995830265d1R188