### PR TITLE
Make testing internal survey link open in a new tab.

### DIFF
--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -849,7 +849,7 @@ Do the automated tests have more than 93% green (flakiness < 7%) on CQ and CI bu
 <li>Yes. There are non-automatable test cases and I have completed test execution or allocated resources to ensure the coverage of these test cases.
 <li>Yes. There are non-automatable test cases and my feature impacts Google products.
 </ul>
-<b>(4) If your feature impacts Google products, please fill in <a href="http://go/chrome-wp-test-survey">go/chrome-wp-test-survey</a>.</b> Make a copy, answer the survey questions, and provide a link to your document here.
+<b>(4) If your feature impacts Google products, please fill in <a href="http://go/chrome-wp-test-survey" target="_blank">go/chrome-wp-test-survey</a>.</b> Make a copy, answer the survey questions, and provide a link to your document here.
 `
 );
 


### PR DESCRIPTION
This makes the internal testing survey link open in a new tab so that the user does not lose the app state of our SPA.  I had added the target="" attribute to other links but missed this one.