### PR TITLE
Name intent fields properly in activity field

### DIFF
--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -484,7 +484,6 @@ export const ALL_FIELDS = {
 
   'intent_to_implement_url': {
     type: 'input',
-    name: 'intent_thread_url',
     attrs: URL_FIELD_ATTRS,
     required: false,
     label: 'Intent to Prototype link',
@@ -635,7 +634,6 @@ export const ALL_FIELDS = {
   },
 
   'intent_to_ship_url': {
-    name: 'intent_thread_url',
     type: 'input',
     attrs: URL_FIELD_ATTRS,
     required: false,
@@ -654,7 +652,6 @@ export const ALL_FIELDS = {
   },
 
   'intent_to_experiment_url': {
-    name: 'intent_thread_url',
     type: 'input',
     attrs: URL_FIELD_ATTRS,
     required: false,
@@ -664,7 +661,6 @@ export const ALL_FIELDS = {
   },
 
   'intent_to_extend_experiment_url': {
-    name: 'intent_thread_url',
     type: 'input',
     attrs: URL_FIELD_ATTRS,
     required: false,
@@ -675,7 +671,6 @@ export const ALL_FIELDS = {
 
   'r4dt_url': {
     // form field name matches underlying DB field (sets "intent_to_experiment_url" field in DB).
-    name: 'intent_thread_url',
     type: 'input',
     attrs: URL_FIELD_ATTRS,
     required: false,


### PR DESCRIPTION
This change updates the intent fields so that they are named properly in the list of changed fields for notifications and activity entities. This should have no further effect on the way the fields are saved in the features API.

e.g. Activity created will now list an intent change as `intent_to_ship_url` rather than the ambiguous `intent_thread_url`.