### PR TITLE
Trial creation button displays as disabled when a creation request is pending

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -648,7 +648,19 @@ class ChromedashFeatureDetail extends LitElement {
     // TODO(DanielRyanSmith): uncomment this section to make the trial creation
     // request form available for users.
     /*
-    if (this.canEdit) {
+    if (this.canEdit && feStage.ot_action_requested) {
+      // Display the button as disabled with tooltip text if a request
+      // has already been submitted.
+      return html`
+        <sl-tooltip content="Action already requested. For further inquiries, contact origin-trials-core@google.com.">
+          <sl-button
+            size="small"
+            variant="primary"
+            disabled
+            >Request Trial Creation</sl-button>
+        </sl-tooltip>`;
+    // Display the creation request button if user has edit access.
+    } else if (this.canEdit) {
       return html`
         <sl-button
           size="small"

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -262,8 +262,8 @@ class AssociateOTs(FlaskHandler):
     if trial_stage.intent_thread_url is None:
       trial_stage.intent_thread_url = trial_data['intent_to_experiment_url']
 
-    if trial_stage.origin_trial_feedback_url is None:
-      trial_stage.origin_trial_feedback_url = trial_data['feedback_url']
+    if trial_stage.ot_feedback_submission_url is None:
+      trial_stage.ot_feedback_submission_url = trial_data['feedback_url']
 
     if trial_stage.ot_documentation_url is None:
       trial_stage.ot_documentation_url = trial_data['documentation_url']
@@ -273,6 +273,9 @@ class AssociateOTs(FlaskHandler):
 
     if not trial_stage.ot_is_deprecation_trial:
       trial_stage.ot_is_deprecation_trial = trial_data['type'] == 'DEPRECATION'
+
+    # Clear the trial creation request if it's active.
+    trial_stage.ot_action_requested = False
 
   def parse_feature_id(self, chromestatus_url: str|None) -> int|None:
       if chromestatus_url is None:


### PR DESCRIPTION
The trial creation request button will display as disabled after submitting the request, with an additional tooltip on hover.
![Screenshot 2023-09-18 at 8 36 27 AM](https://github.com/GoogleChrome/chromium-dashboard/assets/56164590/9aeba048-c911-409b-b53c-df793b958036)

This disabled button will display for feature editors until the stage is associated with an actual origin trial ID, which will then cause the detail page to display the "View Origin Trial" button that links to the OT Console.

Additionally, this change updates the OT association cron job to clear any action requests that are set to true if a trial is associated with that stage.