### PR TITLE
Revert "temporarily remove OT cron"

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -29,3 +29,8 @@ cron:
 - description: Update all feature links that are staled.
   url: /cron/update_all_feature_links
   schedule: every tuesday 05:00
+- description: |
+    Check for origin trials and associate them with their respective
+    ChromeStatus feature entry.
+  url: /cron/associate_origin_trials
+  schedule: every day 6:00

--- a/main.py
+++ b/main.py
@@ -241,6 +241,7 @@ internals_routes: list[Route] = [
       inactive_users.RemoveInactiveUsersHandler),
   Route('/cron/reindex_all', search_fulltext.ReindexAllFeatures),
   Route('/cron/update_all_feature_links', feature_links.UpdateAllFeatureLinksHandlers),
+  Route('/cron/associate_origin_trials', maintenance_scripts.AssociateOTs),
 
   Route('/admin/find_stop_words', search_fulltext.FindStopWords),
 


### PR DESCRIPTION
Adds back the trigger for the OT cron job.