### PR TITLE
Find quoted thread links in LGTM emails.

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -103,12 +103,12 @@ def detect_feature_id(body):
 
 THREAD_LINK_RE = re.compile(
     r'To view this discussion on the web visit\s+'
-    r'(https://groups\.google\.com/a/chromium.org/d/msgid/blink-dev/'
-    r'\S+)[.]')
+    r'(> )?(https://groups\.google\.com/a/chromium.org/d/msgid/blink-dev/'
+    r'\S+)[\n> .]', re.MULTILINE)
 STAGING_THREAD_LINK_RE = re.compile(
     r'To view this discussion on the web visit\s+'
-    r'(https://groups\.google\.com/d/msgid/jrobbins-test/'
-    r'\S+)[.]')
+    r'(> )?(https://groups\.google\.com/d/msgid/jrobbins-test/'
+    r'\S+)[\n> .]', re.MULTILINE)
 
 
 def detect_thread_url(body):
@@ -116,7 +116,7 @@ def detect_thread_url(body):
   match = (THREAD_LINK_RE.search(body) or
            STAGING_THREAD_LINK_RE.search(body))
   if match:
-    return match.group(1)
+    return match.group(2)
   return None
 
 

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -271,6 +271,31 @@ class FunctionTest(testing_config.CustomTestCase):
          '-oNTb%2BZjiJk%2B6RNb9%2Bv05w%40mail.gmail.com'),
         detect_intent.detect_thread_url(footer))
 
+  def test_detect_thread_url__quoted(self):
+    """We can parse a quoted thread archive link from the body footer."""
+    footer = (
+        'On 7/27/23 12:29 PM, USER NAME wrote:'
+        '>'
+        '>  [SNIP]'
+        '> --\n'
+        '> You received this message because you are subscribed to the Google\n'
+        '> Groups "blink-dev" group.\n'
+        '> To unsubscribe from this group and stop receiving emails from it, send\n'
+        '> an email to blink-dev+unsubscribe@chromium.org.\n'
+        '> To view this discussion on the web visit\n'
+        '> https://groups.google.com/a/chromium.org/d/msgid/blink-dev/CAL5BFfULP5d3fNCAqeO2gLP56R3HCytmaNk%2B9kpYsC2dj4%3DqoQ%40mail.gmail.com\n'
+        '> <https://groups.google.com/a/chromium.org/d/msgid/blink-dev/CAL5BFfULP5d3fNCAqeO2gLP56R3HCytmaNk%2B9kpYsC2dj4%3DqoQ%40mail.gmail.com?utm_medium=email&utm_source=foo\\n'
+        'ter>.\n'
+        '\n'
+        '--\n'
+        'You received this message because you are subscribed to the Google Groups "blink-dev" group.\n'
+        'To unsubscribe from this group and stop receiving emails from it, send an email to blink-dev+unsubscribe@chromium.org.\n'
+        'To view this discussion on the web visit https://groups.google.com/a/chromium.org/d/msgid/blink-dev/7c94d7c3-212a-62de-dfa4-76bbd25990c9%40chromium.org.')
+    self.assertEqual(
+        ('https://groups.google.com'
+         '/a/chromium.org/d/msgid/blink-dev/CAL5BFfULP5d3fNCAqeO2gLP56R3HCytmaNk%2B9kpYsC2dj4%3DqoQ%40mail.gmail.com'),
+        detect_intent.detect_thread_url(footer))
+
   def test_detect_thread_url__staging(self):
     """We can parse the staging thread archive link from the body footer."""
     footer = (


### PR DESCRIPTION
This resolves issue #3229.

It is tricky to determine the blink-dev thread that contains a given inbound email because the legacy bundled services library does not give us the `References` email header.  Instead, we look for the Google Groups web view link in the body of the message.

When a user replies to an email, their email client may keep the text of the previous message and quote the whole thing with no modifications within each quoted, or it may quote a word-wrapped version of the previous message with an extra `>` quotation prefix on each line.

This PR makes our regex for finding these links cope with word-wrapped quoted text.