### PR TITLE
Accuracy verification bug fix

### DIFF
--- a/client-src/elements/utils.js
+++ b/client-src/elements/utils.js
@@ -299,7 +299,7 @@ export function formatFeatureChanges(fieldValues, featureId) {
   const stages = {};
   for (const {name, touched, value, stageId, implicitValue} of fieldValues) {
     // Only submit changes for touched fields or accuracy verification updates.
-    if (!touched && (name !== 'accurate_as_of' || value !== true)) {
+    if (!touched && !(name === 'accurate_as_of' && value === true)) {
       continue;
     }
 

--- a/client-src/elements/utils.js
+++ b/client-src/elements/utils.js
@@ -298,8 +298,8 @@ export function formatFeatureChanges(fieldValues, featureId) {
   // Multiple stages can be mutated, so this object is a stage of stages.
   const stages = {};
   for (const {name, touched, value, stageId, implicitValue} of fieldValues) {
-    // Only submit changes for touched fields.
-    if (!touched) {
+    // Only submit changes for touched fields or accuracy verification updates.
+    if (!touched && (name !== 'accurate_as_of' || value !== true)) {
       continue;
     }
 


### PR DESCRIPTION
This change fixes a bug that caused the `accurate_as_of` date to not update unless the user interacted with the checkbox to confirm accuracy.

Note: this is a quick fix, and #3236 should be implemented in order to more gracefully handle this problem.