### PR TITLE
Let feature owners request an N/A.

### DIFF
--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -61,9 +61,9 @@ class VotesAPI(basehandlers.APIHandler):
     approval_defs.set_vote(feature_id, None, new_state,
         user.email(), gate_id)
 
-    if new_state == Vote.REVIEW_REQUESTED:
+    if new_state in (Vote.REVIEW_REQUESTED, Vote.NA_REQUESTED):
       notifier_helpers.notify_approvers_of_reviews(
-          feature, gate, user.email())
+          feature, gate, new_state, user.email())
     else:
       notifier_helpers.notify_subscribers_of_vote_changes(
           feature, gate, user.email(), new_state, old_state)
@@ -73,7 +73,7 @@ class VotesAPI(basehandlers.APIHandler):
 
   def require_permissions(self, user, feature, gate, new_state):
     """Abort the request if the user lacks permission to set this vote."""
-    is_requesting_review = (new_state == Vote.REVIEW_REQUESTED)
+    is_requesting_review = new_state in (Vote.REVIEW_REQUESTED, Vote.NA_REQUESTED)
     is_editor = permissions.can_edit_feature(user, feature.key.integer_id())
     approvers = approval_defs.get_approvers(gate.gate_type)
     is_approver = permissions.can_review_gate(user, feature, gate, approvers)

--- a/api/reviews_api_test.py
+++ b/api/reviews_api_test.py
@@ -281,7 +281,8 @@ class VotesAPITest(testing_config.CustomTestCase):
     self.assertEqual(vote.state, Vote.REVIEW_REQUESTED)
 
     mock_notifier.assert_called_once_with(
-        self.feature_1, self.gate_1, 'owner1@example.com')
+        self.feature_1, self.gate_1, Vote.REVIEW_REQUESTED,
+        'owner1@example.com')
 
 
 class GatesAPITest(testing_config.CustomTestCase):

--- a/client-src/elements/chromedash-gate-chip.js
+++ b/client-src/elements/chromedash-gate-chip.js
@@ -12,6 +12,7 @@ const GATE_STATE_TO_NAME = {
   6: 'Denied', // DENIED
   // TODO(jrobbins): COMPLETE for auto-approved.
   8: 'Internal review', // INTERNAL_REVIEW
+  9: 'N/A requested', // NA_REQUESTED
 };
 
 const GATE_STATE_TO_ICON = {
@@ -29,6 +30,7 @@ const GATE_STATE_TO_ICON = {
 const GATE_STATE_TO_ABBREV = {
   1: 'N/A', //  NA
   8: 'INT', // INTERNAL_REVIEW
+  9: 'N/A?', // INTERNAL_REVIEW
 };
 
 
@@ -136,6 +138,14 @@ class ChromedashGateChip extends LitElement {
        align-items: baseline;
      }
 
+     sl-button.na_requested::part(base) {
+       background: var(--gate-pending-background);
+       color: var(--gate-pending-color);
+     }
+     sl-button.na_requested::part(prefix) {
+       align-items: baseline;
+     }
+
      .abbrev {
        padding-left: var(--content-padding-quarter);
        font-weight: 900;
@@ -171,7 +181,8 @@ class ChromedashGateChip extends LitElement {
     }
     const teamName = this.gate.team_name;
     const stateName = GATE_STATE_TO_NAME[this.gate.state];
-    const className = stateName.toLowerCase().replaceAll(' ', '_');
+    const className = (
+      stateName.toLowerCase().replaceAll(' ', '_').replaceAll('/', ''));
     const selected = (this.gate.id == this.selectedGateId) ? 'selected' : '';
 
     const statusIconName = GATE_STATE_TO_ICON[this.gate.state];

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -435,7 +435,7 @@ export class ChromedashGateColumn extends LitElement {
     }
 
     const dialog = html`
-      <sl-dialog ${ref(this.rationaleDialogRef)} label="Request an N/A">
+      <sl-dialog ${ref(this.rationaleDialogRef)} label="Request a N/A">
         <p style="padding: var(--content-padding)">
           Please briefly explain why your feature does not require a review.
           Your response will be posted as a comment on this review gate

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -360,7 +360,7 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   handleNARequestSubmitted() {
-    const commentText = ('A "N/A" response is requested because: ' +
+    const commentText = ('An "N/A" response is requested because: ' +
                          this.rationaleRef.value.value);
     this.postComment(commentText);
     window.csClient.setVote(
@@ -435,7 +435,7 @@ export class ChromedashGateColumn extends LitElement {
     }
 
     const dialog = html`
-      <sl-dialog ${ref(this.rationaleDialogRef)} label="Request a N/A">
+      <sl-dialog ${ref(this.rationaleDialogRef)} label="Request an N/A">
         <p style="padding: var(--content-padding)">
           Please briefly explain why your feature does not require a review.
           Your response will be posted as a comment on this review gate

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -360,7 +360,7 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   handleNARequestSubmitted() {
-    const commentText = ('An "N/A" response is requested because: ' +
+    const commentText = ('A "N/A" response is requested because: ' +
                          this.rationaleRef.value.value);
     this.postComment(commentText);
     window.csClient.setVote(

--- a/client-src/elements/form-field-enums.js
+++ b/client-src/elements/form-field-enums.js
@@ -334,6 +334,7 @@ export const GATE_TYPES = {
 
 export const GATE_PREPARING = 0;
 export const GATE_REVIEW_REQUESTED = 2;
+export const GATE_NA_REQUESTED = 9;
 export const VOTE_OPTIONS = {
   NO_RESPONSE: [7, 'No response'],
   NA: [1, 'N/a or Ack'],
@@ -348,6 +349,7 @@ export const GATE_ACTIVE_REVIEW_STATES = [
   VOTE_OPTIONS.REVIEW_STARTED[0],
   VOTE_OPTIONS.NEEDS_WORK[0],
   VOTE_OPTIONS.INTERNAL_REVIEW[0],
+  GATE_NA_REQUESTED,
 ];
 export const GATE_FINISHED_REVIEW_STATES = [
   VOTE_OPTIONS.NA[0],

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -333,7 +333,7 @@ def _calc_gate_state(votes: list[Vote], rule: str) -> int:
   for vote in sorted(votes, reverse=True, key=lambda v: v.set_on):
     if vote.state in (
         Vote.NEEDS_WORK, Vote.REVIEW_STARTED, Vote.REVIEW_REQUESTED,
-        Vote.DENIED, Vote.INTERNAL_REVIEW):
+        Vote.DENIED, Vote.INTERNAL_REVIEW, Vote.NA_REQUESTED):
       return vote.state
 
   # The feature owner has not requested review yet, or the request was
@@ -354,7 +354,7 @@ def update_gate_approval_state(gate: Gate, votes: list[Vote]) -> bool:
     gate.requested_on = min(v.set_on for v in votes)
 
   # Starting a review resets responded_on.
-  if new_state == Vote.REVIEW_REQUESTED:
+  if new_state in (Vote.REVIEW_REQUESTED, Vote.NA_REQUESTED):
     gate.responded_on = None
 
   return True

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -95,7 +95,7 @@ def notify_approvers_of_reviews(
   changed_props = {
       'prop_name': 'Review status change in %s' % (gate_url),
       'old_val': 'na',
-      'new_val': 'review_requested',
+      'new_val': new_value_str,
   }
 
   params = {

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -80,10 +80,11 @@ def notify_subscribers_and_save_amendments(fe: 'FeatureEntry',
 
 
 def notify_approvers_of_reviews(
-    fe: 'FeatureEntry', gate: Gate, email: str) -> None:
+    fe: 'FeatureEntry', gate: Gate, new_state: int, email: str) -> None:
   """Notify approvers of a review requested from a Gate."""
+  new_value_str = Vote.VOTE_VALUES.get(new_state, 'None')
   amendment = Amendment(field_name='review_status',
-                        old_value='None', new_value='review_requested')
+                        old_value='None', new_value=new_value_str)
   gate_id = gate.key.integer_id()
   activity = Activity(feature_id=fe.key.integer_id(), gate_id=gate_id,
                       author=email, amendments=[amendment])

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -93,6 +93,7 @@ class Vote(ndb.Model):
   DENIED = 6
   NO_RESPONSE = 7
   INTERNAL_REVIEW = 8
+  NA_REQUESTED = 9
   VOTE_VALUES = {
       # Not used: PREPARING: 'preparing',
       NA: 'na',
@@ -103,6 +104,7 @@ class Vote(ndb.Model):
       DENIED: 'denied',
       NO_RESPONSE: 'no_response',
       INTERNAL_REVIEW: 'internal_review',
+      NA_REQUESTED: 'na_requested',
   }
 
   FINAL_STATES = [NA, APPROVED, DENIED]
@@ -151,7 +153,7 @@ class Gate(ndb.Model):
   PREPARING = 0
   PENDING_STATES = [
       Vote.REVIEW_REQUESTED, Vote.REVIEW_STARTED, Vote.NEEDS_WORK,
-      Vote.INTERNAL_REVIEW]
+      Vote.INTERNAL_REVIEW, Vote.NA_REQUESTED]
   FINAL_STATES = [Vote.NA, Vote.APPROVED, Vote.DENIED]
 
   feature_id = ndb.IntegerProperty(required=True)


### PR DESCRIPTION
Some features have a small scope to the extent that the feature owner is confident that there is no possible concern about privacy, security, etc.  For these cases, the feature owners have always been able to post a comment asking for an "N/A" response and then request a review.   However, feature owners find that unintuitive because the button specifically says "request review" whereas they are actually asking to avoid a review.

In this PR:
* Implement a second button at the top of the gate column that says "Request N/A".
* Clicking that button prompts for a rationale comment, and then posts a vote NA_REQUESTED.
* If the only vote on a gate is NA_REQUESTED, then the gate state becomes NA_REQUESTED.
* If a gate has state NA_REQUESTED, show the gate as blue for pending with prefix "N/A?".