### PR TITLE
Resolve more lit-analyzer errors.

### DIFF
--- a/client-src/elements/chromedash-activity-log.js
+++ b/client-src/elements/chromedash-activity-log.js
@@ -73,7 +73,7 @@ customElements.define('chromedash-amendment', ChromedashAmendment);
 export class ChromedashActivity extends LitElement {
   static get properties() {
     return {
-      user: {type: Object},
+      user: {attribute: false},
       featureId: {type: Number},
       activity: {type: Object},
       narrow: {type: Boolean},

--- a/client-src/elements/chromedash-add-stage-dialog.js
+++ b/client-src/elements/chromedash-add-stage-dialog.js
@@ -29,7 +29,7 @@ class ChromedashAddStageDialog extends LitElement {
       featureId: {type: Number},
       featureType: {type: Number},
       canSubmit: {type: Boolean},
-      onSubmitCustomHandler: {type: Function},
+      onSubmitCustomHandler: {attribute: false},
     };
   }
 

--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -520,9 +520,9 @@ class ChromedashApp extends LitElement {
   }
 
   render() {
-    let styleMargin = styleMap({'margin-left': '20px'});
+    let styleMargin = {'margin-left': '20px'};
     if (!IS_MOBILE && this.drawerOpen) {
-      styleMargin = styleMap({'margin-left': (DRAWER_WIDTH_PX + 10) + 'px'});
+      styleMargin = {'margin-left': (DRAWER_WIDTH_PX + 10) + 'px'};
     }
 
     // The <slot> below is for the Google sign-in button, this is because
@@ -552,7 +552,7 @@ class ChromedashApp extends LitElement {
                 .googleSignInClientId=${this.googleSignInClientId}>
               </chromedash-drawer>
             </div>
-            <div style=${styleMargin}>
+            <div style=${styleMap(styleMargin)}>
               <chromedash-banner
                 .message=${this.bannerMessage}
                 .timestamp=${this.bannerTime}>

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -92,7 +92,7 @@ export class ChromedashFeaturePage extends LitElement {
 
   static get properties() {
     return {
-      user: {type: Object},
+      user: {attribute: false},
       featureId: {type: Number},
       feature: {type: Object},
       featureLinks: {type: Array},
@@ -111,7 +111,7 @@ export class ChromedashFeaturePage extends LitElement {
 
   constructor() {
     super();
-    this.user = {};
+    this.user = null;
     this.featureId = 0;
     this.feature = {};
     this.featureLinks = [];


### PR DESCRIPTION
My PR #3140 is blocked by lit-analyzer failures.  This PR resolves the remaining failures.  It does not seem to have any user-visible effect.

In this PR:
* Change `{type: Object}` to `{attribute: false}` for cases where we always set the value using the `.` prefix notation rather than an attribute.  This allows the value to be set to `null` in unit tests.
* Likewise, don't use `{type: Function}` because there is no such type defined in lit.
* styleMap is a directive and apparently directives are supposed to only be used inside of a lit-html template, at least that makes lit-analyzer allow it.