### PR TITLE
Remove lit-labs/context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
         "packages/playwright"
       ],
       "dependencies": {
-        "@lit-labs/context": "^0.5.1",
         "@polymer/iron-collapse": "^3.0.1",
         "@polymer/iron-icon": "^3.0.1",
         "@polymer/iron-iconset-svg": "^3.0.1",
@@ -2158,27 +2157,10 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
-    "node_modules/@lit-labs/context": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/context/-/context-0.5.1.tgz",
-      "integrity": "sha512-ELR50iyIFb0mOTkzR7bSUamipLY8QzbiXzTElJr+fInBhUpUbe4bx7Z2ekPO+WbunQRB2Bc3z/V7lIPTN+tbVQ==",
-      "dependencies": {
-        "@lit/context": "^1.0.0"
-      }
-    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz",
       "integrity": "sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g=="
-    },
-    "node_modules/@lit/context": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.0.0.tgz",
-      "integrity": "sha512-bdqj6z6Mj+TpYfo2seHy1mlBzYrW+CyHnDQLD0DI7iQLELs2Fk6icZwvbvbskR0E94QG4aO/35j6PTJ9wWTv0Q==",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.2 || ^2.0.0",
-        "lit": "^2.7.5 || ^3.0.0"
-      }
     },
     "node_modules/@lit/react": {
       "version": "1.0.0",
@@ -2187,14 +2169,6 @@
       "dev": true,
       "peerDependencies": {
         "@types/react": "17 || 18"
-      }
-    },
-    "node_modules/@lit/reactive-element": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.2.tgz",
-      "integrity": "sha512-rDfl+QnCYjuIGf5xI2sVJWdYIi56CTCwWa+nidKYX6oIuBYwUbT/vX4qbUDlHiZKJ/3FRNQ/tWJui44p6/stSA==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/@lukeed/csprng": {
@@ -17139,27 +17113,10 @@
         }
       }
     },
-    "@lit-labs/context": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/context/-/context-0.5.1.tgz",
-      "integrity": "sha512-ELR50iyIFb0mOTkzR7bSUamipLY8QzbiXzTElJr+fInBhUpUbe4bx7Z2ekPO+WbunQRB2Bc3z/V7lIPTN+tbVQ==",
-      "requires": {
-        "@lit/context": "^1.0.0"
-      }
-    },
     "@lit-labs/ssr-dom-shim": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz",
       "integrity": "sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g=="
-    },
-    "@lit/context": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.0.0.tgz",
-      "integrity": "sha512-bdqj6z6Mj+TpYfo2seHy1mlBzYrW+CyHnDQLD0DI7iQLELs2Fk6icZwvbvbskR0E94QG4aO/35j6PTJ9wWTv0Q==",
-      "requires": {
-        "@lit/reactive-element": "^1.6.2 || ^2.0.0",
-        "lit": "^2.7.5 || ^3.0.0"
-      }
     },
     "@lit/react": {
       "version": "1.0.0",
@@ -17167,14 +17124,6 @@
       "integrity": "sha512-uTuU6vpxtZvCWxcu3GNosckP2JpFWZpMKjhwQ42Bzu/OU9kjStJspA04o7RadecQfx0YiFIImX3qek15BXhaWQ==",
       "dev": true,
       "requires": {}
-    },
-    "@lit/reactive-element": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.2.tgz",
-      "integrity": "sha512-rDfl+QnCYjuIGf5xI2sVJWdYIi56CTCwWa+nidKYX6oIuBYwUbT/vX4qbUDlHiZKJ/3FRNQ/tWJui44p6/stSA==",
-      "requires": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
     },
     "@lukeed/csprng": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@lit-labs/context": "^0.5.1",
     "@polymer/iron-collapse": "^3.0.1",
     "@polymer/iron-icon": "^3.0.1",
     "@polymer/iron-iconset-svg": "^3.0.1",


### PR DESCRIPTION
Note: If we ever come back to it, context has graduated to stable and
we should use @lit/context[1] instead.

[1] https://www.npmjs.com/package/@lit/context