### PR TITLE
Fix display of INTERNAL_REVIEW gates on reviewer dashboard.

### DIFF
--- a/client-src/elements/chromedash-feature-row.js
+++ b/client-src/elements/chromedash-feature-row.js
@@ -4,6 +4,7 @@ import {
   GATE_TEAM_ORDER,
   STAGE_SHORT_NAMES,
 } from './form-field-enums';
+import {ACTIVE_REVIEW_STATES} from './chromedash-gate-column';
 
 
 class ChromedashFeatureRow extends LitElement {
@@ -147,7 +148,7 @@ class ChromedashFeatureRow extends LitElement {
   }
 
   isActiveGate(gate) {
-    return gate.state == 2 || gate.state == 3 || gate.state == 4;
+    return ACTIVE_REVIEW_STATES.includes(gate.state);
   }
 
   getActiveStages(feature) {


### PR DESCRIPTION
A while back, to prepare for the privacy and security reviews, we added a new enum INTERNAL_REVIEW for votes and gate states.   That was not being considered an active gate state in the logic that decides what gate chips to show on the rows of the feature table on the "My features" pending reviews box.

In this PR:
* Actually use the set of active review state enums that was previously defined.