### PR TITLE
Add index for FeatureLinks cron

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -472,3 +472,10 @@ indexes:
   - name: type
   - name: url
   - name: updated
+- kind: FeatureLinks
+  properties:
+  - name: http_error_code
+  - name: is_error
+  - name: type
+  - name: updated
+  - name: url


### PR DESCRIPTION
Pingren updated an existing index on FeatureLinks to add a field needed in a new query, but ndb requires an exact match and the existing index has a field that is not in the new query.  So, ndb generated an error message that requests this additional index.

Pingren's PR: https://github.com/GoogleChrome/chromium-dashboard/pull/3235/files