### PR TITLE
Disable Google Cloud Logging and Debugger.

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,19 +55,12 @@ from pages import users
 import settings
 
 # Sets up Cloud Logging client library.
-if not settings.UNIT_TEST_MODE and not settings.DEV_MODE:
-  import google.cloud.logging
-  client = google.cloud.logging.Client()
-  client.get_default_handler()
-  client.setup_logging()
-
-# Sets up Cloud Debugger client library.
-if not settings.UNIT_TEST_MODE and not settings.DEV_MODE:
-  try:
-    import googleclouddebugger
-    googleclouddebugger.enable(breakpoint_enable_canary=False)
-  except ImportError:
-    pass
+# TODO(jrobbins): Re-enable Google Cloud Logging when #3197 is resolved.
+# if not settings.UNIT_TEST_MODE and not settings.DEV_MODE:
+#   import google.cloud.logging
+#   client = google.cloud.logging.Client()
+#   client.get_default_handler()
+#   client.setup_logging()
 
 
 # Note: In the URLs below, parameters like <int:feature_id> are


### PR DESCRIPTION
This is a work-around for the exceptions that we were seeing on staging after upgrading to python3.11.
See issue #3197 for details.