### PR TITLE
Ensure milestone comparison is made between two int types

### DIFF
--- a/client-src/elements/chromedash-enterprise-release-notes-page.js
+++ b/client-src/elements/chromedash-enterprise-release-notes-page.js
@@ -392,7 +392,8 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
       m => m === this.selectedMilestone)}
     ${this.renderReleaseNotesDetailsSection(
       `Upcoming Chrome browser updates`, this.upcomingFeatures,
-      (m, milestones) => milestones.find(x => x> this.selectedMilestone) === m)}`;
+      (m, milestones) => milestones
+        .find(x => parseInt(x) > parseInt(this.selectedMilestone)) === m)}`;
   }
 
   render() {


### PR DESCRIPTION
When highlighting the next milestone in the "Upcoming changes" from the enterprise release notes, the comparison was done between strings, which gave unwanted results such as highlighting 1245 instead of 125 when 125 and 1245 are available and M124 is selected.