### PR TITLE
Add origin trials API key variable to server settings

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -49,3 +49,6 @@ tutorial-env
 
 # Testdata for Python tests
 testdata
+
+# API Key for local development
+ot_api_key.txt

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ coverage
 
 # venv directory
 cs-env
+
+# API Key for local development
+ot_api_key.txt

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ This will start a local datastore emulator, run unit tests, and then shut down t
 
 There are some developing information in developer-documentation.md.
 
+### Origin Trials
+To test the functionality of this application locally that interacts with data from the Origin Trials API, an API key will need to be acquired. To do this, run the following command:
+
+```bash
+npm run dev-ot-key
+```
+
+Note: *Only developers with access to the cr-status-staging GCP project will be able to successfully run this command. If you need to test this and you don't have access, open an issue.*
 
 **Notes**
 

--- a/framework/secrets.py
+++ b/framework/secrets.py
@@ -138,7 +138,7 @@ def get_ot_api_key() -> str|None:
         settings.OT_API_KEY = f.read().strip()
         return settings.OT_API_KEY
     except:
-      print('No key found locally for the Origin Trials API.')
+      logging.info('No key found locally for the Origin Trials API.')
       return None
   else:
     # If in staging or prod, pull the API key from the project secrets.

--- a/framework/secrets.py
+++ b/framework/secrets.py
@@ -27,6 +27,7 @@ from google.cloud import ndb  # type: ignore
 RANDOM_KEY_LENGTH = 128
 RANDOM_KEY_CHARACTERS = string.ascii_letters + string.digits
 
+OT_API_KEY: str|None = None
 
 def make_random_key(length=RANDOM_KEY_LENGTH, chars=RANDOM_KEY_CHARACTERS):
   """Return a string with lots of random characters."""
@@ -129,9 +130,12 @@ def get_ot_api_key(app_id, root_dir, is_dev_mode) -> str|None:
     # In dev or unit test mode, pull the API key from a local file.
     try:
       with open(f'{root_dir}/ot_api_key.txt', 'r') as f:
-        return f.read().strip()
+        OT_API_KEY = f.read().strip()
+        return
     except:
-      return None
+      print('No key found locally for the Origin Trials API.')
+      OT_API_KEY = None
+      return
   else:
     # If in staging or prod, pull the API key from the project secrets.
     from google.cloud.secretmanager import SecretManagerServiceClient
@@ -139,5 +143,6 @@ def get_ot_api_key(app_id, root_dir, is_dev_mode) -> str|None:
     name = f'{client.secret_path(app_id, "OT_API_KEY")}/versions/latest'
     response = client.access_secret_version(request={'name': name})
     if response:
-      return response.payload.data.decode("UTF-8")
-  return None
+      OT_API_KEY = response.payload.data.decode("UTF-8")
+      return
+  OT_API_KEY = None

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "clean-setup": "rm -rf node_modules cs-env; npm run setup",
     "deps": "source cs-env/bin/activate; pip install -r requirements.txt --upgrade; pip install -r requirements.dev.txt --upgrade",
     "dev-deps": "echo 'dev-deps is no longer needed'",
+    "dev-ot-key": "gcloud secrets versions access latest --secret=DEV_OT_API_KEY  --out-file=ot_api_key.txt --project=cr-status-staging",
     "do-tests": "source cs-env/bin/activate; curl -X POST 'http://localhost:15606/reset' && python3.11 -m unittest discover -p '*_test.py'  -b",
     "start-emulator-persist": "gcloud beta emulators datastore start --host-port=:15606 --consistency=1.0",
     "start-emulator": "gcloud beta emulators datastore start --host-port=:15606 --no-store-on-disk --consistency=1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ google-api-python-client==2.47.0
 google-cloud-tasks==2.7.0
 google-cloud-ndb==1.11.1
 google-cloud-logging==3.6.0
+google-cloud-secret-manager==2.16.2
 google-auth==1.31.0
 requests==2.31.0
 redis==4.4.4

--- a/settings.py
+++ b/settings.py
@@ -117,7 +117,7 @@ def get_ot_api_key() -> str|None:
     # If in staging or prod, pull the API key from the project secrets.
     from google.cloud.secretmanager import SecretManagerServiceClient
     client = SecretManagerServiceClient()
-    name = client.secret_path(APP_ID, 'OT_API_KEY') + '/versions/latest'
+    name = f'{client.secret_path(APP_ID, 'OT_API_KEY')}/versions/latest'
     response = client.access_secret_version(request={'name': name})
     if response:
       return response.payload.data.decode("UTF-8")

--- a/settings.py
+++ b/settings.py
@@ -117,7 +117,7 @@ def get_ot_api_key() -> str|None:
     # If in staging or prod, pull the API key from the project secrets.
     from google.cloud.secretmanager import SecretManagerServiceClient
     client = SecretManagerServiceClient()
-    name = f'{client.secret_path(APP_ID, 'OT_API_KEY')}/versions/latest'
+    name = f'{client.secret_path(APP_ID, "OT_API_KEY")}/versions/latest'
     response = client.access_secret_version(request={'name': name})
     if response:
       return response.payload.data.decode("UTF-8")

--- a/settings.py
+++ b/settings.py
@@ -107,12 +107,6 @@ elif APP_ID == 'cr-status-staging':
 else:
   logging.error('Unexpected app ID %r, please configure settings.py.', APP_ID)
 
-OT_API_KEY: str|None = get_ot_api_key(
-  app_id=APP_ID,
-  root_dir=ROOT_DIR,
-  is_dev_mode=DEV_MODE or UNIT_TEST_MODE
-)
-
 RSS_FEED_LIMIT = 15
 
 DEFAULT_CACHE_TIME = 3600 # seconds

--- a/settings.py
+++ b/settings.py
@@ -77,6 +77,7 @@ MAX_LOG_LINE = 200 * 1000
 
 # Origin trials API URL
 OT_API_URL = 'https://staging-chromeorigintrials-pa.sandbox.googleapis.com'
+OT_API_KEY: str|None = None  # Value is set later when request is needed.
 
 if UNIT_TEST_MODE:
   APP_TITLE = 'Local testing'

--- a/settings.py
+++ b/settings.py
@@ -105,7 +105,7 @@ elif APP_ID == 'cr-status-staging':
 else:
   logging.error('Unexpected app ID %r, please configure settings.py.', APP_ID)
 
-def get_ot_api_key() -> str:
+def get_ot_api_key() -> str|None:
   # In dev or unit test mode, pull the API key from a local file.
   if DEV_MODE or UNIT_TEST_MODE:
     try:

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+from framework.secrets import get_ot_api_key
+
 
 ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -105,26 +107,11 @@ elif APP_ID == 'cr-status-staging':
 else:
   logging.error('Unexpected app ID %r, please configure settings.py.', APP_ID)
 
-def get_ot_api_key() -> str|None:
-  # In dev or unit test mode, pull the API key from a local file.
-  if DEV_MODE or UNIT_TEST_MODE:
-    try:
-      with open(f'{ROOT_DIR}/ot_api_key.txt', 'r') as f:
-        return f.read().strip()
-    except:
-      return None
-  else:
-    # If in staging or prod, pull the API key from the project secrets.
-    from google.cloud.secretmanager import SecretManagerServiceClient
-    client = SecretManagerServiceClient()
-    name = f'{client.secret_path(APP_ID, "OT_API_KEY")}/versions/latest'
-    response = client.access_secret_version(request={'name': name})
-    if response:
-      return response.payload.data.decode("UTF-8")
-  return None
-
-
-OT_API_KEY: str|None = get_ot_api_key()
+OT_API_KEY: str|None = get_ot_api_key(
+  app_id=APP_ID,
+  root_dir=ROOT_DIR,
+  is_dev_mode=DEV_MODE or UNIT_TEST_MODE
+)
 
 RSS_FEED_LIMIT = 15
 


### PR DESCRIPTION
This change adds the a new variable to the server settings, `OT_API_KEY`. The value is obtained from a local text file when in dev mode or unit test mode, and is obtained from the project's secrets manager when on staging or prod. This key will be used to query the origin trials API to obtain origin trial data.