### PR TITLE
Make footer the top element

### DIFF
--- a/client-src/elements/chromedash-footer.js
+++ b/client-src/elements/chromedash-footer.js
@@ -17,6 +17,7 @@ export class ChromedashFooter extends LitElement {
           align-items: center;
           margin-top: 2em;
           padding: var(--content-padding-half);
+          z-index: 800;
         }
 
         footer div > * + * {


### PR DESCRIPTION
Fix #3168. Set the z-index to 800, ahead of  `--sl-z-index-drawer: 700` but nothing else in base.css
<img width="1180" alt="Screenshot 2023-07-14 at 11 36 44 AM" src="https://github.com/GoogleChrome/chromium-dashboard/assets/8611520/23780bba-ae0c-44c3-a09c-f2e47497c60c">
