### PR TITLE
Show explainer links at top of the feature detail page if there is no spec

### DIFF
--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -400,15 +400,13 @@ export class ChromedashFeaturePage extends LitElement {
         </section>
       `: nothing}
 
-      ${this.feature.standards.spec ? html`
+      ${(this.feature.standards.spec || this.feature.explainer_links?.length) ? html`
         <section id="specification">
           <h3>Specification</h3>
-          <p>${enhanceUrl(this.feature.standards.spec, this.featureLinks)}</p>
-          <br>
-          <p>
-            <label>Status:</label>
-            ${this.feature.standards.maturity.text}
-          </p>
+          ${this.feature.explainer_links?.map((link) =>
+      html`<p>Explainer: ${enhanceUrl(link, this.featureLinks)}</p>`)}
+          <p>Spec: ${enhanceUrl(this.feature.standards.spec, this.featureLinks)}</p>
+          <p>Spec status: ${this.feature.standards.maturity.text}</p>
         </section>
       `: nothing}
     `;

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -378,7 +378,7 @@ export class ChromedashFeaturePage extends LitElement {
         </section>
       `: nothing}
 
-      ${this.feature.resources && this.feature.resources.samples ? html`
+      ${this.feature.resources?.samples?.length ? html`
         <section id="demo">
           <h3>Demos and samples</h3>
           <ul>
@@ -389,7 +389,7 @@ export class ChromedashFeaturePage extends LitElement {
         </section>
       `: nothing}
 
-      ${this.feature.resources && this.feature.resources.docs ? html`
+      ${this.feature.resources?.docs?.length ? html`
         <section id="documentation">
           <h3>Documentation</h3>
           <ul>
@@ -400,13 +400,17 @@ export class ChromedashFeaturePage extends LitElement {
         </section>
       `: nothing}
 
-      ${(this.feature.standards.spec || this.feature.explainer_links?.length) ? html`
+      ${this.feature.standards.spec ? html`
         <section id="specification">
           <h3>Specification</h3>
-          ${this.feature.explainer_links?.map((link) =>
-      html`<p>Explainer: ${enhanceUrl(link, this.featureLinks)}</p>`)}
-          <p>Spec: ${enhanceUrl(this.feature.standards.spec, this.featureLinks)}</p>
+          <p>${enhanceUrl(this.feature.standards.spec, this.featureLinks)}</p>
           <p>Spec status: ${this.feature.standards.maturity.text}</p>
+        </section>
+        `: this.feature.explainer_links?.length ? html`
+        <section id="specification">
+          <h3>Explainer(s)</h3>
+          ${this.feature.explainer_links?.map((link) =>
+      html`<p>${enhanceUrl(link, this.featureLinks)}</p>`)}
         </section>
       `: nothing}
     `;


### PR DESCRIPTION
This should resolve #624.

In this PR:
* If there is an explainer link but no spec link, then show the explainer links at the top of the feature detail page
* Also, fix the conditionals on the headers for demos and docs