### PR TITLE
Make features_api also update feature_links.

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -27,6 +27,7 @@ from framework import users
 from internals.core_enums import *
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
 from internals.data_types import CHANGED_FIELDS_LIST_TYPE
+from internals import feature_links
 from internals import notifier_helpers
 from internals.review_models import Gate
 from internals.data_types import VerboseFeatureDict
@@ -299,7 +300,7 @@ class FeaturesAPI(basehandlers.APIHandler):
       feature.accurate_as_of = now
       feature.outstanding_notifications = 0
       has_updated = True
-    
+
     if has_updated:
       user_email = self.get_current_user().email()
       feature.updater_email = user_email
@@ -321,7 +322,7 @@ class FeaturesAPI(basehandlers.APIHandler):
       self._update_field_value(feature, field, field_type, new_value)
       changed_fields.append((field, old_value, new_value))
       has_updated = True
-    
+
     self._patch_update_special_fields(feature, feature_changes, has_updated)
     feature.put()
 
@@ -355,6 +356,7 @@ class FeaturesAPI(basehandlers.APIHandler):
     # Update full-text index.
     if feature:
       search_fulltext.index_feature(feature)
+      feature_links.update_feature_links(feature, changed_fields)
 
     return {'message': f'Feature {feature_id} updated.'}
 

--- a/internals/feature_links.py
+++ b/internals/feature_links.py
@@ -190,12 +190,12 @@ def batch_index_feature_entries(fes: list[FeatureEntry], skip_existing: bool) ->
   The function `batch_index_feature_entries` takes a list of `FeatureEntry` objects, generates feature
   links for each entry, and stores them in batches in the database, skipping existing entries if
   specified.
-  
+
   :param fes: fes is a list of FeatureEntry
   :param skip_existing: A boolean value indicating whether to skip feature entries that already have
   existing feature links
   """
-  
+
   link_count = 0
 
   for fe in fes:


### PR DESCRIPTION
Feature links were not being updated after each user edit because the method to update them was not being called.  It was only being called from guide.py, and this week we are shifting to using features_api.py instead.