### PR TITLE
Only copy assigned reviewers if rules match.

### DIFF
--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -199,6 +199,7 @@ def auto_assign_reviewer(gate):
     other_afd = APPROVAL_FIELDS_BY_ID[other_gate.gate_type]
     if (other_gate.key.integer_id() != gate.key.integer_id() and
         other_afd.team_name == afd.team_name and
+        other_afd.rule == afd.rule and
         other_gate.assignee_emails):
       gate.assignee_emails = other_gate.assignee_emails
       gate.put()


### PR DESCRIPTION
In a previous PR, I added functionality to copy the assigned reviewers from a prior gate when a review is requested on a new gate.  This PR makes the guard condition on that a little more precise to avoid copying when the approval definition rules don't match.  

The main example of this is the API Owners origin trial gate which requires 1 approval and the API Owners shipping gate which requires 3 approvals.  In that case, even if the origin trial review was assigned to a reviewer, the shipping review would still be open to all API Owners so they would all be notified of comments, etc.