### PR TITLE
Create new EntitiesAPIHandler base class

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -127,7 +127,7 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
     fields_dict = {}
     for field, field_type in api_specs.FEATURE_FIELD_DATA_TYPES:
       if field in body:
-        fields_dict[field] = self._format_field_val(
+        fields_dict[field] = self.format_field_val(
             field, field_type, body[field])
 
     # Try to create the feature using the provided data.

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -47,76 +47,8 @@ URL_RE = re.compile(r'\b%s%s%s\b' % (
 ALLOWED_SCHEMES = [None, 'http', 'https']
 
 
-class FeaturesAPI(basehandlers.APIHandler):
+class FeaturesAPI(basehandlers.EntitiesAPIHandler):
   """Features are the the main records that we track."""
-
-  def _abort_invalid_data_type(
-      self, field: str, field_type: str, value: Any) -> None:
-    """Abort the process if an invalid data type is given."""
-    self.abort(400, msg=(
-        f'Bad value for field {field} of type {field_type}: {value}'))
-
-  def _extract_link(self, s):
-    if s:
-      match_obj = URL_RE.search(str(s))
-      if match_obj and match_obj.group('scheme') in ALLOWED_SCHEMES:
-        link = match_obj.group()
-        if not link.startswith(('http://', 'https://')):
-          link = 'http://' + link
-        return link
-
-    return None
-
-  def _split_list_input(
-      self,
-      field: str,
-      field_type: str,
-      value: str,
-      delimiter: str='\\r?\\n'
-    ) -> list[str]:
-    try:
-      formatted_list = [
-        x.strip() for x in re.split(delimiter, value) if x.strip()]
-    except TypeError:
-      self._abort_invalid_data_type(field, field_type, value)
-    return formatted_list
-
-  def _format_field_val(
-      self,
-      field: str,
-      field_type: str,
-      value: Any,
-    ) -> str | int | bool | list | None:
-    """Format the given feature value based on the field type."""
-
-    # If the field is empty, no need to format.
-    if value is None:
-      return None
-
-    # TODO(DanielRyanSmith): Write checks to ensure enum values are valid.
-    if field_type == 'emails' or field_type == 'split_str':
-      list_val = self._split_list_input(field, field_type, value, ',')
-      if field == 'blink_components' and len(value) == 0:
-        return [settings.DEFAULT_COMPONENT]
-      return list_val
-    elif field_type == 'link':
-      return self._extract_link(value)
-    elif field_type == 'links':
-      list_val = self._split_list_input(field, field_type, value)
-      # Filter out any URLs that do not conform to the proper pattern.
-      return [self._extract_link(link)
-              for link in list_val if link]
-    elif field_type == 'int':
-      # Int fields can be unset by giving null or nothing in the input field.
-      if value == '' or value is None:
-        return None
-      try:
-        return int(value)
-      except ValueError:
-        self._abort_invalid_data_type(field, field_type, value)
-    elif field_type == 'bool':
-      return bool(value)
-    return str(value)
 
   def get_one_feature(self, feature_id: int) -> VerboseFeatureDict:
     feature = FeatureEntry.get_by_id(feature_id)
@@ -234,16 +166,6 @@ class FeaturesAPI(basehandlers.APIHandler):
       if new_gates:
         ndb.put_multi(new_gates)
 
-  def _update_field_value(
-      self,
-      entity: FeatureEntry | MilestoneSet | Stage,
-      field: str,
-      field_type: str,
-      value: Any
-    ) -> None:
-    new_value = self._format_field_val(field, field_type, value)
-    setattr(entity, field, new_value)
-
   def _patch_update_stages(
       self,
       stage_changes_list: list[dict[str, Any]],
@@ -274,7 +196,7 @@ class FeaturesAPI(basehandlers.APIHandler):
 
         old_value = getattr(stage, field)
         new_value = change_info[field]['value']
-        self._update_field_value(stage, field, field_type, new_value)
+        self.update_field_value(stage, field, field_type, new_value)
         # The OT additional details does not need to be sent to subscribers.
         if form_field_name != 'ot_request_note':
           changed_fields.append((form_field_name, old_value, new_value))
@@ -290,7 +212,7 @@ class FeaturesAPI(basehandlers.APIHandler):
         form_field_name = change_info[field]['form_field_name']
         old_value = getattr(milestones, field)
         new_value = change_info[field]['value']
-        self._update_field_value(milestones, field, field_type, new_value)
+        self.update_field_value(milestones, field, field_type, new_value)
         changed_fields.append((form_field_name, old_value, new_value))
         stage_was_updated = True
       stage.milestones = milestones
@@ -341,7 +263,7 @@ class FeaturesAPI(basehandlers.APIHandler):
         continue
       old_value = getattr(feature, field)
       new_value = feature_changes[field]
-      self._update_field_value(feature, field, field_type, new_value)
+      self.update_field_value(feature, field, field_type, new_value)
       changed_fields.append((field, old_value, new_value))
       has_updated = True
 

--- a/api/stages_api.py
+++ b/api/stages_api.py
@@ -124,10 +124,8 @@ class StagesAPI(basehandlers.EntitiesAPIHandler):
     if 'stage_type' not in body:
       self.abort(404, msg='Stage type not specified.')
     stage_type = int(body['stage_type'])
-    stage = self._create_stage(feature_id, feature.feature_type, stage_type)
-    changed_fields: CHANGED_FIELDS_LIST_TYPE = []
     # Add the specified field values to the stage. Create a gate if needed.
-    self._update_stage(stage, body, changed_fields)
+    stage = self._create_stage(feature_id, feature.feature_type, stage_type)
 
     # Changing stage values means the cached feature should be invalidated.
     lookup_key = FeatureEntry.feature_cache_key(

--- a/api/stages_api.py
+++ b/api/stages_api.py
@@ -13,65 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
 
 from api import converters
+from api import api_specs
 from framework import basehandlers
 from framework import permissions
 from framework import rediscache
-from internals import core_enums, stage_helpers
+from internals import notifier_helpers
+from internals import stage_helpers
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
+from internals.data_types import CHANGED_FIELDS_LIST_TYPE
 from internals.review_models import Gate
 
 
-class StagesAPI(basehandlers.APIHandler):
-
-  # Categorized field names of the Stage kind.
-  GENERAL_FIELDS: list[str] = [
-      'browser',
-      'pm_emails',
-      'tl_emails',
-      'ux_emails',
-      'te_emails',
-      'intent_thread_url']
-
-  MILESTONE_FIELDS: list[str] = [
-      'desktop_first',
-      'desktop_last',
-      'android_first',
-      'android_last',
-      'ios_first',
-      'ios_last',
-      'webview_first',
-      'webview_last']
-
-  OT_FIELDS: list[str] = [
-      'experiment_goals',
-      'experiment_risks',
-      'origin_trial_feedback_url']
-
-  OT_EXTENSION_FIELDS: list[str] = [
-      'experiment_extension_reason',
-      'ot_stage_id']
-
-  SHIPPING_FIELDS: list[str] = [
-      'announcement_url',
-      'finch_url']
-
-  ENTERPRISE_FIELDS: list[str] = [
-      'rollout_impact',
-      'rollout_milestone',
-      'rollout_platforms',
-      'rollout_details',
-      'enterprise_policies']
-
-  # Fields that should default to an empty list if null.
-  FIELDS_DEFAULT_TO_LIST: list[str] = [
-      'pm_emails',
-      'tl_emails',
-      'ux_emails',
-      'te_emails',
-      'rollout_platforms',
-      'enterprise_policies']
+class StagesAPI(basehandlers.EntitiesAPIHandler):
 
   def _create_gate_for_stage(
       self, feature_id: int, stage_id: int, gate_type: int) -> None:
@@ -80,58 +36,56 @@ class StagesAPI(basehandlers.APIHandler):
         state=Gate.PREPARING)
     gate.put()
 
-  def _add_given_stage_vals(self,
-      stage: Stage, body: dict, fields: list[str]) -> None:
-    """Add given fields of the stage entity."""
-    for field in fields:
-      if field in body:
-        setattr(stage, field, body[field])
+  def _create_stage(self, feature_id: int, feature_type: int, stage_type: int):
+    """Create a new Stage entity."""
+    stage = Stage(feature_id=feature_id, stage_type=stage_type)
+    stage.put()
+    gate_type: int | None = stage_helpers.get_gate_for_stage(
+        feature_type, stage.stage_type)
+    if gate_type is not None:
+        self._create_gate_for_stage(
+        stage.feature_id, stage.key.integer_id(), gate_type)
+    return stage
 
-  def _update_stage_vals(self, stage: Stage, feature_type: int,
-      use_stage_type: bool=True, create_gate: bool=False) -> None:
-    """Check for relevant stage fields and update stage as needed."""
-    body = self.get_json_param_dict()
-    if use_stage_type:
-      if 'stage_type' not in body:
-        self.abort(404, msg='Stage type not specified.')
-      stage.stage_type = int(body['stage_type'])
-    s_type = stage.stage_type
+  def _update_stage(
+      self,
+      stage: Stage,
+      change_info: dict[str, Any],
+      changed_fields: CHANGED_FIELDS_LIST_TYPE,
+    ) -> bool:
+    """Update stage fields with changes provided."""
+    stage_was_updated = False
+    # Check if valid ID is provided and fetch stage if it exists.
 
-    for field in self.GENERAL_FIELDS:
-      if field in body:
-        setattr(stage, field, body[field])
+    # Update stage fields.
+    for field, field_type in api_specs.STAGE_FIELD_DATA_TYPES:
+      if field not in change_info:
+        continue
+      form_field_name = change_info[field]['form_field_name']
+      old_value = getattr(stage, field)
+      new_value = change_info[field]['value']
+      self.update_field_value(stage, field, field_type, new_value)
+      changed_fields.append((form_field_name, old_value, new_value))
+      stage_was_updated = True
 
     # Update milestone fields.
-    for field in self.MILESTONE_FIELDS:
-      if field in body:
-        if stage.milestones is None:
-          stage.milestones = MilestoneSet()
-        setattr(stage.milestones, field, body[field])
+    milestones = stage.milestones
+    for field, field_type in api_specs.MILESTONESET_FIELD_DATA_TYPES:
+      if field not in change_info:
+        continue
+      if milestones is None:
+        milestones = MilestoneSet()
+      form_field_name = change_info[field]['form_field_name']
+      old_value = getattr(milestones, field)
+      new_value = change_info[field]['value']
+      self.update_field_value(milestones, field, field_type, new_value)
+      changed_fields.append((form_field_name, old_value, new_value))
+      stage_was_updated = True
+    stage.milestones = milestones
 
-    # Keep the gate type that might need to be created for the stage type.
-    gate_type: int | None = stage_helpers.get_gate_for_stage(feature_type, s_type)
-    # Update type-specific fields.
-
-    if s_type == core_enums.STAGE_TYPES_ORIGIN_TRIAL[feature_type]:
-      self._add_given_stage_vals(stage, body, self.OT_FIELDS)
-
-    if s_type == core_enums.STAGE_TYPES_EXTEND_ORIGIN_TRIAL[feature_type]:
-      self._add_given_stage_vals(stage, body, self.OT_EXTENSION_FIELDS)
-
-    if s_type == core_enums.STAGE_TYPES_SHIPPING[feature_type]: # pragma: no cover
-      self._add_given_stage_vals(stage, body, self.SHIPPING_FIELDS)
-
-    if s_type == core_enums.STAGE_TYPES_ROLLOUT[feature_type]: # pragma: no cover
-      self._add_given_stage_vals(stage, body, self.ENTERPRISE_FIELDS)
-
-    stage.put()
-
-    # If we should create a gate and this is a stage that requires a gate,
-    # create it.
-    if create_gate and gate_type is not None:
-      self._create_gate_for_stage(
-          stage.feature_id, stage.key.integer_id(), gate_type)
-
+    if stage_was_updated:
+      stage.put()
+    return stage_was_updated
 
   def do_get(self, **kwargs):
     """Return a specified stage based on the given ID."""
@@ -166,11 +120,14 @@ class StagesAPI(basehandlers.APIHandler):
     if redirect_resp:
       return redirect_resp
 
-    # Create the stage.
-    stage = Stage(feature_id=feature_id)
+    body = self.get_json_param_dict()
+    if 'stage_type' not in body:
+      self.abort(404, msg='Stage type not specified.')
+    stage_type = int(body['stage_type'])
+    stage = self._create_stage(feature_id, feature.feature_type, stage_type)
+    changed_fields: CHANGED_FIELDS_LIST_TYPE = []
     # Add the specified field values to the stage. Create a gate if needed.
-    self._update_stage_vals(
-        stage, feature.feature_type, use_stage_type=True, create_gate=True)
+    self._update_stage(stage, body, changed_fields)
 
     # Changing stage values means the cached feature should be invalidated.
     lookup_key = FeatureEntry.feature_cache_key(
@@ -194,7 +151,7 @@ class StagesAPI(basehandlers.APIHandler):
     feature: FeatureEntry | None = FeatureEntry.get_by_id(stage.feature_id)
     if feature is None:
       self.abort(404, msg=(f'Feature {stage.feature_id} not found '
-          f'associated with stage {stage_id}'))
+                           f'associated with stage {stage_id}'))
     feature_id = feature.key.integer_id()
     # Validate the user has edit permissions and redirect if needed.
     redirect_resp = permissions.validate_feature_edit_permission(
@@ -202,10 +159,13 @@ class StagesAPI(basehandlers.APIHandler):
     if redirect_resp:
       return redirect_resp
 
-    # Update specified fields. No need to create a gate for existing stage.
-    self._update_stage_vals(
-        stage, feature.feature_type, use_stage_type=False, create_gate=False)
+    body = self.get_json_param_dict()
+    changed_fields: CHANGED_FIELDS_LIST_TYPE = []
+    # Update specified fields.
+    self._update_stage(stage, body, changed_fields)
 
+    notifier_helpers.notify_subscribers_and_save_amendments(
+        feature, changed_fields, notify=True)
     # Changing stage values means the cached feature should be invalidated.
     lookup_key = FeatureEntry.feature_cache_key(
         FeatureEntry.DEFAULT_CACHE_KEY, feature_id)

--- a/client-src/elements/chromedash-ot-creation-page.js
+++ b/client-src/elements/chromedash-ot-creation-page.js
@@ -102,8 +102,11 @@ export class ChromedashOTCreationPage extends LitElement {
 
   handleFormSubmit(e) {
     e.preventDefault();
-    const submitBody = formatFeatureChanges(this.fieldValues, this.featureId);
-    csClient.updateFeature(submitBody).then(() => {
+    const featureSubmitBody = formatFeatureChanges(this.fieldValues, this.featureId);
+    // We only need the single stage changes.
+    const stageSubmitBody = featureSubmitBody.stages[0];
+
+    window.csClient.updateStage(this.featureId, this.stageId, stageSubmitBody).then(() => {
       showToastMessage('Creation request submitted!');
       setTimeout(() => {
         window.location.href = this.nextPage || `/feature/${this.featureId}`;

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -341,6 +341,10 @@ class ChromeStatusClient {
     return this.doPost(`/features/${featureId}/stages`, body);
   }
 
+  updateStage(featureId, stageId, body) {
+    return this.doPatch(`/features/${featureId}/stages/${stageId}`, body);
+  }
+
   // Processes API
   getFeatureProcess(featureId) {
     return this.doGet(`/features/${featureId}/process`);


### PR DESCRIPTION
This PR creates a new shared `EntitiesAPIHandler` class, which the StagesAPI and FeaturesAPI inherit from. The class contains shared methods used for mutating entity data. These changes mostly involve moving methods from the FeaturesAPI class to the EntitiesAPIHandler class and refactoring the StagesAPI class to effectively use those inherited methods.


```
     APIHandler
         |
         V
 EntitiesAPIHandler
         |
         V
FeaturesAPI/StagesAPI
```