### PR TITLE
Add the motivation field to more feature types, as per the launching-features doc

### DIFF
--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -213,6 +213,7 @@ const FLAT_PROTOTYPE_FIELDS = {
     {
       name: 'Prototype a solution',
       fields: [
+        'motivation',
         'spec_link',
         'standard_maturity',
         'api_spec',
@@ -412,6 +413,7 @@ const PSA_IMPLEMENT_FIELDS = {
     {
       name: 'Start prototyping',
       fields: [
+        'motivation',
         'spec_link',
         'standard_maturity',
       ],


### PR DESCRIPTION
This should resolve #3450.

The `motivation` field was offered for the feature types that mentioned it in the launching-features doc, but I believe that over time that doc was changed and chromestatus was not updated.  So, this catches us up.