### PR TITLE
Let every review team have a 5-day SLO.

### DIFF
--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -531,8 +531,8 @@ class GateConvertersTest(testing_config.CustomTestCase):
         next_action=datetime(2022, 12, 25),
         additional_review=True)
     gate.put()
-    # The review weas due on Friday 2022-12-16.
-    mock_now.return_value = datetime(2022, 12, 20, 1, 2, 3)  # Tuesday after.
+    # The review weas due on Wednesday 2022-12-21.
+    mock_now.return_value = datetime(2022, 12, 23, 1, 2, 3)  # Thursday after.
 
     actual = converters.gate_value_to_json_dict(gate)
     appr_def = approval_defs.APPROVAL_FIELDS_BY_ID[gate.gate_type]

--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -531,7 +531,7 @@ class GateConvertersTest(testing_config.CustomTestCase):
         next_action=datetime(2022, 12, 25),
         additional_review=True)
     gate.put()
-    # The review weas due on Wednesday 2022-12-21.
+    # The review was due on Wednesday 2022-12-21.
     mock_now.return_value = datetime(2022, 12, 23, 1, 2, 3)  # Thursday after.
 
     actual = converters.gate_value_to_json_dict(gate)

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -58,8 +58,7 @@ TESTING_APPROVERS = [
     'vivianz@google.com',
 ]
 
-DEFAULT_SLO_LIMIT = 2  # Two weekdays in the Pacific timezone.
-LONGER_SLO_LIMIT = 5  # Five weekdays in the Pacific timezone.
+DEFAULT_SLO_LIMIT = 5  # Five weekdays in the Pacific timezone.
 
 @dataclass(eq=True, frozen=True)
 class ApprovalFieldDef:
@@ -79,29 +78,25 @@ PrototypeApproval = ApprovalFieldDef(
     'Intent to Prototype',
     'Not normally used.  If a review is requested, API Owners can approve.',
     core_enums.GATE_API_PROTOTYPE, ONE_LGTM,
-    approvers=API_OWNERS_URL, team_name='API Owners',
-    slo_initial_response=LONGER_SLO_LIMIT)
+    approvers=API_OWNERS_URL, team_name='API Owners')
 
 ExperimentApproval = ApprovalFieldDef(
     'Intent to Experiment',
     'One API Owner must approve your intent',
     core_enums.GATE_API_ORIGIN_TRIAL, ONE_LGTM,
-    approvers=API_OWNERS_URL, team_name='API Owners',
-    slo_initial_response=LONGER_SLO_LIMIT)
+    approvers=API_OWNERS_URL, team_name='API Owners')
 
 ExtendExperimentApproval = ApprovalFieldDef(
     'Intent to Extend Experiment',
     'One API Owner must approve your intent',
     core_enums.GATE_API_EXTEND_ORIGIN_TRIAL, ONE_LGTM,
-    approvers=API_OWNERS_URL, team_name='API Owners',
-    slo_initial_response=LONGER_SLO_LIMIT)
+    approvers=API_OWNERS_URL, team_name='API Owners')
 
 ShipApproval = ApprovalFieldDef(
     'Intent to Ship',
     'Three API Owners must approve your intent',
     core_enums.GATE_API_SHIP, THREE_LGTM,
-    approvers=API_OWNERS_URL, team_name='API Owners',
-    slo_initial_response=LONGER_SLO_LIMIT)
+    approvers=API_OWNERS_URL, team_name='API Owners')
 
 PrivacyOriginTrialApproval = ApprovalFieldDef(
     'Privacy OT Review',

--- a/internals/processes_test.py
+++ b/internals/processes_test.py
@@ -36,7 +36,7 @@ BAKE_APPROVAL_DEF_DICT = collections.OrderedDict([
     ('field_id', 9),
     ('rule', approval_defs.ONE_LGTM),
     ('approvers', ['chef@example.com']),
-    ('slo_initial_response', 2),
+    ('slo_initial_response', 5),
     ])
 
 PI_COLD_DOUGH = processes.ProgressItem('Cold dough', 'dough')

--- a/internals/slo_test.py
+++ b/internals/slo_test.py
@@ -261,7 +261,7 @@ class SLOReportingTests(testing_config.CustomTestCase):
     self.assertFalse(slo.is_gate_overdue(
         self.gate_1, APPR_FIELDS, DEFAULT_SLO_LIMIT))
 
-    mock_now.return_value = datetime.datetime(2023, 6, 12, 12, 30, 0)  # Mon
+    mock_now.return_value = datetime.datetime(2023, 6, 15, 12, 30, 0)  # Thu
     self.assertTrue(slo.is_gate_overdue(
         self.gate_1, APPR_FIELDS, DEFAULT_SLO_LIMIT))
 
@@ -272,14 +272,14 @@ class SLOReportingTests(testing_config.CustomTestCase):
     self.assertFalse(slo.is_gate_overdue(
         self.gate_1, {}, DEFAULT_SLO_LIMIT))
 
-    mock_now.return_value = datetime.datetime(2023, 6, 12, 12, 30, 0)  # Mon
+    mock_now.return_value = datetime.datetime(2023, 6, 15, 12, 30, 0)  # Thu
     self.assertTrue(slo.is_gate_overdue(
         self.gate_1, {}, DEFAULT_SLO_LIMIT))
 
   @mock.patch('internals.slo.now_utc')
   def test_get_overdue_gates(self, mock_now):
     """We can tell if a gate is overdue based on a default SLO limit."""
-    mock_now.return_value = datetime.datetime(2023, 6, 12, 12, 30, 0)  # Mon
+    mock_now.return_value = datetime.datetime(2023, 6, 15, 12, 30, 0)  # Thu
 
     actual = slo.get_overdue_gates(APPR_FIELDS, DEFAULT_SLO_LIMIT)
     # gate_1 is overdue.


### PR DESCRIPTION
After seeing red clock icons, every review team has requested that they get a 5-day SLO rather than the 2-day default that we started with.