### PR TITLE
Display OT creation request note on admin page

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -40,7 +40,7 @@ from internals.user_models import (
     AppUser, BlinkComponent, FeatureOwner, UserPref)
 
 
-OT_CORE_EMAIL = 'origin-trials-core@google.com'
+OT_SUPPORT_EMAIL = 'origin-trials-support@google.com'
 
 
 def _determine_milestone_string(ship_stages: list[Stage]) -> str:
@@ -547,7 +547,7 @@ class OriginTrialCreationRequestHandler(basehandlers.FlaskHandler):
 """
 
     return {
-      'to': OT_CORE_EMAIL,
+      'to': OT_SUPPORT_EMAIL,
       'subject': f'New Trial Creation Request for {stage["ot_display_name"]}',
       'reply_to': None,
       'html': email_body,

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -820,7 +820,7 @@ class OriginTrialCreationRequestHandlerTest(testing_config.CustomTestCase):
 </p>
 """
     expected = {
-      'to': 'origin-trials-core@google.com',
+      'to': 'origin-trials-support@google.com',
       'subject': f'New Trial Creation Request for A new origin trial',
       'reply_to': None,
       'html': expected_body,

--- a/templates/admin/features/ot_requests.html
+++ b/templates/admin/features/ot_requests.html
@@ -61,7 +61,7 @@
 </section>
 <section class="additional-comments">
   <h4>Additional comments:</h4>
-  <p>Additional comments and concerns. This is just a test to make sure everything is functional. Additional comments and concerns. This is just a test to make sure everything is functional.</p>
+  {{stage.ot_request_note}}
 </section>
 {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Missed a field populated with test data.

Also updating `origin-trials-core@google.com` to `origin-trials-support@google.com`, as the former email cannot receive messages from non-google.com emails.