### PR TITLE
Add indexes needed for feature_links admin page samples.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -479,3 +479,11 @@ indexes:
   - name: type
   - name: updated
   - name: url
+- kind: FeatureLinks
+  properties:
+  - name: is_error
+  - name: url
+- kind: FeatureLinks
+  properties:
+  - name: type
+  - name: url


### PR DESCRIPTION
These indexes were suggested in error messages that showed up on staging.  The staging server works now that theses have been deployed there.