### PR TITLE
Work around sl-select bug.

### DIFF
--- a/templates/spa.html
+++ b/templates/spa.html
@@ -88,6 +88,14 @@ limitations under the License.
   See https://github.com/GoogleChrome/chromium-dashboard/issues/2014
   #}
   <script type="module" nonce="{{nonce}}" src="/static/js/shared.min.js?v={{app_version}}"></script>
+
+  {# Work-around for bug in sl-select:
+     https://github.com/GoogleChrome/chromium-dashboard/issues/3137
+  #}
+  <script nonce="{{nonce}}">
+    let process = { env: {} };
+  </script>
+
 </body>
 
 </html>


### PR DESCRIPTION
This works-around issue #3137 by using a simplified version of the code suggested in the bug report.

The underlying defect seems to be in the floating-ui package.  It seems to have been fixed floating-ui/core-1.2.5.
https://github.com/floating-ui/floating-ui/pull/2251

But we are on floating-ui/core/1.2.2  because we have not been running `npm upgrade`.  Running that seems to resolve the problem without needing this work-around, but I made this PR as an option so that we have time to carefully test the impact of upgrading all our JS libs.