### PR TITLE
Show toast message shortly after OT creation request submission

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -653,7 +653,7 @@ class ChromedashFeatureDetail extends LitElement {
       // Display the button as disabled with tooltip text if a request
       // has already been submitted.
       return html`
-        <sl-tooltip content="Action already requested. For further inquiries, contact origin-trials-discuss@google.com.">
+        <sl-tooltip content="Action already requested. For further inquiries, contact origin-trials-support@google.com.">
           <sl-button
             size="small"
             variant="primary"

--- a/client-src/elements/chromedash-ot-create-prereqs-dialog.js
+++ b/client-src/elements/chromedash-ot-create-prereqs-dialog.js
@@ -103,7 +103,7 @@ class ChromedashOTCreationPrereqsDialog extends LitElement {
           <a href="https://www.chromium.org/blink/origin-trials/running-an-origin-trial/">
             running an origin trial
           </a>.
-          If you have any further questions, contact us at origin-trials-discuss@google.com.
+          If you have any further questions, contact us at origin-trials-support@google.com.
         </p>
         <br>
         <sl-button id="continue-button" variant="primary"

--- a/client-src/elements/chromedash-ot-creation-page.js
+++ b/client-src/elements/chromedash-ot-creation-page.js
@@ -104,7 +104,10 @@ export class ChromedashOTCreationPage extends LitElement {
     e.preventDefault();
     const submitBody = formatFeatureChanges(this.fieldValues, this.featureId);
     csClient.updateFeature(submitBody).then(() => {
-      window.location.href = this.nextPage || `/feature/${this.featureId}`;
+      showToastMessage('Creation request submitted!');
+      setTimeout(() => {
+        window.location.href = this.nextPage || `/feature/${this.featureId}`;
+      }, 1000);
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });

--- a/client-src/elements/chromedash-toast.js
+++ b/client-src/elements/chromedash-toast.js
@@ -52,7 +52,7 @@ class ChromedashToast extends LitElement {
 
       :host([open]) {
         opacity: 1;
-        transform: translateY(0px);
+        transform: translateY(-32px);
       }
 
       #action {


### PR DESCRIPTION
This PR adds a new toast message that will display after OT creation request form submission, for a short period before navigating back to the feature detail page.

This change also fixes a slight issue with the toast component, which was partially hidden behind the page's footer when displayed.

https://github.com/GoogleChrome/chromium-dashboard/assets/56164590/70c61afb-9ecd-4e4f-a75f-76906b2f13c4

An unrelated change to the OT email address is also in this PR.