### PR TITLE
Defaut to opening the menu drawer on the old feature list page.

### DIFF
--- a/pages/testdata/featurelist_test/test_html_rendering.html
+++ b/pages/testdata/featurelist_test/test_html_rendering.html
@@ -190,7 +190,7 @@ limitations under the License.
         flexWrapper.style = shiftedStyle;
 
         function shiftPage() {
-            let slDrawer = drawer.shadowRoot.querySelector('sl-drawer');
+            const slDrawer = drawer.shadowRoot.querySelector('sl-drawer');
             const isOpening = !slDrawer.open;
             flexWrapper.style = isOpening ? shiftedStyle : '';
         }

--- a/pages/testdata/featurelist_test/test_html_rendering.html
+++ b/pages/testdata/featurelist_test/test_html_rendering.html
@@ -177,6 +177,26 @@ limitations under the License.
       };
       loadFeatureLegendViews(VIEWS);
     })();
+
+    // Since we don't use chromedash-app on this page, re-implement a little
+    // logic for the main menu shifting the page content on desktop.
+    const isMobile = window.screen.width < 701;
+    if (!isMobile) {
+        const header = document.querySelector('chromedash-header');
+        const drawer = document.querySelector('chromedash-drawer');
+        const flexWrapper = document.querySelector('#content-flex-wrapper');
+        const shiftedStyle = 'margin-left: 210px; justify-content: start';
+        drawer.defaultOpen = true;
+        flexWrapper.style = shiftedStyle;
+
+        function shiftPage() {
+            let slDrawer = drawer.shadowRoot.querySelector('sl-drawer');
+            const isOpening = !slDrawer.open;
+            flexWrapper.style = isOpening ? shiftedStyle : '';
+        }
+        header.addEventListener('drawer-clicked', shiftPage);
+    }
+
   </script>
 
 

--- a/templates/features.html
+++ b/templates/features.html
@@ -56,5 +56,25 @@
       };
       loadFeatureLegendViews(VIEWS);
     })();
+
+    // Since we don't use chromedash-app on this page, re-implement a little
+    // logic for the main menu shifting the page content on desktop.
+    const isMobile = window.screen.width < 701;
+    if (!isMobile) {
+        const header = document.querySelector('chromedash-header');
+        const drawer = document.querySelector('chromedash-drawer');
+        const flexWrapper = document.querySelector('#content-flex-wrapper');
+        const shiftedStyle = 'margin-left: 210px; justify-content: start';
+        drawer.defaultOpen = true;
+        flexWrapper.style = shiftedStyle;
+
+        function shiftPage() {
+            let slDrawer = drawer.shadowRoot.querySelector('sl-drawer');
+            const isOpening = !slDrawer.open;
+            flexWrapper.style = isOpening ? shiftedStyle : '';
+        }
+        header.addEventListener('drawer-clicked', shiftPage);
+    }
+
   </script>
 {% endblock %}

--- a/templates/features.html
+++ b/templates/features.html
@@ -69,7 +69,7 @@
         flexWrapper.style = shiftedStyle;
 
         function shiftPage() {
-            let slDrawer = drawer.shadowRoot.querySelector('sl-drawer');
+            const slDrawer = drawer.shadowRoot.querySelector('sl-drawer');
             const isOpening = !slDrawer.open;
             flexWrapper.style = isOpening ? shiftedStyle : '';
         }


### PR DESCRIPTION
This resolves #3167.

Basically, take the same approach that chromedash-app uses to shift page content when the menu is open and apply that to the old MPA page for the feature list.  

Having the margin shifting working allows us to make the menu open by default on desktop. This feels very natural as a user because the menu would always be open when the user using it to navigate to this page, so it should still be open on the page once the user gets there.