### PR TITLE
Extend devcontainer docker compose file for playwright

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,14 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/python-3/.devcontainer/base.Dockerfile
 
 # [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
-ARG VARIANT=""
+# Update 'VARIANT' to pick a version of Python: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+# Append -bullseye or -buster to pin to an OS version.
+# Use -bullseye variants on local arm64/Apple Silicon.
+ARG VARIANT="3.11-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="none"
+ARG NODE_VERSION="18"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \ 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@
 # Append -bullseye or -buster to pin to an OS version.
 # Use -bullseye variants on local arm64/Apple Silicon.
 ARG VARIANT="3.11-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT} as ide
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="18"
@@ -38,3 +38,13 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
        libxi6
 
 RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g gulp-cli" 2>&1
+
+FROM ide as dev
+WORKDIR /workspace
+COPY openapi /workspace/openapi/
+COPY gen /workspace/gen/
+# Cache the infrequent but time consuming changes early
+COPY requirements.txt requirements.dev.txt package.json package-lock.json /workspace/
+RUN npm run setup
+# Copy the rest
+COPY . /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -64,5 +64,12 @@
 	"postCreateCommand": "npm run clean-setup; . cs-env/bin/activate; npm run setup; python -m pip install pylint==2.13.4",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+
+	"features": {
+		// https://github.com/devcontainers/features/tree/main/src/docker-in-docker
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"dockerDashComposeVersion": "v2"
+		}
+	}
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,14 +5,6 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
-      args:
-        # Update 'VARIANT' to pick a version of Python: 3, 3.10, 3.9, 3.8, 3.7, 3.6
-        # Append -bullseye or -buster to pin to an OS version.
-        # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: 3.10-bullseye
-        # Optional Node.js version to install
-        NODE_VERSION: "18"
-
     volumes:
       - ..:/workspace:cached
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
+      target: ide
     volumes:
       - ..:/workspace:cached
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,9 +9,6 @@ jobs:
   playwright:
     name: 'Playwright Tests'
     runs-on: ubuntu-latest
-    container:
-      # Note: the version of the docker container for playwright must exactly match the version used in package.json.
-      image: mcr.microsoft.com/playwright:v1.35.1-jammy
     steps:
         - uses: actions/checkout@v3
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,13 +19,5 @@ jobs:
         - uses: actions/setup-node@v3
           with:
             node-version: 18
-        - name: Install dependencies
-          run: npm ci
         - name: Run your tests
-          run: npx playwright test
-        - uses: actions/upload-artifact@v3
-          if: failure()
-          with:
-            name: test-results
-            path: test-results/
-            retention-days: 30
+          run: npm run pwtests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,4 +17,5 @@ jobs:
           with:
             node-version: 18
         - name: Run your tests
+          timeout-minutes: 15
           run: npm run pwtests

--- a/.playwright/Dockerfile
+++ b/.playwright/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/playwright:v1.35.1-jammy
+ARG UID
+ARG GID
+
+WORKDIR /work
+RUN useradd pwuser -u $UID -g $GID -m -s /bin/bash || true && \
+    mkdir /work/node_modules && \
+    chown -R pwuser /work/
+USER pwuser

--- a/.playwright/Dockerfile
+++ b/.playwright/Dockerfile
@@ -1,9 +1,12 @@
 FROM mcr.microsoft.com/playwright:v1.35.1-jammy
-ARG UID
-ARG GID
 
-WORKDIR /work
-RUN useradd pwuser -u $UID -g $GID -m -s /bin/bash || true && \
-    mkdir /work/node_modules && \
-    chown -R pwuser /work/
+# playwright already created this user
 USER pwuser
+WORKDIR /work
+COPY --chown=pwuser:pwuser openapi /work/openapi/
+COPY --chown=pwuser:pwuser gen /work/gen/
+# Cache the infrequent but time consuming changes early
+COPY --chown=pwuser:pwuser requirements.txt requirements.dev.txt package.json package-lock.json /work/
+RUN npm ci && npx playwright install
+# Copy the rest
+COPY --chown=pwuser:pwuser . /work

--- a/.playwright/Dockerfile
+++ b/.playwright/Dockerfile
@@ -1,6 +1,16 @@
 FROM mcr.microsoft.com/playwright:v1.35.1-jammy
 
-# playwright already created this user
+ARG USERID
+ARG GROUPID
+
+USER root
+# playwright already created this user. Delete it and use the UID & GID from the host
+RUN userdel -r pwuser && \
+    groupadd -g $GROUPID pwuser && \
+    useradd pwuser -u $USERID -g $GROUPID -m -s /bin/bash && \
+    mkdir -p /work/client-src/elements/__screenshots__ && \
+    chown -R pwuser /work
+
 USER pwuser
 WORKDIR /work
 COPY --chown=pwuser:pwuser openapi /work/openapi/

--- a/.playwright/docker-compose.yml
+++ b/.playwright/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  playwright:
+    build:
+      context: .
+      dockerfile: ../.playwright/Dockerfile
+      args:
+        UID: ${UID}
+        GID: ${GID}
+    working_dir: /work
+    volumes:
+      - ..:/work/
+      - /work/cs-env
+    user: pwuser
+    depends_on:
+      - myapp
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+    network_mode: service:db
+
+  myapp:
+    extends:
+      file: ../.devcontainer/docker-compose.yml
+      service: app
+    depends_on:
+      - db
+    user: vscode
+    working_dir: /workspace
+    command: bash -c "npm run setup && source cs-env/bin/activate; npm run start-app"
+    network_mode: service:db

--- a/.playwright/docker-compose.yml
+++ b/.playwright/docker-compose.yml
@@ -3,30 +3,24 @@ version: '3.8'
 services:
   playwright:
     build:
-      context: .
-      dockerfile: ../.playwright/Dockerfile
-      args:
-        UID: ${UID}
-        GID: ${GID}
-    working_dir: /work
-    volumes:
-      - ..:/work/
-      - /work/cs-env
-    user: pwuser
+      context: ..
+      dockerfile: ./.playwright/Dockerfile
     depends_on:
       - myapp
-
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
     network_mode: service:db
 
   myapp:
-    extends:
-      file: ../.devcontainer/docker-compose.yml
-      service: app
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+      target: dev
     depends_on:
       - db
-    user: vscode
-    working_dir: /workspace
-    command: bash -c "npm run setup && source cs-env/bin/activate; npm run start-app"
+    command: bash -c "source cs-env/bin/activate; npm run start-app"
     network_mode: service:db
+
+    environment:
+      DATASTORE_PROJECT_ID: cr-status-staging
+      DATASTORE_EMULATOR_HOST: localhost:15606

--- a/.playwright/docker-compose.yml
+++ b/.playwright/docker-compose.yml
@@ -9,7 +9,9 @@ services:
       - myapp
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
-    network_mode: service:db
+    network_mode: host
+    volumes:
+      - ../client-src/elements/__screenshots__:/work/client-src/elements/__screenshots__
 
   myapp:
     build:
@@ -17,10 +19,15 @@ services:
       dockerfile: .devcontainer/Dockerfile
       target: dev
     depends_on:
-      - db
+      - mydb
     command: bash -c "source cs-env/bin/activate; npm run start-app"
-    network_mode: service:db
+    network_mode: host
 
     environment:
       DATASTORE_PROJECT_ID: cr-status-staging
       DATASTORE_EMULATOR_HOST: localhost:15606
+  mydb:
+    extends:
+      file: ../.devcontainer/docker-compose.yml
+      service: db
+    network_mode: host

--- a/.playwright/wait-for-app.sh
+++ b/.playwright/wait-for-app.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+while [[ "$(curl --connect-timeout 2 -s -o /dev/null -w ''%{http_code}'' http://localhost:8080)" != "200" ]]; do
+    echo ..
+    sleep 5
+done
+echo backend is up

--- a/.playwright/wait-for-app.sh
+++ b/.playwright/wait-for-app.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+echo "waiting for backend to come up"
 while [[ "$(curl --connect-timeout 2 -s -o /dev/null -w ''%{http_code}'' http://localhost:8080)" != "200" ]]; do
     echo ..
-    sleep 5
+    sleep 10
 done
 echo backend is up

--- a/package.json
+++ b/package.json
@@ -44,8 +44,11 @@
     "openapi-backend": "rm -rf gen/py/chromestatus_openapi && openapi-generator-cli generate -i openapi/api.yaml -g python-flask  -o gen/py/chromestatus_openapi --additional-properties=packageName=chromestatus_openapi && pip install -r requirements.txt",
     "openapi-validate": "openapi-generator-cli validate -i openapi/api.yaml",
     "//pwtests": "The version of the docker playwright image used here must exactly match the versions of @playwright/test in devDependencies and the Github Actions configuration (in playwright.yml).  The version of playwright used in devDependencies should not include the ^ prefix, so it doesn't auto-upgrade and get out of sync.",
-    "pwtests": "docker compose -f .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml build && docker compose -f .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml run playwright bash -c \"./.playwright/wait-for-app.sh && npx playwright test\"",
-    "pwtests-update": "docker run --rm --network host --volume $(pwd):/work/ --workdir /work/ -it mcr.microsoft.com/playwright:v1.35.1-jammy /bin/bash -c \"npm ci && npx playwright test --update-snapshots\""
+    "pwtests-build": "docker compose -f .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml build --build-arg USERID=$(id -u ${USER}) --build-arg GROUPID=$(id -g ${USER})",
+    "pwtests": "npm run pwtests-build && docker compose -f .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml run playwright bash -c \"./.playwright/wait-for-app.sh && npx playwright test\"",
+    "pwtests-update": "npm run pwtests-build && docker compose -f .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml run playwright bash -c \"./.playwright/wait-for-app.sh && npx playwright test --update-snapshots\"",
+    "pwtests-shell": "npm run pwtests-build && docker compose -f .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml run playwright bash",
+    "pwtests-ui": "npm run pwtests-build && docker compose -f .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml run playwright bash -c \"./.playwright/wait-for-app.sh && npx playwright test --ui --ui-port=8123\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "setup": "npm ci; python3 -m venv cs-env; npm run deps",
     "clean-setup": "rm -rf node_modules cs-env; npm run setup",
-    "deps": "source cs-env/bin/activate; pip install -r requirements.txt --upgrade; pip install -r requirements.dev.txt --upgrade",
+    "deps": "bash -c \"source cs-env/bin/activate; pip install -r requirements.txt --upgrade; pip install -r requirements.dev.txt --upgrade\"",
     "dev-deps": "echo 'dev-deps is no longer needed'",
     "do-tests": "source cs-env/bin/activate; curl -X POST 'http://localhost:15606/reset' && python3 -m unittest discover -p '*_test.py'  -b",
     "start-emulator-persist": "gcloud beta emulators datastore start --host-port=:15606 --consistency=1.0",
@@ -44,7 +44,7 @@
     "openapi-backend": "rm -rf gen/py/chromestatus_openapi && openapi-generator-cli generate -i openapi/api.yaml -g python-flask  -o gen/py/chromestatus_openapi --additional-properties=packageName=chromestatus_openapi && pip install -r requirements.txt",
     "openapi-validate": "openapi-generator-cli validate -i openapi/api.yaml",
     "//pwtests": "The version of the docker playwright image used here must exactly match the versions of @playwright/test in devDependencies and the Github Actions configuration (in playwright.yml).  The version of playwright used in devDependencies should not include the ^ prefix, so it doesn't auto-upgrade and get out of sync.",
-    "pwtests": "docker run --rm --network host --volume $(pwd):/work/ --workdir /work/ -it mcr.microsoft.com/playwright:v1.35.1-jammy /bin/bash -c \"npm ci && npx playwright test\"",
+    "pwtests": "docker compose  -f  .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml build playwright --build-arg UID=$(id -u ${USER}) --build-arg GID=$(id -g ${USER}) && docker compose  -f  .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml run playwright bash -c \"./.playwright/wait-for-app.sh && npm ci && npx playwright install && npx playwright test\"",
     "pwtests-update": "docker run --rm --network host --volume $(pwd):/work/ --workdir /work/ -it mcr.microsoft.com/playwright:v1.35.1-jammy /bin/bash -c \"npm ci && npx playwright test --update-snapshots\""
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "openapi-backend": "rm -rf gen/py/chromestatus_openapi && openapi-generator-cli generate -i openapi/api.yaml -g python-flask  -o gen/py/chromestatus_openapi --additional-properties=packageName=chromestatus_openapi && pip install -r requirements.txt",
     "openapi-validate": "openapi-generator-cli validate -i openapi/api.yaml",
     "//pwtests": "The version of the docker playwright image used here must exactly match the versions of @playwright/test in devDependencies and the Github Actions configuration (in playwright.yml).  The version of playwright used in devDependencies should not include the ^ prefix, so it doesn't auto-upgrade and get out of sync.",
-    "pwtests": "docker compose  -f  .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml build playwright --build-arg UID=$(id -u ${USER}) --build-arg GID=$(id -g ${USER}) && docker compose  -f  .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml run playwright bash -c \"./.playwright/wait-for-app.sh && npm ci && npx playwright install && npx playwright test\"",
+    "pwtests": "docker compose -f .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml build && docker compose -f .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml run playwright bash -c \"./.playwright/wait-for-app.sh && npx playwright test\"",
     "pwtests-update": "docker run --rm --network host --volume $(pwd):/work/ --workdir /work/ -it mcr.microsoft.com/playwright:v1.35.1-jammy /bin/bash -c \"npm ci && npx playwright test --update-snapshots\""
   },
   "repository": {


### PR DESCRIPTION
Create another docker compose file for playwright. That new one extends the existing docker compose

Should be able to run:

`npm run pwtests`

With this, I was able to get:

```sh
$ npm run pwtests

> pwtests
> docker compose  -f  .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml build playwright --build-arg UID=$(id -u ${USER}) --build-arg GID=$(id -g ${USER}) && docker compose  -f  .playwright/docker-compose.yml -f .devcontainer/docker-compose.yml run playwright bash -c "./.playwright/wait-for-app.sh && npm ci && npx playwright install && npx playwright test"

WARN[0000] The "UID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "GID" variable is not set. Defaulting to a blank string. 
[+] Building 0.6s (7/7) FINISHED                                                                                             
 => [internal] load build definition from Dockerfile                                                                    0.2s
 => => transferring dockerfile: 32B                                                                                     0.0s
 => [internal] load .dockerignore                                                                                       0.4s
 => => transferring context: 2B                                                                                         0.0s
 => [internal] load metadata for mcr.microsoft.com/playwright:v1.35.1-jammy                                             0.0s
 => [1/3] FROM mcr.microsoft.com/playwright:v1.35.1-jammy                                                               0.0s
 => CACHED [2/3] WORKDIR /work                                                                                          0.0s
 => CACHED [3/3] RUN useradd pwuser -u 1000 -g 1000 -m -s /bin/bash || true &&     mkdir /work/node_modules &&     cho  0.0s
 => exporting to image                                                                                                  0.2s
 => => exporting layers                                                                                                 0.0s
 => => writing image sha256:feb5be3a0e2b78207da0dbfe2797e78bc67048e9252a976302fcd212a9878a89                            0.0s
 => => naming to docker.io/library/playwright-playwright                                                                0.0s
WARN[0000] The "GID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "UID" variable is not set. Defaulting to a blank string. 
[+] Running 2/0
 ✔ Container playwright-db-1     Running                                                                                0.0s 
 ✔ Container playwright-myapp-1  Running                                                                                0.0s 
backend is up
npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm WARN deprecated source-map-url@0.4.1: See https://github.com/lydell/source-map-url#deprecated
npm WARN deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated
npm WARN deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
npm WARN deprecated rollup-plugin-babel-minify@10.0.0: Please use rollup-plugin-terser instead.
npm WARN deprecated chokidar@2.1.8: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies

added 1288 packages, and audited 1290 packages in 1m

109 packages are looking for funding
  run `npm fund` for details

10 vulnerabilities (1 moderate, 9 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
npm notice 
npm notice New minor version of npm available! 9.5.1 -> 9.8.0
npm notice Changelog: https://github.com/npm/cli/releases/tag/v9.8.0
npm notice Run npm install -g npm@9.8.0 to update!
npm notice 
Downloading Chromium 115.0.5790.24 (playwright build v1067) from https://playwright.azureedge.net/builds/chromium/1067/chromium-linux.zip
146.4 Mb [====================] 100% 0.0s
Chromium 115.0.5790.24 (playwright build v1067) downloaded to /ms-playwright/chromium-1067
Downloading Firefox 113.0 (playwright build v1408) from https://playwright.azureedge.net/builds/firefox/1408/firefox-ubuntu-22.04.zip
78.7 Mb [====================] 100% 0.0s
Firefox 113.0 (playwright build v1408) downloaded to /ms-playwright/firefox-1408
Downloading Webkit 16.4 (playwright build v1860) from https://playwright.azureedge.net/builds/webkit/1860/webkit-ubuntu-22.04.zip
75.7 Mb [====================] 100% 0.0s
Webkit 16.4 (playwright build v1860) downloaded to /ms-playwright/webkit-1860

Running 2 tests using 2 workers
  1) [chromium] › client-src/elements/chromedash-guide-new-page_pwtest.js:39:1 › navigate to create feature page 

    Error: expect(received).toBe(expected) // Object.is equality

    Expected: 1
    Received: 122

      55 |
      56 |   const maintabs = page.locator('div');
    > 57 |   expect(await maintabs.count()).toBe(1);
         |                                  ^
      58 |
      59 |   // Navigate to the new feature page.
      60 |   // await page.locator('sl-button[data-testid=create-feature]').click();

        at /work/client-src/elements/chromedash-guide-new-page_pwtest.js:57:34

  2) [firefox] › client-src/elements/chromedash-guide-new-page_pwtest.js:39:1 › navigate to create feature page 

    Error: expect(received).toBe(expected) // Object.is equality

    Expected: 1
    Received: 129

      55 |
      56 |   const maintabs = page.locator('div');
    > 57 |   expect(await maintabs.count()).toBe(1);
         |                                  ^
      58 |
      59 |   // Navigate to the new feature page.
      60 |   // await page.locator('sl-button[data-testid=create-feature]').click();

        at /work/client-src/elements/chromedash-guide-new-page_pwtest.js:57:34

  2 failed
    [chromium] › client-src/elements/chromedash-guide-new-page_pwtest.js:39:1 › navigate to create feature page 
    [firefox] › client-src/elements/chromedash-guide-new-page_pwtest.js:39:1 › navigate to create feature page 

  Serving HTML report at http://localhost:9323. Press Ctrl+C to quit.
```

Also added two new commands `pwtests-shell` and pwtests-ui`

With UI, we can debug it in the UI mode:

![image](https://github.com/GoogleChrome/chromium-dashboard/assets/7788930/c6d94e6b-7050-4e20-bbf2-7061ae8cc9bb)

In the normal pwtests command, we can also see the html report too

![image](https://github.com/GoogleChrome/chromium-dashboard/assets/7788930/d2adf94a-adce-4e63-8c01-3ef18aed1d42)

