### PR TITLE
Upgrade playwright to 1.37.

### DIFF
--- a/packages/playwright/Dockerfile
+++ b/packages/playwright/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.35.1-jammy
+FROM mcr.microsoft.com/playwright:v1.37.1-jammy
 
 ARG USERID
 ARG GROUPID


### PR DESCRIPTION
When trying to run playwright tests, one error message told me to upgrade this version.  I have not gotten it to work locally, so let's see if it works in CI.