### PR TITLE
Support parsing crbug.com feature link

### DIFF
--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -36,8 +36,11 @@ LINK_TYPE_GITHUB_MARKDOWN = 'github_markdown'
 LINK_TYPE_WEB = 'web'
 LINK_TYPES_REGEX = {
     # https://bugs.chromium.org/p/chromium/issues/detail?id=
-    LINK_TYPE_CHROMIUM_BUG: re.compile(r'https://bugs\.chromium\.org/p/chromium/issues/detail\?.*'),
+    # https://crbug.com/
+    LINK_TYPE_CHROMIUM_BUG: re.compile(r'https://bugs\.chromium\.org/p/chromium/issues/detail\?.*|https://crbug\.com/\d+'),
+    # https://github.com/GoogleChrome/chromium-dashboard/issues/999
     LINK_TYPE_GITHUB_ISSUE: re.compile(r'https://(www\.)?github\.com/.*issues/\d+'),
+    # https://github.com/w3c/reporting/blob/master/EXPLAINER.md
     LINK_TYPE_GITHUB_MARKDOWN: re.compile(r'https://(www\.)?github\.com/.*\.md.*'),
     LINK_TYPE_WEB: re.compile(r'https?://.*'),
 }
@@ -192,7 +195,10 @@ class Link():
     endpoint = 'https://bugs.chromium.org/prpc/monorail.Issues/GetIssue'
 
     parsed_url = urlparse(self.url)
-    issue_id = parsed_url.query.split('id=')[-1].split('&')[0]
+    if parsed_url.netloc == 'bugs.chromium.org':
+      issue_id = parsed_url.query.split('id=')[-1].split('&')[0]
+    elif parsed_url.netloc == 'crbug.com':
+      issue_id = parsed_url.path.lstrip('/')
 
     # csrf token is required, its expiration is about 2 hours according to the tokenExpiresSec field
     # technically, we could cache the csrf token and reuse it for 2 hours

--- a/internals/link_helpers_test.py
+++ b/internals/link_helpers_test.py
@@ -139,6 +139,10 @@ class LinkHelperTest(testing_config.CustomTestCase):
     self.assertEqual(link.is_error, True)
     self.assertEqual(link.http_error_code, 404)
 
+  def test_link_crbug(self):
+    link = Link("https://crbug.com/1352598")
+    self.assertEqual(link.type, LINK_TYPE_CHROMIUM_BUG)
+
   def test_link_chromium(self):
     link = Link("https://bugs.chromium.org/p/chromium/issues/detail?id=100000")
     self.assertEqual(link.type, LINK_TYPE_CHROMIUM_BUG)


### PR DESCRIPTION
Feature link is available on production. I noticed `https://crbug.com` is not being parsed. This PR add necessary logic to cover the case.

#### Examples
- ❌ `https://crbug.com` https://chromestatus.com/feature/5130100260995072 
- 🆗 `https://bugs.chromium.org/p/chromium/issues/` https://chromestatus.com/feature/5074132743487488 