### PR TITLE
Use feature links in demo, documentation and specification

### DIFF
--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -383,7 +383,7 @@ export class ChromedashFeaturePage extends LitElement {
           <h3>Demos and samples</h3>
           <ul>
             ${this.feature.resources.samples.map((sampleLink) => html`
-              <li><a href="${sampleLink}">${sampleLink}</a></li>
+              <li>${enhanceUrl(sampleLink, this.featureLinks)}</li>
             `)}
           </ul>
         </section>
@@ -394,7 +394,7 @@ export class ChromedashFeaturePage extends LitElement {
           <h3>Documentation</h3>
           <ul>
             ${this.feature.resources.docs.map((docLink) => html`
-              <li><a href="${docLink}">${docLink}</a></li>
+              <li>${enhanceUrl(docLink, this.featureLinks)}</li>
             `)}
           </ul>
         </section>
@@ -403,9 +403,7 @@ export class ChromedashFeaturePage extends LitElement {
       ${this.feature.standards.spec ? html`
         <section id="specification">
           <h3>Specification</h3>
-          <p><a href=${this.feature.standards.spec} target="_blank" rel="noopener">
-            Specification link
-          </a></p>
+          <p>${enhanceUrl(this.feature.standards.spec, this.featureLinks)}</p>
           <br>
           <p>
             <label>Status:</label>


### PR DESCRIPTION
Before:
<img width="623" alt="截屏2023-08-12 18 04 32" src="https://github.com/GoogleChrome/chromium-dashboard/assets/5123601/27a273c7-c8e0-4b5c-91b9-e982e7652580">

After:
<img width="474" alt="截屏2023-08-12 18 03 51" src="https://github.com/GoogleChrome/chromium-dashboard/assets/5123601/885b5f92-7609-46f9-a54b-6bf4723c15d8">
