### PR TITLE
Add "Stable soon" mode to roadmap page.

### DIFF
--- a/api/channels_api.py
+++ b/api/channels_api.py
@@ -48,6 +48,13 @@ def construct_chrome_channels_details():
     channels['dev'] = fetch_chrome_release_info(new_dev_version)
     channels['dev']['version'] = new_dev_version
 
+  # In the situation where some versions are in a gap between
+  # stable and beta, show one as 'stable_soon'.
+  if channels['stable']['version'] + 1 < channels['beta']['version']:
+    stable_soon_version = channels['stable']['version'] + 1
+    channels['stable_soon'] = fetch_chrome_release_info(stable_soon_version)
+    channels['stable_soon']['version'] = stable_soon_version
+
   return channels
 
 


### PR DESCRIPTION
This should resolve issue #3395.

The Omaha backend is giving chromestatus data saying that stable=117 and beta=119.  This caused us to display those two milestones, but not 118 which is between them.  This PR checks for that situation on the server side and fills in data for the a new `stable_soon` item in the channels API response.  The client side notices this and displays it if present.

Also, there's a tweak to the calculation of the first previous milestone to fetch on the client side.  Instead of beta - 1, it now looks for stable - 1.