### PR TITLE
Revert "npm: bump @shoelace-style/shoelace from 2.5.2 to 2.6.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@openapitools/openapi-generator-cli": "^2.7.0",
         "@rollup/plugin-babel": "^6.0.3",
         "@rollup/plugin-node-resolve": "^15.1.0",
-        "@shoelace-style/shoelace": "^2.6.0",
+        "@shoelace-style/shoelace": "^2.5.2",
         "@web/test-runner": "^0.16.1",
         "@web/test-runner-playwright": "^0.10.1",
         "acorn": ">=8.10.0",
@@ -2845,9 +2845,9 @@
       "dev": true
     },
     "node_modules/@shoelace-style/shoelace": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.6.0.tgz",
-      "integrity": "sha512-Pa5Ll8GkFHtttES1FuFpkJ5pbUdlCAn86LVlU94pRHzqYNI81wQQzckkXPT+8aHCMSlfcr+t9RhaFY62T4iU+w==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.5.2.tgz",
+      "integrity": "sha512-pUvhI0bUEHzfQOdmj9AsDGspissJWnemhkaxpZCvi1i5MKi1eX73uzmPqziQTLvKUS/e8weSVKLNzqgN8tZDpw==",
       "dev": true,
       "dependencies": {
         "@ctrl/tinycolor": "^3.5.0",
@@ -17068,9 +17068,9 @@
       "dev": true
     },
     "@shoelace-style/shoelace": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.6.0.tgz",
-      "integrity": "sha512-Pa5Ll8GkFHtttES1FuFpkJ5pbUdlCAn86LVlU94pRHzqYNI81wQQzckkXPT+8aHCMSlfcr+t9RhaFY62T4iU+w==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.5.2.tgz",
+      "integrity": "sha512-pUvhI0bUEHzfQOdmj9AsDGspissJWnemhkaxpZCvi1i5MKi1eX73uzmPqziQTLvKUS/e8weSVKLNzqgN8tZDpw==",
       "dev": true,
       "requires": {
         "@ctrl/tinycolor": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@openapitools/openapi-generator-cli": "^2.7.0",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-node-resolve": "^15.1.0",
-    "@shoelace-style/shoelace": "^2.6.0",
+    "@shoelace-style/shoelace": "^2.5.2",
     "@web/test-runner": "^0.16.1",
     "@web/test-runner-playwright": "^0.10.1",
     "acorn": ">=8.10.0",


### PR DESCRIPTION
Reverts GoogleChrome/chromium-dashboard#3225