### PR TITLE
Add an ndb index for /admin/feature_links.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -464,3 +464,10 @@ indexes:
   - name: state
   - name: requested_on
   - name: feature_id
+- kind: FeatureLinks
+  properties:
+  - name: feature_ids
+  - name: http_error_code
+  - name: is_error
+  - name: type
+  - name: url


### PR DESCRIPTION
Apparently fetching data from Google Cloud NDB with a specific projection (a subset of fields) requires that there be an index with those fields.  This is needed for https://github.com/GoogleChrome/chromium-dashboard/blob/main/internals/feature_links.py#L241