### PR TITLE
Fix Cancel button on stage editing page.

### DIFF
--- a/client-src/elements/chromedash-guide-stage-page.js
+++ b/client-src/elements/chromedash-guide-stage-page.js
@@ -394,7 +394,7 @@ export class ChromedashGuideStagePage extends LitElement {
           <!-- TODO(DanielRyanSmith): Update this form to submit using a class method -->
           <!-- and the formatFeatureChanges function to make the API call. -->
           <button id="cancel-button"
-            @click=${this.submitChanges}>Cancel</button>
+            @click=${this.handleCancelClick}>Cancel</button>
         </div>
       </form>
     `;


### PR DESCRIPTION
I was testing editing widgets and hit cancel.  I was surprised to see that my changes were in fact saved.

This looks like it might have been an autocomplete error in 
https://github.com/GoogleChrome/chromium-dashboard/pull/2981