### PR TITLE
Allow feature editors to comment.

### DIFF
--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -85,7 +85,9 @@ class CommentsAPI(basehandlers.APIHandler):
 
     comment_content = self.get_param('comment', required=False)
     if comment_content:
-      if not permissions.can_comment(user):
+      can_comment = (permissions.can_comment(user) or
+                     permissions.can_edit_feature(user, feature_id))
+      if not can_comment:
         self.abort(403, msg='User is not allowed to comment')
 
       comment_activity = Activity(feature_id=feature_id, gate_id=gate_id,

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -722,7 +722,6 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   renderCommentsSkeleton() {
-    // TODO(jrobbins): Include activities too.
     return html`
       <h2>Comments</h2>
       <sl-skeleton effect="sheen"></sl-skeleton>
@@ -743,7 +742,8 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   renderControls() {
-    if (!this.user || !this.user.can_comment) return nothing;
+    const canComment = this.user?.can_comment || this.userCanRequestReview();
+    if (!canComment) return nothing;
 
     const postButton = html`
       <sl-button variant="primary"


### PR DESCRIPTION
This should prevent issue #3453 from happening again.

We will allow feature editors to post comments on review gates.  Previously the rule was that registered users could comment, with the assumption that anyone participating in tracking a feature or the review of it would be a registered user.  However, it is possible for one registered user to list additional email addresses as feature owners or editors, even if they are not registered users.  Those users will expect to be able to comment.