### PR TITLE
Add new prerequisites dialog for origin trial creation request form

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -2,6 +2,7 @@ import {LitElement, css, html, nothing} from 'lit';
 import {getStageValue, renderHTMLIf} from './utils';
 import {enhanceUrl} from './feature-link';
 import {openAddStageDialog} from './chromedash-add-stage-dialog';
+import {openPrereqsDialog} from './chromedash-ot-create-prereqs-dialog';
 import {makeDisplaySpecs} from './form-field-specs';
 import {
   FLAT_ENTERPRISE_METADATA_FIELDS,
@@ -652,7 +653,7 @@ class ChromedashFeatureDetail extends LitElement {
       // Display the button as disabled with tooltip text if a request
       // has already been submitted.
       return html`
-        <sl-tooltip content="Action already requested. For further inquiries, contact origin-trials-core@google.com.">
+        <sl-tooltip content="Action already requested. For further inquiries, contact origin-trials-discuss@google.com.">
           <sl-button
             size="small"
             variant="primary"
@@ -661,11 +662,12 @@ class ChromedashFeatureDetail extends LitElement {
         </sl-tooltip>`;
     // Display the creation request button if user has edit access.
     } else if (this.canEdit) {
+      const stageId = feStage.id;
       return html`
         <sl-button
           size="small"
           variant="primary"
-          href="/ot_creation_request/${this.feature.id}/${feStage.id}"
+          @click="${() => openPrereqsDialog(this.feature.id, stageId)}"
           >Request Trial Creation</sl-button>`;
     }
     */

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -2,7 +2,7 @@ import {LitElement, css, html, nothing} from 'lit';
 import {getStageValue, renderHTMLIf} from './utils';
 import {enhanceUrl} from './feature-link';
 import {openAddStageDialog} from './chromedash-add-stage-dialog';
-import {openPrereqsDialog} from './chromedash-ot-create-prereqs-dialog';
+// import {openPrereqsDialog} from './chromedash-ot-create-prereqs-dialog';
 import {makeDisplaySpecs} from './form-field-specs';
 import {
   FLAT_ENTERPRISE_METADATA_FIELDS,

--- a/client-src/elements/chromedash-ot-create-prereqs-dialog.js
+++ b/client-src/elements/chromedash-ot-create-prereqs-dialog.js
@@ -1,0 +1,118 @@
+import {LitElement, css, html} from 'lit';
+import {SHARED_STYLES} from '../css/shared-css.js';
+
+let prereqsDialogEl;
+let currentFeatureId;
+let currentStageId;
+
+
+export async function openPrereqsDialog(featureId, stageId) {
+  if (!prereqsDialogEl || currentFeatureId !== featureId ||
+      currentStageId !== stageId) {
+    prereqsDialogEl = document.createElement('chromedash-ot-create-prereqs-dialog');
+    prereqsDialogEl.featureId = featureId;
+    prereqsDialogEl.stageId = stageId;
+    document.body.appendChild(prereqsDialogEl);
+    await prereqsDialogEl.updateComplete;
+  }
+  currentFeatureId = featureId;
+  currentStageId = stageId;
+  prereqsDialogEl.show();
+}
+
+
+class ChromedashOTCreationPrereqsDialog extends LitElement {
+  static get properties() {
+    return {
+      featureId: {type: Number},
+      stageId: {type: Number},
+    };
+  }
+
+  constructor() {
+    super();
+    this.featureId = 0;
+    this.stageId = 0;
+  }
+
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      css`
+      #prereqs-list li {
+        margin-left: 8px;
+        margin-bottom: 8px;
+        list-style: circle;
+      }
+      #prereqs-header {
+        margin-bottom: 8px;
+      }
+      #continue-button {
+        float: right;
+      }
+      `,
+    ];
+  }
+
+  show() {
+    this.shadowRoot.querySelector('sl-dialog').show();
+  }
+
+  render() {
+    return html`
+      <sl-dialog label="Origin trial creation prerequisites">
+        <div id="prereqs-header">
+          <strong>Before submitting a request</strong>, please ensure the following
+          prerequisite steps have been completed:
+        </div>
+        <br>
+        <ul id="prereqs-list">
+          <li>Your Intent to Experiment has been drafted.</li>
+          <li>The required LGTMs have been received.</li>
+          <li>
+            The trial's UseCounter has landed on
+            <a href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/use_counter/metrics/web_feature.mojom" target="_blank">
+              web_feature.mojom
+            </a> and is being properly used.
+          </li>
+          <li>
+            A Chromium trial name has landed on
+            <a href="https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/renderer/platform/runtime_enabled_features.json5" target="_blank">
+              runtime_enabled_features.json5
+            </a>
+            <strong>that has not been used for any previous trials</strong>.
+            No trial names can be reused, even if used for the same feature!
+          </li>
+          <li>
+            For a third-party trial, the feature entry in
+            <a href="https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/renderer/platform/runtime_enabled_features.json5" target="_blank">
+              runtime_enabled_features.json5
+            </a>
+            contains the key "origin_trials_allows_third_party: true".
+          </li>
+          <li>
+            For a critical trial, the feature name has been added to the
+            <a href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/common/origin_trials/manual_completion_origin_trial_features.cc;l=17" target="_blank">
+              kHasExpiryGracePeriod array
+            </a>.
+          </li>
+        </ul>
+        <br>
+        <p>
+          If you haven't already, please review the docs for
+          <a href="https://www.chromium.org/blink/origin-trials/running-an-origin-trial/">
+            running an origin trial
+          </a>.
+          If you have any further questions, contact us at origin-trials-discuss@google.com.
+        </p>
+        <br>
+        <sl-button id="continue-button" variant="primary"
+          @click=${() => location.assign(`/ot_creation_request/${this.featureId}/${this.stageId}`)}
+          size="small"
+        >Proceed</sl-button>
+      </sl-dialog>`;
+  }
+}
+
+
+customElements.define('chromedash-ot-create-prereqs-dialog', ChromedashOTCreationPrereqsDialog);


### PR DESCRIPTION
This change adds a dialog to the "Request Trial Creation" button that will display a list of prerequisite steps to complete before requesting the creation of an origin trial. The user can then select "Proceed" to move on to the creation form page.

<img width="717" alt="Screenshot 2023-09-25 at 2 43 29 PM" src="https://github.com/GoogleChrome/chromium-dashboard/assets/56164590/7db071ce-9304-444c-8897-f003eca65a68">
