### PR TITLE
Hide enterprise features from /features page

### DIFF
--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -426,6 +426,7 @@ def get_features_by_impl_status(limit: int | None=None, update_cache: bool=False
     feature_list = []
     for section in query_results:
       if len(section) > 0:
+        section = [f for f in section if f.feature_type != FEATURE_TYPE_ENTERPRISE_ID]
         section = [converters.feature_entry_to_json_basic(
             f, all_stages[f.key.integer_id()]) for f in section]
         section[0]['first_of_section'] = True


### PR DESCRIPTION
Enterprise features were shown on /features when they should never be shown there.
This PR filters out enterprise features from the features sent to /features