### PR TITLE
Use GateDef for privacy and security.

### DIFF
--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -109,7 +109,7 @@ class GetApproversTest(testing_config.CustomTestCase):
               MOCK_APPROVALS_BY_ID)
   @mock.patch('internals.approval_defs.fetch_owners')
   def test__ndb_new(self, mock_fetch_owner):
-    """Some approvals will have appovers in NDB, but they are not found."""
+    """Some approvals will have approvers in NDB, but they are not found."""
     actual = approval_defs.get_approvers(3)
     mock_fetch_owner.assert_not_called()
     self.assertEqual(actual, [])

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -122,7 +122,7 @@ class GetApproversTest(testing_config.CustomTestCase):
               MOCK_APPROVALS_BY_ID)
   @mock.patch('internals.approval_defs.fetch_owners')
   def test__ndb_existing(self, mock_fetch_owner):
-    """Some approvals will have appovers in NDB, use it if found."""
+    """Some approvals will have approvers in NDB, use it if found."""
     gate_def_3 = GateDef(gate_type=3, approvers=['a', 'b'])
     gate_def_3.put()
     actual = approval_defs.get_approvers(3)

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -67,7 +67,7 @@ class GateDef(ndb.Model):
   slo_initial_response = ndb.IntegerProperty()
 
   @classmethod
-  def get_gate_def(cls, gate_type: int) -> GateDef | None:
+  def get_gate_def(cls, gate_type: int) -> GateDef:
     """Load an existing GateDef and or create a new one."""
     query: ndb.Query = GateDef.query(GateDef.gate_type == gate_type)
     gate_defs = query.fetch(1)

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -22,7 +22,6 @@ import logging
 from typing import Optional
 from google.cloud import ndb  # type: ignore
 
-
 class OwnersFile(ndb.Model):
   """Describes the properties to store raw API_OWNERS content."""
   url = ndb.StringProperty(required=True)
@@ -53,6 +52,33 @@ class OwnersFile(ndb.Model):
       return None
 
     return owners_file.raw_content
+
+
+class GateDef(ndb.Model):
+  """Configuration for a review gate."""
+  gate_type = ndb.IntegerProperty(required=True)
+  approvers = ndb.StringProperty(repeated=True)
+
+  # TODO(jrobbins): Use these and phase out approval_devs.ApprovalFieldDef.
+  name = ndb.StringProperty()
+  description = ndb.StringProperty()
+  rule = ndb.StringProperty()
+  team_name = ndb.StringProperty()
+  slo_initial_response = ndb.IntegerProperty()
+
+  @classmethod
+  def get_gate_def(cls, gate_type: int) -> GateDef | None:
+    """Load an existing GateDef and or create a new one."""
+    query: ndb.Query = GateDef.query(GateDef.gate_type == gate_type)
+    gate_defs = query.fetch(1)
+    if gate_defs:
+      gate_def = gate_defs[0]
+    else:
+      logging.info(f'Creating empty GateDef for {gate_type}')
+      gate_def = GateDef(gate_type=gate_type)
+      gate_def.put()
+
+    return gate_def
 
 
 class Vote(ndb.Model):


### PR DESCRIPTION
Instead of listing configured approver emails in our source code, we now have an option to to store these in NDB.

In this PR:
* When looking up approvers for a gate type, check for special value IN_NDB.
* Implement GateDef entity with a list of approvers and placeholders for fields to be moved there in the future.
* Implement get_gate_def() to find the needed GateDef or create a blank entity for an admin to fill in via cloud console.