### PR TITLE
Upgrade google_cloud_logging.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ google-api-python-client==2.47.0
 
 google-cloud-tasks==2.7.0
 google-cloud-ndb==1.11.1
-google-cloud-logging==3.0.0
+google-cloud-logging==3.6.0
 google-auth==1.31.0
 requests==2.31.0
 redis==4.4.4


### PR DESCRIPTION
We had identified this as a possible solution to #2250.
It seems to move some of the stderr output that I see in staging right now, but not all of it.