### PR TITLE
Accept http://crbug.com in addition to https.

### DIFF
--- a/client-src/elements/autolink.js
+++ b/client-src/elements/autolink.js
@@ -6,10 +6,6 @@ import {html} from 'lit';
 import {enhanceAutolink} from './feature-link.js';
 const CRBUG_DEFAULT_PROJECT = 'chromium';
 const CRBUG_URL = 'https://bugs.chromium.org';
-const CRBUG_LINK_RE = /(\b(https?:\/\/)?crbug\.com\/)((\b[-a-z0-9]+)(\/))?(\d+)\b(\#c[0-9]+)?/gi;
-const CRBUG_LINK_RE_PROJECT_GROUP = 4;
-const CRBUG_LINK_RE_ID_GROUP = 6;
-const CRBUG_LINK_RE_COMMENT_GROUP = 7;
 const ISSUE_TRACKER_RE = /(\b(issues?|bugs?)[ \t]*(:|=|\b)|\bfixed[ \t]*:)([ \t]*((\b[-a-z0-9]+)[:\#])?(\#?)(\d+)\b(,?[ \t]*(and|or)?)?)+/gi;
 const PROJECT_LOCALID_RE = /((\b(issue|bug)[ \t]*(:|=)?[ \t]*|\bfixed[ \t]*:[ \t]*)?((\b[-a-z0-9]+)[:\#])?(\#?)(\d+))/gi;
 const PROJECT_COMMENT_BUG_RE = /(((\b(issue|bug)[ \t]*(:|=)?[ \t]*)(\#?)(\d+)[ \t*])?((\b((comment)[ \t]*(:|=)?[ \t]*(\#?))|(\B((\#))(c)))(\d+)))/gi;
@@ -38,13 +34,6 @@ Components.set(
   {
     refRegs: [PROJECT_COMMENT_BUG_RE],
     replacer: replaceCommentBugRef,
-  },
-);
-Components.set(
-  '01-tracker-crbug',
-  {
-    refRegs: [CRBUG_LINK_RE],
-    replacer: replaceCrbugIssueRef,
   },
 );
 Components.set(
@@ -78,19 +67,6 @@ Components.set(
 // Replace plain text references with links functions.
 function replaceIssueRef(stringMatch, projectName, localId, commentId) {
   return createIssueRefRun(projectName, localId, stringMatch, commentId);
-}
-
-function replaceCrbugIssueRef(match) {
-  // When crbug links don't specify a project, the default project is Chromium.
-  const projectName =
-    match[CRBUG_LINK_RE_PROJECT_GROUP] || CRBUG_DEFAULT_PROJECT;
-  const localId = match[CRBUG_LINK_RE_ID_GROUP];
-  let commentId = '';
-  if (match[CRBUG_LINK_RE_COMMENT_GROUP] !== undefined) {
-    commentId = match[CRBUG_LINK_RE_COMMENT_GROUP];
-  }
-  return [replaceIssueRef(match[0], projectName, localId,
-    commentId)];
 }
 
 function replaceTrackerIssueRef(match, currentProjectName=CRBUG_DEFAULT_PROJECT) {

--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -37,11 +37,11 @@ LINK_TYPE_WEB = 'web'
 LINK_TYPES_REGEX = {
     # https://bugs.chromium.org/p/chromium/issues/detail?id=
     # https://crbug.com/
-    LINK_TYPE_CHROMIUM_BUG: re.compile(r'https://bugs\.chromium\.org/p/chromium/issues/detail\?.*|https://crbug\.com/\d+'),
+    LINK_TYPE_CHROMIUM_BUG: re.compile(r'https?://bugs\.chromium\.org/p/chromium/issues/detail\?.*|https?://crbug\.com/\d+'),
     # https://github.com/GoogleChrome/chromium-dashboard/issues/999
-    LINK_TYPE_GITHUB_ISSUE: re.compile(r'https://(www\.)?github\.com/.*issues/\d+'),
+    LINK_TYPE_GITHUB_ISSUE: re.compile(r'https?://(www\.)?github\.com/.*issues/\d+'),
     # https://github.com/w3c/reporting/blob/master/EXPLAINER.md
-    LINK_TYPE_GITHUB_MARKDOWN: re.compile(r'https://(www\.)?github\.com/.*\.md.*'),
+    LINK_TYPE_GITHUB_MARKDOWN: re.compile(r'https?://(www\.)?github\.com/.*\.md.*'),
     LINK_TYPE_WEB: re.compile(r'https?://.*'),
 }
 


### PR DESCRIPTION
Sometimes users don't bother to type the `s` in a link that should have `https` scheme.  Or, some old feature entries might have had links that used `http` before `https` became so universally used.

In this PR:
* Remove the special handling of https://crbug.com links in the old autolinker code.  That was simplified from monorail code that had more logic to provide hover text and cross-outs for closed issues.  That is superseded by the new feature_links functionality.  Using a canonical URL for issues makes that URL !== to the URL that the server used.
* Change the feature_link regexes to make the `s` in `https` optional. 