### PR TITLE
Add `origin_trial_id` stage field

### DIFF
--- a/api/api_specs.py
+++ b/api/api_specs.py
@@ -102,6 +102,7 @@ STAGE_FIELD_DATA_TYPES: FIELD_INFO_DATA_TYPE = [
   ('experiment_extension_reason', 'str'),
   ('intent_thread_url', 'link'),
   ('origin_trial_feedback_url', 'link'),
+  ('origin_trial_id', 'str'),
   ('rollout_impact', 'int'),
   ('rollout_milestone', 'int'),
   ('rollout_platforms', 'split_str'),

--- a/api/converters.py
+++ b/api/converters.py
@@ -187,6 +187,7 @@ def stage_to_json_dict(
     'announcement_url': stage.announcement_url,
     'experiment_goals': stage.experiment_goals,
     'experiment_risks': stage.experiment_risks,
+    'origin_trial_id': stage.origin_trial_id,
     'origin_trial_feedback_url': stage.origin_trial_feedback_url,
     'extensions': [],
     'experiment_extension_reason': stage.experiment_extension_reason,

--- a/api/stages_api_test.py
+++ b/api/stages_api_test.py
@@ -62,7 +62,9 @@ class StagesAPITest(testing_config.CustomTestCase):
         created=self.now)
     self.stage_3.put()
 
-    self.stage_4 = Stage(id=40, feature_id=1, stage_type=150, browser='Chrome',
+    self.stage_4 = Stage(
+        id=40, feature_id=1, stage_type=150, browser='Chrome',
+        origin_trial_id='-5269211564023480319',
         ux_emails=['ux_person@example.com'],
         intent_thread_url='https://example.com/intent',
         milestones=MilestoneSet(desktop_first=100),
@@ -88,6 +90,7 @@ class StagesAPITest(testing_config.CustomTestCase):
         'desktop_last': None,
         'display_name': None,
         'enterprise_policies': [],
+        'origin_trial_id': None,
         'origin_trial_feedback_url': None,
         'experiment_extension_reason': None,
         'experiment_goals': 'To be the very best.',
@@ -180,6 +183,7 @@ class StagesAPITest(testing_config.CustomTestCase):
         'finch_url': None,
         'ios_first': None,
         'ios_last': None,
+        'origin_trial_id': None,
         'ot_stage_id': 40,
         'rollout_details': None,
         'rollout_impact': 2,
@@ -211,6 +215,7 @@ class StagesAPITest(testing_config.CustomTestCase):
         'extensions': [extension],
         'announcement_url': None,
         'enterprise_policies': [],
+        'origin_trial_id': '-5269211564023480319',
         'origin_trial_feedback_url': None,
         'rollout_details': None,
         'rollout_impact': 2,

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -276,6 +276,7 @@ class Stage(ndb.Model):
   experiment_extension_reason = ndb.TextProperty()
   intent_thread_url = ndb.StringProperty()
   intent_subject_line = ndb.StringProperty()
+  origin_trial_id = ndb.StringProperty()
   origin_trial_feedback_url = ndb.StringProperty()
   announcement_url = ndb.StringProperty()
   # Origin trial stage id that this stage extends, if trial extension stage.

--- a/internals/data_types.py
+++ b/internals/data_types.py
@@ -38,6 +38,7 @@ class StageDict(TypedDict):
 
 
   # Origin trial specific fields.
+  origin_trial_id: str | None
   experiment_goals: str | None
   experiment_risks: str | None
   extensions: list[StageDict]  # type: ignore


### PR DESCRIPTION
This PR adds the `origin_trial_id` field to denote the ID used for an origin trial in the OT database and used for the OT console URL (e.g. https://developer.chrome.com/origintrials/#/view_trial/2347501305766871041 ). The field will not yet be exposed to users on the client side. This ID can be used to query specific data about an origin trial so we can display that information accurately as it currently exists in the OT database.

The ID is stored as a string because origin trial IDs can be numbers large enough to cause floating point errors in JavaScript if represented as an integer.