### PR TITLE
Cron job to update all feature links

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -26,3 +26,6 @@ cron:
 - description: Removes any users that have been inactive for 9 months.
   url: /cron/remove_inactive_users
   schedule: 1st monday of month 9:00
+- description: Update all feature links that are staled.
+  url: /cron/update_all_feature_links
+  schedule: every tuesday 05:00

--- a/index.yaml
+++ b/index.yaml
@@ -471,3 +471,4 @@ indexes:
   - name: is_error
   - name: type
   - name: url
+  - name: updated

--- a/internals/feature_links.py
+++ b/internals/feature_links.py
@@ -16,7 +16,7 @@
 import logging
 import datetime
 from framework import cloud_tasks_helpers
-from framework import basehandlers
+from framework.basehandlers import FlaskHandler
 from typing import Any
 from urllib.parse import urlparse
 from internals.core_models import FeatureEntry
@@ -26,7 +26,7 @@ from collections import Counter
 from google.cloud import ndb  # type: ignore
 
 LINK_STALE_MINUTES = 30
-
+CRON_JOB_LINK_STALE_DAYS = 8
 
 class FeatureLinks(ndb.Model):
   """Links that occur in the fields of the feature.
@@ -142,12 +142,13 @@ def get_by_feature_id(feature_id: int, update_stale_links: bool) -> tuple[list[d
     feature_link_ids = [link.key.id() for link in stale_feature_links]
     cloud_tasks_helpers.enqueue_task(
         '/tasks/update-feature-links', {
-            'feature_link_ids': feature_link_ids
+            'feature_link_ids': feature_link_ids,
+            'should_notify_on_error': False
         })
   return [link.to_dict(include=['url', 'type', 'information', 'http_error_code']) for link in feature_links], has_stale_links
 
 
-class FeatureLinksUpdateHandler(basehandlers.FlaskHandler):
+class FeatureLinksUpdateHandler(FlaskHandler):
   """This task handles update feature links information with the given ids."""
 
   IS_INTERNAL_HANDLER = True
@@ -158,13 +159,14 @@ class FeatureLinksUpdateHandler(basehandlers.FlaskHandler):
     logging.info('Starting indexing feature links')
 
     feature_link_ids = self.get_param('feature_link_ids')
+    should_notify_on_error = self.get_bool_param('should_notify_on_error', False)
 
-    _index_feature_links_by_ids(feature_link_ids)
+    _index_feature_links_by_ids(feature_link_ids, should_notify_on_error=should_notify_on_error)
     logging.info('Finished indexing feature links')
     return {'message': 'Done'}
 
 
-def _index_feature_links_by_ids(feature_link_ids: list[Any]) -> None:
+def _index_feature_links_by_ids(feature_link_ids: list[Any], should_notify_on_error) -> None:
   """index the links in the given feature links ids"""
   for feature_link_id in feature_link_ids:
     feature_link: FeatureLinks = FeatureLinks.get_by_id(feature_link_id)
@@ -172,17 +174,23 @@ def _index_feature_links_by_ids(feature_link_ids: list[Any]) -> None:
       link = Link(feature_link.url)
       link.parse()
       if link.is_error:
+        if not feature_link.is_error and should_notify_on_error:
+          # TODO: if feature_link turns from no-error to error, notify users
+          pass
+        if link.http_error_code:
+          feature_link.http_error_code = link.http_error_code
         feature_link.is_error = link.is_error
+        logging.info(f'Update indexed link {feature_link_id} {feature_link.url} encountered error')
       else:
-        # only update the information if it is not an error
+        # update the information if it is not an error
         feature_link.information = link.information
+        feature_link.is_error = False
+        feature_link.http_error_code = None
+        logging.info(f'Update indexed link {feature_link_id} {feature_link.url} successfully')
 
-      if link.http_error_code:
-        feature_link.http_error_code = link.http_error_code
       feature_link.type = link.type
       feature_link.put()
 
-    logging.info(f'Update information for indexed link {link.url}')
 
 
 def _extract_feature_urls(fe: FeatureEntry) -> list[str]:
@@ -263,3 +271,62 @@ def get_feature_links_summary():
       "link_types": link_types,
       "uncovered_link_domains": uncovered_link_domains,
   }
+
+class UpdateAllFeatureLinksHandlers(FlaskHandler):
+
+  def get_template_data(self, **kwargs) -> str:
+    """
+    retrieves feature links from a database, identifies which links need to be updated based on certain conditions, 
+    and enqueues tasks to update those links in batches.
+    """
+    
+    self.require_cron_header()
+
+    should_notify_on_error = self.get_bool_arg('should_notify_on_error', True)
+    update_all_links = self.get_bool_arg('update_all_links', False)
+
+    feature_links = FeatureLinks.query().fetch(
+      projection=[
+        FeatureLinks.url,
+        FeatureLinks.type,
+        FeatureLinks.is_error,
+        FeatureLinks.http_error_code,
+        FeatureLinks.updated,
+      ]
+    )
+
+    ids_to_update = []
+
+    if update_all_links:
+      # for backfill purposes
+      ids_to_update = [fe.key.integer_id() for fe in feature_links]
+    else:
+      stale_time = datetime.datetime.now(
+      tz=datetime.timezone.utc) - datetime.timedelta(days=CRON_JOB_LINK_STALE_DAYS)
+      stale_time = stale_time.replace(tzinfo=None)
+      for fe in feature_links:
+        # if stale
+        if fe.updated < stale_time:
+          ids_to_update.append(fe.key.integer_id())
+        # if error exists
+        elif fe.is_error or fe.http_error_code:
+          ids_to_update.append(fe.key.integer_id())
+        # if type changed since last update
+        elif fe.type != Link.get_type(fe.url):
+          ids_to_update.append(fe.key.integer_id())
+
+    BATCH_SIZE = 500
+    batch_update_ids = [ids_to_update[i:i+BATCH_SIZE] for i in range(0, len(ids_to_update), BATCH_SIZE)]
+
+    for batch in batch_update_ids:
+      cloud_tasks_helpers.enqueue_task(
+          '/tasks/update-feature-links',
+          {
+              'feature_link_ids': batch,
+              'should_notify_on_error': should_notify_on_error
+          }
+      )
+
+    msg = f'Started updating {len(ids_to_update)} Feature Links in {len(batch_update_ids)} batches'
+    logging.info(msg)
+    return msg

--- a/internals/feature_links.py
+++ b/internals/feature_links.py
@@ -283,7 +283,7 @@ class UpdateAllFeatureLinksHandlers(FlaskHandler):
     self.require_cron_header()
 
     should_notify_on_error = self.get_bool_arg('should_notify_on_error', True)
-    update_all_links = self.get_bool_arg('update_all_links', False)
+    no_filter = self.get_bool_arg('no_filter', False)
 
     feature_links = FeatureLinks.query().fetch(
       projection=[
@@ -297,7 +297,7 @@ class UpdateAllFeatureLinksHandlers(FlaskHandler):
 
     ids_to_update = []
 
-    if update_all_links:
+    if no_filter:
       # for backfill purposes
       ids_to_update = [fe.key.integer_id() for fe in feature_links]
     else:

--- a/internals/feature_links_test.py
+++ b/internals/feature_links_test.py
@@ -16,9 +16,13 @@
 import testing_config
 from unittest import mock
 from internals.core_models import FeatureEntry
-from internals.feature_links import FeatureLinks, update_feature_links, get_feature_links_summary
+from internals.feature_links import FeatureLinks, update_feature_links, get_feature_links_summary, UpdateAllFeatureLinksHandlers
 from internals.link_helpers import LINK_TYPE_CHROMIUM_BUG, LINK_TYPE_WEB
+from google.cloud import ndb
+from datetime import datetime
+import flask
 
+test_app = flask.Flask(__name__)
 
 class LinkTest(testing_config.CustomTestCase):
 
@@ -54,39 +58,39 @@ class LinkTest(testing_config.CustomTestCase):
 
   def test_get_feature_links_summary(self):
     links = [
-      FeatureLinks(url='https://bugs.chromium.org/p/chromium/issues/detail?id=100000', type=LINK_TYPE_CHROMIUM_BUG),
-      FeatureLinks(url='https://docs.google.com/document/d/xxx', type=LINK_TYPE_WEB),
-      FeatureLinks(url='https://docs.google.com/spreadsheets/d/xxx', type=LINK_TYPE_WEB),
-      FeatureLinks(url='https://www.google.com', type=LINK_TYPE_WEB),
+        FeatureLinks(url='https://bugs.chromium.org/p/chromium/issues/detail?id=100000', type=LINK_TYPE_CHROMIUM_BUG),
+        FeatureLinks(url='https://docs.google.com/document/d/xxx', type=LINK_TYPE_WEB),
+        FeatureLinks(url='https://docs.google.com/spreadsheets/d/xxx', type=LINK_TYPE_WEB),
+        FeatureLinks(url='https://www.google.com', type=LINK_TYPE_WEB),
     ]
     for link in links:
       link.put()
     summary = get_feature_links_summary()
 
     self.assertEqual(
-          summary,
-          {
-              "total_count": 4,
-              "covered_count": 1,
-              "uncovered_count": 3,
-              "link_types": [
-                  {"key": "web", "count": 3},
-                  {"key": "chromium_bug", "count": 1},
-              ],
-              "uncovered_link_domains": [
+        summary,
+        {
+            "total_count": 4,
+            "covered_count": 1,
+            "uncovered_count": 3,
+            "link_types": [
+                {"key": "web", "count": 3},
+                {"key": "chromium_bug", "count": 1},
+            ],
+            "uncovered_link_domains": [
                 {"key": "https://docs.google.com", "count": 2},
                 {"key": "https://www.google.com", "count": 1},
-              ],
-          },
-      )
+            ],
+        },
+    )
 
   def test_feature_changed_add_and_remove_url(self):
     url = "https://bugs.chromium.org/p/chromium/issues/detail?id=100000"
     query = FeatureLinks.query(FeatureLinks.url == url)
 
     changed_fields = [
-      ('bug_url', None, url),
-      ('launch_bug_url', None, url),
+        ('bug_url', None, url),
+        ('launch_bug_url', None, url),
     ]
 
     # add two same links in a feature fields
@@ -108,7 +112,7 @@ class LinkTest(testing_config.CustomTestCase):
 
     # remove launch_bug_url field, the link should be deleted
     changed_fields_remove = [
-      ('launch_bug_url', url, None)]
+        ('launch_bug_url', url, None)]
     self.mock_user_change_fields(changed_fields_remove)
     link = query.get()
     self.assertIsNone(link)
@@ -118,7 +122,7 @@ class LinkTest(testing_config.CustomTestCase):
     url = "https://bugs.chromium.org/p/chromium/issues/detail?id=100000000000"
     query = FeatureLinks.query(FeatureLinks.url == url)
     changed_fields = [
-      ('bug_url', None, url),
+        ('bug_url', None, url),
     ]
 
     # add invalid url to feature
@@ -130,7 +134,7 @@ class LinkTest(testing_config.CustomTestCase):
     url = "https://bugs.chromium.org/p/chromium/issues/detail?id=100000"
     query = FeatureLinks.query(FeatureLinks.url == url)
     changed_fields = [
-      ('bug_url', None, url),
+        ('bug_url', None, url),
     ]
     # add same link to both features
     self.mock_user_change_fields(changed_fields)
@@ -142,8 +146,36 @@ class LinkTest(testing_config.CustomTestCase):
 
     # remove link from one feature
     changed_fields_remove = [
-      ('bug_url', url, None)]
+        ('bug_url', url, None)]
     self.mock_user_change_fields(changed_fields_remove)
     link = query.get()
     self.assertNotIn(self.feature_id, link.feature_ids)
     self.assertIn(self.feature2_id, link.feature_ids)
+
+  def test_update_all_feature_links(self):
+    feature_links = [
+        # not stale feature link
+        FeatureLinks(
+            url='https://docs.google.com/',
+            type=LINK_TYPE_WEB,
+        ),
+        # link type changed
+        FeatureLinks(
+            url='https://bugs.chromium.org/p/chromium/issues/detail?id=100000',
+            type=LINK_TYPE_WEB
+        ),
+        # link with error
+        FeatureLinks(
+            url='https://docs.google.com/document/d/xxx',
+            type=LINK_TYPE_WEB,
+            is_error=True,
+        ),
+    ]
+    ndb.put_multi(feature_links)
+
+    update_all_feature_links = UpdateAllFeatureLinksHandlers()
+    with test_app.test_request_context('/cron/update_all_feature_links', query_string={'should_notify_on_error': False}):
+      result = update_all_feature_links.get_template_data()
+    expected = 'Started updating 2 Feature Links in 1 batches'
+    
+    self.assertEqual(result, expected)

--- a/main.py
+++ b/main.py
@@ -229,6 +229,7 @@ internals_routes: list[Route] = [
   Route('/cron/remove_inactive_users',
       inactive_users.RemoveInactiveUsersHandler),
   Route('/cron/reindex_all', search_fulltext.ReindexAllFeatures),
+  Route('/cron/update_all_feature_links', feature_links.UpdateAllFeatureLinksHandlers),
 
   Route('/admin/find_stop_words', search_fulltext.FindStopWords),
 


### PR DESCRIPTION
In this PR:

- Add `/cron/update_all_feature_links`: a weekly cron job to update feature links
- This cron job filters feature links based on certain conditions:
  1. **stale**: If it is has not been updated for 8 days
  2. **type changed**: If its type has changed. e.g. LINK_TYPE_WEB -> new link type we support later
  3. **has error**: if last time parsing had an error
- Filter links ids are sent to cloud task `/tasks/update-feature-links`, with a maximum of 500 in batches to prevent 600 seconds timeout
- For backfill purpose, when passing query params `no_filter=true`, it will simply update all feature links without any condition check.

So to backfill all feature links with information:
1. Run `/scripts/backfill_feature_links`, this extract and backfill all feature links from FeatureEntry into Google Cloud NDB
2. Run `/cron/update_all_feature_links?no_filter=true`, this update all feature links in Google Cloud NDB with latest information