### PR TITLE
Fix go-link for running-an-origin-trial.

### DIFF
--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -1052,7 +1052,8 @@ export const ALL_FIELDS = {
     initial: false,
     label: 'Critical origin trial',
     help_text: html`
-      See <a href="go/running-an-origin-trial">go/running-an-origin-trial</a>
+      See <a href="https://goto.google.com/running-an-origin-trial"
+      >go/running-an-origin-trial</a>
       for criteria and additional process requirements.`,
   },
 


### PR DESCRIPTION
This should resolve #3267 .

The syntax for the link was wrong: Since it lacked a scheme, the word "go" was treated as a relative URL on our site rather than the intend link to a separate site.

There is still the problem that the destination doc is private, but at least not the link can be clicked by googlers.