### PR TITLE
Fix sequence of events when requesting an NA.

### DIFF
--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -362,28 +362,26 @@ export class ChromedashGateColumn extends LitElement {
     `;
   }
 
-  handleReviewRequested() {
-    window.csClient.setVote(
-      this.feature.id, this.gate.id, GATE_REVIEW_REQUESTED)
-      .then(() => {
-        this._fireEvent('refetch-needed', {});
-      });
+  async handleReviewRequested() {
+    await window.csClient.setVote(
+      this.feature.id, this.gate.id, GATE_REVIEW_REQUESTED);
+    this._fireEvent('refetch-needed', {});
   }
 
   handleNARequested() {
     this.rationaleDialogRef.value.show();
   }
 
-  handleNARequestSubmitted() {
+  async handleNARequestSubmitted() {
+    await window.csClient.setVote(
+      this.feature.id, this.gate.id, GATE_NA_REQUESTED);
+    // Post the comment after the review request so that it will go
+    // to the assigned reviewer rather than all reviewers.
     const commentText = ('An "N/A" response is requested because: ' +
                          this.rationaleRef.value.value);
-    this.postComment(commentText);
-    window.csClient.setVote(
-      this.feature.id, this.gate.id, GATE_NA_REQUESTED)
-      .then(() => {
-        this._fireEvent('refetch-needed', {});
-      });
+    await this.postComment(commentText);
     this.rationaleDialogRef.value.hide();
+    this._fireEvent('refetch-needed', {});
   }
 
   /* A user that can edit the current feature can request a review. */


### PR DESCRIPTION
When requesting an NA, we post a comment and set a vote (a vote to request an N/A).   That did not work well with assigned reviewers because the comment was first sent to all possible reviewers, even if the review was then assigned to a specific reviewer milliseconds later.

In this PR:
* Set the vote first, so that if there will be an assigned reviewer, it will happen before the comment notifications are sent.
* Switch to using the `await` JS syntax to avoid deeply nested `.then()` calls.
* Keep the dialog open until after both calls have completed, which should make any errors more obvious.