### PR TITLE
Handle invalid urls

### DIFF
--- a/client-src/elements/feature-link.js
+++ b/client-src/elements/feature-link.js
@@ -196,7 +196,7 @@ function enhanceGithubMarkdownLink(featureLink, text) {
   </a>`;
 }
 
-function _enhanceLink(featureLink, fallback, text) {
+function _enhanceLink(featureLink, fallback, text, ignoreHttpErrorCodes = []) {
   if (!fallback) {
     throw new Error('fallback html is required');
   }
@@ -204,7 +204,8 @@ function _enhanceLink(featureLink, fallback, text) {
     return fallback;
   }
   if (!featureLink.information) {
-    if (featureLink.http_error_code) {
+    if (featureLink.http_error_code &&
+       !ignoreHttpErrorCodes.includes(featureLink.http_error_code)) {
       return html`<div class="feature-link">
         <sl-tag>
           <sl-icon library="material" name="link"></sl-icon>
@@ -248,5 +249,5 @@ export function enhanceUrl(url, featureLinks = [], fallback, text) {
 
 export function enhanceAutolink(part, featureLink) {
   const fallback = html`<a href="${part.href}" target="_blank" rel="noopener noreferrer">${part.content}</a>`;
-  return _enhanceLink(featureLink, fallback);
+  return _enhanceLink(featureLink, fallback, part.content, [404]);
 }

--- a/internals/feature_links.py
+++ b/internals/feature_links.py
@@ -61,8 +61,9 @@ def update_feature_links(fe: FeatureEntry, changed_fields: list[tuple[str, Any, 
         link = Link(url)
         if link.type:
           feature_link = _get_index_link(link, fe, should_parse_new_link=True)
-          feature_link.put()
-          logging.info(f'Indexed feature_link {feature_link.url} to {feature_link.key.integer_id()} for feature {fe.key.integer_id()}')
+          if feature_link:
+            feature_link.put()
+            logging.info(f'Indexed feature_link {feature_link.url} to {feature_link.key.integer_id()} for feature {fe.key.integer_id()}')
 
 def _get_index_link(link: Link, fe: FeatureEntry, should_parse_new_link: bool = False) -> FeatureLinks:
   """
@@ -80,6 +81,8 @@ def _get_index_link(link: Link, fe: FeatureEntry, should_parse_new_link: bool = 
   else:
     if should_parse_new_link:
       link.parse()
+      if link.is_error:
+        return None
     feature_link = FeatureLinks(
         feature_ids=[feature_id],
         type=link.type,
@@ -211,7 +214,8 @@ def batch_index_feature_entries(fes: list[FeatureEntry], skip_existing: bool) ->
       link = Link(url)
       if link.type:
         fl = _get_index_link(link, fe, should_parse_new_link=False)
-        feature_links.append(fl)
+        if fl:
+          feature_links.append(fl)
 
     ndb.put_multi(feature_links)
     link_count += len(feature_links)

--- a/internals/feature_links.py
+++ b/internals/feature_links.py
@@ -65,10 +65,10 @@ def update_feature_links(fe: FeatureEntry, changed_fields: list[tuple[str, Any, 
             feature_link.put()
             logging.info(f'Indexed feature_link {feature_link.url} to {feature_link.key.integer_id()} for feature {fe.key.integer_id()}')
 
-def _get_index_link(link: Link, fe: FeatureEntry, should_parse_new_link: bool = False) -> FeatureLinks:
+def _get_index_link(link: Link, fe: FeatureEntry, should_parse_new_link: bool = False) -> FeatureLinks | None:
   """
   indexes a given link for a specific feature by creating or updating a `FeatureLinks` object.
-  Returns the `FeatureLinks` object.
+  Returns the `FeatureLinks` object or None.
   """
 
   feature_id = fe.key.integer_id()

--- a/internals/feature_links_test.py
+++ b/internals/feature_links_test.py
@@ -96,8 +96,7 @@ class LinkTest(testing_config.CustomTestCase):
     # add invalid url to feature
     self.mock_user_change_fields(changed_fields)
     link = query.get()
-    self.assertIsNotNone(link)
-    self.assertIsNone(link.information)
+    self.assertIsNone(link)
 
   def test_features_with_same_link(self):
     url = "https://bugs.chromium.org/p/chromium/issues/detail?id=100000"

--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -47,6 +47,12 @@ LINK_TYPES_REGEX = {
 
 URL_REGEX = re.compile(r'(https?://\S+)')
 
+def valid_url(url):
+    try:
+        result = urlparse(url)
+        return all([result.scheme, result.netloc, result.path])
+    except:
+        return False
 
 def get_github_api_client():
   """Set up the GitHub client."""
@@ -75,11 +81,11 @@ class Link():
       urls = URL_REGEX.findall(value)
       # remove trailing punctuation
       urls = [url.rstrip(punctuation) for url in urls]
-      return urls
     elif isinstance(value, list):
-      return [url for url in value if isinstance(url, str) and URL_REGEX.match(url)]
+      urls = [url for url in value if isinstance(url, str) and URL_REGEX.match(url)]
     else:
-      return []
+      urls = []
+    return [url for url in urls if valid_url(url)]
 
   @classmethod
   def get_type(cls, link: str) -> str | None:

--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -23,7 +23,7 @@ from ghapi.core import GhApi
 from urllib.error import HTTPError
 from urllib.parse import urlparse
 import base64
-
+import validators
 from framework import secrets
 
 
@@ -49,8 +49,7 @@ URL_REGEX = re.compile(r'(https?://\S+)')
 
 def valid_url(url):
     try:
-        result = urlparse(url)
-        return all([result.scheme, result.netloc, result.path])
+        return validators.url(url, public=True)
     except:
         return False
 

--- a/internals/link_helpers_test.py
+++ b/internals/link_helpers_test.py
@@ -208,7 +208,7 @@ class LinkHelperTest(testing_config.CustomTestCase):
 
   def test_link_no_type(self):
     """We can find a link in text, but have that link not match any type."""
-    urls = Link.extract_urls_from_value('Some kind of https://... link.')
+    urls = Link.extract_urls_from_value('Some kind of https://g.com link.')
     url = urls[0]
     link = Link(url)
     self.assertEqual(link.type, None)

--- a/internals/link_helpers_test.py
+++ b/internals/link_helpers_test.py
@@ -31,12 +31,14 @@ class LinkHelperTest(testing_config.CustomTestCase):
   def test_valid_url(self):
       invalid_urls = [
         'http://',
-        'http://w',
+        'http://.',
         'https://invalid',
       ]
       valid_urls = [
         'http://www.google.com/',
         'https://www.google.com/',
+        'http://www.google.com',
+        'https://www.google.com',
       ]
       for url in invalid_urls:
         with self.subTest(url=url):

--- a/internals/link_helpers_test.py
+++ b/internals/link_helpers_test.py
@@ -20,12 +20,31 @@ from internals.link_helpers import (
     LINK_TYPE_CHROMIUM_BUG,
     LINK_TYPE_GITHUB_ISSUE,
     LINK_TYPE_GITHUB_MARKDOWN,
-    LINK_TYPE_WEB
+    LINK_TYPE_WEB,
+    valid_url
 )
 
 
 class LinkHelperTest(testing_config.CustomTestCase):
 
+
+  def test_valid_url(self):
+      invalid_urls = [
+        'http://',
+        'http://w',
+        'https://invalid',
+      ]
+      valid_urls = [
+        'http://www.google.com/',
+        'https://www.google.com/',
+      ]
+      for url in invalid_urls:
+        with self.subTest(url=url):
+          self.assertFalse(valid_url(url))
+      for url in valid_urls:
+        with self.subTest(url=url):
+          self.assertTrue(valid_url(url))
+        
   def test_real_server_error_url(self):
     link = Link("http://httpstat.us/503")
 
@@ -57,7 +76,7 @@ class LinkHelperTest(testing_config.CustomTestCase):
     urls = Link.extract_urls_from_value(field_value)
     self.assertEqual(urls, [field_value])
 
-    field_value = "leadinghttps:https://www.chromestatus.com/feature/1234, https://www.chromestatus.com/feature/5678 is valid"
+    field_value = "leadinghttps:https://www.chromestatus.com/feature/1234');, https://www.chromestatus.com/feature/5678 is valid"
     urls = Link.extract_urls_from_value(field_value)
     self.assertEqual(urls, ["https://www.chromestatus.com/feature/1234", "https://www.chromestatus.com/feature/5678"])
 

--- a/internals/link_helpers_test.py
+++ b/internals/link_helpers_test.py
@@ -206,9 +206,6 @@ class LinkHelperTest(testing_config.CustomTestCase):
     self.assertEqual(link.is_error, True)
     self.assertEqual(link.information, None)
 
-  def test_link_no_type(self):
-    """We can find a link in text, but have that link not match any type."""
-    urls = Link.extract_urls_from_value('Some kind of https://g.com link.')
-    url = urls[0]
-    link = Link(url)
-    self.assertEqual(link.type, None)
+  def test_extract_invalid_url(self):
+    urls = Link.extract_urls_from_value('Some kind of https://... link.')
+    self.assertEqual(len(urls), 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ Werkzeug==2.3.3
 click==8.1.3
 itsdangerous==2.1.2
 ghapi==1.0.3
+validators==0.20.0
 # Work-around for failure to deploy
 # https://stackoverflow.com/questions/69936420/google-cloud-platform-app-deploy-failure-due-to-pyparsing
 pyparsing==2.4.7


### PR DESCRIPTION
In this PR:

- Added a `valid_url` function as an extra guard in `extract_urls_from_value` to filter out invalid URLs if possible.
- On the frontend, preventing 404 errors from showing up for long text fields with `_enhanceLink`.
- Skipped indexing feature_links if parsing encountered errors. This way, invalid links won’t be indexed in the first place.