### PR TITLE
Update cron description

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -29,7 +29,7 @@ cron:
 - description: Update all feature links that are staled.
   url: /cron/update_all_feature_links
   schedule: every tuesday 05:00
-- description: |
+- description: >
     Check for origin trials and associate them with their respective
     ChromeStatus feature entry.
   url: /cron/associate_origin_trials

--- a/cron.yaml
+++ b/cron.yaml
@@ -29,8 +29,6 @@ cron:
 - description: Update all feature links that are staled.
   url: /cron/update_all_feature_links
   schedule: every tuesday 05:00
-- description: >
-    Check for origin trials and associate them with their respective
-    ChromeStatus feature entry.
+- description: Check origin trials and associate with their ChromeStatus entry.
   url: /cron/associate_origin_trials
   schedule: every day 6:00


### PR DESCRIPTION
trying to deploy the recent change to staging causes the error:

```
ERROR: (gcloud.beta.app.deploy) An error occurred while parsing file
Unable to assign value 'Check for origin trials and associate them with their respective
ChromeStatus feature entry.
' to attribute 'description':
Value 'Check for origin trials and associate them with their respective
ChromeStatus feature entry.
' for description does not match expression '^(?:^.{0,499}$)$'
```

This is because the `|` character denotes a string literal and keeps new line characters in the string, which are not allowed in the description. The right bracket `>` character denotes a folded string that converts new line characters into spaces.

TIL!

Edit: Just trimming down the description and using a one-line description instead