### PR TITLE
Fix undesired navigation to previous gate column.

### DIFF
--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -297,7 +297,6 @@ class ChromedashApp extends LitElement {
       this.pageComponent.user = this.user;
       this.pageComponent.contextLink = this.contextLink;
       this.pageComponent.selectedGateId = this.selectedGateId;
-      this.pageComponent.rawQuery = parseRawQuery(ctx.querystring);
       this.pageComponent.appTitle = this.appTitle;
       this.currentPage = ctx.path;
       if (this.pageComponent.featureId != this.gateColumnRef.value?.feature?.id) {

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -30,7 +30,9 @@ import '@polymer/iron-icon';
 import './chromedash-activity-log';
 import './chromedash-callout';
 import './chromedash-gate-chip';
-import {autolink, findProcessStage, flattenSections} from './utils.js';
+import {
+  autolink, findProcessStage, flattenSections, parseRawQuery,
+} from './utils.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 
 export const DETAILS_STYLES = [css`
@@ -71,7 +73,6 @@ class ChromedashFeatureDetail extends LitElement {
       dismissedCues: {type: Array},
       anyCollapsed: {type: Boolean},
       selectedGateId: {type: Number},
-      rawQuery: {type: Object},
       openStage: {type: Number},
     };
   }
@@ -89,7 +90,6 @@ class ChromedashFeatureDetail extends LitElement {
     this.previousStageTypeRendered = 0;
     this.sameTypeRendered = 0;
     this.selectedGateId = 0;
-    this.rawQuery = {};
     this.openStage = 0;
   }
 
@@ -193,14 +193,11 @@ class ChromedashFeatureDetail extends LitElement {
   }
 
   intializeGateColumn() {
-    if (!this.rawQuery) {
+    const rawQuery = parseRawQuery(window.location.search);
+    if (!rawQuery.hasOwnProperty('gate')) {
       return;
     }
-
-    if (!this.rawQuery.hasOwnProperty('gate')) {
-      return;
-    }
-    const gateVal = this.rawQuery['gate'];
+    const gateVal = rawQuery['gate'];
     const foundGates = this.gates.filter(g => g.id == gateVal);
     if (!foundGates.length) {
       return;
@@ -678,7 +675,7 @@ class ChromedashFeatureDetail extends LitElement {
         originTrialsURL = `https://developer.chrome.com/origintrials/#/view_trial/${feStage.origin_trial_id}`;
       }
       return html`
-        <sl-button 
+        <sl-button
           size="small"
           variant="primary"
           href=${originTrialsURL}

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -105,7 +105,6 @@ export class ChromedashFeaturePage extends LitElement {
       starred: {type: Boolean},
       loading: {attribute: false},
       selectedGateId: {type: Number},
-      rawQuery: {type: Object},
     };
   }
 
@@ -124,7 +123,6 @@ export class ChromedashFeaturePage extends LitElement {
     this.starred = false;
     this.loading = true;
     this.selectedGateId = 0;
-    this.rawQuery = {};
   }
 
   connectedCallback() {
@@ -582,7 +580,6 @@ export class ChromedashFeaturePage extends LitElement {
         .comments=${this.comments}
         .process=${this.process}
         .dismissedCues=${this.dismissedCues}
-        .rawQuery=${this.rawQuery}
         .featureLinks=${this.featureLinks}
         selectedGateId=${this.selectedGateId}
        >

--- a/client-src/elements/chromedash-gate-chip.js
+++ b/client-src/elements/chromedash-gate-chip.js
@@ -1,5 +1,6 @@
 import {LitElement, css, html, nothing} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
+import {updateURLParams} from './utils';
 
 
 const GATE_STATE_TO_NAME = {
@@ -167,6 +168,8 @@ class ChromedashGateChip extends LitElement {
   }
 
   handleClick() {
+    // Add the gate id to the URL.
+    updateURLParams('gate', this.gate.id);
     // Handled in chromedash-app.js.
     this._fireEvent('show-gate-column', {
       feature: this.feature,


### PR DESCRIPTION
This should resolve the UX aspect of #3468.

The user had followed a link from a notification email that included the `gate=` query string parameter for gate A.  Then he navigated to a different gate B chip and requested a review there.  Then, surprisingly, the gate column showed gate A again.

In this PR:
* In chromedash-gate-chip.js, update the `gate=` query string parameter whenever the user clicks a gate chip.  This gives a bookmarkable URL that opens the current gate for any user that visits it rather than keeping the ID of the original gate.
* In the other files, stop passing in the rawQuery object that was parsed when a page.js navigation event occurred because it can be stale.  Instead, parse any query string parameters directly from `window.location.search`.