### PR TITLE
Revert "Work around sl-select bug."

### DIFF
--- a/templates/spa.html
+++ b/templates/spa.html
@@ -88,14 +88,6 @@ limitations under the License.
   See https://github.com/GoogleChrome/chromium-dashboard/issues/2014
   #}
   <script type="module" nonce="{{nonce}}" src="/static/js/shared.min.js?v={{app_version}}"></script>
-
-  {# Work-around for bug in sl-select:
-     https://github.com/GoogleChrome/chromium-dashboard/issues/3137
-  #}
-  <script nonce="{{nonce}}">
-    let process = { env: {} };
-  </script>
-
 </body>
 
 </html>


### PR DESCRIPTION
Reverts GoogleChrome/chromium-dashboard#3139

After PR #3140 is merged, then the work-around in #3139 should no longer be needed.