### PR TITLE
OT requests admin page

### DIFF
--- a/main.py
+++ b/main.py
@@ -53,6 +53,7 @@ from pages import featurelist
 from pages import guide
 from pages import intentpreview
 from pages import metrics
+from pages import ot_requests
 from pages import users
 import settings
 
@@ -208,6 +209,7 @@ spa_page_routes = [
 
 mpa_page_routes: list[Route] = [
     Route('/admin/users/new', users.UserListHandler),
+    Route('/admin/ot_requests', ot_requests.OriginTrialsRequests),
 
     Route('/admin/features/launch/<int:feature_id>',
         intentpreview.IntentEmailPreviewHandler),

--- a/pages/ot_requests.py
+++ b/pages/ot_requests.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from api.converters import stage_to_json_dict
+from internals.core_models import Stage
+
+from framework import basehandlers
+from framework import permissions
+
+
+class OriginTrialsRequests(basehandlers.FlaskHandler):
+  """Display any origin trials requests."""
+
+  TEMPLATE_PATH = 'admin/features/ot_requests.html'
+
+  @permissions.require_admin_site
+  def get_template_data(self, **kwargs):
+    stages_with_requests = Stage.query(
+        Stage.ot_action_requested == True).fetch()
+    
+    return {'stages': [stage_to_json_dict(s) for s in stages_with_requests]}

--- a/pages/ot_requests.py
+++ b/pages/ot_requests.py
@@ -28,5 +28,11 @@ class OriginTrialsRequests(basehandlers.FlaskHandler):
   def get_template_data(self, **kwargs):
     stages_with_requests = Stage.query(
         Stage.ot_action_requested == True).fetch()
-    
-    return {'stages': [stage_to_json_dict(s) for s in stages_with_requests]}
+    stages = []
+    for stage in stages_with_requests:
+      stage_dict = stage_to_json_dict(stage)
+      # Add the request note that is not typically visible to non-admins.
+      if stage.ot_request_note:
+        stage_dict['ot_request_note'] = stage.ot_request_note
+      stages.append(stage_dict)
+    return {'stages': stages}

--- a/templates/admin/features/ot_requests.html
+++ b/templates/admin/features/ot_requests.html
@@ -4,64 +4,92 @@
 
 {% block css %}
 <link rel="stylesheet" href="/static/css/forms.css?v={{app_version}}">
-<link rel="stylesheet" href="/static/css/features/launch.css?v={{app_version}}">
+<link rel="stylesheet" href="/static/css/features/ot_requests.css?v={{app_version}}">
 {% endblock %}
 
 {% block content %}
-<p>Body
-  <span class="tooltip copy-text" style="float:right"
-        title="Copy text to clipboard">
-      <a href="#" data-tooltip>
-        <iron-icon icon="chromestatus:content_copy"
-                   id="copy-email-body"></iron-icon>
-      </a>
-  </span>
-</p>
-{# <!-- {% for contact in stage.ot_emails|slice:"1:" %}{{contact}}{% endfor %} --> #}
-<h4>Daniel Test</h4>
-<div class="email">
-<table>
-  {% for stage in stages %}
-  <tr>
-    <td>{{stage.display_name}}</td>
-    <td>Pending</td>
-    <td>{{stage.ot_emails.0}}</td>
-    <td>{% for contact in stage.ot_emails[1:] %}{{contact}}<br>{% endfor %}</td>
-    <td>{{stage.milestones.desktop_first}}</td>
-    <td>{{stage.milestones.desktop_last}}</td>
-    <td></td>
-    <td>{{stage.ot_chromium_trial_name}}</td>
-    <td>{{stage.ot_webfeature_use_counter}}</td>
-    <td>{{stage.intent_thread_url}}</td>
-    <td>https://chromestatus.com/feature/{{stage.feature_id}}</td>
-    <td>{{stage.ot_feedback_submission_url}}</td>
-    <td>{{stage.ot_description}}</td>
-    <td>{% if stage.ot_has_third_party_support %}Yes{% else %}No{% endif %}</td>
-    <td>{% if stage.ot_is_critical_trial %}Yes{% else %}No{% endif %}</td>
-    <td>{% if stage.ot_is_deprecation_trial %}Yes{% else %}No{% endif %}</td>
-  </tr>
-  {% endfor %}
-</table>
+
+<div id="subheader">
+  <div>
+    <h2>Origin Trial Requests</h2>
+  </div>
 </div>
+
+<div id="subheader">
+  <div>
+    <h2>Copy row directly into "Trials - Validated" spreadsheet (
+      <a href="https://goto.google.com/ot-pipeline-internal" target="_blank">
+        go/ot-pipeline-internal
+      </a>)
+    </h2>
+  </div>
+</div>
+
+{% for stage in stages %}
+<section>
+  <h3>
+    Request for: {{stage.ot_display_name}}
+    <span class="tooltip copy-text" style="float:right" title="Copy text to clipboard">
+      <a href="#" data-tooltip>
+        <iron-icon icon="chromestatus:content_copy" id="copy-body-{{loop.index}}"></iron-icon>
+      </a>
+    </span>
+  </h3>
+  <div id="row-{{loop.index}}">
+    <table>
+      <tr>
+        <td>{{stage.ot_display_name}}</td>
+        <td>Pending</td>
+        <td>{{stage.ot_owner_email}}</td>
+        <td>{% for contact in stage.ot_emails %}{{contact}}<br>{% endfor %}</td>
+        <td>{{stage.desktop_first}}</td>
+        <td>{{stage.desktop_last}}</td>
+        <td></td>
+        <td>{{stage.ot_chromium_trial_name}}</td>
+        <td>{{stage.ot_webfeature_use_counter}}</td>
+        <td>{{stage.intent_thread_url}}</td>
+        <td>{{stage.ot_documentation_url}}</td>
+        <td>https://chromestatus.com/feature/{{stage.feature_id}}</td>
+        <td>{{stage.ot_feedback_submission_url}}</td>
+        <td>{{stage.ot_description}}</td>
+        <td>{% if stage.ot_has_third_party_support %}Yes{% else %}No{% endif %}</td>
+        <td>{% if stage.ot_is_critical_trial %}Yes{% else %}No{% endif %}</td>
+        <td>{% if stage.ot_is_deprecation_trial %}Yes{% else %}No{% endif %}</td>
+      </tr>
+    </table>
+  </div>
+</section>
+<section class="additional-comments">
+  <h4>Additional comments:</h4>
+  <p>Additional comments and concerns. This is just a test to make sure everything is functional. Additional comments and concerns. This is just a test to make sure everything is functional.</p>
+</section>
+{% endfor %}
 {% endblock %}
 
 {% block js %}
 <script nonce="{{nonce}}">
-// Remove loading spinner at page load.
+  // Remove loading spinner at page load.
   document.body.classList.remove('loading');
 
-  const copyEmailBodyEl = document.querySelector('#copy-email-body');
-  const emailBodyEl = document.querySelector('.email');
+  // Add "copy to clipboard" functionality.
   const toastEl = document.querySelector('chromedash-toast');
-  if (copyEmailBodyEl && emailBodyEl) {
-      copyEmailBodyEl.addEventListener('click', () => {
-          window.getSelection().removeAllRanges();
-          const range = document.createRange();
-          range.selectNode(emailBodyEl);
-          window.getSelection().addRange(range);
-          document.execCommand('copy');
-          toastEl.showMessage('Email body copied');
+  let counter = 1;
+  let copyButtonEl;
+  do {
+    const i = counter;
+    copyButtonEl = document.querySelector(`#copy-body-${counter}`);
+    counter++;
+    if (copyButtonEl) {
+      copyButtonEl.addEventListener('click', () => {
+        window.getSelection().removeAllRanges();
+        const range = document.createRange();
+        range.selectNode(document.querySelector(`#row-${i}`));
+        window.getSelection().addRange(range);
+        document.execCommand('copy');
+        toastEl.showMessage('Row copied!');
       });
-  }
+    }
+
+  } while (copyButtonEl);
 </script>
 {% endblock %}

--- a/templates/admin/features/ot_requests.html
+++ b/templates/admin/features/ot_requests.html
@@ -1,0 +1,67 @@
+{% extends "_base.html" %}
+
+{% block page_title %}OT Requests - {% endblock %}
+
+{% block css %}
+<link rel="stylesheet" href="/static/css/forms.css?v={{app_version}}">
+<link rel="stylesheet" href="/static/css/features/launch.css?v={{app_version}}">
+{% endblock %}
+
+{% block content %}
+<p>Body
+  <span class="tooltip copy-text" style="float:right"
+        title="Copy text to clipboard">
+      <a href="#" data-tooltip>
+        <iron-icon icon="chromestatus:content_copy"
+                   id="copy-email-body"></iron-icon>
+      </a>
+  </span>
+</p>
+{# <!-- {% for contact in stage.ot_emails|slice:"1:" %}{{contact}}{% endfor %} --> #}
+<h4>Daniel Test</h4>
+<div class="email">
+<table>
+  {% for stage in stages %}
+  <tr>
+    <td>{{stage.display_name}}</td>
+    <td>Pending</td>
+    <td>{{stage.ot_emails.0}}</td>
+    <td>{% for contact in stage.ot_emails[1:] %}{{contact}}<br>{% endfor %}</td>
+    <td>{{stage.milestones.desktop_first}}</td>
+    <td>{{stage.milestones.desktop_last}}</td>
+    <td></td>
+    <td>{{stage.ot_chromium_trial_name}}</td>
+    <td>{{stage.ot_webfeature_use_counter}}</td>
+    <td>{{stage.intent_thread_url}}</td>
+    <td>https://chromestatus.com/feature/{{stage.feature_id}}</td>
+    <td>{{stage.ot_feedback_submission_url}}</td>
+    <td>{{stage.ot_description}}</td>
+    <td>{% if stage.ot_has_third_party_support %}Yes{% else %}No{% endif %}</td>
+    <td>{% if stage.ot_is_critical_trial %}Yes{% else %}No{% endif %}</td>
+    <td>{% if stage.ot_is_deprecation_trial %}Yes{% else %}No{% endif %}</td>
+  </tr>
+  {% endfor %}
+</table>
+</div>
+{% endblock %}
+
+{% block js %}
+<script nonce="{{nonce}}">
+// Remove loading spinner at page load.
+  document.body.classList.remove('loading');
+
+  const copyEmailBodyEl = document.querySelector('#copy-email-body');
+  const emailBodyEl = document.querySelector('.email');
+  const toastEl = document.querySelector('chromedash-toast');
+  if (copyEmailBodyEl && emailBodyEl) {
+      copyEmailBodyEl.addEventListener('click', () => {
+          window.getSelection().removeAllRanges();
+          const range = document.createRange();
+          range.selectNode(emailBodyEl);
+          window.getSelection().addRange(range);
+          document.execCommand('copy');
+          toastEl.showMessage('Email body copied');
+      });
+  }
+</script>
+{% endblock %}


### PR DESCRIPTION
This PR adds a new temporary page available only to site admins that displays any origin trial creation requests that have been submitted by users.

![Screenshot 2023-09-21 at 4 26 29 PM](https://github.com/GoogleChrome/chromium-dashboard/assets/56164590/c5316d3f-5aff-4484-bd8c-d52efb0a271d)

This is a temporary solution to allow for the existing manual process to continue. The data collected from the trial creation request is given so that it is easy to paste the data to the existing origin trials spreadsheet, with a "copy to clipboard" button available.

Requests should be cleared from this page when the origin trial is detected via the origin trial association cron job.
