### PR TITLE
Clean up some JS lint output.

### DIFF
--- a/client-src/elements/chromedash-form-field.js
+++ b/client-src/elements/chromedash-form-field.js
@@ -16,7 +16,7 @@ export class ChromedashFormField extends LitElement {
       loading: {type: Boolean},
       fieldProps: {type: Object},
       forEnterprise: {type: Boolean},
-      stageType: {type: Number | undefined},
+      stageType: {type: Number},
       componentChoices: {type: Object}, // just for the blink component select field
     };
   }

--- a/client-src/elements/chromedash-guide-metadata.js
+++ b/client-src/elements/chromedash-guide-metadata.js
@@ -153,6 +153,7 @@ export class ChromedashGuideMetadata extends LitElement {
               <th>Feature type</th>
               <td>${this.feature.feature_type}</td>
             </tr>
+          </table>
         </div>
       </div>
     `;


### PR DESCRIPTION
Running `npm run presubmit` does a `npm run lint-fix` which finds the following errors (among others):

```
./client-src/elements/chromedash-guide-metadata.js
    This tag isn't closed.
    109:  <div id="metadata-readonly">
    no-unclosed-tag

    This tag isn't closed.
    123:  <div class="flex-cols">
    no-unclosed-tag

    This tag isn't closed.
    124:  <table class="property-sheet">
    no-unclosed-tag

./client-src/elements/chromedash-form-field.js
    'Number | undefined' is not a valid type for the default converter. Have you considered '{attribute: false}' instead?
    19:  stageType: {type: Number | undefined},
    no-incompatible-property-type
```

This PR resolves the first set of warnings by adding a missing `</table>` closing tag.

And, it resolves the second by specifying type `Number`.   This expression is not a TS type expression and there is no support for using `|`.   The JS expressions `Number | undefined` evaluates to `0`, so lit probably interprets this as the default converter, which is the same as `String`.

I don't think that either one of these problems caused any user-visible defect, but I did not probe into it too much.