### PR TITLE
Work around threading error with Google Cloud Logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,11 +57,11 @@ import settings
 
 # Sets up Cloud Logging client library.
 # TODO(jrobbins): Re-enable Google Cloud Logging when #3197 is resolved.
-# if not settings.UNIT_TEST_MODE and not settings.DEV_MODE:
-#   import google.cloud.logging
-#   client = google.cloud.logging.Client()
-#   client.get_default_handler()
-#   client.setup_logging()
+if True: #not settings.UNIT_TEST_MODE and not settings.DEV_MODE:
+  import google.cloud.logging
+  client = google.cloud.logging.Client()
+  client.get_default_handler()
+  client.setup_logging()
 
 
 # Note: In the URLs below, parameters like <int:feature_id> are

--- a/main.py
+++ b/main.py
@@ -56,11 +56,9 @@ from pages import users
 import settings
 
 # Sets up Cloud Logging client library.
-# TODO(jrobbins): Re-enable Google Cloud Logging when #3197 is resolved.
-if True: #not settings.UNIT_TEST_MODE and not settings.DEV_MODE:
+if settings.UNIT_TEST_MODE and not settings.DEV_MODE:
   import google.cloud.logging
   client = google.cloud.logging.Client()
-  client.get_default_handler()
   client.setup_logging()
 
 


### PR DESCRIPTION
This resolves #3197.

For reasons still unknown, Google Cloud Logging under python 3.11 seems to cause errors when each instance shuts down.  It looks like it is somehow trying to kill its background worker thread twice, causing a KeyError in the standard python library threading.py.  I tested same versions of Google Cloud Logging that previously worked under 3.10 and it had the same error in 3.11, so the problem only arises with a combination of python 3.11 and GCL and our app.

In this PR:
* Patch Thread._delete to make it catch the KeyError.
* Remove an unneeded call to get_default_logger() 

This change is live on staging now and it seems to get us back to the point where we had things working in python 3.10.  Log lines are grouped by requests, Error Report entries have a full stack thread, but there is the ongoing low-priority problem of some log lines exceeding a maximum size.