### PR TITLE
Move OT notifier to stages API

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -173,7 +173,6 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
     ) -> bool:
     """Update stage fields with changes provided in the PATCH request."""
     stages: list[Stage] = []
-    ot_action_requested_stage: Stage | None = None
     for change_info in stage_changes_list:
       stage_was_updated = False
       # Check if valid ID is provided and fetch stage if it exists.
@@ -189,10 +188,6 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
         if field not in change_info:
           continue
         form_field_name = change_info[field]['form_field_name']
-
-        # If a creation request has been submitted, save for notification.
-        if form_field_name == 'ot_action_requested':
-          ot_action_requested_stage = stage
 
         old_value = getattr(stage, field)
         new_value = change_info[field]['value']

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -224,10 +224,6 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
     if stages:
       ndb.put_multi(stages)
 
-    # Notify of OT request if one was sent.
-    if ot_action_requested_stage:
-      notifier_helpers.send_ot_creation_notification(ot_action_requested_stage)
-
     # Return a boolean representing if any changes were made to any stages.
     return len(stages) > 0
 

--- a/api/stages_api.py
+++ b/api/stages_api.py
@@ -55,6 +55,7 @@ class StagesAPI(basehandlers.EntitiesAPIHandler):
     ) -> bool:
     """Update stage fields with changes provided."""
     stage_was_updated = False
+    ot_action_requested = False
     # Check if valid ID is provided and fetch stage if it exists.
 
     # Update stage fields.
@@ -62,6 +63,8 @@ class StagesAPI(basehandlers.EntitiesAPIHandler):
       if field not in change_info:
         continue
       form_field_name = change_info[field]['form_field_name']
+      if form_field_name == 'ot_action_requested':
+        ot_action_requested = True
       old_value = getattr(stage, field)
       new_value = change_info[field]['value']
       self.update_field_value(stage, field, field_type, new_value)
@@ -85,6 +88,11 @@ class StagesAPI(basehandlers.EntitiesAPIHandler):
 
     if stage_was_updated:
       stage.put()
+
+    # Notify of OT request if one was sent.
+    if ot_action_requested:
+      notifier_helpers.send_ot_creation_notification(stage)
+
     return stage_was_updated
 
   def do_get(self, **kwargs):


### PR DESCRIPTION
This fixes a regression caused by the OT action email notifier logic still existing on the features API. This change moves the logic correctly to the stages API.