### PR TITLE
Improve the visual style of the main menu drawer.

### DIFF
--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -4,6 +4,8 @@ import {styleMap} from 'lit-html/directives/style-map.js';
 import {showToastMessage, parseRawQuery, updateURLParams, IS_MOBILE} from './utils';
 import page from 'page';
 import {SHARED_STYLES} from '../css/shared-css.js';
+import {DRAWER_WIDTH_PX} from './chromedash-drawer.js';
+
 
 class ChromedashApp extends LitElement {
   gateColumnRef = createRef();
@@ -36,7 +38,7 @@ class ChromedashApp extends LitElement {
         }
 
         #content {
-          margin: var(--content-padding);
+          margin: 0;
           position: relative;
           min-height: 500px;
         }
@@ -520,7 +522,7 @@ class ChromedashApp extends LitElement {
   render() {
     let styleMargin = styleMap({'margin-left': '20px'});
     if (!IS_MOBILE && this.drawerOpen) {
-      styleMargin = styleMap({'margin-left': '300px'});
+      styleMargin = styleMap({'margin-left': (DRAWER_WIDTH_PX + 10) + 'px'});
     }
 
     // The <slot> below is for the Google sign-in button, this is because

--- a/client-src/elements/chromedash-drawer.js
+++ b/client-src/elements/chromedash-drawer.js
@@ -3,6 +3,9 @@ import {showToastMessage, IS_MOBILE} from './utils';
 import {SHARED_STYLES} from '../css/shared-css.js';
 
 
+export const DRAWER_WIDTH_PX = 200;
+
+
 export class ChromedashDrawer extends LitElement {
   static get styles() {
     return [
@@ -15,7 +18,7 @@ export class ChromedashDrawer extends LitElement {
 
           --nav-link-color: var(--md-gray-700-alpha);
           --nav-link-font-size: 16px;
-          --nav-link-hover-background: var(--md-gray-100-alpha);
+          --nav-link-hover-background: var(--md-gray-50-alpha);
           --nav-link-active-color: var(--md-blue-900);
           --nav-link-active-background: var(--light-accent-color);
         }
@@ -25,8 +28,7 @@ export class ChromedashDrawer extends LitElement {
           align-items: baseline;
           user-select: none;
           background: var(--card-background);
-          border-bottom: var(--card-border);
-          box-shadow: var(--card-box-shadow);
+          border: none;
           align-items: center;
           margin: 0 var(--content-padding);
           -webkit-font-smoothing: initial;
@@ -39,6 +41,7 @@ export class ChromedashDrawer extends LitElement {
           padding: var(--content-padding-half) var(--content-padding);
           color: var(--nav-link-color);
           white-space: nowrap;
+          border-radius: var(--pill-border-radius);
         }
         nav a:hover {
           color: black;
@@ -52,8 +55,8 @@ export class ChromedashDrawer extends LitElement {
           color: var(--nav-link-active-color);
           background: var(--nav-link-active-background);
         }
-        nav [active] a {
-          color: var(--nav-link-active-color);
+        nav [active]:hover {
+          background: var(--md-gray-100-alpha);
         }
         ul {
           top: 80%;
@@ -198,7 +201,8 @@ export class ChromedashDrawer extends LitElement {
 
     return html`
       <sl-drawer label="Menu" placement="start" class="drawer-placement-start"
-        style="--size: 300px;" contained noHeader ?open=${!IS_MOBILE}>
+        style="--size: ${DRAWER_WIDTH_PX}px;" contained noHeader
+        ?open=${!IS_MOBILE}>
         ${accountMenu}
         <a class="flex-item" href="/roadmap" ?active=${this.isCurrentPage('/roadmap')}>Roadmap</a>
         ${this.user?.email ? html`

--- a/client-src/elements/chromedash-header.js
+++ b/client-src/elements/chromedash-header.js
@@ -23,7 +23,7 @@ export class ChromedashHeader extends LitElement {
 
         header {
           display: flex;
-          align-items: baseline;
+          align-items: center;
           user-select: none;
           background: var(--card-background);
           border-bottom: var(--card-border);
@@ -108,6 +108,7 @@ export class ChromedashHeader extends LitElement {
           display: flex;
           justify-content: flex-end;
           flex-wrap: wrap;
+          align-items: center;
           width: 100%;
         }
 
@@ -285,7 +286,7 @@ export class ChromedashHeader extends LitElement {
     return html`
       <header>
         <sl-icon-button variant="text" library="material" class="menu"
-          style="font-size: 1.2rem;" name="menu_20px" @click="${this.handleDrawer}">
+          style="font-size: 2.4rem;" name="menu_20px" @click="${this.handleDrawer}">
         </sl-icon-button >
         <aside>
           <hgroup>

--- a/client-src/elements/chromedash-header.js
+++ b/client-src/elements/chromedash-header.js
@@ -84,24 +84,15 @@ export class ChromedashHeader extends LitElement {
         header nav .nav-dropdown-container ul:hover {
           display: block;
         }
-        header aside {
-          --logoSize: 32px;
-
-          background: url(/static/img/chrome_logo.svg) no-repeat var(--content-padding) 50%;
-          background-size: var(--logoSize);
-          padding: 0.75em 2em;
-          padding-left: calc(var(--logoSize) + var(--content-padding) + var(--content-padding) / 2);
-        }
-        header aside hgroup a {
+        header aside a {
           color: var(--logo-color);
         }
         header aside h1 {
           line-height: 1;
         }
         header aside img {
-          height: 45px;
-          width: 45px;
-          margin-right: 7px;
+          height: 24px;
+          width: 24px;
         }
 
         .flex-container {
@@ -289,9 +280,12 @@ export class ChromedashHeader extends LitElement {
           style="font-size: 2.4rem;" name="menu_20px" @click="${this.handleDrawer}">
         </sl-icon-button >
         <aside>
-          <hgroup>
-            <a href="/features" target="_top"><h1>${this.appTitle}</h1></a>
-          </hgroup>
+            <a href="/roadmap" target="_top">
+              <h1>
+                <img src="/static/img/chrome_logo.svg">
+                ${this.appTitle}
+              </h1>
+            </a>
         </aside>
         <nav>
           ${accountMenu}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -324,6 +324,7 @@ sl-skeleton {
   --max-content-width: 860px;
   --border-radius: 4px;
   --large-border-radius: 8px;
+  --pill-border-radius: 500px;
   --logo-color: var(--default-color);
   --logo-size: 32px;
   --icon-size: 22px;
@@ -443,7 +444,7 @@ body.loading #spinner {
 }
 
 #content {
-  margin: var(--content-padding);
+  margin: 0;
   position: relative;
   min-height: 500px;
 }


### PR DESCRIPTION
In this PR:
* Make the main menu drawer narrower, and introduce a JS constant for it.
* Remove margin around the edges of the page that made the menu look disconnected.
* Remove extra border at top of page content area.
* Round the corners of the main menu items.  
* When hovering over the active item, use a background color that looks a bit like a combination of the hover color and active color.
* Increase the size of the main menu icon and use `align-items: center` all the way across the header (which is now possible because there are no longer any tabs in the header).
* Make the logo clickable, and make it and site title navigate to the roadmap page.