### PR TITLE
Skip extension stages in script where MilestoneSet is null

### DIFF
--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -370,6 +370,9 @@ class AssociateOTs(FlaskHandler):
       return 0
     extension_stages_to_update = []
     for extension_stage in extension_stages:
+      # skip the stage if it doesn't have an end milestone explicitly defined.
+      if extension_stage.milestones is None:
+        continue
       extension_end = extension_stage.milestones.desktop_last
       # If the end milestone of the trial is equal or greater than the
       # requested end milestone on the extension stage, we can assume the


### PR DESCRIPTION
This PR fixes an AttributeError that arises when the OT cron job runs and clears existing trial requests. If the milestones entity on the extension stage entity is null, skip that stage.