### PR TITLE
Validate feature links http status code

### DIFF
--- a/client-src/elements/feature-link.js
+++ b/client-src/elements/feature-link.js
@@ -165,6 +165,12 @@ function enhanceGithubMarkdownLink(featureLink, text) {
 
   function renderTooltipContent() {
     return html`<div class="feature-link-tooltip">
+    ${title && html`
+    <div>
+      <strong>Title:</strong>
+      <span>${title}</span>
+    </div>
+  `}
     ${path && html`
       <div>
         <strong>File:</strong>

--- a/client-src/elements/feature-link.js
+++ b/client-src/elements/feature-link.js
@@ -198,7 +198,14 @@ function _enhanceLink(featureLink, fallback, text) {
     return fallback;
   }
   if (!featureLink.information) {
-    // TODO: render 403/404 link empty information
+    if (featureLink.http_error_code) {
+      return html`<div class="feature-link">
+        <sl-tag>
+          <sl-badge size="small" variant="${featureLink.http_error_code >= 500 ? 'danger' : 'warning'}">${featureLink.http_error_code}</sl-badge>
+          ${fallback}
+        </sl-tag>
+      </div>`;
+    }
     return fallback;
   }
   if (!text) {

--- a/client-src/elements/feature-link.js
+++ b/client-src/elements/feature-link.js
@@ -201,7 +201,10 @@ function _enhanceLink(featureLink, fallback, text) {
     if (featureLink.http_error_code) {
       return html`<div class="feature-link">
         <sl-tag>
-          <sl-badge size="small" variant="${featureLink.http_error_code >= 500 ? 'danger' : 'warning'}">${featureLink.http_error_code}</sl-badge>
+          <sl-icon library="material" name="link"></sl-icon>
+          <sl-badge size="small" variant="${featureLink.http_error_code >= 500 ? 'danger' : 'warning'}">
+            ${featureLink.http_error_code}
+          </sl-badge>
           ${fallback}
         </sl-tag>
       </div>`;

--- a/internals/feature_links.py
+++ b/internals/feature_links.py
@@ -138,7 +138,7 @@ def get_by_feature_id(feature_id: int, update_stale_links: bool) -> tuple[list[d
         '/tasks/update-feature-links', {
             'feature_link_ids': feature_link_ids
         })
-  return [link.to_dict(include=['url', 'type', 'information']) for link in feature_links], has_stale_links
+  return [link.to_dict(include=['url', 'type', 'information', 'http_error_code']) for link in feature_links], has_stale_links
 
 
 class FeatureLinksUpdateHandler(basehandlers.FlaskHandler):

--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -69,6 +69,7 @@ class Link():
     self.type = Link.get_type(url)
     self.is_parsed = False
     self.is_error = False
+    self.http_error_code = None
     self.information = None
 
   def _parse_github_markdown(self) -> dict[str, object]:
@@ -169,10 +170,26 @@ class Link():
     information: dict[str, Any] = json.loads(json_str)
 
     return information.get('issue', None)
-
+  
+  def _validate_url(self) -> bool:
+    """The `_validate_url` method is used to validate the URL associated with the Link object. It
+    sends a GET request to the URL and checks the response status code. If the status code is not
+    200 (OK), it sets the `is_error` flag to True and stores the HTTP error code. This method is
+    used to determine if the URL is accessible and valid."""
+    res = requests.get(self.url, allow_redirects=True)
+    if res.status_code != 200:
+      self.is_error = True
+      self.http_error_code = res.status_code
+      return False
+    return True
+  
   def parse(self):
     """Parse the link and store the information."""
     try:
+      if not self.type or not self._validate_url():
+        # if the link is not valid, return early
+        self.is_parsed = True
+        return
       if self.type == LINK_TYPE_CHROMIUM_BUG:
         self.information = self._parse_chromium_bug()
       elif self.type == LINK_TYPE_GITHUB_ISSUE:
@@ -180,12 +197,12 @@ class Link():
       elif self.type == LINK_TYPE_GITHUB_MARKDOWN:
         self.information = self._parse_github_markdown()
       elif self.type == LINK_TYPE_WEB:
-        # TODO: parse other url title and description, og tags, etc.
         self.information = None
     except Exception as e:
       logging.error(f'Error parsing {self.type} {self.url}: {e}')
       self.error = e
       self.is_error = True
+      if isinstance(e, HTTPError):
+        self.http_error_code = e.code
       self.information = None
-      # TODO: store error information and show 404/403 error icon for the link
     self.is_parsed = True

--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -17,7 +17,7 @@ import re
 import requests
 import json
 import logging
-from typing import Any
+from typing import Any, Optional
 from string import punctuation
 from ghapi.core import GhApi
 from urllib.error import HTTPError
@@ -69,7 +69,7 @@ class Link():
     self.type = Link.get_type(url)
     self.is_parsed = False
     self.is_error = False
-    self.http_error_code = None
+    self.http_error_code: Optional[int] = None
     self.information = None
 
   def _parse_github_markdown(self) -> dict[str, object]:

--- a/internals/link_helpers_test.py
+++ b/internals/link_helpers_test.py
@@ -26,8 +26,23 @@ from internals.link_helpers import (
 
 class LinkHelperTest(testing_config.CustomTestCase):
 
+  def test_real_server_error_url(self):
+    link = Link("http://httpstat.us/503")
+    
+    link.parse()
+    self.assertEqual(link.type, LINK_TYPE_WEB)
+    self.assertEqual(link.is_error, True)
+    self.assertEqual(link.http_error_code, 503)
+
+    link = Link("https://httpstat.us/400")
+
+    link.parse()
+    self.assertEqual(link.type, LINK_TYPE_WEB)
+    self.assertEqual(link.is_error, True)
+    self.assertEqual(link.http_error_code, 400)
+
   @mock.patch('requests.get')
-  def test_invalid_url(self, mock_requests_get):
+  def test_mock_not_found_url(self, mock_requests_get):
     mock_requests_get.return_value = testing_config.Blank(
         status_code=404, content='')  
 

--- a/internals/link_helpers_test.py
+++ b/internals/link_helpers_test.py
@@ -20,10 +20,23 @@ from internals.link_helpers import (
     LINK_TYPE_CHROMIUM_BUG,
     LINK_TYPE_GITHUB_ISSUE,
     LINK_TYPE_GITHUB_MARKDOWN,
+    LINK_TYPE_WEB
 )
 
 
 class LinkHelperTest(testing_config.CustomTestCase):
+
+  @mock.patch('requests.get')
+  def test_invalid_url(self, mock_requests_get):
+    mock_requests_get.return_value = testing_config.Blank(
+        status_code=404, content='')  
+
+    link = Link("https://www.google.com/")
+    link.parse()
+    self.assertEqual(link.type, LINK_TYPE_WEB)
+    self.assertEqual(link.is_error, True)
+    self.assertEqual(link.http_error_code, 404)
+  
   def test_extract_urls_from_value(self):
     field_value = "https://www.chromestatus.com/feature/1234"
     urls = Link.extract_urls_from_value(field_value)
@@ -109,6 +122,7 @@ class LinkHelperTest(testing_config.CustomTestCase):
     self.assertEqual(link.type, LINK_TYPE_GITHUB_ISSUE)
     self.assertEqual(link.is_parsed, True)
     self.assertEqual(link.is_error, True)
+    self.assertEqual(link.http_error_code, 404)
 
   def test_link_chromium(self):
     link = Link("https://bugs.chromium.org/p/chromium/issues/detail?id=100000")

--- a/static/shoelace/assets/material-icons/link.svg
+++ b/static/shoelace/assets/material-icons/link.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M17 7h-4v2h4c1.65 0 3 1.35 3 3s-1.35 3-3 3h-4v2h4c2.76 0 5-2.24 5-5s-2.24-5-5-5zm-6 8H7c-1.65 0-3-1.35-3-3s1.35-3 3-3h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-2zm-3-4h8v2H8z"/></svg>


### PR DESCRIPTION
In this PR:
- add a helper function to validate feature_link
- add `is_error` and `http_error_code` in feature_link schema
   - `is_error` stands for any error happened when parsing links. For example:
       1. user input wrong url, url points to 403/500. **`http_error_code` will store http code for this case.**
       2. APIs to fetch information is down or changed.
       3. all tokens hit Github rate limiting.
       4. ...any exceptions raised.
 - When update existing indexed feature link, update information if there is no error. In this way, old information will not overwritten by `None`
 - Display http error code to user  

<img width="558" alt="截屏2023-07-10 23 52 24" src="https://github.com/GoogleChrome/chromium-dashboard/assets/5123601/445330af-c08e-4951-9b89-39003791771e">
