### PR TITLE
Tweak style of feature links.

### DIFF
--- a/client-src/css/shared-css.js
+++ b/client-src/css/shared-css.js
@@ -167,6 +167,7 @@ export const SHARED_STYLES = [
     align-items: center;
     column-gap: 0.3em;
     padding: 1px 5px;
+    margin: 1px 0;
   }
 
   .feature-link sl-tag::part(base):hover {

--- a/client-src/css/shared-css.js
+++ b/client-src/css/shared-css.js
@@ -148,28 +148,28 @@ export const SHARED_STYLES = [
     text-decoration: none;
   }
 
-  .feature-link .badge::part(base) {
-    height: 16px;
+  .feature-link sl-badge::part(base) {
+    height: 14px;
     padding: 4px;
     border-width: 0;
     text-transform: capitalize;
+    font-weight: 400;
   }
 
-  .feature-link .tag::part(base) {
+  .feature-link sl-tag::part(base) {
     vertical-align: middle;
-    height: 22px;
+    height: 18px;
     background-color: rgb(232,234,237);
     color: var(--default-font-color);
-    font-weight: 400;
-    border-left-width 0px;
-    border-right-width 0px;
-    border-radius: 8px;
+    border: none;
+    border-radius: 500px;
     display: inline-flex;
     align-items: center;
     column-gap: 0.3em;
+    padding: 1px 5px;
   }
 
-  .feature-link .tag::part(base):hover {
+  .feature-link sl-tag::part(base):hover {
     background-color: rgb(209,211,213);
   }
 

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -156,7 +156,10 @@ class ChromedashFeatureDetail extends LitElement {
       .inline-list {
         display: inline-block;
         padding: 0;
-        margin: 0;
+      }
+
+      .inline-list li + li {
+        margin-top: 2px;
       }
 
       .longtext {

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -158,10 +158,6 @@ class ChromedashFeatureDetail extends LitElement {
         padding: 0;
       }
 
-      .inline-list li + li {
-        margin-top: 2px;
-      }
-
       .longtext {
         display: block;
         white-space: pre-wrap;

--- a/client-src/elements/feature-link.js
+++ b/client-src/elements/feature-link.js
@@ -70,11 +70,11 @@ function enhanceChromeStatusLink(featureLink, text) {
   return html`<a class="feature-link" href="${featureLink.url}" target="_blank" rel="noopener noreferrer">
     <sl-tooltip style="--sl-tooltip-arrow-size: 0;--max-width: 50vw;">
         <div slot="content">${renderTooltipContent()}</div>
-        <sl-badge class="tag">
-          <sl-tag size="small" class="badge" variant="${statusRef.meansOpen ? 'success' : 'neutral'}">${statusRef.status}</sl-tag>
+        <sl-tag>
           <img src="https://bugs.chromium.org/static/images/monorail.ico" alt="icon" class="icon" />
+          <sl-badge size="small" variant="${statusRef.meansOpen ? 'success' : 'neutral'}">${statusRef.status}</sl-badge>
           ${_formatLongText(text)}
-        </sl-badge>
+        </sl-tag>
     </sl-tooltip>
   </a>`;
 }
@@ -144,11 +144,11 @@ function enhanceGithubIssueLink(featureLink, text) {
   return html`<a class="feature-link" href="${featureLink.url}" target="_blank" rel="noopener noreferrer">
     <sl-tooltip style="--sl-tooltip-arrow-size: 0;--max-width: 50vw;">
         <div slot="content">${renderTooltipContent()}</div>
-        <sl-badge class="tag">
-          <sl-tag size="small" class="badge" variant="${state === 'open' ? 'success' : 'neutral'}">${state}</sl-tag>
+        <sl-tag>
           <img src="https://docs.github.com/assets/cb-600/images/site/favicon.png" alt="icon" class="icon" />
+          <sl-badge size="small" variant="${state === 'open' ? 'success' : 'neutral'}">${state}</sl-badge>
           ${_formatLongText(`#${number} ` + text)}
-        </sl-badge>
+        </sl-tag>
     </sl-tooltip>
   </a>`;
 }
@@ -182,10 +182,10 @@ function enhanceGithubMarkdownLink(featureLink, text) {
   return html`<a class="feature-link" href="${featureLink.url}" target="_blank" rel="noopener noreferrer">
     <sl-tooltip style="--sl-tooltip-arrow-size: 0;--max-width: 50vw;">
         <div slot="content">${renderTooltipContent()}</div>
-        <sl-badge class="tag">
+        <sl-tag>
           <img src="https://docs.github.com/assets/cb-600/images/site/favicon.png" alt="icon" class="icon" />
           ${_formatLongText('Markdown: ' + text)}
-        </sl-badge>
+        </sl-tag>
     </sl-tooltip>
   </a>`;
 }


### PR DESCRIPTION
I noticed that the font size of the text in the feature links smart chip looked a little too small.   So, I made some small changes.

In this PR:
* Use sl-badge for the issue status and sl-tag for the overall smart chip.  This makes for cleaner code and I believe that it is closer to the intent of those shoelace-style elements.  This makes the issue title appear in regular-sized text.
* Make the height of the smart-chips a little smaller, allowing them to fit better into paragraphs.
* Always put the site favicon first.  This allows it to fit into the rounded part of the smart chip, so we need less padding.
* Add a little margin between items in a list so that the backgrounds do not touch.
* Use `border-radius: 500px` which is an idiom for pill-shapes in CSS.