### PR TITLE
Support more link types

### DIFF
--- a/client-src/elements/feature-link.js
+++ b/client-src/elements/feature-link.js
@@ -4,6 +4,7 @@ const LINK_TYPE_CHROMIUM_BUG = 'chromium_bug';
 const LINK_TYPE_GITHUB_ISSUE = 'github_issue';
 const LINK_TYPE_GITHUB_PULL_REQUEST = 'github_pull_request';
 const LINK_TYPE_GITHUB_MARKDOWN = 'github_markdown';
+const LINK_TYPE_MDN_DOCS = 'mdn_docs';
 
 function _formatLongText(text, maxLength = 50) {
   if (text.length > maxLength) {
@@ -213,6 +214,43 @@ function enhanceGithubMarkdownLink(featureLink, text) {
   </a>`;
 }
 
+function enhanceMDNDocsLink(featureLink, text) {
+  const information = featureLink.information;
+  const title = information.title;
+  const description = information.description;
+
+
+  if (!text) {
+    text = title;
+  }
+
+  function renderTooltipContent() {
+    return html`<div class="feature-link-tooltip">
+    ${title && html`
+    <div>
+      <strong>Title:</strong>
+      <span>${title}</span>
+    </div>
+  `}
+    ${description && html`
+      <div>
+        <strong>Description:</strong>
+        <span>${description}</span>
+      </div>
+    `}
+    </div>`;
+  }
+  return html`<a class="feature-link" href="${featureLink.url}" target="_blank" rel="noopener noreferrer">
+    <sl-tooltip style="--sl-tooltip-arrow-size: 0;--max-width: 50vw;">
+        <div slot="content">${renderTooltipContent()}</div>
+        <sl-tag>
+          <img src="https://developer.mozilla.org/favicon-48x48.png" alt="icon" class="icon" />
+          ${_formatLongText(title)}
+        </sl-tag>
+    </sl-tooltip>
+  </a>`;
+}
+
 function _enhanceLink(featureLink, fallback, text, ignoreHttpErrorCodes = []) {
   if (!fallback) {
     throw new Error('fallback html is required');
@@ -245,11 +283,13 @@ function _enhanceLink(featureLink, fallback, text, ignoreHttpErrorCodes = []) {
       case LINK_TYPE_GITHUB_ISSUE:
         return enhanceGithubIssueLink(featureLink);
       case LINK_TYPE_GITHUB_PULL_REQUEST:
-        // we use github issue api to get pull request information, 
+        // we use github issue api to get pull request information,
         // the result will be the similar to github issue
         return enhanceGithubIssueLink(featureLink);
       case LINK_TYPE_GITHUB_MARKDOWN:
         return enhanceGithubMarkdownLink(featureLink);
+      case LINK_TYPE_MDN_DOCS:
+        return enhanceMDNDocsLink(featureLink);
       default:
         return fallback;
     }

--- a/client-src/elements/feature-link.js
+++ b/client-src/elements/feature-link.js
@@ -2,6 +2,7 @@ import {html} from 'lit';
 // LINK_TYPES should be consistent with the server link_helpers.py
 const LINK_TYPE_CHROMIUM_BUG = 'chromium_bug';
 const LINK_TYPE_GITHUB_ISSUE = 'github_issue';
+const LINK_TYPE_GITHUB_PULL_REQUEST = 'github_pull_request';
 const LINK_TYPE_GITHUB_MARKDOWN = 'github_markdown';
 
 function _formatLongText(text, maxLength = 50) {
@@ -97,6 +98,10 @@ function enhanceGithubIssueLink(featureLink, text) {
   const title = information.title;
   const owner = information.user_login;
   const number = information.number;
+  const repo = information.url.split('/').slice(4, 6).join('/');
+  const typePath = featureLink.url.split('/').slice(-2)[0];
+  const type = typePath === 'issues' ? 'Issue' : typePath === 'pull' ? 'Pull Request' : typePath;
+
   if (!text) {
     text = title;
   }
@@ -107,6 +112,18 @@ function enhanceGithubIssueLink(featureLink, text) {
     <div>
       <strong>Title:</strong>
       <span>${title}</span>
+    </div>
+  `}
+    ${repo && html`
+      <div>
+        <strong>Repo:</strong>
+        <span>${repo}</span>
+      </div>
+    `}
+    ${type && html`
+    <div>
+      <strong>Type:</strong>
+      <span>${type}</span>
     </div>
   `}
     ${createdAt && html`
@@ -226,6 +243,10 @@ function _enhanceLink(featureLink, fallback, text, ignoreHttpErrorCodes = []) {
       case LINK_TYPE_CHROMIUM_BUG:
         return enhanceChromeStatusLink(featureLink);
       case LINK_TYPE_GITHUB_ISSUE:
+        return enhanceGithubIssueLink(featureLink);
+      case LINK_TYPE_GITHUB_PULL_REQUEST:
+        // we use github issue api to get pull request information, 
+        // the result will be the similar to github issue
         return enhanceGithubIssueLink(featureLink);
       case LINK_TYPE_GITHUB_MARKDOWN:
         return enhanceGithubMarkdownLink(featureLink);

--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -33,6 +33,7 @@ github_api_client = None
 LINK_TYPE_CHROMIUM_BUG = 'chromium_bug'
 LINK_TYPE_GITHUB_ISSUE = 'github_issue'
 LINK_TYPE_GITHUB_MARKDOWN = 'github_markdown'
+LINK_TYPE_GITHUB_PULL_REQUEST = 'github_pull_request'
 LINK_TYPE_WEB = 'web'
 LINK_TYPES_REGEX = {
     # https://bugs.chromium.org/p/chromium/issues/detail?id=
@@ -40,6 +41,8 @@ LINK_TYPES_REGEX = {
     LINK_TYPE_CHROMIUM_BUG: re.compile(r'https?://bugs\.chromium\.org/p/chromium/issues/detail\?.*|https?://crbug\.com/\d+'),
     # https://github.com/GoogleChrome/chromium-dashboard/issues/999
     LINK_TYPE_GITHUB_ISSUE: re.compile(r'https?://(www\.)?github\.com/.*issues/\d+'),
+    # https://github.com/GoogleChrome/chromium-dashboard/pull/3044
+    LINK_TYPE_GITHUB_PULL_REQUEST: re.compile(r'https?://(www\.)?github\.com/.*pull/\d+'),
     # https://github.com/w3c/reporting/blob/master/EXPLAINER.md
     LINK_TYPE_GITHUB_MARKDOWN: re.compile(r'https?://(www\.)?github\.com/.*\.md.*'),
     LINK_TYPE_WEB: re.compile(r'https?://.*'),
@@ -261,6 +264,10 @@ class Link():
       if self.type == LINK_TYPE_CHROMIUM_BUG:
         self.information = self._parse_chromium_bug()
       elif self.type == LINK_TYPE_GITHUB_ISSUE:
+        self.information = self._parse_github_issue()
+      elif self.type == LINK_TYPE_GITHUB_PULL_REQUEST:
+        # we can also use github issue api to get pull request information
+        # pull request api can get more information but we don't need it for now
         self.information = self._parse_github_issue()
       elif self.type == LINK_TYPE_GITHUB_MARKDOWN:
         self.information = self._parse_github_markdown()

--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -34,6 +34,7 @@ LINK_TYPE_CHROMIUM_BUG = 'chromium_bug'
 LINK_TYPE_GITHUB_ISSUE = 'github_issue'
 LINK_TYPE_GITHUB_MARKDOWN = 'github_markdown'
 LINK_TYPE_GITHUB_PULL_REQUEST = 'github_pull_request'
+LINK_TYPE_MDN_DOCS = 'mdn_docs'
 LINK_TYPE_WEB = 'web'
 LINK_TYPES_REGEX = {
     # https://bugs.chromium.org/p/chromium/issues/detail?id=
@@ -45,16 +46,20 @@ LINK_TYPES_REGEX = {
     LINK_TYPE_GITHUB_PULL_REQUEST: re.compile(r'https?://(www\.)?github\.com/.*pull/\d+'),
     # https://github.com/w3c/reporting/blob/master/EXPLAINER.md
     LINK_TYPE_GITHUB_MARKDOWN: re.compile(r'https?://(www\.)?github\.com/.*\.md.*'),
+    # https://developer.mozilla.org/en-US/docs/Web/API/DOMException
+    LINK_TYPE_MDN_DOCS: re.compile(r'https?://(www\.)?developer\.mozilla\.org/.*'),
     LINK_TYPE_WEB: re.compile(r'https?://.*'),
 }
 
 URL_REGEX = re.compile(r'(https?://\S+)')
 
+
 def valid_url(url):
-    try:
-        return validators.url(url, public=True)
-    except:
-        return False
+  try:
+    return validators.url(url, public=True)
+  except:
+    return False
+
 
 def get_github_api_client():
   """Set up the GitHub client."""
@@ -107,8 +112,8 @@ class Link():
     logging.info(f'Constructed Link for {url} with type {self.type}')
 
   def _fetch_github_file(
-      self, owner: str, repo: str, ref: str, file_path: str,
-      retries=1):
+          self, owner: str, repo: str, ref: str, file_path: str,
+          retries=1):
     """Get a file from GitHub."""
     client = get_github_api_client()
     try:
@@ -124,7 +129,7 @@ class Link():
 
     try:
       information = client.repos.get_content(
-        owner=owner, repo=repo, path=file_path, ref=ref)
+          owner=owner, repo=repo, path=file_path, ref=ref)
       return information
     except HTTPError as e:
       logging.info(f'Got http response code {e.code}')
@@ -155,8 +160,8 @@ class Link():
     return information
 
   def _fetch_github_issue(
-      self, owner: str, repo: str, issue_id: int,
-      retries=1) -> dict[str, Any]:
+          self, owner: str, repo: str, issue_id: int,
+          retries=1) -> dict[str, Any]:
     """Get an issue from GitHub."""
     try:
       client = get_github_api_client()
@@ -194,7 +199,7 @@ class Link():
         'created_at': resp.get('created_at'),
         'updated_at': resp.get('updated_at'),
         'closed_at': resp.get('closed_at'),
-        }
+    }
 
     return information
 
@@ -242,6 +247,18 @@ class Link():
 
     return information.get('issue', None)
 
+  def _parse_html_head(self):
+    html_str = requests.get(self.url).text
+    title = re.search(r'<title>(.*?)</title>', html_str)
+    title_og = re.search(r'<meta property="og:title" content="(.*?)"', html_str)
+    description = re.search(r'<meta name="description" content="(.*?)"', html_str)
+    description_og = re.search(r'<meta property="og:description" content="(.*?)"', html_str)
+
+    return {
+        'title': title.group(1) if title else (title_og.group(1) if title_og else None),
+        'description': description.group(1) if description else (description_og.group(1) if description_og else None),
+    }
+
   def _validate_url(self) -> bool:
     """The `_validate_url` method is used to validate the URL associated with the Link object. It
     sends a GET request to the URL and checks the response status code. If the status code is not
@@ -271,6 +288,8 @@ class Link():
         self.information = self._parse_github_issue()
       elif self.type == LINK_TYPE_GITHUB_MARKDOWN:
         self.information = self._parse_github_markdown()
+      elif self.type == LINK_TYPE_MDN_DOCS:
+        self.information = self._parse_html_head()
       elif self.type == LINK_TYPE_WEB:
         self.information = None
     except Exception as e:

--- a/internals/link_helpers_test.py
+++ b/internals/link_helpers_test.py
@@ -21,12 +21,22 @@ from internals.link_helpers import (
     LINK_TYPE_GITHUB_ISSUE,
     LINK_TYPE_GITHUB_MARKDOWN,
     LINK_TYPE_WEB,
+    LINK_TYPE_MDN_DOCS,
     valid_url
 )
 
 
 class LinkHelperTest(testing_config.CustomTestCase):
 
+  def test_mdn_docs_url(self):
+    link = Link("https://developer.mozilla.org/en-US/docs/Web/HTML")
+    link.parse()
+    self.assertEqual(link.type, LINK_TYPE_MDN_DOCS)
+    self.assertEqual(link.url, "https://developer.mozilla.org/en-US/docs/Web/HTML")
+    self.assertTrue(link.is_parsed)
+    self.assertFalse(link.is_error)
+    self.assertIsNotNone(link.information.get('title'))
+    self.assertIsNotNone(link.information.get('description'))
 
   def test_valid_url(self):
       invalid_urls = [


### PR DESCRIPTION
In this PR:

- Adding support for `GITHUB_PULL_REQUEST` link type
- Update tooltip content for `GITHUB_PULL_REQUEST` and `GITHUB_ISSUE`, show repo name and its type
- Adding support for `MDN_DOCS` type, and extract its information from HTML head tags

<img width="448" alt="截屏2023-08-12 18 45 19" src="https://github.com/GoogleChrome/chromium-dashboard/assets/5123601/9c978e76-84b1-41f2-9eb6-e43bbafd6b27">
<img width="466" alt="截屏2023-08-12 18 45 28" src="https://github.com/GoogleChrome/chromium-dashboard/assets/5123601/5a9ea4f7-18f9-4844-962e-10453be495d4">
<img width="887" alt="截屏2023-08-12 19 23 17" src="https://github.com/GoogleChrome/chromium-dashboard/assets/5123601/2dcd0881-cacb-410d-be7f-898162907799">
