### PR TITLE
Replace omahaproxy with version history.googleapis.com

### DIFF
--- a/internals/fetchchannels.py
+++ b/internals/fetchchannels.py
@@ -24,6 +24,18 @@ OMAHA_URL_TEMPLATE = (
     'https://versionhistory.googleapis.com'
     '/v1/chrome/platforms/win/channels/%s/versions/?pageSize=1')
 
+# Expected response for the "stable" channel looks like:
+# {
+#  "versions": [
+#   {
+#    "name": "chrome/platforms/android/channels/stable/versions/119.0.6045.163",
+#    "version": "119.0.6045.163"
+#   }
+#  ],
+#  "nextPageToken": "202090764"
+# }
+# We really only need the version string.
+
 
 def get_channel_version(channel):
   """Return the version string that is live on the given channel."""

--- a/internals/fetchchannels.py
+++ b/internals/fetchchannels.py
@@ -24,27 +24,30 @@ OMAHA_URL_TEMPLATE = (
     'https://versionhistory.googleapis.com'
     '/v1/chrome/platforms/win/channels/%s/versions/?pageSize=1')
 
-def get_channel_info(channel):
+
+def get_channel_version(channel):
+  """Return the version string that is live on the given channel."""
   url = OMAHA_URL_TEMPLATE % channel
   logging.info('fetching %s' % url)
   result = requests.get(url)
   if result.status_code != 200:
     logging.info('Could not fetch channel info')
-    return None
+    return '0.0'
   channel_info = json.loads(result.content)
   logging.info('channel_info is %r', channel_info)
   version = channel_info['versions'][0]['version']
-  return {'channel': channel, 'version': version}
+  return version
 
 
 def get_omaha_data():
   omaha_data = rediscache.get('omaha_data')
 
   if omaha_data is None:
-    stable_info = get_channel_info('stable')
-    beta_info = get_channel_info('beta')
-    dev_info = get_channel_info('dev')
-    win_versions = [stable_info, beta_info, dev_info]
+    win_versions = [
+        {'channel': 'stable', 'version': get_channel_version('stable')},
+        {'channel': 'beta', 'version': get_channel_version('beta')},
+        {'channel': 'dev', 'version': get_channel_version('dev')},
+        ]
     omaha_info = [{'versions': win_versions}]
     omaha_data = json.dumps(omaha_info)
     rediscache.set('omaha_data', omaha_data, time=86400) # cache for 24hrs.

--- a/internals/fetchchannels.py
+++ b/internals/fetchchannels.py
@@ -26,13 +26,13 @@ OMAHA_URL_TEMPLATE = (
 
 # Expected response for the "stable" channel looks like:
 # {
-#  "versions": [
-#   {
-#    "name": "chrome/platforms/android/channels/stable/versions/119.0.6045.163",
-#    "version": "119.0.6045.163"
-#   }
-#  ],
-#  "nextPageToken": "202090764"
+#   "versions": [
+#     {
+#       "name": "chrome/platforms/win/channels/stable/versions/119.0.6045.160",
+#       "version": "119.0.6045.160"
+#     }
+#   ],
+#   "nextPageToken": "652474890"
 # }
 # We really only need the version string.
 

--- a/internals/fetchchannels.py
+++ b/internals/fetchchannels.py
@@ -31,7 +31,7 @@ def get_channel_version(channel):
   logging.info('fetching %s' % url)
   result = requests.get(url)
   if result.status_code != 200:
-    logging.info('Could not fetch channel info')
+    logging.info('Could not fetch channel info for %s', channel)
     return '0.0'
   channel_info = json.loads(result.content)
   logging.info('channel_info is %r', channel_info)

--- a/internals/fetchchannels.py
+++ b/internals/fetchchannels.py
@@ -14,17 +14,39 @@
 # limitations under the License.
 
 import json
+import logging
 import requests
 
 from framework import rediscache
 # Note: this file cannot import core_models because it would be circular.
 
+OMAHA_URL_TEMPLATE = (
+    'https://versionhistory.googleapis.com'
+    '/v1/chrome/platforms/win/channels/%s/versions/?pageSize=1')
+
+def get_channel_info(channel):
+  url = OMAHA_URL_TEMPLATE % channel
+  logging.info('fetching %s' % url)
+  result = requests.get(url)
+  if result.status_code != 200:
+    logging.info('Could not fetch channel info')
+    return None
+  channel_info = json.loads(result.content)
+  logging.info('channel_info is %r', channel_info)
+  version = channel_info['versions'][0]['version']
+  return {'channel': channel, 'version': version}
+
 
 def get_omaha_data():
   omaha_data = rediscache.get('omaha_data')
+
   if omaha_data is None:
-    result = requests.get('https://omahaproxy.appspot.com/all.json')
-    if result.status_code == 200:
-      omaha_data = result.content
-      rediscache.set('omaha_data', omaha_data, time=86400) # cache for 24hrs.
+    stable_info = get_channel_info('stable')
+    beta_info = get_channel_info('beta')
+    dev_info = get_channel_info('dev')
+    win_versions = [stable_info, beta_info, dev_info]
+    omaha_info = [{'versions': win_versions}]
+    omaha_data = json.dumps(omaha_info)
+    rediscache.set('omaha_data', omaha_data, time=86400) # cache for 24hrs.
+
   return json.loads(omaha_data)


### PR DESCRIPTION
The backend that chromestatus previously used was phased out and we were supposed to migrate to this other backend server instead.  The OmahaProxy backend gave info about which version of chrome was live on each channel.

In this PR:
+ Rewrite fetchchannel.py to hit the new backend, but keep the format of the returned/cached string basically the same to avoid needing to change other code