### PR TITLE
Fix calls to flask.abort().

### DIFF
--- a/framework/sendemail.py
+++ b/framework/sendemail.py
@@ -35,7 +35,7 @@ def require_task_header():
   if settings.UNIT_TEST_MODE or settings.DEV_MODE:
     return
   if 'X-AppEngine-QueueName' not in flask.request.headers:
-    flask.abort(403, msg='Lacking X-AppEngine-QueueName header')
+    flask.abort(403, description='Lacking X-AppEngine-QueueName header')
 
 
 def get_param(request, name, required=True):
@@ -43,7 +43,7 @@ def get_param(request, name, required=True):
   json_body = request.get_json(force=True)
   val = json_body.get(name)
   if required and not val:
-    flask.abort(400, msg='Missing parameter %r' % name)
+    flask.abort(400, description='Missing parameter %r' % name)
   return val
 
 


### PR DESCRIPTION
The `flask.abort()` call can take a `description=` parameter to send an error message in the response to the browser.  Most of our request handler code is in subclasses of `base handlers.BaseHandler` which implements a convent wrapper that we can call like `self.abort(404, msg='something not found')`.   The error was that the sendemail.py code was in a simple function rather than a class, and it was calling `flask.abort()` directly, so it needed to use `description=`.

In this PR:
+ Change these keyword arguments to match what is accepted by `flask.abort()` rather than our shorthand.