### PR TITLE
Add IWA-only category

### DIFF
--- a/client-src/elements/form-field-enums.js
+++ b/client-src/elements/form-field-enums.js
@@ -26,6 +26,7 @@ export const FEATURE_CATEGORIES = {
   LAYERED: [19, 'Layered APIs'],
   WEBASSEMBLY: [20, 'WebAssembly'],
   CAPABILITIES: [21, 'Capabilities (Fugu)'],
+  IWA: [22, 'Isolated Web Apps-specific API'],
 };
 
 export const ENTERPRISE_FEATURE_CATEGORIES = {

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -41,6 +41,7 @@ WEBRTC = 18
 LAYERED = 19
 WEBASSEMBLY = 20
 CAPABILITIES = 21
+IWA = 22
 
 
 PLATFORM_ANDROID = 1
@@ -104,7 +105,8 @@ FEATURE_CATEGORIES = {
   WEBRTC: 'WebRTC',
   LAYERED: 'Layered APIs',
   WEBASSEMBLY: 'WebAssembly',
-  CAPABILITIES: 'Capabilities (Fugu)'
+  CAPABILITIES: 'Capabilities (Fugu)',
+  IWA: 'Isolated Web Apps-specific API',
   }
 
 FEATURE_TYPE_INCUBATE_ID = 0


### PR DESCRIPTION
This is a first step in supporting a variation the blink feature types to add some process support for Isolated Web App-only APIs.

In this PR:
+ Just add a new enum value to the category field