### PR TITLE
Catch unparsable link urls.

### DIFF
--- a/internals/feature_links.py
+++ b/internals/feature_links.py
@@ -226,17 +226,22 @@ def batch_index_feature_entries(fes: list[FeatureEntry], skip_existing: bool) ->
   return link_count
 
 
+def get_domain_with_scheme(url):
+  try:
+    parse_result = urlparse(url)
+    scheme = parse_result.scheme
+    host = parse_result.netloc
+  except ValueError as e:
+    return 'Invalid: ' + url[:30]
+  return f"{scheme}://{host}"
+
+
 def get_feature_links_summary():
   """
   The function `get_feature_links_summary` retrieves feature links from a database, groups them by
   type and uncovered domains, and returns a summary of the counts and types of links.
   """
-
   MAX_RESULTS = 100
-
-  def get_domain_with_scheme(url):
-    scheme, host = urlparse(url).scheme, urlparse(url).netloc
-    return f"{scheme}://{host}"
 
   feature_links = FeatureLinks.query().fetch(
       projection=[

--- a/internals/feature_links_test.py
+++ b/internals/feature_links_test.py
@@ -16,7 +16,7 @@
 import testing_config
 from unittest import mock
 from internals.core_models import FeatureEntry
-from internals.feature_links import FeatureLinks, update_feature_links, get_feature_links_summary
+from internals.feature_links import FeatureLinks, update_feature_links, get_domain_with_scheme, get_feature_links_summary
 from internals.link_helpers import LINK_TYPE_CHROMIUM_BUG, LINK_TYPE_WEB
 
 
@@ -51,6 +51,37 @@ class LinkTest(testing_config.CustomTestCase):
     self.feature.put()
 
     update_feature_links(target_feature, changed_fields)
+
+  def test_get_domain_and_scheme__valid(self):
+    self.assertEqual(
+        'https://example.com',
+        get_domain_with_scheme('https://example.com'))
+    self.assertEqual(
+        'https://example.com',
+        get_domain_with_scheme('https://example.com/'))
+    self.assertEqual(
+        'https://example.com',
+        get_domain_with_scheme('https://example.com/something?foo=bar#baz'))
+    self.assertEqual(
+        'https://localhost',
+        get_domain_with_scheme('https://localhost'))
+    self.assertEqual(
+        'https://localhost:8080',
+        get_domain_with_scheme('https://localhost:8080'))
+    self.assertEqual(
+        'https://192.168.0.1',
+        get_domain_with_scheme('https://192.168.0.1/'))
+    self.assertEqual(
+        'https://[2a01:5cc0:1:2::4]',
+        get_domain_with_scheme('https://[2a01:5cc0:1:2::4]/something'))
+
+  def test_get_domain_and_scheme__invalid(self):
+    self.assertEqual(
+        'Invalid: https://[2a01:5cc0:1:2:$::4]/s',
+        get_domain_with_scheme('https://[2a01:5cc0:1:2:$::4]/something'))
+    self.assertEqual(
+        'Invalid: http://[::1.2.3',
+        get_domain_with_scheme('http://[::1.2.3'))
 
   def test_get_feature_links_summary(self):
     links = [


### PR DESCRIPTION
The /admin/feature_links page was failing on a link url value of `http://1:2:` which raises a ValueError in `urlparse()`.

Your recent changes will prevent a 404 link from being created as a FeatureLink entity, so this fix is redundant, but I think it is worth to make the page more robust.