### PR TITLE
suppress "annotation-unchecked" mypy notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "do-coverage": "coverage3 erase && coverage3 run -m unittest discover -p '*_test.py' -b && coverage3 html",
     "coverage": "source cs-env/bin/activate; (npm run start-emulator > /dev/null 2>&1 &); sleep 3; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-coverage;  npm run stop-emulator",
     "view-coverage": "pushd htmlcov/; python3.11 -m http.server 8080; popd",
-    "mypy": "source cs-env/bin/activate; mypy --ignore-missing-imports --exclude cs-env/ --exclude gen/ --exclude appengine_config.py .",
+    "mypy": "source cs-env/bin/activate; mypy --ignore-missing-imports --exclude cs-env/ --exclude gen/ --exclude appengine_config.py --disable-error-code \"annotation-unchecked\" .",
     "lint": "gulp lint-fix && lit-analyzer \"client-src/elements/chromedash-!(featurelist)*.js\"",
     "presubmit": "npm test && npm run webtest && npm run lint && npm run mypy",
     "pylint": "pylint --output-format=parseable *py api/*py framework/*py internals/*py pages/*py",


### PR DESCRIPTION
An update of mypy came with a series of notes reminding the user that untyped functions are not checked. This change suppresses those notes so that relevant mypy issues are not lost in these reminders.
![Screenshot 2023-10-17 at 5 31 48 PM](https://github.com/GoogleChrome/chromium-dashboard/assets/56164590/667254cd-53e2-4ea9-9f55-19377e2c69a8)
