### PR TITLE
Remove lit properties for class fields.

### DIFF
--- a/client-src/elements/chromedash-admin-blink-component-listing.js
+++ b/client-src/elements/chromedash-admin-blink-component-listing.js
@@ -84,7 +84,6 @@ export class ChromedashAdminBlinkComponentListing extends LitElement {
 
   static get properties() {
     return {
-      _client: {attribute: false},
       editing: {type: Boolean, reflect: true},
       component: {type: Object},
       index: {type: Number},

--- a/client-src/elements/chromedash-admin-blink-page.js
+++ b/client-src/elements/chromedash-admin-blink-page.js
@@ -64,10 +64,7 @@ export class ChromedashAdminBlinkPage extends LitElement {
     return {
       loading: {type: Boolean},
       user: {type: Object},
-      _client: {attribute: false},
       _editMode: {type: Boolean},
-      components: {type: Array},
-      usersMap: {type: Object},
     };
   }
 


### PR DESCRIPTION
We have a pending dependbot PR #3496 to upgrade @web/test-runner.  It is failing in CI because of an error that says that class fields cannot be lit reactive properties.  I looked at these fields and took a stab at resolving the error by simply not having them as lit properties.  The /admin/blink page seems to work on staging with these changes.