### PR TITLE
"Add Step" button displays on edit all page for enterprise only

### DIFF
--- a/client-src/elements/chromedash-guide-editall-page.js
+++ b/client-src/elements/chromedash-guide-editall-page.js
@@ -322,15 +322,13 @@ export class ChromedashGuideEditallPage extends LitElement {
 
   // render the button to add a new stage. Displays for enterprise features only.
   renderAddStageButton() {
-    if (!this.feature.is_enterprise_feature) {
-      return nothing;
-    }
-
-    return html`
-    <sl-button size="small" @click="${
+    return renderHTMLIf(
+      this.feature.is_enterprise_feature,
+      html`
+      <sl-button size="small" @click="${
         () => openAddStageDialog(this.feature.id, this.feature.feature_type_int, this.addNewStageToCreate.bind(this))}">
-      Add Step
-    </sl-button>`;
+        Add Step
+      </sl-button>`);
   }
 
   addNewStageToCreate(newStage) {

--- a/client-src/elements/chromedash-guide-editall-page.js
+++ b/client-src/elements/chromedash-guide-editall-page.js
@@ -320,12 +320,16 @@ export class ChromedashGuideEditallPage extends LitElement {
     return stageIds.join(',');
   }
 
+  // render the button to add a new stage. Displays for enterprise features only.
   renderAddStageButton() {
-    const text = this.feature.is_enterprise_feature ? 'Add Step': 'Add Stage';
+    if (!this.feature.is_enterprise_feature) {
+      return nothing;
+    }
+
     return html`
     <sl-button size="small" @click="${
         () => openAddStageDialog(this.feature.id, this.feature.feature_type_int, this.addNewStageToCreate.bind(this))}">
-      ${text}
+      Add Step
     </sl-button>`;
   }
 


### PR DESCRIPTION
Adding a stage is less common for non-enterprise features, so it seems better to remove it from the bottom of the edit all page for now, but keep the existing button and dialog on the feature detail page.