### PR TITLE
Add links to associated origin trials

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -57,6 +57,7 @@ const LONG_TEXT = 60;
 class ChromedashFeatureDetail extends LitElement {
   static get properties() {
     return {
+      appTitle: {type: String},
       featureLinks: {type: Array},
       user: {type: Object},
       canEdit: {type: Boolean},
@@ -73,6 +74,7 @@ class ChromedashFeatureDetail extends LitElement {
 
   constructor() {
     super();
+    this.appTitle = '';
     this.user = {};
     this.canEdit = false;
     this.feature = {};
@@ -611,7 +613,7 @@ class ChromedashFeatureDetail extends LitElement {
     if (feStage.origin_trial_id) {
       let originTrialsURL = `https://origintrials-staging.corp.google.com/origintrials/#/view_trials/${feStage.origin_trial_id}`;
       // If this is the production host, link to the production OT site.
-      if (window.location.host === 'chromestatus.com') {
+      if (this.appTitle === 'Chrome Platform Status') {
         originTrialsURL = `https://developer.chrome.com/origintrials/#/view_trials/${feStage.origin_trial_id}`;
       }
       visitTrialButton = html`

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -123,7 +123,7 @@ class ChromedashFeatureDetail extends LitElement {
         margin-right: 4px;
       }
 
-      sl-details sl-button[variant~="default"]::part(base) {
+      sl-details sl-button[variant="default"]::part(base) {
         color: var(--sl-color-primary-600);
         border: 1px solid var(--sl-color-primary-600);
       }

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -118,7 +118,12 @@ class ChromedashFeatureDetail extends LitElement {
         padding: 8px 16px;
       }
 
-      sl-details sl-button::part(base) {
+      sl-details sl-button {
+        float: right;
+        margin-right: 4px;
+      }
+
+      sl-details sl-button[variant~="default"]::part(base) {
         color: var(--sl-color-primary-600);
         border: 1px solid var(--sl-color-primary-600);
       }
@@ -582,27 +587,44 @@ class ChromedashFeatureDetail extends LitElement {
     }
     const isActive = this.feature.active_stage_id === feStage.id;
 
-    // Show a button to add a trial extension stage for origin trial stages.
+    // Show any buttons that should be displayed at the top of the detail card.
     let addExtensionButton = nothing;
+    let editButton = nothing;
+    let visitTrialButton = nothing;
     if (this.canEdit && STAGE_TYPES_ORIGIN_TRIAL.has(feStage.stage_type)) {
       // Button text changes based on whether or not an extension stage already exists.
       const extensionAlreadyExists = (feStage.extensions && feStage.extensions.length > 0);
       const extensionButtonText = extensionAlreadyExists ?
         'Add another trial extension' : 'Add a trial extension';
       addExtensionButton = html`
-      <sl-button size="small" style="float:right"
+      <sl-button size="small"
           @click=${() => this.createExtensionStage(feStage, extensionAlreadyExists)}
           >${extensionButtonText}</sl-button>`;
     }
-
-    const editButton = html`
-      <sl-button size="small" style="float:right"
-          href="/guide/stage/${this.feature.id}/${processStage.outgoing_stage}/${feStage.id}"
-          >Edit fields</sl-button>
-`;
+    if (this.canEdit) {
+      editButton = html`
+        <sl-button size="small"
+            href="/guide/stage/${this.feature.id}/${processStage.outgoing_stage}/${feStage.id}"
+            >Edit fields</sl-button>`;
+    }
+    // If we have an origin trial ID associated with the stage, add a link to the trial.
+    if (feStage.origin_trial_id) {
+      let originTrialsURL = `https://origintrials-staging.corp.google.com/origintrials/#/view_trials/${feStage.origin_trial_id}`;
+      // If this is the production host, link to the production OT site.
+      if (window.location.host === 'chromestatus.com') {
+        originTrialsURL = `https://developer.chrome.com/origintrials/#/view_trials/${feStage.origin_trial_id}`;
+      }
+      visitTrialButton = html`
+        <sl-button 
+          size="small"
+          variant="primary"
+          href=${originTrialsURL}
+          target="_blank">View Origin Trial</sl-button>`;
+    }
     const content = html`
       <p class="description">
-        ${this.canEdit ? editButton : nothing}
+        ${visitTrialButton}
+        ${editButton}
         ${addExtensionButton}
         ${processStage.description}
       </p>

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -543,6 +543,7 @@ export class ChromedashFeaturePage extends LitElement {
   renderFeatureDetails() {
     return html`
       <chromedash-feature-detail
+        appTitle=${this.appTitle}
         .loading=${this.loading}
         .user=${this.user}
         ?canEdit=${this.userCanEdit()}


### PR DESCRIPTION
This PR adds direct links to the origin trial registration pages of trials that have been associated with ChromeStatus entries, opening them in a new tab when clicked. Additionally, this fixes some small spacing issues on the buttons that display together at the top-right of detail sections.

### View when user is not a feature owner/editor:
<img width="871" alt="Screenshot 2023-08-30 at 1 52 36 PM" src="https://github.com/GoogleChrome/chromium-dashboard/assets/56164590/2ec60d6f-0f26-42ae-874a-2e6798719a7d">

### View when user has edit access to the feature:
<img width="868" alt="Screenshot 2023-08-30 at 1 51 37 PM" src="https://github.com/GoogleChrome/chromium-dashboard/assets/56164590/0e7d00fd-d170-4252-975e-b21e623dbee4">
