### PR TITLE
Change gate chip N/A color to green and INT to blue.

### DIFF
--- a/client-src/elements/chromedash-gate-chip.js
+++ b/client-src/elements/chromedash-gate-chip.js
@@ -4,7 +4,7 @@ import {SHARED_STYLES} from '../css/shared-css.js';
 
 const GATE_STATE_TO_NAME = {
   0: 'Preparing', // PREPARING
-  1: 'FYI', //  NA
+  1: 'Not applicable', //  NA
   2: 'Pending', // REVIEW_REQUESTED
   3: 'Pending', // REVIEW_STARTED
   4: 'Needs work', // NEEDS_WORK
@@ -80,11 +80,11 @@ class ChromedashGateChip extends LitElement {
        text-decoration: underline;
      }
 
-     sl-button.fyi::part(base) {
-       background: var(--gate-fyi-background);
-       color: var(--gate-fyi-color);
+     sl-button.not_applicable::part(base) {
+       background: var(--gate-not-applicable-background);
+       color: var(--gate-not-applicable-color);
      }
-     sl-button.fyi::part(prefix) {
+     sl-button.not_applicable::part(prefix) {
        align-items: baseline;
      }
 
@@ -129,8 +129,8 @@ class ChromedashGateChip extends LitElement {
      }
 
      sl-button.internal_review::part(base) {
-       background: var(--gate-fyi-background);
-       color: var(--gate-fyi-color);
+       background: var(--gate-pending-background);
+       color: var(--gate-pending-color);
      }
      sl-button.internal_review::part(prefix) {
        align-items: baseline;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -379,9 +379,9 @@ sl-skeleton {
   --toast-color: var(--md-gray-50);
   --toast-action-color: var(--md-orange-200);
   --chip-border: none;
-  --gate-fyi-background: var(--md-gray-100);
-  --gate-fyi-color: var(--md-gray-800);
-  --gate-fyi-icon-color: var(--md-gray-800);
+  --gate-not-applicable-background: var(--md-green-50);
+  --gate-not-applicable-color: var(--md-green-700);
+  --gate-not-applicable-icon-color: var(--md-green-600);
   --gate-preparing-background: var(--md-gray-100);
   --gate-preparing-color: var(--md-gray-800);
   --gate-preparing-icon-color: var(--md-gray-800);
@@ -396,7 +396,7 @@ sl-skeleton {
   --gate-approved-icon-color: var(--md-green-600);
   --gate-denied-background: var(--md-red-50);
   --gate-denied-color: var(--md-red-700);
-  --gate-denided-icon-color: var(--md-red-600);
+  --gate-denied-icon-color: var(--md-red-600);
   --gate-complete-background: var(--gate-approved-background);
   --gate-complete-color: var(--gate-approved-color);
   --gate-complete-icon-color: var(--gate-approved-icon-color);


### PR DESCRIPTION
When we asked the API Owners to review the state of preceding gate when they do their review, they pointed out that a preceding gate that is marked "N/A" should be green to indicate that that gate has been satisfied.  Also, that made me realize that the "internal review" state should be blue like the other "pending" states to show that a review is still in progress.  And, we are not using the term "FYI" for "N/A".

In this PR:
* Change tooltip text and CSS class name from "FYI" to "Not applicable".
* Change color of not_applicable gates to green
* Change color of internal_review gates to blue
* Fix typo in the color of the denied icon