### PR TITLE
Remove required fields from OT stage form

### DIFF
--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -562,13 +562,7 @@ const DEPRECATION_ORIGIN_TRIAL_FIELDS = {
         'ongoing_constraints',
         'r4dt_url', // map to name="intent_to_experiment_url" field upon form submission
         'r4dt_lgtms', // map to name="i2e_lgtms" field upon form submission
-        'ot_chromium_trial_name',
-        'ot_webfeature_use_counter',
-        'ot_documentation_url',
         'origin_trial_feedback_url',
-        'ot_is_deprecation_trial',
-        'ot_has_third_party_support',
-        'ot_is_critical_trial',
       ],
     },
     // Implementation


### PR DESCRIPTION
Fixes #3492

This change removes some previously optional fields from the OT deprecation trial stage form. These details are now requested in the OT creation form, and are required on that form.