### PR TITLE
Fix failing unit test for Google Docs description.

### DIFF
--- a/internals/link_helpers_test.py
+++ b/internals/link_helpers_test.py
@@ -63,7 +63,6 @@ class LinkHelperTest(testing_config.CustomTestCase):
     self.assertTrue(link.is_parsed)
     self.assertFalse(link.is_error)
     self.assertIsNotNone(link.information.get('title'))
-    self.assertIsNotNone(link.information.get('description'))
 
   def test_mdn_docs_url(self):
     link = Link("https://developer.mozilla.org/en-US/docs/Web/HTML")


### PR DESCRIPTION
It looks like docs.google.com used to serve docs in a page with a <meta name="description" ...> tag, but then it stopped doing that.  I don't see any different field that has similar content, or what the content of that field would have been anyway.  So, let's just stop looking for it in the test.