### PR TITLE
Add semantic check for consistency between the feature name and type when type is deprecation

### DIFF
--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -110,6 +110,21 @@ export const ALL_FIELDS = {
       <li>CSS Flexbox: intrinsic size algorithm</li>
       <li>Permissions-Policy header</li>
     </ul>`,
+    check: (value, getFieldValue) => {
+      // if the name includes "deprecate" or "remove",
+      // the feature_type should be "Feature deprecation".
+      const name = (value || '').toLowerCase();
+      if (name.includes('deprecat') || name.includes('remov')) {
+        const featureType = Number(getFieldValue('feature_type_radio_group') ?? 0);
+        if (featureType !== FEATURE_TYPES.FEATURE_TYPE_DEPRECATION_ID[0]) {
+          return {
+            warning: `Feature name should contain "deprecate" or "remove"
+            if and only if the feature type is "Feature deprecation"`,
+          };
+        }
+      }
+    },
+    dependents: ['feature_type_radio_group'],
   },
 
   'summary': {
@@ -250,7 +265,7 @@ export const ALL_FIELDS = {
     choices: FEATURE_TYPES,
     label: 'Feature type',
     help_text: html`
-    Feature type chosen at time of creation.
+        Feature type chosen at time of creation.
         <br/>
         <p style="color: red"><strong>Note:</strong> The feature type field
         cannot be changed. If this field needs to be modified, a new feature
@@ -269,6 +284,19 @@ export const ALL_FIELDS = {
         <p style="color: red"><strong>Note:</strong> The feature type field
         cannot be changed. If this field needs to be modified, a new feature
         would need to be created.</p>`,
+    check: (value, getFieldValue) => {
+      const featureType = Number(value ?? 0);
+      if (featureType === FEATURE_TYPES.FEATURE_TYPE_DEPRECATION_ID[0]) {
+        const name = (getFieldValue('name') || '').toLowerCase();
+        if (!(name.includes('deprecat') || name.includes('remov'))) {
+          return {
+            warning: `Feature name should contain "deprecate" or "remove"
+            if and only if the feature type is "Feature deprecation"`,
+          };
+        }
+      }
+    },
+    dependents: ['name'],
   },
 
   'set_stage': {

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -14,7 +14,7 @@ import {
   WEB_DEV_VIEWS,
 } from './form-field-enums';
 
-import {checkMilestoneStartEnd} from './utils.js';
+import {checkFeatureNameAndType, checkMilestoneStartEnd} from './utils.js';
 
 /* Patterns from https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s01.html
  * Removing single quote ('), backtick (`), and pipe (|) since they are risky unless properly escaped everywhere.
@@ -110,21 +110,10 @@ export const ALL_FIELDS = {
       <li>CSS Flexbox: intrinsic size algorithm</li>
       <li>Permissions-Policy header</li>
     </ul>`,
-    check: (value, getFieldValue) => {
-      // if the name includes "deprecate" or "remove",
-      // the feature_type should be "Feature deprecation".
-      const name = (value || '').toLowerCase();
-      if (name.includes('deprecat') || name.includes('remov')) {
-        const featureType = Number(getFieldValue('feature_type_radio_group') ?? 0);
-        if (featureType !== FEATURE_TYPES.FEATURE_TYPE_DEPRECATION_ID[0]) {
-          return {
-            warning: `Feature name should contain "deprecate" or "remove"
-            if and only if the feature type is "Feature deprecation"`,
-          };
-        }
-      }
+    check: (_value, getFieldValue) => {
+      return checkFeatureNameAndType(getFieldValue);
     },
-    dependents: ['feature_type_radio_group'],
+    dependents: ['feature_type', 'feature_type_radio_group'],
   },
 
   'summary': {
@@ -270,6 +259,10 @@ export const ALL_FIELDS = {
         <p style="color: red"><strong>Note:</strong> The feature type field
         cannot be changed. If this field needs to be modified, a new feature
         would need to be created.</p>`,
+    check: (_value, getFieldValue) => {
+      return checkFeatureNameAndType(getFieldValue);
+    },
+    dependents: ['name'],
   },
 
   'feature_type_radio_group': {
@@ -284,17 +277,8 @@ export const ALL_FIELDS = {
         <p style="color: red"><strong>Note:</strong> The feature type field
         cannot be changed. If this field needs to be modified, a new feature
         would need to be created.</p>`,
-    check: (value, getFieldValue) => {
-      const featureType = Number(value ?? 0);
-      if (featureType === FEATURE_TYPES.FEATURE_TYPE_DEPRECATION_ID[0]) {
-        const name = (getFieldValue('name') || '').toLowerCase();
-        if (!(name.includes('deprecat') || name.includes('remov'))) {
-          return {
-            warning: `Feature name should contain "deprecate" or "remove"
-            if and only if the feature type is "Feature deprecation"`,
-          };
-        }
-      }
+    check: (_value, getFieldValue) => {
+      return checkFeatureNameAndType(getFieldValue);
     },
     dependents: ['name'],
   },

--- a/client-src/elements/utils.js
+++ b/client-src/elements/utils.js
@@ -2,7 +2,7 @@
 
 import {markupAutolinks} from './autolink.js';
 import {nothing, html} from 'lit';
-import {STAGE_FIELD_NAME_MAPPING} from './form-field-enums';
+import {STAGE_FIELD_NAME_MAPPING, FEATURE_TYPES} from './form-field-enums';
 
 let toastEl;
 
@@ -397,6 +397,29 @@ export function checkMilestoneStartEnd(startEndPair, getFieldValue) {
   if (startMilestone != null && endMilestone != null) {
     if (endMilestone <= startMilestone) {
       return {error: 'Start milestone must be before end milestone'};
+    }
+  }
+}
+
+
+export function checkFeatureNameAndType(getFieldValue) {
+  const name = (getFieldValue('name') || '').toLowerCase();
+  const featureType = Number(getFieldValue('feature_type') || '0');
+  const deprecationName =
+    (name.includes('deprecat') || name.includes('remov'));
+  const deprecationType =
+    (featureType === FEATURE_TYPES.FEATURE_TYPE_DEPRECATION_ID[0]);
+  if (deprecationName !== deprecationType) {
+    if (deprecationName) {
+      return {
+        warning: `If the feature name contains "deprecate" or "remove",
+        the feature type should be "Feature deprecation"`,
+      };
+    } else {
+      return {
+        warning: `If the feature type is "Feature deprecation",
+        the feature name should contain "deprecate" or "remove"`,
+      };
     }
   }
 }


### PR DESCRIPTION
This PR adds a semantic check for consistency between the feature name and type when type is deprecation.
If the name includes "deprecate" or "remove" (or variations, e.g. "Deprecation..."), then the type should only be "Feature deprecation", and vice versa.

This applies both in the "New feature" page and when editing the feature any time later (since the feature name can be changed).

![image](https://github.com/GoogleChrome/chromium-dashboard/assets/570125/0fb64bc7-32e6-402a-9735-be8f74f3d20e)

![image](https://github.com/GoogleChrome/chromium-dashboard/assets/570125/6d49f288-7dd9-45a6-8c1c-43cdf927c626)
