### PR TITLE
Fix for semantic  check complaining when resetting numeric field to empty string

### DIFF
--- a/client-src/elements/utils.js
+++ b/client-src/elements/utils.js
@@ -394,7 +394,6 @@ export function checkMilestoneStartEnd(startEndPair, getFieldValue) {
   const {start, end} = startEndPair;
   const startMilestone = getValue(start);
   const endMilestone = getValue(end);
-  console.info(`after getValue: start: ${startMilestone} end: ${endMilestone}`);
   if (startMilestone != null && endMilestone != null) {
     if (endMilestone <= startMilestone) {
       return {error: 'Start milestone must be before end milestone'};

--- a/client-src/elements/utils.js
+++ b/client-src/elements/utils.js
@@ -387,12 +387,14 @@ export function checkMilestoneStartEnd(startEndPair, getFieldValue) {
   const getValue = (name) => {
     const value = getFieldValue(name);
     if (typeof value === 'string') {
+      if (value === '') return undefined;
       return Number(value);
     }
   };
   const {start, end} = startEndPair;
   const startMilestone = getValue(start);
   const endMilestone = getValue(end);
+  console.info(`after getValue: start: ${startMilestone} end: ${endMilestone}`);
   if (startMilestone != null && endMilestone != null) {
     if (endMilestone <= startMilestone) {
       return {error: 'Start milestone must be before end milestone'};


### PR DESCRIPTION
This PR fixes #3525 by checking for empty string explicitly to return an undefined value rather than converting it to 0.