### PR TITLE
Add "overdue" to the tooltip on overdue gate chips.

### DIFF
--- a/client-src/elements/chromedash-gate-chip.js
+++ b/client-src/elements/chromedash-gate-chip.js
@@ -185,14 +185,16 @@ class ChromedashGateChip extends LitElement {
       `;
     }
 
-    const overdueIcon = (this.gate.slo_initial_response_remaining < 0) ?
+    const overdue = this.gate.slo_initial_response_remaining < 0;
+    const overdueIcon = overdue ?
       html`<sl-icon slot="suffix" library="material" class="overdue"
                  name="clock_loader_60_20px"></sl-icon>` :
       nothing;
+    const overdueTitle = overdue ? '. Overdue.' : '';
 
     return html`
       <sl-button pill size="small" class="${className} ${selected}"
-        title="${teamName}: ${gateName}: ${stateName}"
+        title="${teamName}: ${gateName}: ${stateName}${overdueTitle}"
         @click=${this.handleClick}
         >
         ${statusIcon}


### PR DESCRIPTION
Carol and Dharani have pointed out that the red clock icon is not obvious enough by itself.   I think users can figure it out because the same icon is used in the gate column with more text that explains it, but it would be helpful to add the word "overdue" to the tooltip on the gate chips as well.  