### PR TITLE
Features API PATCH request creates Activity entity and notifies subscribers

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -26,10 +26,13 @@ from framework import rediscache
 from framework import users
 from internals.core_enums import *
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
+from internals.data_types import CHANGED_FIELDS_LIST_TYPE
+from internals import notifier_helpers
 from internals.review_models import Gate
 from internals.data_types import VerboseFeatureDict
 from internals import feature_helpers
 from internals import search
+from internals import search_fulltext
 import settings
 
 
@@ -227,7 +230,8 @@ class FeaturesAPI(basehandlers.APIHandler):
 
   def _patch_update_stages(
       self,
-      stage_changes_list: list[dict[str, Any]]
+      stage_changes_list: list[dict[str, Any]],
+      changed_fields: CHANGED_FIELDS_LIST_TYPE
     ) -> bool:
     """Update stage fields with changes provided in the PATCH request."""
     stages: list[Stage] = []
@@ -245,7 +249,10 @@ class FeaturesAPI(basehandlers.APIHandler):
       for field, field_type in api_specs.STAGE_FIELD_DATA_TYPES:
         if field not in change_info:
           continue
-        self._update_field_value(stage, field, field_type, change_info[field])
+        old_value = getattr(stage, field)
+        new_value = change_info[field]
+        self._update_field_value(stage, field, field_type, new_value)
+        changed_fields.append((field, old_value, new_value))
         stage_was_updated = True
 
       # Update milestone fields.
@@ -255,8 +262,10 @@ class FeaturesAPI(basehandlers.APIHandler):
           continue
         if milestones is None:
           milestones = MilestoneSet()
-        self._update_field_value(
-            milestones, field, field_type, change_info[field])
+        old_value = getattr(milestones, field)
+        new_value = change_info[field]
+        self._update_field_value(milestones, field, field_type, new_value)
+        changed_fields.append((field, old_value, new_value))
         stage_was_updated = True
       stage.milestones = milestones
 
@@ -293,14 +302,17 @@ class FeaturesAPI(basehandlers.APIHandler):
       self,
       feature: FeatureEntry,
       feature_changes: dict[str, Any],
-      has_updated: bool
+      has_updated: bool,
+      changed_fields: CHANGED_FIELDS_LIST_TYPE
     ) -> None:
     """Update feature fields with changes provided in the PATCH request."""
     for field, field_type in api_specs.FEATURE_FIELD_DATA_TYPES:
       if field not in feature_changes:
         continue
-      self._update_field_value(
-          feature, field, field_type, feature_changes[field])
+      old_value = getattr(feature, field)
+      new_value = feature_changes[field]
+      self._update_field_value(feature, field, field_type, new_value)
+      changed_fields.append((field, old_value, new_value))
       has_updated = True
     
     self._patch_update_special_fields(feature, feature_changes, has_updated)
@@ -324,8 +336,18 @@ class FeaturesAPI(basehandlers.APIHandler):
     if redirect_resp:
       return redirect_resp
 
-    has_updated = self._patch_update_stages(body['stages'])
-    self._patch_update_feature(feature, body['feature_changes'], has_updated)
+    changed_fields: CHANGED_FIELDS_LIST_TYPE = []
+    has_updated = self._patch_update_stages(body['stages'], changed_fields)
+    self._patch_update_feature(
+      feature, body['feature_changes'], has_updated, changed_fields)
+
+    notifier_helpers.notify_subscribers_and_save_amendments(
+        feature, changed_fields, notify=True)
+    # Remove all feature-related cache.
+    rediscache.delete_keys_with_prefix(FeatureEntry.feature_cache_prefix())
+    # Update full-text index.
+    if feature:
+      search_fulltext.index_feature(feature)
 
     return {'message': f'Feature {feature_id} updated.'}
 

--- a/internals/data_types.py
+++ b/internals/data_types.py
@@ -17,8 +17,11 @@
 # https://stackoverflow.com/a/33533514
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Any, TypedDict
 
+# List of changed fields to be used to create Activity entities
+# and notify subscribed users of changes to a feature.
+CHANGED_FIELDS_LIST_TYPE = list[tuple[str, Any, Any]]
 
 # JSON representation of Stage entity data.
 class StageDict(TypedDict):

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -17,13 +17,14 @@ from typing import Any, TYPE_CHECKING
 from api import converters
 from framework import cloud_tasks_helpers, users
 from internals import core_enums, approval_defs, core_models
+from internals.data_types import CHANGED_FIELDS_LIST_TYPE
 from internals.review_models import Gate, Amendment, Activity, Vote
 
 if TYPE_CHECKING:
   from internals.core_models import FeatureEntry
 
 def _get_changes_as_amendments(
-    changed_fields: list[tuple[str, Any, Any]]) -> list[Amendment]:
+    changed_fields: CHANGED_FIELDS_LIST_TYPE) -> list[Amendment]:
   """Convert list of field changes to Amendment entities."""
   # Diff values to see what properties have changed.
   amendments = []
@@ -61,7 +62,7 @@ def notify_feature_subscribers_of_changes(fe: 'FeatureEntry',
   cloud_tasks_helpers.enqueue_task('/tasks/email-subscribers', params)
 
 def notify_subscribers_and_save_amendments(fe: 'FeatureEntry',
-    changed_fields: list[tuple[str, Any, Any]], notify: bool=True) -> None:
+    changed_fields: CHANGED_FIELDS_LIST_TYPE, notify: bool=True) -> None:
   """Notify subscribers of changes to FeatureEntry and save amendments."""
   amendments = _get_changes_as_amendments(changed_fields)
 

--- a/internals/notifier_helpers_test.py
+++ b/internals/notifier_helpers_test.py
@@ -16,6 +16,7 @@ from unittest import mock
 from internals import notifier_helpers
 import testing_config  # Must be imported before the module under test.
 from internals.core_models import FeatureEntry, Stage, MilestoneSet
+from internals.data_types import CHANGED_FIELDS_LIST_TYPE
 from internals.review_models import Activity, Vote, Gate
 
 class ActivityTest(testing_config.CustomTestCase):
@@ -50,10 +51,11 @@ class ActivityTest(testing_config.CustomTestCase):
     testing_config.sign_out()
 
   def test_activities__created(self):
-    changed_fields_1 = [('name', 'feature a', 'feature Z'),
+    changed_fields_1: CHANGED_FIELDS_LIST_TYPE = [
+        ('name', 'feature a', 'feature Z'),
         ('summary', 'sum', 'A new and more accurate summary.'),
         ('shipped_milestone', 1, 100)]
-    changed_fields_2 = [('category', 1, 2)]
+    changed_fields_2: CHANGED_FIELDS_LIST_TYPE = [('category', 1, 2)]
     notifier_helpers.notify_subscribers_and_save_amendments(
         self.feature_1, changed_fields_1)
     notifier_helpers.notify_subscribers_and_save_amendments(
@@ -72,7 +74,7 @@ class ActivityTest(testing_config.CustomTestCase):
 
   def test_activities_created__no_changes(self):
     """No Activity should be logged if submitted with no changes."""
-    changed_fields = []
+    changed_fields: CHANGED_FIELDS_LIST_TYPE = []
     notifier_helpers.notify_subscribers_and_save_amendments(
         self.feature_1, changed_fields)
 
@@ -82,7 +84,7 @@ class ActivityTest(testing_config.CustomTestCase):
 
   def test_activities_created__empty_list_not_created(self):
     """No amendment should be logged if the value moved from None to empty list."""
-    changed_fields = [('editor_emails', None, [])]
+    changed_fields: CHANGED_FIELDS_LIST_TYPE = [('editor_emails', None, [])]
     notifier_helpers.notify_subscribers_and_save_amendments(
         self.feature_1, changed_fields)
 

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -27,6 +27,7 @@ from framework import permissions
 from internals import core_enums, notifier_helpers
 from internals import stage_helpers
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
+from internals.data_types import CHANGED_FIELDS_LIST_TYPE
 from internals.review_models import Gate
 from internals import processes
 from internals import search_fulltext
@@ -355,7 +356,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     raise ValueError(f'Unknown field data type: {field_type}')
 
   def _add_changed_field(self, fe: FeatureEntry, field: str, new_val: Any,
-      changed_fields: list[tuple[str, Any, Any]]) -> None:
+      changed_fields: CHANGED_FIELDS_LIST_TYPE) -> None:
     """Add values to the list of changed fields if the values differ."""
     old_val = getattr(fe, field)
     if new_val != old_val:
@@ -382,7 +383,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
     logging.info('POST is %r', self.form)
 
     stage_update_items: list[tuple[str, Any]] = []
-    changed_fields: list[tuple[str, Any, Any]] = []
+    changed_fields: CHANGED_FIELDS_LIST_TYPE = []
 
     form_fields_str = self.form.get('form_fields')
     form_fields: list[str] = []
@@ -480,7 +481,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
 
   def update_multiple_stages(self, feature_id: int, feature_type: int,
       update_items: list[tuple[str, Any]],
-      changed_fields: list[tuple[str, Any, Any]]) -> None:
+      changed_fields: CHANGED_FIELDS_LIST_TYPE) -> None:
     """Handle updating stages when IDs have not been specified."""
     # Get all existing stages associated with the feature.
     stages = stage_helpers.get_feature_stages(feature_id)
@@ -535,7 +536,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
 
   def update_single_stage(self, stage_id: int, feature_type: int,
       update_items: list[tuple[str, Any]],
-      changed_fields: list[tuple[str, Any, Any]]) -> None:
+      changed_fields: CHANGED_FIELDS_LIST_TYPE) -> None:
     """Update the fields of the stage of a given ID."""
     stage_to_update = Stage.get_by_id(stage_id)
     if stage_to_update is None:
@@ -579,7 +580,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
       feature_id: int,
       feature_type: int,
       stage_ids: list[int],
-      changed_fields: list[tuple[str, Any, Any]],
+      changed_fields: CHANGED_FIELDS_LIST_TYPE,
       form_fields: list[str]) -> None:
     """Handle the updates for stages on the edit-all page."""
     id_to_field_suffix = {}


### PR DESCRIPTION
Part of the changes to phase out server-side web page rendering and form processing.

Changes in this PR:
- Gather all changes made to a feature in the Features API PATCH request to create an Activity entity and send notification emails to subscribers of changes made.
- Invalidates all cached versions of the feature after changes are made in the PATCH request.
- Adds a new data type for the `changed_fields` list, and references that data type where it is relevant.