### PR TITLE
Ensure all available features for a release note are fetched

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -144,6 +144,16 @@ class FeaturesAPI(basehandlers.APIHandler):
           'total_count': total_count,
           }
 
+    # Query-string parameter 'releaseNotesMilestone' is provided
+    release_notes_milestone = self.get_int_arg('releaseNotesMilestone')
+    if release_notes_milestone:
+      features_in_release_notes = feature_helpers.get_features_in_release_notes(
+        milestone=release_notes_milestone)
+      return {
+        'features': features_in_release_notes,
+        'total_count': len(features_in_release_notes)
+        }
+
     user_query = self.request.args.get('q', '')
     sort_spec = self.request.args.get('sort')
     num = self.get_int_arg('num', search.DEFAULT_RESULTS_PER_PAGE)

--- a/client-src/elements/chromedash-enterprise-release-notes-page_test.js
+++ b/client-src/elements/chromedash-enterprise-release-notes-page_test.js
@@ -6,7 +6,7 @@ import './chromedash-toast';
 import '../js-src/cs-client';
 import sinon from 'sinon';
 
-describe('chromedash-feature-page', () => {
+describe('chromedash-enterprise-release-notes-page', () => {
   const featuresPromise = Promise.resolve(
     {
       features: [
@@ -226,14 +226,14 @@ describe('chromedash-feature-page', () => {
   beforeEach(async () => {
     await fixture(html`<chromedash-toast></chromedash-toast>`);
     window.csClient = new ChromeStatusClient('fake_token', 1);
-    sinon.stub(window.csClient, 'searchFeatures');
+    sinon.stub(window.csClient, 'getFeaturesForEnterpriseReleaseNotes');
     sinon.stub(window.csClient, 'getChannels');
-    window.csClient.searchFeatures.returns(featuresPromise);
+    window.csClient.getFeaturesForEnterpriseReleaseNotes.returns(featuresPromise);
     window.csClient.getChannels.returns(channelsPromise);
   });
 
   afterEach(() => {
-    window.csClient.searchFeatures.restore();
+    window.csClient.getFeaturesForEnterpriseReleaseNotes.restore();
     window.csClient.getChannels.restore();
     clearURLParams('milestone');
   });
@@ -258,7 +258,7 @@ describe('chromedash-feature-page', () => {
 
   it('renders with no data', async () => {
     const invalidFeaturePromise = Promise.reject(new Error('Got error response from server'));
-    window.csClient.searchFeatures.returns(invalidFeaturePromise);
+    window.csClient.getFeaturesForEnterpriseReleaseNotes.returns(invalidFeaturePromise);
 
     const component = await fixture(html`
       <chromedash-enterprise-release-notes-page></chromedash-enterprise-release-notes-page>`);
@@ -277,7 +277,6 @@ describe('chromedash-feature-page', () => {
       <chromedash-enterprise-release-notes-page></chromedash-enterprise-release-notes-page>`);
     assert.exists(component);
     assert.instanceOf(component, ChromedashEnterpriseReleaseNotesPage);
-    debugger;
 
     const releaseNotesSummary = component.shadowRoot.querySelector('#release-notes-summary');
     const children = [...releaseNotesSummary.querySelectorAll('tr > *')];
@@ -473,6 +472,7 @@ describe('chromedash-feature-page', () => {
 
     // Select a future milestone
     component.selectedMilestone = 2000;
+    component.updateSelectedMilestone();
     await nextFrame();
 
     // Tests summary

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -1422,7 +1422,7 @@ export const ALL_FIELDS = {
 
   'rollout_milestone': {
     type: 'input',
-    attrs: { ...MILESTONE_NUMBER_FIELD_ATTRS, min: 100 },
+    attrs: {...MILESTONE_NUMBER_FIELD_ATTRS, min: 100},
     required: true,
     label: 'Chrome milestone',
     help_text: html`

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -285,6 +285,10 @@ class ChromeStatusClient {
       (resp) => resp['features_by_type']);
   }
 
+  getFeaturesForEnterpriseReleaseNotes(milestone) {
+    return this.doGet(`/features?releaseNotesMilestone=${milestone}`);
+  }
+
   searchFeatures(userQuery, sortSpec, start, num) {
     let url = `/features?q=${userQuery}`;
     if (sortSpec) {

--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -24,6 +24,7 @@ from framework import users
 from internals import stage_helpers
 from internals.core_enums import *
 from internals.core_models import FeatureEntry, Stage
+from internals.data_types import VerboseFeatureDict
 
 
 def filter_unlisted(feature_list: list[dict]) -> list[dict]:
@@ -84,7 +85,7 @@ def get_features_in_release_notes(milestone: int):
   
   feature_ids = list(set({
       *[s.feature_id for s in stages]}))
-  features = [converters.feature_entry_to_json_verbose(f)
+  features = [dict(converters.feature_entry_to_json_verbose(f))
             for f in _get_future_results(_get_entries_by_id_async(feature_ids))]
   features = [f for f in filter_unlisted(features) 
     if f['breaking_change'] == True or f['feature_type_int'] == FEATURE_TYPE_ENTERPRISE_ID]

--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -77,11 +77,8 @@ def get_features_in_release_notes(milestone: int):
           Stage.milestones.ios_last >= milestone,
           Stage.milestones.webview_last >= milestone,
           Stage.rollout_milestone >= milestone),
-      ndb.OR(Stage.stage_type == STAGE_BLINK_SHIPPING,
-          Stage.stage_type == STAGE_PSA_SHIPPING,
-          Stage.stage_type == STAGE_FAST_SHIPPING,
-          Stage.stage_type == STAGE_DEP_SHIPPING,
-          Stage.stage_type == STAGE_ENT_ROLLOUT)).filter().fetch()
+      Stage.stage_type.IN([STAGE_BLINK_SHIPPING, STAGE_PSA_SHIPPING,
+          STAGE_FAST_SHIPPING, STAGE_DEP_SHIPPING, STAGE_ENT_ROLLOUT])).filter().fetch()
   
   feature_ids = list(set({
       *[s.feature_id for s in stages]}))


### PR DESCRIPTION
- Add new query parameter releaseNotesMilestone to the GET /features route
- Ensure all shipping and enterprise features are returned from the milestone specified in releaseNotesMilestone until the latest available feature
- Update front end logic to wait for a channel to be selected before getting the features for the release notes
- Update front end logic to fetch policies each time the target milestone is changed