### PR TITLE
Dont show na_requested as a response vote.

### DIFF
--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -741,9 +741,14 @@ export class ChromedashGateColumn extends LitElement {
     `;
   }
 
+  isReviewRequest(vote) {
+    return (vote.state === GATE_REVIEW_REQUESTED ||
+            vote.state === GATE_NA_REQUESTED);
+  }
+
   renderVotes() {
     const canVote = this.userCanVote();
-    const responses = this.votes.filter((v) => v.state !== GATE_REVIEW_REQUESTED);
+    const responses = this.votes.filter((v) => !this.isReviewRequest(v));
     const responseEmails = responses.map((v) => v.set_by);
     const othersPending = this.gate.assignee_emails.filter((ae) =>
       !responseEmails.includes(ae) && ae != this.user?.email);


### PR DESCRIPTION
We record the feature owner's request for review as a vote with state REVIEW_REQUESTED or NA_REQUESTED.  We don't want to show these in the table of reviewer responses because they are review requests that initiate the review rather than responses to that request.  There was previously logic to avoid showing REVIEW_REQUESTED votes, and this PR adds NA_REQUESTED to that logic.