### PR TITLE
Use sectionRef width for card calculation

### DIFF
--- a/client-src/elements/chromedash-roadmap-page.js
+++ b/client-src/elements/chromedash-roadmap-page.js
@@ -64,9 +64,9 @@ export class ChromedashRoadmapPage extends LitElement {
     const margin = 16;
 
     let numColumns = 3;
-    if (window.matchMedia('(max-width: 768px)').matches) {
+    if (containerWidth < 768) {
       numColumns = 1;
-    } else if (window.matchMedia('(max-width: 1152px)').matches) {
+    } else if (containerWidth < 1152) {
       numColumns = 2;
     }
     this.numColumns = numColumns;


### PR DESCRIPTION
https://github.com/GoogleChrome/chromium-dashboard/issues/3014 and a follow-up for https://github.com/GoogleChrome/chromium-dashboard/pull/3112. Resolve UI glitches where cards are overlapping, when resizing and drawer is open

Before
![9F6gGri8X3b3Ysv](https://github.com/GoogleChrome/chromium-dashboard/assets/8611520/0394653e-eb74-4a98-b804-beb9f64d1300)
