### PR TITLE
Implementation status checkbox uses by chromedash-form-field component

### DIFF
--- a/client-src/elements/chromedash-form-field.js
+++ b/client-src/elements/chromedash-form-field.js
@@ -13,6 +13,7 @@ export class ChromedashFormField extends LitElement {
       value: {type: String},
       index: {type: Number}, // Represents which field this is on the form.
       disabled: {type: Boolean},
+      checkboxLabel: {type: String}, // Optional override of default label.
       loading: {type: Boolean},
       fieldProps: {type: Object},
       forEnterprise: {type: Boolean},
@@ -27,6 +28,7 @@ export class ChromedashFormField extends LitElement {
     this.stageId = 0;
     this.value = '';
     this.index = -1;
+    this.checkboxLabel = '';
     this.disabled = false;
     this.loading = false;
     this.forEnterprise = false;
@@ -111,6 +113,7 @@ export class ChromedashFormField extends LitElement {
 
     let fieldHTML = '';
     if (type === 'checkbox') {
+      const label = this.checkboxLabel || this.fieldProps.label;
       // value can be a js or python boolean value converted to a string
       // or the initial value specified in form-field-spec
       fieldHTML = html`
@@ -121,7 +124,7 @@ export class ChromedashFormField extends LitElement {
           ?checked=${fieldValue === 'true' || fieldValue === 'True'}
           ?disabled=${this.disabled || fieldDisabled}
           @sl-change="${this.handleFieldUpdated}">
-          ${this.fieldProps.label}
+          ${label}
         </sl-checkbox>
       `;
     } else if (type === 'select') {

--- a/client-src/elements/chromedash-form-field_test.js
+++ b/client-src/elements/chromedash-form-field_test.js
@@ -10,7 +10,7 @@ describe('chromedash-form-field', () => {
         name="unlisted"
         value="True"
         checked="True"
-        checkbox-label="A specific label">
+        checkboxLabel="A specific label">
       </chromedash-form-field>`);
     assert.exists(component);
     assert.instanceOf(component, ChromedashFormField);

--- a/client-src/elements/chromedash-form-field_test.js
+++ b/client-src/elements/chromedash-form-field_test.js
@@ -6,7 +6,11 @@ describe('chromedash-form-field', () => {
   it('renders a checkbox type of field', async () => {
     const component = await fixture(
       html`
-      <chromedash-form-field name="unlisted" value="True" checked="True">
+      <chromedash-form-field
+        name="unlisted"
+        value="True"
+        checked="True"
+        checkbox-label="A specific label">
       </chromedash-form-field>`);
     assert.exists(component);
     assert.instanceOf(component, ChromedashFormField);
@@ -17,6 +21,7 @@ describe('chromedash-form-field', () => {
     assert.include(renderElement.innerHTML, 'Unlisted');
     assert.include(renderElement.innerHTML, 'sl-checkbox');
     assert.include(renderElement.innerHTML, 'checked');
+    assert.include(renderElement.innerHTML, 'A specific label');
   });
 
   it('renders a select type of field', async () => {

--- a/client-src/elements/chromedash-guide-stage-page.js
+++ b/client-src/elements/chromedash-guide-stage-page.js
@@ -326,43 +326,33 @@ export class ChromedashGuideStagePage extends LitElement {
 
     if (!implStatusName && !this.implStatusFormFields) return nothing;
 
+    // Set the checkbox label based on the current implementation status.
+    let label = `Set implementation status to: ${implStatusName}`;
+    if (alreadyOnThisImplStatus) {
+      label = `This feature already has implementation status: ${implStatusName}`;
+    }
+    const index = this.fieldValues.length;
+    this.fieldValues.push({
+      name: 'impl_status_chrome',
+      touched: false,
+      value: alreadyOnThisImplStatus,
+      implicitValue: section.implStatusValue,
+    });
+
     return html`
       <h3>${section.name}</h3>
       <section class="stage_form">
-        ${implStatusName ? html`
-          <tr>
-            <td colspan="2"><b>Implementation status:</b></span></td>
-          </tr>
-          <tr>
-            ${alreadyOnThisImplStatus ?
-              html`
-                <td style="padding: 6px 10px;">
-                    This feature already has implementation status:
-                    <b>${implStatusName}</b>.
-                </td>
-              ` :
-              // TODO(jrobbins): When checked, make some milestone fields required.
-              html`
-                <td style="padding: 6px 10px;">
-                  <input type="hidden" name="impl_status_offered"
-                          value=${section.implStatusValue}>
-                  <sl-checkbox name="set_impl_status"
-                          id="set_impl_status"
-                          size="small">
-                    Set implementation status to: <b>${implStatusName}</b>
-                  </sl-checkbox>
-                </td>
-                <td style="padding: 6px 10px;">
-                  <span class="helptext"
-                        style="display: block; font-size: small; margin-top: 2px;">
-                    Check this box to update the implementation
-                    status of this feature in Chromium.
-                  </span>
-                </td>
-              `}
-          </tr>
-        `: nothing}
-
+        <input type="hidden" name="impl_status_offered"
+            value=${section.implStatusValue}>
+        <!-- TODO(jrobbins): When checked, make some milestone fields required. -->
+        <chromedash-form-field
+          name="set_impl_status"
+          value=${alreadyOnThisImplStatus}
+          index=${index}
+          checkbox-label=${label}
+          ?disabled=${alreadyOnThisImplStatus}
+          @form-field-update="${this.handleFormFieldUpdate}">
+        </chromedash-form-field>
         ${this.renderFields(formattedFeature, section)}
       </section>
     `;

--- a/client-src/elements/chromedash-guide-stage-page.js
+++ b/client-src/elements/chromedash-guide-stage-page.js
@@ -349,7 +349,7 @@ export class ChromedashGuideStagePage extends LitElement {
           name="set_impl_status"
           value=${alreadyOnThisImplStatus}
           index=${index}
-          checkbox-label=${label}
+          checkboxLabel=${label}
           ?disabled=${alreadyOnThisImplStatus}
           @form-field-update="${this.handleFormFieldUpdate}">
         </chromedash-form-field>

--- a/client-src/elements/chromedash-guide-stage-page_test.js
+++ b/client-src/elements/chromedash-guide-stage-page_test.js
@@ -150,7 +150,6 @@ describe('chromedash-guide-stage-page', () => {
     assert.include(form.innerHTML, 'Implementation in Chromium');
     assert.include(form.innerHTML, '4');
     assert.include(form.innerHTML, 'type="hidden" name="impl_status_offered"');
-    assert.include(form.innerHTML, 'sl-checkbox name="set_impl_status"');
     assert.notInclude(form.innerHTML, 'This feature already has implementation status');
   });
 });

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -285,6 +285,14 @@ export const ALL_FIELDS = {
         default, be sure to set the equivalent Process stage.`,
   },
 
+  'set_impl_status': {
+    type: 'checkbox',
+    label: 'Implementation status',
+    help_text: html`
+        Check this box to update the implementation status of
+        this feature in Chromium.`,
+  },
+
   'bug_url': {
     type: 'input',
     attrs: URL_FIELD_ATTRS,


### PR DESCRIPTION
Part of the changes to phase out server-side web page rendering and form processing.

Changes in this PR:
- Adds a new optional override for checkbox fields in the chromedash-form-field component to use a conditional label rather duplicating the label described in `fieldProps`.
- Changes the implementation status checkbox field that is displayed on the stage edit page to use chromedash-form-field. This allows the tracking of changes to the field like all other fields to be used for PATCH updates in the Features API.