### PR TITLE
Update enterprise release notes style and text content

### DIFF
--- a/client-src/elements/chromedash-enterprise-release-notes-page.js
+++ b/client-src/elements/chromedash-enterprise-release-notes-page.js
@@ -7,7 +7,7 @@ import {
   STAGE_ENT_ROLLOUT,
   STAGE_TYPES_SHIPPING,
 } from './form-field-enums.js';
-import {showToastMessage, updateURLParams, parseRawQuery} from './utils.js';
+import {showToastMessage, updateURLParams, parseRawQuery, renderHTMLIf} from './utils.js';
 
 const milestoneQueryParamKey = 'milestone';
 
@@ -88,6 +88,7 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
 
       li {
         list-style: circle;
+        margin-block-end: 16px;
       }
 
       .feature {
@@ -176,7 +177,6 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
         rollout_milestone: Number(milestone),
         rollout_platforms: Array.from(platforms),
         rollout_impact: 1,
-        rollout_details: 'Missing details, no rollout step was created for this',
       }));
   }
 
@@ -352,10 +352,10 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
   getStageTitle(stage) {
     if (stage.rollout_platforms.length === 0 ||
         stage.rollout_platforms.length === Object.values(PLATFORMS_DISPLAYNAME).length) {
-      return `Chrome ${stage.rollout_milestone}: `;
+      return `Chrome ${stage.rollout_milestone}`;
     }
     return `Chrome ${stage.rollout_milestone} on ` +
-           `${stage.rollout_platforms.map(p => PLATFORMS_DISPLAYNAME[p]).join(', ')}: `;
+           `${stage.rollout_platforms.map(p => PLATFORMS_DISPLAYNAME[p]).join(', ')}`;
   }
 
   renderReleaseNotesDetailsSection(title, features, shouldDisplayStageTitleInBold) {
@@ -367,8 +367,8 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
       ${features.map(f => html`
       <section class="feature">
         <strong>${f.name}</strong>
-        <p class="toremove">< To remove - Owners: ${f.browsers.chrome.owners.join(', ')} - Last Updated: ${f.updated.when} ></p>
-        <p class="summary">${f.summary}</p>
+        <p class="toremove">< To remove - Owners: ${f.browsers.chrome.owners.join(', ')} - Editors: ${(f.editors || []).join(', ')}  - Last Updated: ${f.updated.when} ></p>
+        <p class="summary preformatted">${f.summary}</p>
         <ul>
         ${f.stages.map(s => html`
           <li>
@@ -376,7 +376,7 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
       f.stages.map(s => s.rollout_milestone).sort()) ? 'bold' : ''}">
               ${this.getStageTitle(s)}
             </span>
-            ${s.rollout_details || 'Missing details' }
+            ${renderHTMLIf(s.rollout_details, html`<br/><span class="preformatted">${s.rollout_details}</span>`)}
           </li>`)}
         </ul>
         <div class="screenshots">

--- a/client-src/elements/chromedash-enterprise-release-notes-page_test.js
+++ b/client-src/elements/chromedash-enterprise-release-notes-page_test.js
@@ -14,6 +14,7 @@ describe('chromedash-feature-page', () => {
           id: 1,
           name: 'feature with no stages',
           summary: 'feature 1 summary',
+          editors: ['editor1', 'editor2'],
           enterprise_feature_categories: ['1', '2'],
           new_crbug_url: 'fake crbug link',
           stages: [],
@@ -31,6 +32,7 @@ describe('chromedash-feature-page', () => {
           id: 2,
           name: 'feature with no rollout stages',
           summary: 'feature 2 summary',
+          editors: ['editor1', 'editor2'],
           enterprise_feature_categories: ['1', '3'],
           new_crbug_url: 'fake crbug link',
           stages: [
@@ -58,6 +60,7 @@ describe('chromedash-feature-page', () => {
           name: 'feature with one rollout stages',
           summary: 'feature 3 summary',
           new_crbug_url: 'fake crbug link',
+          editors: ['editor1', 'editor2'],
           enterprise_feature_categories: ['1', '2', '3'],
           stages: [
             {
@@ -88,6 +91,7 @@ describe('chromedash-feature-page', () => {
           name: 'feature with two consecutive rollout stages',
           summary: 'feature 4 summary',
           new_crbug_url: 'fake crbug link',
+          editors: ['editor1'],
           enterprise_feature_categories: ['3'],
           stages: [
             {
@@ -109,7 +113,7 @@ describe('chromedash-feature-page', () => {
           ],
           browsers: {
             chrome: {
-              owners: ['owner1', 'owner2'],
+              owners: ['owner1'],
             },
           },
           updated: {
@@ -122,6 +126,7 @@ describe('chromedash-feature-page', () => {
           name: 'feature with past and future rollout stages',
           summary: 'feature 5 summary',
           new_crbug_url: 'fake crbug link',
+          editors: ['editor1', 'editor2'],
           enterprise_feature_categories: ['2'],
           stages: [
             {
@@ -156,6 +161,7 @@ describe('chromedash-feature-page', () => {
           name: 'feature with upcoming rollout stages',
           summary: 'feature 6 summary',
           new_crbug_url: 'fake crbug link',
+          editors: ['editor1', 'editor2'],
           enterprise_feature_categories: ['2'],
           stages: [
             {
@@ -182,6 +188,7 @@ describe('chromedash-feature-page', () => {
           name: 'normal feature with shipping stage',
           summary: 'normal feature summary',
           new_crbug_url: 'fake crbug link',
+          editors: ['editor1', 'editor2'],
           enterprise_feature_categories: [],
           stages: [
             {
@@ -338,16 +345,16 @@ describe('chromedash-feature-page', () => {
           'feature with two consecutive rollout stages',
           features[0].querySelector('strong').textContent);
         assert.equal(
-          '< To remove - Owners: owner1, owner2 - Last Updated: feature 4 updated >',
+          '< To remove - Owners: owner1 - Editors: editor1  - Last Updated: feature 4 updated >',
           features[0].querySelector('.toremove').textContent);
         assert.equal(
           'feature 4 summary',
           features[0].querySelector('.summary').textContent);
         const stages = [...features[0].querySelectorAll('li')];
         assert.equal(2, stages.length);
-        assert.include(stages[0].textContent, 'Chrome 100: ');
+        assert.include(stages[0].textContent, 'Chrome 100');
         assert.include(stages[0].textContent, 'fake rollout details 100');
-        assert.include(stages[1].textContent, 'Chrome 101: ');
+        assert.include(stages[1].textContent, 'Chrome 101');
         assert.include(stages[1].textContent, 'fake rollout details 101');
 
         const screenshots = [...features[0].querySelectorAll('.screenshots img')];
@@ -364,14 +371,14 @@ describe('chromedash-feature-page', () => {
           'feature with one rollout stages',
           features[1].querySelector('strong').textContent);
         assert.equal(
-          '< To remove - Owners: owner - Last Updated: updated when >',
+          '< To remove - Owners: owner - Editors: editor1, editor2  - Last Updated: updated when >',
           features[1].querySelector('.toremove').textContent);
         assert.equal(
           'feature 3 summary',
           features[1].querySelector('.summary').textContent);
         const stages = [...features[1].querySelectorAll('li')];
         assert.equal(1, stages.length);
-        assert.include(stages[0].textContent, 'Chrome 100: ');
+        assert.include(stages[0].textContent, 'Chrome 100');
         assert.include(stages[0].textContent, 'fake rollout details 100');
 
         const screenshots = [...features[1].querySelectorAll('.screenshots img')];
@@ -386,29 +393,17 @@ describe('chromedash-feature-page', () => {
           'normal feature with shipping stage',
           features[2].querySelector('strong').textContent);
         assert.equal(
-          '< To remove - Owners: owner - Last Updated: updated when >',
+          '< To remove - Owners: owner - Editors: editor1, editor2  - Last Updated: updated when >',
           features[2].querySelector('.toremove').textContent);
         assert.equal(
           'normal feature summary',
           features[2].querySelector('.summary').textContent);
         const stages = [...features[2].querySelectorAll('li')];
         assert.equal(4, stages.length);
-        assert.include(stages[0].textContent, 'Chrome 100 on Windows, Mac, Linux, Android: ');
-        assert.include(
-          stages[0].textContent,
-          'Missing details, no rollout step was created for this');
-        assert.include(stages[1].textContent, 'Chrome 101 on Windows, Mac, Linux, Android: ');
-        assert.include(
-          stages[1].textContent,
-          'Missing details, no rollout step was created for this');
-        assert.include(stages[2].textContent, 'Chrome 102 on iOS, Android: ');
-        assert.include(
-          stages[2].textContent,
-          'Missing details, no rollout step was created for this');
-        assert.include(stages[3].textContent, 'Chrome 103 on iOS: ');
-        assert.include(
-          stages[3].textContent,
-          'Missing details, no rollout step was created for this');
+        assert.include(stages[0].textContent, 'Chrome 100 on Windows, Mac, Linux, Android');
+        assert.include(stages[1].textContent, 'Chrome 101 on Windows, Mac, Linux, Android');
+        assert.include(stages[2].textContent, 'Chrome 102 on iOS, Android');
+        assert.include(stages[3].textContent, 'Chrome 103 on iOS');
 
         const screenshots = [...features[1].querySelectorAll('.screenshots img')];
         assert.lengthOf(screenshots, 1);
@@ -430,14 +425,14 @@ describe('chromedash-feature-page', () => {
           'feature with upcoming rollout stages',
           features[0].querySelector('strong').textContent);
         assert.equal(
-          '< To remove - Owners: owner - Last Updated: updated when >',
+          '< To remove - Owners: owner - Editors: editor1, editor2  - Last Updated: updated when >',
           features[0].querySelector('.toremove').textContent);
         assert.equal(
           'feature 6 summary',
           features[0].querySelector('.summary').textContent);
         const stages = [...features[0].querySelectorAll('li')];
         assert.equal(1, stages.length);
-        assert.include(stages[0].textContent, 'Chrome 999: ');
+        assert.include(stages[0].textContent, 'Chrome 999');
         assert.include(stages[0].textContent, 'fake rollout details 999');
 
         const screenshots = [...features[0].querySelectorAll('.screenshots img')];
@@ -450,16 +445,16 @@ describe('chromedash-feature-page', () => {
           'feature with past and future rollout stages',
           features[1].querySelector('strong').textContent);
         assert.equal(
-          '< To remove - Owners: owner - Last Updated: updated when >',
+          '< To remove - Owners: owner - Editors: editor1, editor2  - Last Updated: updated when >',
           features[1].querySelector('.toremove').textContent);
         assert.equal(
           'feature 5 summary',
           features[1].querySelector('.summary').textContent);
         const stages = [...features[1].querySelectorAll('li')];
         assert.equal(2, stages.length);
-        assert.include(stages[0].textContent, 'Chrome 1: ');
+        assert.include(stages[0].textContent, 'Chrome 1');
         assert.include(stages[0].textContent, 'fake rollout details 1');
-        assert.include(stages[1].textContent, 'Chrome 1000: ');
+        assert.include(stages[1].textContent, 'Chrome 1000');
         assert.include(stages[1].textContent, 'fake rollout details 1000');
 
         const screenshots = [...features[1].querySelectorAll('.screenshots img')];

--- a/client-src/elements/chromedash-form-field.js
+++ b/client-src/elements/chromedash-form-field.js
@@ -151,6 +151,7 @@ export class ChromedashFormField extends LitElement {
           hoist
           multiple
           cleareable
+          ?required=${this.fieldProps.required}
           ?disabled=${fieldDisabled || this.disabled || this.loading}
           @sl-change="${this.handleFieldUpdated}">
           ${Object.values(choices).map(

--- a/client-src/elements/chromedash-guide-editall-page.js
+++ b/client-src/elements/chromedash-guide-editall-page.js
@@ -112,7 +112,7 @@ export class ChromedashGuideEditallPage extends LitElement {
       hiddenTokenField.value = window.csClient.token;
       return csClient.updateFeature(submitBody);
     }).then(() => {
-      window.location.href = this.nextPage || `/guide/edit/${this.featureId}`;
+      window.location.href = this.getNextPage();
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });
@@ -161,8 +161,13 @@ export class ChromedashGuideEditallPage extends LitElement {
   }
 
   getNextPage() {
-    return this.nextPage || this.feature.is_enterprise_feature ?
-    `/feature/${this.featureId}` : `/guide/edit/${this.featureId}`;
+    if (this.nextPage) {
+      return this.nextPage;
+    }
+    if (this.feature.is_enterprise_feature) {
+      return `/feature/${this.featureId}`;
+    }
+    return `/guide/edit/${this.featureId}`;
   }
 
   renderSubheader() {

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -1423,8 +1423,8 @@ export const ALL_FIELDS = {
   'rollout_milestone': {
     type: 'input',
     attrs: MILESTONE_NUMBER_FIELD_ATTRS,
-    required: false,
-    label: 'Rollout milestone',
+    required: true,
+    label: 'Chrome milestone',
     help_text: html`
     The milestone in which this stage rolls out to the stable channel (even a 1% rollout). If you don't yet know which milestone it will be, put in your best estimate. You can always change this later.`,
   },
@@ -1432,7 +1432,7 @@ export const ALL_FIELDS = {
   'rollout_platforms': {
     type: 'multiselect',
     choices: PLATFORM_CATEGORIES,
-    required: false,
+    required: true,
     label: 'Rollout platforms',
     help_text: html`
       The platform(s) affected by this stage`,
@@ -1442,7 +1442,7 @@ export const ALL_FIELDS = {
     type: 'textarea',
     attrs: {rows: 4},
     required: false,
-    label: 'Rollout details',
+    label: 'Rollout details (optional)',
     help_text: html`
       Explain what specifically is changing in this milestone, for the given platforms.
       Many features are composed of multiple stages on different milestones. For example,

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -118,8 +118,8 @@ class EnterpriseFeatureCreateHandler(FeatureCreateHandler):
 
   @permissions.require_create_feature
   def process_post_data(self, **kwargs):
-    owners = self.split_emails('owner')
-    editors = self.split_emails('editors')
+    owners = self.split_emails('owner_emails')
+    editors = self.split_emails('editor_emails')
 
     signed_in_user = ndb.User(
         email=self.get_current_user().email(),


### PR DESCRIPTION
- Make the summary and rollout details preformatted so that they keep the line returns.
- Replace the rollout details text to mention that it is optional
- Replace the Rollout milestone text to Chrome milestone
- Fix next page logic on the /editall/ page by making all references to a next page use this.getNextPage
- Fix owners and editors not being added in enterprise feature creation
- Make rollout platforms and milestones mandatory for rollout steps
