### PR TITLE
Ignore links with type None.

### DIFF
--- a/internals/feature_links.py
+++ b/internals/feature_links.py
@@ -59,9 +59,10 @@ def update_feature_links(fe: FeatureEntry, changed_fields: list[tuple[str, Any, 
           _remove_link(link, fe)
       for url in urls_to_add:
         link = Link(url)
-        feature_link = _get_index_link(link, fe, should_parse_new_link=True)
-        feature_link.put()
-        logging.info(f'Indexed feature_link {feature_link.url} to {feature_link.key.integer_id()} for feature {fe.key.integer_id()}')
+        if link.type:
+          feature_link = _get_index_link(link, fe, should_parse_new_link=True)
+          feature_link.put()
+          logging.info(f'Indexed feature_link {feature_link.url} to {feature_link.key.integer_id()} for feature {fe.key.integer_id()}')
 
 def _get_index_link(link: Link, fe: FeatureEntry, should_parse_new_link: bool = False) -> FeatureLinks:
   """
@@ -205,7 +206,13 @@ def batch_index_feature_entries(fes: list[FeatureEntry], skip_existing: bool) ->
         continue
 
     urls = _extract_feature_urls(fe)
-    feature_links = [_get_index_link(Link(url), fe, should_parse_new_link=False) for url in urls]
+    feature_links = []
+    for url in urls:
+      link = Link(url)
+      if link.type:
+        fl = _get_index_link(link, fe, should_parse_new_link=False)
+        feature_links.append(fl)
+
     ndb.put_multi(feature_links)
     link_count += len(feature_links)
     logging.info(f'Feature {fe.key.integer_id()} indexed {len(feature_links)} urls')

--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -96,6 +96,7 @@ class Link():
     self.is_error = False
     self.http_error_code: Optional[int] = None
     self.information = None
+    logging.info(f'Constructed Link for {url} with type {self.type}')
 
   def _fetch_github_file(
       self, owner: str, repo: str, ref: str, file_path: str,
@@ -232,7 +233,7 @@ class Link():
     information: dict[str, Any] = json.loads(json_str)
 
     return information.get('issue', None)
-  
+
   def _validate_url(self) -> bool:
     """The `_validate_url` method is used to validate the URL associated with the Link object. It
     sends a GET request to the URL and checks the response status code. If the status code is not
@@ -244,7 +245,7 @@ class Link():
       self.http_error_code = res.status_code
       return False
     return True
-  
+
   def parse(self):
     """Parse the link and store the information."""
     try:

--- a/internals/link_helpers_test.py
+++ b/internals/link_helpers_test.py
@@ -28,7 +28,7 @@ class LinkHelperTest(testing_config.CustomTestCase):
 
   def test_real_server_error_url(self):
     link = Link("http://httpstat.us/503")
-    
+
     link.parse()
     self.assertEqual(link.type, LINK_TYPE_WEB)
     self.assertEqual(link.is_error, True)
@@ -44,14 +44,14 @@ class LinkHelperTest(testing_config.CustomTestCase):
   @mock.patch('requests.get')
   def test_mock_not_found_url(self, mock_requests_get):
     mock_requests_get.return_value = testing_config.Blank(
-        status_code=404, content='')  
+        status_code=404, content='')
 
     link = Link("https://www.google.com/")
     link.parse()
     self.assertEqual(link.type, LINK_TYPE_WEB)
     self.assertEqual(link.is_error, True)
     self.assertEqual(link.http_error_code, 404)
-  
+
   def test_extract_urls_from_value(self):
     field_value = "https://www.chromestatus.com/feature/1234"
     urls = Link.extract_urls_from_value(field_value)
@@ -186,3 +186,10 @@ class LinkHelperTest(testing_config.CustomTestCase):
     self.assertEqual(link.is_parsed, True)
     self.assertEqual(link.is_error, True)
     self.assertEqual(link.information, None)
+
+  def test_link_no_type(self):
+    """We can find a link in text, but have that link not match any type."""
+    urls = Link.extract_urls_from_value('Some kind of https://... link.')
+    url = urls[0]
+    link = Link(url)
+    self.assertEqual(link.type, None)


### PR DESCRIPTION
I ran the backfill script in production and it failed on saving a FeatureLinks entity that had type == None.

The regex for LINK_TYPE_WEB looks like it would catch every possible link that is detected by regex URL_REGEX.  However, after using URL_REGEX, we strip all trailing punctuation, and a slash is a punctuation character.  So, it is possible for the punctuation stripping to strip `'https://...'` to give `'https'`, and that will not match LINK_TYPE_WEB.

In cases where URL_REGEX detected a URL but link.type is None, the code simply skips that link.

I have also left a logging statement in the constructor so that I can see URLs in the logs.  This will be helpful during the next backfill attempt if there is some other text value that causes a different error.