### PR TITLE
Auto-assign reviewers on gates that have rotations.

### DIFF
--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -73,6 +73,7 @@ class VotesAPI(basehandlers.APIHandler):
         user.email(), gate_id)
 
     if new_state in (Vote.REVIEW_REQUESTED, Vote.NA_REQUESTED):
+      approval_defs.auto_assign_reviewer(gate)
       notifier_helpers.notify_approvers_of_reviews(
           fe, gate, new_state, user.email())
     else:

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -58,6 +58,7 @@ class GateDef(ndb.Model):
   """Configuration for a review gate."""
   gate_type = ndb.IntegerProperty(required=True)
   approvers = ndb.StringProperty(repeated=True)
+  rotation_url = ndb.StringProperty()
 
   # TODO(jrobbins): Use these and phase out approval_devs.ApprovalFieldDef.
   name = ndb.StringProperty()


### PR DESCRIPTION
This is the last main piece of the assigned reviewers functionality.

If a rotations_url is configured in datastore, that URL is used when a user requests a review.  It gets the list of on-call user emails and assigns the review to them.  (Usually it would always be a list of one person.)