### PR TITLE
Prompt users to switch to a paired account that can edit or review.

### DIFF
--- a/api/permissions_api.py
+++ b/api/permissions_api.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from framework import basehandlers
 from framework import permissions
+from framework.users import User
 from internals import approval_defs
 
 
@@ -25,22 +25,37 @@ class PermissionsAPI(basehandlers.APIHandler):
 
   def do_get(self, **kwargs):
     """Return the permissions and the email of the user."""
-
     # No user data if not signed in
     user_data = None
 
     # get user permission data if signed in
     user = self.get_current_user()
     if user:
-      user_data = {
-        'can_create_feature': permissions.can_create_feature(user),
-        'approvable_gate_types': sorted(
-            approval_defs.fields_approvable_by(user)),
-        'can_comment': permissions.can_comment(user),
-        'can_edit_all': permissions.can_edit_any_feature(user),
-        'is_admin': permissions.can_admin_site(user),
-        'email': user.email(),
-        'editable_features': permissions.feature_edit_list(user)
-      }
+      user_data = self.get_all_perms(user)
+      paired_user = self.find_paired_user(user)
+      if paired_user:
+        user_data['paired_user'] = self.get_all_perms(paired_user)
 
     return {'user': user_data}
+
+  def get_all_perms(self, user):
+    """Return a dict of permissions for the given user."""
+    return {
+      'can_create_feature': permissions.can_create_feature(user),
+      'approvable_gate_types': sorted(
+          approval_defs.fields_approvable_by(user)),
+      'can_comment': permissions.can_comment(user),
+      'can_edit_all': permissions.can_edit_any_feature(user),
+      'is_admin': permissions.can_admin_site(user),
+      'email': user.email(),
+      'editable_features': permissions.feature_edit_list(user)
+    }
+
+  def find_paired_user(self, user):
+    """If @google.com or @chromium.org, return the other one."""
+    username, domain = user.email().split('@', 1)
+    if domain == 'google.com':
+      return User(email=username + '@chromium.org')
+    if domain == 'chromium.org':
+      return User(email=username + '@google.com')
+    return None

--- a/api/permissions_api_test.py
+++ b/api/permissions_api_test.py
@@ -68,6 +68,15 @@ class PermissionsAPITest(testing_config.CustomTestCase):
         'can_edit_all': False,
         'is_admin': False,
         'email': 'one@google.com',
-        'editable_features': []
+        'editable_features': [],
+        'paired_user': {
+            'can_create_feature': True,
+            'approvable_gate_types': [],
+            'can_comment': True,
+            'can_edit_all': False,
+            'is_admin': False,
+            'email': 'one@chromium.org',
+            'editable_features': []
+          }
         }}
     self.assertEqual(expected, actual)

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -282,6 +282,12 @@ export class ChromedashFeaturePage extends LitElement {
              this.user.editable_features.includes(this.featureId)));
   }
 
+  pairedUserCanEdit() {
+    return (this.user?.paired_user &&
+            (this.user.paired_user.can_edit_all ||
+             this.user.paired_user.editable_features.includes(this.featureId)));
+  }
+
   renderSubHeader() {
     const canEdit = this.userCanEdit();
 
@@ -334,23 +340,45 @@ export class ChromedashFeaturePage extends LitElement {
   }
 
   renderWarnings() {
+    const warnings = [];
     if (this.feature.deleted) {
-      return html`
+      warnings.push(html`
         <div id="deleted" class="warning">
           This feature is marked as deleted.  It does not appear in
           feature lists and is only viewable by users who can edit it.
         </div>
-      `;
+      `);
     }
     if (this.feature.unlisted) {
-      return html`
+      warnings.push(html`
         <div id="access" class="warning">
           This feature is only shown in the feature list
           to users with access to edit this feature.
         </div>
-      `;
+      `);
     }
-    return nothing;
+    if (!this.userCanEdit() && this.pairedUserCanEdit()) {
+      warnings.push(html`
+        <div id="switch_to_edit" class="warning">
+          User ${this.user.email} cannot edit this feature or request reviews.
+          But, ${this.user.paired_user.email} can do that.
+          <br>
+          To switch users: sign out and then sign in again.
+        </div>
+      `);
+    }
+    if (this.user?.approvable_gate_types.length == 0 &&
+        this.user?.paired_user?.approvable_gate_types.length > 0) {
+      warnings.push(html`
+        <div id="switch_to_review" class="warning">
+          User ${this.user.email} cannot review this feature.
+          But, ${this.user.paired_user.email} can do that.
+          <br>
+          To switch users: sign out and then sign in again.
+        </div>
+      `);
+    }
+    return warnings;
   }
 
   renderEnterpriseFeatureContent() {

--- a/client-src/elements/chromedash-feature-page_test.js
+++ b/client-src/elements/chromedash-feature-page_test.js
@@ -11,6 +11,7 @@ describe('chromedash-feature-page', () => {
     can_edit_all: true,
     is_admin: false,
     email: 'example@google.com',
+    approvable_gate_types: [],
   };
   const editor = {
     can_create_feature: false,
@@ -18,6 +19,7 @@ describe('chromedash-feature-page', () => {
     editable_features: [123456],
     is_admin: false,
     email: 'editor@example.com',
+    approvable_gate_types: [],
   };
   const visitor = {
     can_create_feature: false,
@@ -25,6 +27,7 @@ describe('chromedash-feature-page', () => {
     editable_features: [],
     is_admin: false,
     email: 'example@example.com',
+    approvable_gate_types: [],
   };
   const anon = null;
   const gatesPromise = Promise.resolve([]);


### PR DESCRIPTION
There have been a couple of recent email threads with feature owners where it looked like the user could not edit or request a review because they were signed into the wrong account.  Googlers who work on chrome often have both a @google.com and a @chromium.org account and can be signed into the wrong one.  So, now we prompt users to switch to the right one.

In this PR:
* In permissions_api.py: add the concept of a `paired_user` and get its permissions.
* In chromedash-feature-page.js: add logic to detect two specific cases of using the wrong account, and display all applicable warnings.