### PR TITLE
Record vote activities with amendments instead of text.

### DIFF
--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -61,6 +61,7 @@ class CommentsAPI(basehandlers.APIHandler):
     """Return a list of all review comments on the given feature."""
     feature_id = kwargs['feature_id']
     gate_id = kwargs.get('gate_id', None)
+    # TODO(jrobbins): Remove comments_only after next deployment.
     comments_only = self.get_bool_arg('comments_only')
     # Note: We assume that anyone may view approval comments.
     comments = Activity.get_activities(

--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -61,11 +61,8 @@ class CommentsAPI(basehandlers.APIHandler):
     """Return a list of all review comments on the given feature."""
     feature_id = kwargs['feature_id']
     gate_id = kwargs.get('gate_id', None)
-    # TODO(jrobbins): Remove comments_only after next deployment.
-    comments_only = self.get_bool_arg('comments_only')
     # Note: We assume that anyone may view approval comments.
-    comments = Activity.get_activities(
-        feature_id, gate_id, comments_only=comments_only)
+    comments = Activity.get_activities(feature_id, gate_id)
     user = self.get_current_user()
     is_admin = permissions.can_admin_site(user)
 

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -120,21 +120,20 @@ class CommentsAPITest(testing_config.CustomTestCase):
     self.assertEqual({'comments': []}, actual_response)
 
   def test_get__legacy_comments(self):
-    """We can get legacy comments."""
+    """We no longer return legacy gate comments when gate_id is specified."""
     testing_config.sign_out()
     testing_config.sign_in('user7@example.com', 123567890)
 
     legacy_comment = Activity(
       feature_id=self.feature_id, author='owner1@example.com',
-      created=NOW, content='nothing')
+      created=NOW, content='nothing')  # no gate_id
     legacy_comment.put()
 
     with test_app.test_request_context(self.request_path):
       actual_response = self.handler.do_get(
           feature_id=self.feature_id, gate_id=self.gate_1_id)
     testing_config.sign_out()
-    actual_comment = actual_response['comments'][0]
-    self.assertEqual('nothing', actual_comment['content'])
+    self.assertEqual([], actual_response['comments'])
 
   def test_get__all_some(self):
     """We can get all comments for a given approval."""

--- a/api/reviews_api_test.py
+++ b/api/reviews_api_test.py
@@ -229,8 +229,9 @@ class VotesAPITest(testing_config.CustomTestCase):
     self.assertEqual(vote.set_by, 'reviewer1@example.com')
     self.assertEqual(vote.state, Vote.NEEDS_WORK)
 
-    mock_notifier.assert_called_once_with(self.feature_1,
-        self.gate_1, 'reviewer1@example.com', Vote.NEEDS_WORK, Vote.NA)
+    mock_notifier.assert_called_once_with(
+        self.feature_1, self.gate_1, 'reviewer1@example.com',
+        Vote.NEEDS_WORK, Vote.NO_RESPONSE)
 
   @mock.patch('internals.notifier_helpers.notify_subscribers_of_vote_changes')
   @mock.patch('internals.approval_defs.get_approvers')
@@ -254,8 +255,9 @@ class VotesAPITest(testing_config.CustomTestCase):
     self.assertEqual(vote.set_by, 'reviewer1@example.com')
     self.assertEqual(vote.state, Vote.DENIED)
 
-    mock_notifier.assert_called_once_with(self.feature_1,
-        self.gate_1, 'reviewer1@example.com', Vote.DENIED, Vote.NA)
+    mock_notifier.assert_called_once_with(
+        self.feature_1, self.gate_1, 'reviewer1@example.com',
+        Vote.DENIED, Vote.APPROVED)
 
   @mock.patch('internals.notifier_helpers.notify_approvers_of_reviews')
   @mock.patch('internals.approval_defs.get_approvers')
@@ -278,7 +280,8 @@ class VotesAPITest(testing_config.CustomTestCase):
     self.assertEqual(vote.set_by, 'owner1@example.com')
     self.assertEqual(vote.state, Vote.REVIEW_REQUESTED)
 
-    mock_notifier.assert_called_once_with(self.feature_1, self.gate_1)
+    mock_notifier.assert_called_once_with(
+        self.feature_1, self.gate_1, 'owner1@example.com')
 
 
 class GatesAPITest(testing_config.CustomTestCase):

--- a/client-src/elements/chromedash-activity-page.js
+++ b/client-src/elements/chromedash-activity-page.js
@@ -70,7 +70,7 @@ export class ChromedashActivityPage extends LitElement {
   fetchComments() {
     this.loading = true;
     Promise.all([
-      window.csClient.getComments(this.featureId, null, false),
+      window.csClient.getComments(this.featureId, null),
     ]).then(([commentRes]) => {
       this.comments = commentRes.comments;
       this.needsPost = false;
@@ -85,7 +85,7 @@ export class ChromedashActivityPage extends LitElement {
     commentArea.value = '';
     this.needsPost = false;
     Promise.all([
-      window.csClient.getComments(this.featureId, null, false),
+      window.csClient.getComments(this.featureId, null),
     ]).then(([commentRes]) => {
       this.comments = commentRes.comments;
     }).catch(() => {

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -141,7 +141,7 @@ export class ChromedashFeaturePage extends LitElement {
     Promise.all([
       window.csClient.getFeature(this.featureId),
       window.csClient.getGates(this.featureId),
-      window.csClient.getComments(this.featureId, null, false),
+      window.csClient.getComments(this.featureId, null),
       window.csClient.getFeatureProcess(this.featureId),
       window.csClient.getDismissedCues(),
       window.csClient.getStars(),
@@ -194,7 +194,7 @@ export class ChromedashFeaturePage extends LitElement {
     Promise.all([
       window.csClient.getFeature(this.featureId),
       window.csClient.getGates(this.featureId),
-      window.csClient.getComments(this.featureId, null, false),
+      window.csClient.getComments(this.featureId, null),
     ]).then(([feature, gatesRes, commentRes]) => {
       this.feature = feature;
       this.gates = gatesRes.gates;

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -170,7 +170,6 @@ export class ChromedashGateColumn extends LitElement {
       window.csClient.getFeatureProcess(featureId),
       window.csClient.getStage(featureId, stageId),
       window.csClient.getVotes(featureId, null),
-      // TODO(jrobbins): Include activities for this gate
       window.csClient.getComments(featureId, gate.id),
     ]).then(([progress, process, stage, votesRes, commentRes]) => {
       this.progress = progress;

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -229,13 +229,10 @@ class ChromeStatusClient {
     return this.doGet(`/features/${featureId}/gates`);
   }
 
-  getComments(featureId, gateId, commentsOnly=true) {
+  getComments(featureId, gateId) {
     let url = `/features/${featureId}/approvals/comments`;
     if (gateId) {
       url = `/features/${featureId}/approvals/${gateId}/comments`;
-    }
-    if (commentsOnly) {
-      url += '?comments_only';
     }
     return this.doGet(url);
   }

--- a/internals/notifier_helpers_test.py
+++ b/internals/notifier_helpers_test.py
@@ -104,7 +104,12 @@ class ActivityTest(testing_config.CustomTestCase):
     self.assertEqual(activities[0].feature_id, feature_id)
     self.assertEqual(activities[0].gate_id, self.gate_1_id)
     self.assertEqual(activities[0].author, 'abc@example.com')
-    self.assertEqual(activities[0].content, expected_content)
+    self.assertEqual(activities[0].content, None)
+    amendments = activities[0].amendments
+    self.assertEqual(len(amendments), 1)
+    self.assertEqual(amendments[0].field_name, 'review_status')
+    self.assertEqual(amendments[0].old_value, 'na')
+    self.assertEqual(amendments[0].new_value, 'denied')
 
     mock_task_helpers.assert_called_once()
 

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -210,12 +210,11 @@ class Activity(ndb.Model):  # copy from Comment
   @classmethod
   def get_activities(cls, feature_id: int, gate_id: Optional[int]=None,
       comments_only: bool=False) -> list[Activity]:
-    """Return actitivies for an approval."""
+    """Return all actitivies for a feature, or a specific gate."""
     query = Activity.query().order(Activity.created)
     query = query.filter(Activity.feature_id == feature_id)
     if gate_id:
-      # Fetch activities with a gate_id or None value.
-      query = query.filter(Activity.gate_id.IN([gate_id, None]))
+      query = query.filter(Activity.gate_id == gate_id)
     acts = query.fetch(None)
     if comments_only:
       return [act for act in acts if act.content]

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -72,24 +72,24 @@ class CommentTest(testing_config.CustomTestCase):
         [c.content for c in actual])
 
   def test_get_activities__specific_fields(self):
-    """We get review comments for specific approval fields if requested."""
+    """We get review comments for specific gates if requested."""
     actual_1 = Activity.get_activities(
         self.feature_1_id, 1, comments_only=True)
-    self.assertEqual(2, len(actual_1))
+    self.assertEqual(1, len(actual_1))
     self.assertEqual(
-        ['some text', 'random'],
+        ['some text'],
         [c.content for c in actual_1])
 
     actual_2 = Activity.get_activities(
         self.feature_1_id, 2, comments_only=True)
-    self.assertEqual(2, len(actual_2))
+    self.assertEqual(1, len(actual_2))
     self.assertEqual(
-        ['some other text', 'random'],
+        ['some other text'],
         [c.content for c in actual_2])
 
     actual_3 = Activity.get_activities(
         self.feature_1_id, 3, comments_only=True)
-    self.assertEqual('random', actual_3[0].content)
+    self.assertEqual([], actual_3)
 
 
 class GateTest(testing_config.CustomTestCase):


### PR DESCRIPTION
We got feedback from reviewers via Dharani that the comments generated for votes look too much like human-generated comments.  The internal launch tool has separate lists for human comments and vote activities.  We can keep a unified list of activity on a gate, but the votes need to be more visually distinguished.  Also, we need an activity in the list for the initial review request.

I decided to keep the same CSS that we have, but record votes using activity amendments rather than comment content.  The amendments already have a distinct visual style because they are preceded by a dark triangle.  Also, they are much less verbose than the comment string that was being generated (which was more appropriate for the email).

In this PR:
* Start phasing out special treatment of "legacy" comments and comments_only mode.  See below.
* Fix the calculation of the old state during a vote state change.  We want that particular reviewer's vote, not the gate state.
* When notifying subscribers, create an Activity with an Amendment rather than comment content.
* Also create an Activity for the initial review request.

Legacy comments were ones generated in 2022 via the old approvals dialog box.  Those did not have a gate_id filled in, so they would have only been shown on the activity log page rather than also being shown in the specific gate where they belonged.  At the time that we launched the gate column, we wanted to show the legacy comments on the gate column, so we just displayed all textual comments that had no gate_id on every gate.   The impact of removing the legacy comments rule is that (1) old comments will only be found on the activity log page and (2) we are now able to show activities with amendments on a gate (even if they have no comment text).