### PR TITLE
Old metadata editing checks for field name prop

### DIFF
--- a/client-src/elements/chromedash-guide-metadata.js
+++ b/client-src/elements/chromedash-guide-metadata.js
@@ -8,6 +8,7 @@ import {
   formatFeatureForEdit,
   FLAT_ENTERPRISE_METADATA_FIELDS,
   FLAT_METADATA_FIELDS} from './form-definition';
+import {ALL_FIELDS} from './form-field-specs';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {FORM_STYLES} from '../css/forms-css.js';
 
@@ -339,9 +340,10 @@ export class ChromedashGuideMetadata extends LitElement {
     return metadataFields.map((field) => {
       // Add the field to this component's stage before creating the field component.
       const index = this.fieldValues.length;
-      const value = formattedFeature[field];
+      const featureJSONKey = ALL_FIELDS[field].name || field;
+      const value = formattedFeature[featureJSONKey];
       this.fieldValues.push({
-        name: field,
+        name: featureJSONKey,
         touched: false,
         value,
       });


### PR DESCRIPTION
Fixes #3222 

This change ensures that fields on the old metadata edit page will be submitted with proper field names in the server request.