### PR TITLE
Show stats about feature link with errors

### DIFF
--- a/client-src/elements/chromedash-admin-feature-links-page.js
+++ b/client-src/elements/chromedash-admin-feature-links-page.js
@@ -51,10 +51,12 @@ export class ChromedashAdminFeatureLinksPage extends LitElement {
   renderComponents() {
     return html`
     <div class="feature-links-summary">
-      <sl-details summary="Links Summary" open>
-        <div class="line">Total Links <b>${this.featureLinkSummary.total_count}</b></div>
+      <sl-details summary="Link Summary" open>
+        <div class="line">All Links <b>${this.featureLinkSummary.total_count}</b></div>
         <div class="line">Covered Links <b>${this.featureLinkSummary.covered_count}</b></div>
-        <div class="line">Uncovered (aka web) Links <b>${this.featureLinkSummary.uncovered_count}</b></div>
+        <div class="line">Uncovered (aka "web") Links <b>${this.featureLinkSummary.uncovered_count}</b></div>
+        <div class="line">All Error Links<b>${this.featureLinkSummary.error_count}</b></div>
+        <div class="line">HTTP Error Links<b>${this.featureLinkSummary.http_error_count}</b></div>
       </sl-details>
       <sl-details summary="Link Types" open>
         ${this.featureLinkSummary.link_types.map((linkType) => html`
@@ -66,6 +68,11 @@ export class ChromedashAdminFeatureLinksPage extends LitElement {
           <div class="line"><a href=${domain.key}>${domain.key}</a> <b>${domain.count}</b></div>
         `)}
       </sl-details>
+      <sl-details summary="Error Link Domains" open>
+      ${this.featureLinkSummary.error_link_domains.map((domain) => html`
+        <div class="line"><a href=${domain.key}>${domain.key}</a> <b>${domain.count}</b></div>
+      `)}
+    </sl-details>
     </div>
     `;
   }

--- a/internals/feature_links.py
+++ b/internals/feature_links.py
@@ -264,19 +264,26 @@ def get_feature_links_summary():
   )
   links = [item.to_dict() for item in feature_links]
   uncovered_links = [link for link in links if link['type'] == 'web']
+  error_links = [link for link in links if link['is_error']]
+  http_error_links = [link for link in links if link['http_error_code']]
 
   link_types_counter = Counter(item['type'] for item in links)
   uncovered_link_domains_counter = Counter(get_domain_with_scheme(item['url']) for item in uncovered_links)
+  error_link_domains_counter = Counter(get_domain_with_scheme(item['url']) for item in error_links)
 
   link_types = [{'key': k, 'count': c} for (k, c) in link_types_counter.most_common(MAX_RESULTS)]
   uncovered_link_domains = [{'key': k, 'count': c} for (k, c) in uncovered_link_domains_counter.most_common(MAX_RESULTS)]
+  error_link_domains = [{'key': k, 'count': c} for (k, c) in error_link_domains_counter.most_common(MAX_RESULTS)]
 
   return {
       "total_count": len(links),
       "covered_count": len(links) - len(uncovered_links),
       "uncovered_count": len(uncovered_links),
+      "error_count": len(error_links),
+      "http_error_count": len(http_error_links),
       "link_types": link_types,
       "uncovered_link_domains": uncovered_link_domains,
+      "error_link_domains": error_link_domains
   }
 
 

--- a/internals/feature_links_test.py
+++ b/internals/feature_links_test.py
@@ -104,6 +104,8 @@ class LinkTest(testing_config.CustomTestCase):
             "total_count": 4,
             "covered_count": 1,
             "uncovered_count": 3,
+            "error_count": 0,
+            "http_error_count": 0,
             "link_types": [
                 {"key": "web", "count": 3},
                 {"key": "chromium_bug", "count": 1},
@@ -112,6 +114,7 @@ class LinkTest(testing_config.CustomTestCase):
                 {"key": "https://docs.google.com", "count": 2},
                 {"key": "https://www.google.com", "count": 1},
             ],
+            "error_link_domains": []
         },
     )
 


### PR DESCRIPTION
This PR adds stats about feature links with parsing/fetching errors. It helps us to get bettering understanding of current feature links status and identify potential bugs /corner cases not covered in our parsing functions in the future.

For example, [this chromium bug url](https://bugs.chromium.org/p/chromium/issues/detail?id=1453803) fails because we don't use authorized monorail client

<img width="873" alt="截屏2023-08-12 17 01 34" src="https://github.com/GoogleChrome/chromium-dashboard/assets/5123601/21c16ae2-f560-45ae-afb1-2b490b697e69">
