### PR TITLE
Fix enum search with underscores.

### DIFF
--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -14,6 +14,7 @@
 
 
 import collections
+import re
 from typing import Optional
 
 
@@ -660,6 +661,14 @@ def convert_enum_int_to_string(property_name, value):
   return converted_value
 
 
+WORD_RE = re.compile(r'[a-z0-9]+')
+def normalize_enum_string(value: str) -> str:
+  """Make enum name comparisons more convienent."""
+  words = WORD_RE.findall(value.lower())
+  normal = '_'.join(w for w in words if w)
+  return normal
+
+
 def convert_enum_string_to_int(property_name, value):
   """If the property is an enum, return its enum value, else -1."""
   try:
@@ -667,9 +676,10 @@ def convert_enum_string_to_int(property_name, value):
   except ValueError:
     pass
 
+  normal_value = normalize_enum_string(value)
   enum_dict = PROPERTY_NAMES_TO_ENUM_DICTS.get(property_name, {})
   for index, enum_str in enum_dict.items():
-    if enum_str == value:
+    if normalize_enum_string(enum_str) == normal_value:
       return index
   return -1
 

--- a/internals/core_enums_test.py
+++ b/internals/core_enums_test.py
@@ -55,6 +55,25 @@ class EnumsFunctionsTest(testing_config.CustomTestCase):
         'impl_status_chrome', 99)
     self.assertEqual(99, actual)
 
+  def test_normalize_enum_string(self):
+    """We can convert enum names to snake_case."""
+    self.assertEqual(
+        'positive', core_enums.normalize_enum_string('Positive'))
+    self.assertEqual(
+        'mixed_signals', core_enums.normalize_enum_string('Mixed signals'))
+    self.assertEqual(
+        'mixed_signals', core_enums.normalize_enum_string('Mixed_signals'))
+    self.assertEqual(
+        'mixed_signals', core_enums.normalize_enum_string('mixed_signals'))
+    self.assertEqual(
+        'mixed_signals', core_enums.normalize_enum_string('mixed-signals'))
+    self.assertEqual(
+        'in_developer_trial_behind_a_flag',
+        core_enums.normalize_enum_string('In developer trial (Behind a flag)'))
+    self.assertEqual(
+        'in_developer_trial_behind_a_flag',
+        core_enums.normalize_enum_string('In_developer_trial_(Behind_a_flag)'))
+
   def test_convert_enum_string_to_int__already_numeric(self):
     """If the value passed in is already an int, go with it."""
     actual = core_enums.convert_enum_string_to_int(
@@ -65,6 +84,10 @@ class EnumsFunctionsTest(testing_config.CustomTestCase):
     """We use the enum representation if it is defined."""
     actual = core_enums.convert_enum_string_to_int(
         'impl_status_chrome', 'No active development')
+    self.assertEqual(core_enums.NO_ACTIVE_DEV, actual)
+
+    actual = core_enums.convert_enum_string_to_int(
+        'impl_status_chrome', 'No_active_development')
     self.assertEqual(core_enums.NO_ACTIVE_DEV, actual)
 
     actual = core_enums.convert_enum_string_to_int(


### PR DESCRIPTION
This should resolve #3279.

With this PR, the server ignores capitalization and punctuation in enum values.  So, a query can specify ```impl_status_chrome="Behind a flag"``` or ```impl_status_chrome="Behind_a_flag"```  or ```impl_status_chrome=behind_a_flag```.