### PR TITLE
Hide CSS metrics ending in "(obsolete)".

### DIFF
--- a/client-src/elements/chromedash-stack-rank-page.js
+++ b/client-src/elements/chromedash-stack-rank-page.js
@@ -67,7 +67,9 @@ export class ChromedashStackRankPage extends LitElement {
     fetch(endpoint, options).then((res) => res.json()).then((props) => {
       for (let i = 0, item; item = props[i]; ++i) {
         item.percentage = (item.day_percentage * 100).toFixed(6);
-        item.obsolete = item.property_name && item.property_name.startsWith('OBSOLETE_');
+        item.obsolete = item.property_name &&
+            (item.property_name.startsWith('OBSOLETE_') ||
+             item.property_name.endsWith('(obsolete)'));
       }
       const viewList = props.filter((item) => {
         return !['ERROR', 'PageVisits', 'PageDestruction'].includes(item.property_name);


### PR DESCRIPTION
A while back we started hiding UseCounters that have a name that starts with "OBSOLETE_".  Those were mainly JS/HTML use counters.  Recently I noticed that some CSS UseCounters are also marked "(obsolete)".  So, this PR detects those too.