### PR TITLE
Trim footer height

### DIFF
--- a/client-src/elements/chromedash-footer.js
+++ b/client-src/elements/chromedash-footer.js
@@ -26,7 +26,7 @@ export class ChromedashFooter extends LitElement {
 
         #footer-spacer {
           display: none;
-          height: calc(54px + var(--content-padding) * 2);
+          height: calc(28px + var(--content-padding-half));
         }
 
         @media only screen and (min-width: 601px) and (min-height: 601px) {


### PR DESCRIPTION
Fix #3169. Trim footer height so that there is almost no gap (except a 2em margin) between drawer/main content and footer
<img width="1680" alt="Screenshot 2023-07-14 at 12 08 08 PM" src="https://github.com/GoogleChrome/chromium-dashboard/assets/8611520/7a0f72bb-8ffd-43ba-a6f6-54713180cac7">
