### PR TITLE
Click to show feature link samples in admin page

### DIFF
--- a/api/feature_links_api.py
+++ b/api/feature_links_api.py
@@ -16,7 +16,7 @@
 from framework import basehandlers
 from internals.core_enums import *
 from internals.core_models import FeatureEntry
-from internals.feature_links import get_feature_links_summary, get_by_feature_id
+from internals.feature_links import get_feature_links_summary, get_by_feature_id, get_feature_links_samples
 from framework import permissions
 
 class FeatureLinksAPI(basehandlers.APIHandler):
@@ -44,8 +44,19 @@ class FeatureLinksAPI(basehandlers.APIHandler):
 
 
 class FeatureLinksSummaryAPI(basehandlers.APIHandler):
-  """FeatureLinksSummaryAPI will return all links to the client."""
+  """FeatureLinksSummaryAPI will return summary of links to the client. """
 
   @permissions.require_admin_site
   def do_get(self, **kwargs):
     return get_feature_links_summary()
+
+class FeatureLinksSamplesAPI(basehandlers.APIHandler):
+  """FeatureLinksSamplesAPI will return sample links to the client. """
+
+  @permissions.require_admin_site
+  def do_get(self, **kwargs):
+    domain = self.request.args.get('domain', None)
+    type = self.request.args.get('type', None)
+    is_error = self.get_bool_arg('is_error', None)
+    if domain:
+      return get_feature_links_samples(domain, type, is_error)

--- a/api/feature_links_api.py
+++ b/api/feature_links_api.py
@@ -44,14 +44,14 @@ class FeatureLinksAPI(basehandlers.APIHandler):
 
 
 class FeatureLinksSummaryAPI(basehandlers.APIHandler):
-  """FeatureLinksSummaryAPI will return summary of links to the client. """
+  """FeatureLinksSummaryAPI will return summary of links to the client."""
 
   @permissions.require_admin_site
   def do_get(self, **kwargs):
     return get_feature_links_summary()
 
 class FeatureLinksSamplesAPI(basehandlers.APIHandler):
-  """FeatureLinksSamplesAPI will return sample links to the client. """
+  """FeatureLinksSamplesAPI will return sample links to the client."""
 
   @permissions.require_admin_site
   def do_get(self, **kwargs):

--- a/client-src/elements/chromedash-admin-feature-links-page.js
+++ b/client-src/elements/chromedash-admin-feature-links-page.js
@@ -58,6 +58,7 @@ export class ChromedashAdminFeatureLinksPage extends LitElement {
       this.loading = false;
     }
   }
+
   calcSampleId(domain, type, isError) {
     return `domain=${domain}&type=${type}&isError=${isError}`;
   }

--- a/client-src/elements/chromedash-admin-feature-links-page.js
+++ b/client-src/elements/chromedash-admin-feature-links-page.js
@@ -33,13 +33,13 @@ export class ChromedashAdminFeatureLinksPage extends LitElement {
       sampleId: {type: String},
       samplesLoading: {type: Boolean},
       featureLinksSamples: {type: Array},
-      featureLinkSummary: {type: Object},
+      featureLinksSummary: {type: Object},
     };
   }
 
   constructor() {
     super();
-    this.featureLinkSummary = {};
+    this.featureLinksSummary = {};
     this.featureLinksSamples = [];
   }
 
@@ -51,7 +51,7 @@ export class ChromedashAdminFeatureLinksPage extends LitElement {
   async fetchData() {
     try {
       this.loading = true;
-      this.featureLinkSummary = await window.csClient.getFeatureLinkSummary();
+      this.featureLinksSummary = await window.csClient.getFeatureLinksSummary();
     } catch {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     } finally {
@@ -67,7 +67,8 @@ export class ChromedashAdminFeatureLinksPage extends LitElement {
     this.featureLinksSamples = [];
     this.samplesLoading = true;
     try {
-      this.featureLinksSamples = await window.csClient.getFeatureLinkSamples(domain, type, isError);
+      this.featureLinksSamples = await
+      window.csClient.getFeatureLinksSamples(domain, type, isError);
     } catch {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     } finally {
@@ -99,19 +100,19 @@ export class ChromedashAdminFeatureLinksPage extends LitElement {
     return html`
     <div class="feature-links-summary">
       <sl-details summary="Link Summary" open>
-        <div class="line">All Links <b>${this.featureLinkSummary.total_count}</b></div>
-        <div class="line">Covered Links <b>${this.featureLinkSummary.covered_count}</b></div>
-        <div class="line">Uncovered (aka "web") Links <b>${this.featureLinkSummary.uncovered_count}</b></div>
-        <div class="line">All Error Links<b>${this.featureLinkSummary.error_count}</b></div>
-        <div class="line">HTTP Error Links<b>${this.featureLinkSummary.http_error_count}</b></div>
+        <div class="line">All Links <b>${this.featureLinksSummary.total_count}</b></div>
+        <div class="line">Covered Links <b>${this.featureLinksSummary.covered_count}</b></div>
+        <div class="line">Uncovered (aka "web") Links <b>${this.featureLinksSummary.uncovered_count}</b></div>
+        <div class="line">All Error Links<b>${this.featureLinksSummary.error_count}</b></div>
+        <div class="line">HTTP Error Links<b>${this.featureLinksSummary.http_error_count}</b></div>
       </sl-details>
       <sl-details summary="Link Types" open>
-        ${this.featureLinkSummary.link_types.map((linkType) => html`
+        ${this.featureLinksSummary.link_types.map((linkType) => html`
           <div class="line">${(linkType.key).toUpperCase()} <b>${linkType.count}</b></div>
         `)}
       </sl-details>
       <sl-details summary="Uncovered Link Domains" open>
-        ${this.featureLinkSummary.uncovered_link_domains.map((domain) => html`
+        ${this.featureLinksSummary.uncovered_link_domains.map((domain) => html`
           <div class="line">
             <div>
               <a href=${domain.key}>${domain.key}</a>
@@ -125,7 +126,7 @@ export class ChromedashAdminFeatureLinksPage extends LitElement {
         `)}
       </sl-details>
       <sl-details summary="Error Link Domains" open>
-      ${this.featureLinkSummary.error_link_domains.map((domain) => html`
+      ${this.featureLinksSummary.error_link_domains.map((domain) => html`
       <div class="line">
         <div>
           <a href=${domain.key}>${domain.key}</a>

--- a/client-src/elements/chromedash-admin-feature-links-page.js
+++ b/client-src/elements/chromedash-admin-feature-links-page.js
@@ -18,11 +18,16 @@ export class ChromedashAdminFeatureLinksPage extends LitElement {
         justify-content: space-between;
         font-size: 16px;
       }
+      sl-icon-button::part(base) {
+        padding: 0;
+        margin-left: 8px;
+      }
       `];
   }
   static get properties() {
     return {
       loading: {type: Boolean},
+      samplesLoading: {type: Boolean},
       featureLinkSummary: {type: Object},
     };
   }
@@ -47,6 +52,16 @@ export class ChromedashAdminFeatureLinksPage extends LitElement {
       this.loading = false;
     }
   }
+  async fetchLinkSamples(domain, type, isError) {
+    try {
+      this.samplesLoading = true;
+      await window.csClient.getFeatureLinkSamples(domain, type, isError);
+    } catch {
+      showToastMessage('Some errors occurred. Please refresh the page or try again later.');
+    } finally {
+      this.samplesLoading = false;
+    }
+  }
 
   renderComponents() {
     return html`
@@ -65,13 +80,29 @@ export class ChromedashAdminFeatureLinksPage extends LitElement {
       </sl-details>
       <sl-details summary="Uncovered Link Domains" open>
         ${this.featureLinkSummary.uncovered_link_domains.map((domain) => html`
-          <div class="line"><a href=${domain.key}>${domain.key}</a> <b>${domain.count}</b></div>
+          <div class="line">
+            <div>
+              <a href=${domain.key}>${domain.key}</a>
+              <sl-icon-button library="material" name="search" slot="prefix" title="Samples"
+              @click=${() => this.fetchLinkSamples(domain.key, 'web', undefined)}>
+              ></sl-icon-button>
+          </div>
+            <b>${domain.count}</b>
+          </div>
         `)}
       </sl-details>
       <sl-details summary="Error Link Domains" open>
       ${this.featureLinkSummary.error_link_domains.map((domain) => html`
-        <div class="line"><a href=${domain.key}>${domain.key}</a> <b>${domain.count}</b></div>
-      `)}
+      <div class="line">
+        <div>
+          <a href=${domain.key}>${domain.key}</a>
+          <sl-icon-button library="material" name="search" slot="prefix" title="Samples"
+          @click=${() => this.fetchLinkSamples(domain.key, undefined, true)}>
+          ></sl-icon-button>
+      </div>
+        <b>${domain.count}</b>
+      </div>
+    `)}
     </sl-details>
     </div>
     `;

--- a/client-src/elements/chromedash-admin-feature-links-page.js
+++ b/client-src/elements/chromedash-admin-feature-links-page.js
@@ -62,6 +62,7 @@ export class ChromedashAdminFeatureLinksPage extends LitElement {
   calcSampleId(domain, type, isError) {
     return `domain=${domain}&type=${type}&isError=${isError}`;
   }
+
   async fetchLinkSamples(domain, type, isError) {
     this.sampleId = this.calcSampleId(domain, type, isError);
     this.featureLinksSamples = [];
@@ -75,6 +76,7 @@ export class ChromedashAdminFeatureLinksPage extends LitElement {
       this.samplesLoading = false;
     }
   }
+
   renderSamples() {
     if (this.samplesLoading) {
       return html`<sl-spinner></sl-spinner>`;
@@ -142,6 +144,7 @@ export class ChromedashAdminFeatureLinksPage extends LitElement {
     </div>
     `;
   }
+
   render() {
     return html`
       ${this.loading ?

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -316,6 +316,17 @@ class ChromeStatusClient {
     return this.doGet('/feature_links_summary');
   }
 
+  getFeatureLinkSamples(domain, type, isError) {
+    let optionalParams = '';
+    if (type) {
+      optionalParams += `&type=${type}`;
+    }
+    if (isError !== undefined && isError !== null) {
+      optionalParams += `&is_error=${isError}`;
+    }
+    return this.doGet(`/feature_links_samples?domain=${domain}${optionalParams}`);
+  }
+
   // Stages API
   getStage(featureId, stageId) {
     return this.doGet(`/features/${featureId}/stages/${stageId}`);

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -312,11 +312,11 @@ class ChromeStatusClient {
     return this.doGet(`/feature_links?feature_id=${featureId}&update_stale_links=${updateStaleLinks}`);
   }
 
-  getFeatureLinkSummary() {
+  getFeatureLinksSummary() {
     return this.doGet('/feature_links_summary');
   }
 
-  getFeatureLinkSamples(domain, type, isError) {
+  getFeatureLinksSamples(domain, type, isError) {
     let optionalParams = '';
     if (type) {
       optionalParams += `&type=${type}`;

--- a/main.py
+++ b/main.py
@@ -107,6 +107,7 @@ api_routes: list[Route] = [
     Route(f'{API_BASE}/features/create', features_api.FeaturesAPI),
     Route(f'{API_BASE}/feature_links', feature_links_api.FeatureLinksAPI),
     Route(f'{API_BASE}/feature_links_summary', feature_links_api.FeatureLinksSummaryAPI),
+    Route(f'{API_BASE}/feature_links_samples', feature_links_api.FeatureLinksSamplesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/votes',
         reviews_api.VotesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/votes/<int:gate_id>',


### PR DESCRIPTION
Currently [`admin/feature_links`](https://chromestatus.com/admin/feature_links) only shows domains.
In order to get better understanding, it is ideal to show what exact urls are not covered or broken.

In this PR:

- Add `FeatureLinksSamplesAPI` to return feature links samples based on `domain`, `type` (optional) and `is_error` (optional)
- Related UI in [`admin/feature_links`](https://chromestatus.com/admin/feature_links) to use this new API to display samples links of uncovered and errors links

https://github.com/GoogleChrome/chromium-dashboard/assets/5123601/6c53924c-4428-40de-98a6-f7f04478d8bb


