### PR TITLE
`accurate_as_of` considered touched at all times

### DIFF
--- a/client-src/elements/chromedash-guide-verify-accuracy-page.js
+++ b/client-src/elements/chromedash-guide-verify-accuracy-page.js
@@ -179,9 +179,13 @@ export class ChromedashGuideVerifyAccuracyPage extends LitElement {
 
       // Add the field to this component's stage before creating the field component.
       const index = this.fieldValues.length;
+      let touched = false;
+      if (featureJSONKey === 'accurate_as_of') {
+        touched = true;
+      }
       this.fieldValues.push({
         name: featureJSONKey,
-        touched: false,
+        touched,
         value,
         stageId: feStage.id,
       });

--- a/client-src/elements/utils.js
+++ b/client-src/elements/utils.js
@@ -309,7 +309,7 @@ export function formatFeatureChanges(fieldValues, featureId) {
   const stages = {};
   for (const {name, touched, value, stageId, implicitValue} of fieldValues) {
     // Only submit changes for touched fields or accuracy verification updates.
-    if (!touched && !(name === 'accurate_as_of' && value === true)) {
+    if (!touched) {
       continue;
     }
 


### PR DESCRIPTION
Small change to update `accurate_as_of` field to be counted as "touched" with the logic in the page component similar to other fields, and remove the special logic in the utils function