### PR TITLE
Upgrade to python3.11.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: pre-installation
         run: |

--- a/.github/workflows/web_tests.yml
+++ b/.github/workflows/web_tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: pre-installation
         run: |

--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -1,6 +1,6 @@
 # This GAE service contains most of the app, including all UI pages.
 
-runtime: python310
+runtime: python311
 service: default
 instance_class: F4_1G
 

--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,6 @@
 # This GAE service contains most of the app, including all UI pages.
 
-runtime: python310
+runtime: python311
 service: default
 instance_class: F4_1G
 

--- a/notifier.staging.yaml
+++ b/notifier.staging.yaml
@@ -1,4 +1,4 @@
-runtime: python310
+runtime: python311
 service: notifier
 
 handlers:

--- a/notifier.yaml
+++ b/notifier.yaml
@@ -1,4 +1,4 @@
-runtime: python310
+runtime: python311
 service: notifier
 
 handlers:

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "./gen/js/*"
   ],
   "scripts": {
-    "setup": "npm ci; python3.10 -m venv cs-env; npm run deps",
+    "setup": "npm ci; python3.11 -m venv cs-env; npm run deps",
     "clean-setup": "rm -rf node_modules cs-env; npm run setup",
     "deps": "source cs-env/bin/activate; pip install -r requirements.txt --upgrade; pip install -r requirements.dev.txt --upgrade",
     "dev-deps": "echo 'dev-deps is no longer needed'",
-    "do-tests": "source cs-env/bin/activate; curl -X POST 'http://localhost:15606/reset' && python3.10 -m unittest discover -p '*_test.py'  -b",
+    "do-tests": "source cs-env/bin/activate; curl -X POST 'http://localhost:15606/reset' && python3.11 -m unittest discover -p '*_test.py'  -b",
     "start-emulator-persist": "gcloud beta emulators datastore start --host-port=:15606 --consistency=1.0",
     "start-emulator": "gcloud beta emulators datastore start --host-port=:15606 --no-store-on-disk --consistency=1.0",
     "stop-emulator": "curl -X POST 'http://localhost:15606/shutdown'",
@@ -30,7 +30,7 @@
     "webtest-coverage": "web-test-runner \"client-src/**/*_test.js\" --node-resolve --playwright --coverage --browsers chromium firefox",
     "do-coverage": "coverage3 erase && coverage3 run -m unittest discover -p '*_test.py' -b && coverage3 html",
     "coverage": "source cs-env/bin/activate; (npm run start-emulator > /dev/null 2>&1 &); sleep 3; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-coverage;  npm run stop-emulator",
-    "view-coverage": "pushd htmlcov/; python3.10 -m http.server 8080; popd",
+    "view-coverage": "pushd htmlcov/; python3.11 -m http.server 8080; popd",
     "mypy": "source cs-env/bin/activate; mypy --ignore-missing-imports --exclude cs-env/ --exclude gen/ --exclude appengine_config.py .",
     "lint": "gulp lint-fix && lit-analyzer \"client-src/elements/chromedash-!(featurelist)*.js\"",
     "presubmit": "npm test && npm run webtest && npm run lint && npm run mypy",


### PR DESCRIPTION
Our cloudtop machines seem to have removed python3.10 so we need to upgrade to 3.11.
I am also upgrading the GAE runtime to match the python version we will use when running locally.

This change seems pretty simple, and I didn't see anything urgent in the python release notes, but it is possible that there is something that I missed and that we will hit some problems with some part of the app.

All developers will need to be sure to have python3.11 on their local machines, and they will need to run `nom run clean-setup`.