### PR TITLE
New OT extension form

### DIFF
--- a/api/api_specs.py
+++ b/api/api_specs.py
@@ -115,6 +115,7 @@ STAGE_FIELD_DATA_TYPES: FIELD_INFO_DATA_TYPE = [
   ('ot_is_deprecation_trial', 'bool'),
   ('ot_owner_email', 'str'),
   ('ot_request_note', 'str'),
+  ('ot_stage_id', 'int'),
   ('ot_webfeature_use_counter', 'str'),
   ('rollout_impact', 'int'),
   ('rollout_milestone', 'int'),

--- a/client-src/components.js
+++ b/client-src/components.js
@@ -82,6 +82,7 @@ import './elements/chromedash-login-required-page';
 import './elements/chromedash-metadata';
 import './elements/chromedash-myfeatures-page';
 import './elements/chromedash-ot-creation-page';
+import './elements/chromedash-ot-extension-page';
 import './elements/chromedash-preflight-dialog';
 import './elements/chromedash-process-overview';
 import './elements/chromedash-settings-page';

--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -382,6 +382,16 @@ class ChromedashApp extends LitElement {
       this.currentPage = ctx.path;
       this.hideSidebar();
     });
+    page('/ot_extension_request/:featureId(\\d+)/:stageId(\\d+)', (ctx) => {
+      if (!this.setupNewPage(ctx, 'chromedash-ot-extension-page')) return;
+      this.pageComponent.featureId = parseInt(ctx.params.featureId);
+      this.pageComponent.stageId = parseInt(ctx.params.stageId);
+      this.pageComponent.nextPage = this.currentPage;
+      this.pageComponent.appTitle = this.appTitle;
+      this.pageComponent.userEmail = this.user.email;
+      this.currentPage = ctx.path;
+      this.hideSidebar();
+    });
     page('/guide/stage/:featureId(\\d+)/metadata', (ctx) => {
       if (!this.setupNewPage(ctx, 'chromedash-guide-metadata-page')) return;
       this.pageComponent.featureId = parseInt(ctx.params.featureId);

--- a/client-src/elements/chromedash-ot-extension-page.js
+++ b/client-src/elements/chromedash-ot-extension-page.js
@@ -158,6 +158,43 @@ export class ChromedashOTExtensionPage extends LitElement {
     `;
   }
 
+  // Add a set of field information that will be sent with a request submission.
+  // These fields are always considered touched, and are not visible to the user.
+  addDefaultRequestFields() {
+    // Add "ot_owner_email" field to represent the requester email.
+    this.fieldValues.push({
+      name: 'ot_owner_email',
+      touched: true,
+      value: this.userEmail,
+      stageId: this.stage.id,
+    });
+
+    // Add a field for updating that an OT extension request has been submitted.
+    this.fieldValues.push({
+      name: 'ot_action_requested',
+      touched: true,
+      value: true,
+      stageId: this.stage.id,
+    });
+
+    // Add "stage_type" field to create extension stage properly.
+    const extensionStageType = OT_EXTENSION_STAGE_MAPPING[this.stage.stage_type];
+    this.fieldValues.push({
+      name: 'stage_type',
+      touched: true,
+      value: extensionStageType,
+      stageId: this.stage.id,
+    });
+
+    // Add "ot_stage_id" field to link extension stage to OT stage.
+    this.fieldValues.push({
+      name: 'ot_stage_id',
+      touched: true,
+      value: this.stage.id,
+      stageId: this.stage.id,
+    });
+  }
+
   renderFields(section) {
     const fields = section.fields.map(field => {
       const value = getStageValue(this.stage, field);
@@ -180,38 +217,9 @@ export class ChromedashOTExtensionPage extends LitElement {
     `;
     });
 
-    // Add "ot_owner_email" field to represent the requester email.
-    this.fieldValues.push({
-      name: 'ot_owner_email',
-      touched: true,
-      value: this.userEmail,
-      stageId: this.stage.id,
-    });
+    // Add additional default hidden fields.
+    this.addDefaultRequestFields();
 
-    // Add a field for updating that an OT extension request has been submitted.
-    this.fieldValues.push({
-      name: 'ot_action_requested',
-      touched: true,
-      value: true,
-      stageId: this.stage.id,
-    });
-
-    const extensionStageType = OT_EXTENSION_STAGE_MAPPING[this.stage.stage_type];
-    // Add "stage_type" field to create extension stage properly.
-    this.fieldValues.push({
-      name: 'stage_type',
-      touched: true,
-      value: extensionStageType,
-      stageId: this.stage.id,
-    });
-
-    // Add "ot_stage_id" field to link extension stage to OT stage.
-    this.fieldValues.push({
-      name: 'ot_stage_id',
-      touched: true,
-      value: this.stage.id,
-      stageId: this.stage.id,
-    });
     return fields;
   }
 

--- a/client-src/elements/chromedash-ot-extension-page.js
+++ b/client-src/elements/chromedash-ot-extension-page.js
@@ -1,0 +1,248 @@
+import {LitElement, css, html} from 'lit';
+import {ref} from 'lit/directives/ref.js';
+import {
+  formatFeatureChanges,
+  getStageValue,
+  showToastMessage,
+  setupScrollToHash} from './utils.js';
+import './chromedash-form-table.js';
+import './chromedash-form-field.js';
+import {ORIGIN_TRIAL_EXTENSION_FIELDS} from './form-definition.js';
+import {OT_EXTENSION_STAGE_MAPPING} from './form-field-enums.js';
+import {SHARED_STYLES} from '../css/shared-css.js';
+import {FORM_STYLES} from '../css/forms-css.js';
+
+
+export class ChromedashOTExtensionPage extends LitElement {
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      ...FORM_STYLES,
+      css`
+      `];
+  }
+
+  static get properties() {
+    return {
+      stageId: {type: Number},
+      featureId: {type: Number},
+      userEmail: {type: String},
+      feature: {type: Object},
+      loading: {type: Boolean},
+      appTitle: {type: String},
+      nextPage: {type: String},
+      fieldValues: {type: Array},
+    };
+  }
+
+  constructor() {
+    super();
+    this.stageId = 0;
+    this.featureId = 0;
+    this.feature = {};
+    this.loading = true;
+    this.appTitle = '';
+    this.nextPage = '';
+    this.fieldValues = [];
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.fetchData();
+  }
+
+  // Handler to update form values when a field update event is fired.
+  handleFormFieldUpdate(event) {
+    const value = event.detail.value;
+    // Index represents which form was updated.
+    const index = event.detail.index;
+    if (index >= this.fieldValues.length) {
+      throw new Error('Out of bounds index when updating field values.');
+    }
+    // The field has been updated, so it is considered touched.
+    this.fieldValues[index].touched = true;
+    this.fieldValues[index].value = value;
+  };
+
+  fetchData() {
+    this.loading = true;
+    Promise.all([
+      window.csClient.getFeature(this.featureId),
+      window.csClient.getStage(this.featureId, this.stageId),
+    ]).then(([feature, stage]) => {
+      this.feature = feature;
+      this.stage = stage;
+
+      if (this.feature.name) {
+        document.title = `${this.feature.name} - ${this.appTitle}`;
+      }
+      this.loading = false;
+    }).catch(() => {
+      showToastMessage('Some errors occurred. Please refresh the page or try again later.');
+    });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    document.title = this.appTitle;
+  }
+
+  async registerHandlers(el) {
+    if (!el) return;
+
+    /* Add the form's event listener after Shoelace event listeners are attached
+    * see more at https://github.com/GoogleChrome/chromium-dashboard/issues/2014 */
+    await el.updateComplete;
+    const submitButton = this.shadowRoot.querySelector('input[id=submit-button]');
+    submitButton.form.addEventListener('submit', (event) => {
+      this.handleFormSubmit(event);
+    });
+
+    setupScrollToHash(this);
+  }
+
+  handleFormSubmit(e) {
+    e.preventDefault();
+    const featureSubmitBody = formatFeatureChanges(this.fieldValues, this.featureId);
+    // We only need the single stage changes.
+    console.log(featureSubmitBody);
+    const stageSubmitBody = featureSubmitBody.stages[0];
+
+    window.csClient.createStage(this.featureId, stageSubmitBody).then(() => {
+      showToastMessage('Extension request submitted!');
+      setTimeout(() => {
+        window.location.href = this.nextPage || `/feature/${this.featureId}`;
+      }, 1000);
+    }).catch(() => {
+      showToastMessage('Some errors occurred. Please refresh the page or try again later.');
+    });
+  }
+
+  handleCancelClick() {
+    window.location.href = `/feature/${this.featureId}`;
+  }
+
+  renderSkeletons() {
+    return html`
+      <h3><sl-skeleton effect="sheen"></sl-skeleton></h3>
+      <section id="metadata">
+        <h3><sl-skeleton effect="sheen"></sl-skeleton></h3>
+        <p>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+          <sl-skeleton effect="sheen"></sl-skeleton>
+        </p>
+      </section>
+    `;
+  }
+
+  getNextPage() {
+    return this.nextPage || `/feature/${this.featureId}`;
+  }
+
+  renderSubheader() {
+    return html`
+      <div id="subheader">
+        <h2 id="breadcrumbs">
+          <a href=${this.getNextPage()}>
+            <iron-icon icon="chromestatus:arrow-back"></iron-icon>
+            Request origin trial extension: ${this.feature.name}
+          </a>
+        </h2>
+      </div>
+    `;
+  }
+
+  renderFields(section) {
+    const fields = section.fields.map(field => {
+      const value = getStageValue(this.stage, field);
+      // Add the field to this component's stage before creating the field component.
+      const index = this.fieldValues.length;
+      this.fieldValues.push({
+        name: field,
+        touched: false,
+        value,
+        stageId: this.stage.id,
+      });
+
+      return html`
+      <chromedash-form-field
+        name=${field}
+        value=${value}
+        index=${index}
+        @form-field-update="${this.handleFormFieldUpdate}">
+      </chromedash-form-field>
+    `;
+    });
+
+    // Add "ot_owner_email" field to represent the requester email.
+    this.fieldValues.push({
+      name: 'ot_owner_email',
+      touched: true,
+      value: this.userEmail,
+      stageId: this.stage.id,
+    });
+
+    // Add a field for updating that an OT extension request has been submitted.
+    this.fieldValues.push({
+      name: 'ot_action_requested',
+      touched: true,
+      value: true,
+      stageId: this.stage.id,
+    });
+
+    const extensionStageType = OT_EXTENSION_STAGE_MAPPING[this.stage.stage_type];
+    // Add "stage_type" field to create extension stage properly.
+    this.fieldValues.push({
+      name: 'stage_type',
+      touched: true,
+      value: extensionStageType,
+      stageId: this.stage.id,
+    });
+
+    // Add "ot_stage_id" field to link extension stage to OT stage.
+    this.fieldValues.push({
+      name: 'ot_stage_id',
+      touched: true,
+      value: this.stage.id,
+      stageId: this.stage.id,
+    });
+    return fields;
+  }
+
+  renderForm() {
+    // OT extension page only has one section.
+    const section = ORIGIN_TRIAL_EXTENSION_FIELDS.sections[0];
+    return html`
+      <form name="feature_form">
+        <chromedash-form-table ${ref(this.registerHandlers)}>
+          <section class="stage_form">
+            ${this.renderFields(section)}
+          </section>
+        </chromedash-form-table>
+        <div class="final_buttons">
+          <input
+            id='submit-button'
+            class="button"
+            type="submit"
+            value="Submit">
+          <button id="cancel-button" @click=${this.handleCancelClick}>Cancel</button>
+        </div>
+      </form>
+    `;
+  }
+
+  render() {
+    return html`
+      ${this.renderSubheader()}
+      ${this.loading ? this.renderSkeletons() : this.renderForm()}
+    `;
+  }
+}
+
+customElements.define('chromedash-ot-extension-page', ChromedashOTExtensionPage);

--- a/client-src/elements/chromedash-ot-extension-page.js
+++ b/client-src/elements/chromedash-ot-extension-page.js
@@ -105,7 +105,6 @@ export class ChromedashOTExtensionPage extends LitElement {
     e.preventDefault();
     const featureSubmitBody = formatFeatureChanges(this.fieldValues, this.featureId);
     // We only need the single stage changes.
-    console.log(featureSubmitBody);
     const stageSubmitBody = featureSubmitBody.stages[0];
 
     window.csClient.createStage(this.featureId, stageSubmitBody).then(() => {

--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -533,6 +533,19 @@ export const ORIGIN_TRIAL_CREATION_FIELDS = {
   ],
 };
 
+export const ORIGIN_TRIAL_EXTENSION_FIELDS = {
+  name: 'Origin trial extension',
+  sections: [
+    {
+      fields: [
+        'ot_extension__intent_to_extend_experiment_url',
+        'ot_extension__milestone_desktop_last',
+        'ot_request_note',
+      ],
+    },
+  ],
+};
+
 // Note: Even though this is similar to another form, it is likely to change.
 const DEPRECATION_ORIGIN_TRIAL_FIELDS = {
   name: 'Origin trial',

--- a/client-src/elements/form-field-enums.js
+++ b/client-src/elements/form-field-enums.js
@@ -240,6 +240,7 @@ export const STAGE_SPECIFIC_FIELDS = new Set([
   'intent_to_extend_experiment_url',
   'intent_thread_url',
   'ot_creation__intent_to_experiment_url',
+  'ot_extension__intent_to_extend_experiment_url',
   'r4dt_url',
 
   // Misc fields.
@@ -259,6 +260,7 @@ export const STAGE_SPECIFIC_FIELDS = new Set([
   'ot_is_critical_trial',
   'ot_creation__milestone_desktop_first',
   'ot_creation__milestone_desktop_last',
+  'ot_extension__milestone_desktop_last',
   'finch_url',
   'experiment_goals',
   'experiment_risks',
@@ -286,6 +288,7 @@ export const STAGE_FIELD_NAME_MAPPING = {
   ot_milestone_webview_end: 'webview_last',
   ot_creation__milestone_desktop_first: 'desktop_first',
   ot_creation__milestone_desktop_last: 'desktop_last',
+  ot_extension__milestone_desktop_last: 'desktop_last',
   dt_milestone_desktop_start: 'desktop_first',
   dt_milestone_android_start: 'android_first',
   dt_milestone_ios_start: 'ios_first',
@@ -300,6 +303,7 @@ export const STAGE_FIELD_NAME_MAPPING = {
   intent_to_experiment_url: 'intent_thread_url',
   intent_to_extend_experiment_url: 'intent_thread_url',
   ot_creation__intent_to_experiment_url: 'intent_thread_url',
+  ot_extension__intent_to_extend_experiment_url: 'intent_thread_url',
   r4dt_url: 'intent_thread_url',
 };
 

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -670,6 +670,20 @@ export const ALL_FIELDS = {
                  discussion thread, link to it here.`,
   },
 
+  'ot_extension__intent_to_extend_experiment_url': {
+    name: 'intent_to_extend_experiment_url',
+    type: 'input',
+    attrs: URL_FIELD_ATTRS,
+    required: true,
+    label: 'Intent to Extend Experiment link',
+    help_text: html`
+      Link to the approved Intent to Extend Experiment, as per
+      <a target="_blank"
+          href="https://www.chromium.org/blink/origin-trials/running-an-origin-trial/#what-is-the-process-to-extend-an-origin-trial">
+        the trial extension process
+      </a>.`,
+  },
+
   'r4dt_url': {
     // form field name matches underlying DB field (sets "intent_to_experiment_url" field in DB).
     name: 'intent_to_experiment_url',
@@ -974,7 +988,7 @@ export const ALL_FIELDS = {
     required: false,
     label: 'Trial extension desktop end',
     help_text: html`
-      The new last desktop milestone for which the trial has been extended. `,
+      The last desktop milestone in which the trial will be available after extension.`,
   },
 
   'extension_android_last': {
@@ -983,7 +997,7 @@ export const ALL_FIELDS = {
     required: false,
     label: 'Trial extension Android end',
     help_text: html`
-      The new last android milestone for which the trial has been extended. `,
+      The last android milestone in which the trial will be available after extension.`,
   },
 
   'extension_webview_last': {
@@ -992,7 +1006,16 @@ export const ALL_FIELDS = {
     required: false,
     label: 'Trial extension WebView end',
     help_text: html`
-      The new last WebView milestone for which the trial has been extended.`,
+      The last WebView milestone in which the trial will be available after extension.`,
+  },
+
+  'ot_extension__milestone_desktop_last': {
+    type: 'input',
+    attrs: MILESTONE_NUMBER_FIELD_ATTRS,
+    required: true,
+    label: 'Trial extension desktop end',
+    help_text: html`
+      The last milestone in which the trial will be available after extension.`,
   },
 
   'ongoing_constraints': {

--- a/main.py
+++ b/main.py
@@ -186,6 +186,8 @@ spa_page_routes = [
       defaults={'require_edit_feature': True}),
   Route('/ot_creation_request/<int:feature_id>/<int:stage_id>',
         defaults={'require_signin': True}),
+  Route('/ot_extension_request/<int:feature_id>/<int:stage_id>',
+        defaults={'require_signin': True}),
   Route('/metrics'),
   Route('/metrics/css'),
   Route('/metrics/css/popularity'),
@@ -256,6 +258,8 @@ internals_routes: list[Route] = [
   Route('/tasks/update-feature-links', feature_links.FeatureLinksUpdateHandler),
   Route('/tasks/email-ot-creation-request',
         notifier.OriginTrialCreationRequestHandler),
+  Route('/tasks/email-ot-extension-request',
+        notifier.OriginTrialExtensionRequestHandler),
 
   # Maintenance scripts.
   Route('/scripts/evaluate_gate_status',


### PR DESCRIPTION
This PR adds a new form that allows feature owners to request an origin trial extension.

---
The extension request button will only be available to Google and Chromium email addresses, on origin trial stages that have an existing origin trial available in the OT Console.

The "Request a trial extension" button will now open the prerequisites dialog for trial extensions. Proceeding will take the user to the extension request form.
![Screenshot 2023-10-16 at 3 05 08 PM](https://github.com/GoogleChrome/chromium-dashboard/assets/56164590/f7851dd0-1d6c-45f1-ac04-93299f3a52a5)

The extension request form has 3 basic fields.
![Screenshot 2023-10-16 at 3 02 37 PM](https://github.com/GoogleChrome/chromium-dashboard/assets/56164590/b47beb12-a5fe-42e3-b5d5-a489d63bff8f)

Like the trial creation form, the extension request form will be locked until the request has been processed.
![Screenshot 2023-10-16 at 3 04 26 PM](https://github.com/GoogleChrome/chromium-dashboard/assets/56164590/897fb08d-0fb7-43a1-a765-38f8aaa39ab9)
