### PR TITLE
Fixes to milestone checks

### DIFF
--- a/client-src/elements/chromedash-guide-editall-page.js
+++ b/client-src/elements/chromedash-guide-editall-page.js
@@ -378,6 +378,8 @@ export class ChromedashGuideEditallPage extends LitElement {
 
   renderForm() {
     const formattedFeature = formatFeatureForEdit(this.feature);
+    this.fieldValues.allFields = formattedFeature;
+
     const formsToRender = this.getForms(formattedFeature, this.feature.stages);
     return html`
       <form name="feature_form">

--- a/client-src/elements/chromedash-guide-metadata-page.js
+++ b/client-src/elements/chromedash-guide-metadata-page.js
@@ -191,6 +191,8 @@ export class ChromedashGuideMetadataPage extends LitElement {
 
   renderForm() {
     const formattedFeature = formatFeatureForEdit(this.feature);
+    this.fieldValues.allFields = formattedFeature;
+
     let sections = FLAT_METADATA_FIELDS.sections;
     if (formattedFeature.is_enterprise_feature) {
       sections = FLAT_ENTERPRISE_METADATA_FIELDS.sections;

--- a/client-src/elements/chromedash-guide-metadata.js
+++ b/client-src/elements/chromedash-guide-metadata.js
@@ -362,6 +362,8 @@ export class ChromedashGuideMetadata extends LitElement {
 
   renderEditForm() {
     const formattedFeature = formatFeatureForEdit(this.feature);
+    this.fieldValues.allFields = formattedFeature;
+
     const metadataFields = flattenSections(this.feature.is_enterprise_feature ?
       FLAT_ENTERPRISE_METADATA_FIELDS :
       FLAT_METADATA_FIELDS);

--- a/client-src/elements/chromedash-guide-new-page.js
+++ b/client-src/elements/chromedash-guide-new-page.js
@@ -136,6 +136,7 @@ export class ChromedashGuideNewPage extends LitElement {
       ENTERPRISE_NEW_FEATURE_FORM_FIELDS :
       NEW_FEATURE_FORM_FIELDS;
     const postAction = this.isEnterpriseFeature ? '/guide/enterprise/new' : '/guide/new';
+    this.fieldValues.allFields = formattedFeature;
 
     const renderFormField = (field, className) => {
       const featureJSONKey = ALL_FIELDS[field].name || field;

--- a/client-src/elements/chromedash-guide-new-page.js
+++ b/client-src/elements/chromedash-guide-new-page.js
@@ -132,11 +132,12 @@ export class ChromedashGuideNewPage extends LitElement {
 
   renderForm() {
     const newFeatureInitialValues = {owner: this.userEmail};
+    this.fieldValues.allFields = newFeatureInitialValues;
+
     const formFields = this.isEnterpriseFeature ?
       ENTERPRISE_NEW_FEATURE_FORM_FIELDS :
       NEW_FEATURE_FORM_FIELDS;
     const postAction = this.isEnterpriseFeature ? '/guide/enterprise/new' : '/guide/new';
-    this.fieldValues.allFields = formattedFeature;
 
     const renderFormField = (field, className) => {
       const featureJSONKey = ALL_FIELDS[field].name || field;

--- a/client-src/elements/chromedash-guide-stage-page.js
+++ b/client-src/elements/chromedash-guide-stage-page.js
@@ -345,6 +345,8 @@ export class ChromedashGuideStagePage extends LitElement {
 
   renderForm() {
     const formattedFeature = formatFeatureForEdit(this.feature);
+    this.fieldValues.allFields = formattedFeature;
+
     return html`
       <form name="feature_form">
         <input type="hidden" name="token">

--- a/client-src/elements/chromedash-guide-verify-accuracy-page.js
+++ b/client-src/elements/chromedash-guide-verify-accuracy-page.js
@@ -282,6 +282,8 @@ export class ChromedashGuideVerifyAccuracyPage extends LitElement {
 
   renderForm() {
     const formattedFeature = formatFeatureForEdit(this.feature);
+    this.fieldValues.allFields = formattedFeature;
+
     const stageIds = this.getAllStageIds();
     const [allFormFields, formsToRender] = this.getForms(formattedFeature, this.feature.stages);
 

--- a/client-src/elements/chromedash-ot-creation-page.js
+++ b/client-src/elements/chromedash-ot-creation-page.js
@@ -7,7 +7,9 @@ import {
   setupScrollToHash} from './utils.js';
 import './chromedash-form-table.js';
 import './chromedash-form-field.js';
-import {ORIGIN_TRIAL_CREATION_FIELDS} from './form-definition.js';
+import {
+  formatFeatureForEdit,
+  ORIGIN_TRIAL_CREATION_FIELDS} from './form-definition.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {FORM_STYLES} from '../css/forms-css.js';
 import {ALL_FIELDS} from './form-field-specs.js';
@@ -266,6 +268,9 @@ export class ChromedashOTCreationPage extends LitElement {
   }
 
   renderForm() {
+    const formattedFeature = formatFeatureForEdit(this.feature);
+    this.fieldValues.allFields = formattedFeature;
+
     // OT creation page only has one section.
     const section = ORIGIN_TRIAL_CREATION_FIELDS.sections[0];
     return html`

--- a/client-src/elements/chromedash-ot-extension-page.js
+++ b/client-src/elements/chromedash-ot-extension-page.js
@@ -6,7 +6,9 @@ import {
   setupScrollToHash} from './utils.js';
 import './chromedash-form-table.js';
 import './chromedash-form-field.js';
-import {ORIGIN_TRIAL_EXTENSION_FIELDS} from './form-definition.js';
+import {
+  formatFeatureForEdit,
+  ORIGIN_TRIAL_EXTENSION_FIELDS} from './form-definition.js';
 import {OT_EXTENSION_STAGE_MAPPING} from './form-field-enums.js';
 import {ALL_FIELDS} from './form-field-specs';
 import {SHARED_STYLES} from '../css/shared-css.js';
@@ -223,6 +225,9 @@ export class ChromedashOTExtensionPage extends LitElement {
   }
 
   renderForm() {
+    const formattedFeature = formatFeatureForEdit(this.feature);
+    this.fieldValues.allFields = formattedFeature;
+
     // OT extension page only has one section.
     const section = ORIGIN_TRIAL_EXTENSION_FIELDS.sections[0];
     return html`

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -78,27 +78,27 @@ const OT_MILESTONE_WEBVIEW_RANGE = {
 };
 
 export const OT_SHIPPED_MILESTONE_DESKTOP_RANGE = {
-  earlier: 'ot_milestone_desktop_end',
+  earlier: 'ot_milestone_desktop_start',
   later: 'shipped_milestone',
-  error: 'Shipped milestone must be after origin trial is completed.',
+  error: 'Origin trial must start before feature is shipped.',
 };
 
 const OT_SHIPPED_MILESTONE_WEBVIEW_RANGE = {
-  earlier: 'ot_milestone_webview_end',
+  earlier: 'ot_milestone_webview_start',
   later: 'shipped_webview_milestone',
-  error: 'Shipped webview milestone must be after origin trial is completed.',
+  error: 'Origin trial must start before feature is shipped.',
 };
 
 const OT_SHIPPED_MILESTONE_ANDROID_RANGE = {
-  earlier: 'ot_milestone_android_end',
+  earlier: 'ot_milestone_android_start',
   later: 'shipped_android_milestone',
-  error: 'Shipped android milestone must be after origin trial is completed.',
+  error: 'Origin trial must start before feature is shipped.',
 };
 
 const OT_SHIPPED_MILESTONE_IOS_RANGE = {
-  earlier: 'ot_milestone_ios_end',
+  earlier: 'ot_milestone_ios_start',
   later: 'shipped_ios_milestone',
-  error: 'Shipped milestone must be after origin trial is completed.',
+  error: 'Origin trial must start before feature is shipped.',
 };
 
 const DT_SHIPPED_MILESTONE_DESKTOP_RANGE = {
@@ -991,8 +991,11 @@ export const ALL_FIELDS = {
       First desktop milestone that will support an origin
       trial of this feature.`,
     check: (_value, getFieldValue) =>
-      checkMilestoneRanges([OT_MILESTONE_DESKTOP_RANGE], getFieldValue),
-    dependents: ['ot_milestone_desktop_end'],
+      checkMilestoneRanges([
+        OT_MILESTONE_DESKTOP_RANGE,
+        OT_SHIPPED_MILESTONE_DESKTOP_RANGE,
+      ], getFieldValue),
+    dependents: ['ot_milestone_desktop_end', 'shipped_milestone'],
   },
 
   'ot_milestone_desktop_end': {
@@ -1004,10 +1007,8 @@ export const ALL_FIELDS = {
       Last desktop milestone that will support an origin
       trial of this feature.`,
     check: (_value, getFieldValue) =>
-      checkMilestoneRanges([
-        OT_SHIPPED_MILESTONE_DESKTOP_RANGE,
-        OT_MILESTONE_DESKTOP_RANGE], getFieldValue),
-    dependents: ['ot_milestone_desktop_start', 'shipped_milestone'],
+      checkMilestoneRanges([OT_MILESTONE_DESKTOP_RANGE], getFieldValue),
+    dependents: ['ot_milestone_desktop_start'],
   },
 
   'ot_milestone_android_start': {
@@ -1019,8 +1020,10 @@ export const ALL_FIELDS = {
       First android milestone that will support an origin
       trial of this feature.`,
     check: (_value, getFieldValue) =>
-      checkMilestoneRanges([OT_MILESTONE_ANDROID_RANGE], getFieldValue),
-    dependents: ['ot_milestone_android_end'],
+      checkMilestoneRanges([
+        OT_MILESTONE_ANDROID_RANGE,
+        OT_SHIPPED_MILESTONE_ANDROID_RANGE], getFieldValue),
+    dependents: ['ot_milestone_android_end', 'shipped_android_milestone'],
 
   },
 
@@ -1033,10 +1036,8 @@ export const ALL_FIELDS = {
       Last android milestone that will support an origin
       trial of this feature.`,
     check: (_value, getFieldValue) =>
-      checkMilestoneRanges([
-        OT_SHIPPED_MILESTONE_ANDROID_RANGE,
-        OT_MILESTONE_ANDROID_RANGE], getFieldValue),
-    dependents: ['ot_milestone_android_end', 'shipped_android_milestone'],
+      checkMilestoneRanges([OT_MILESTONE_ANDROID_RANGE], getFieldValue),
+    dependents: ['ot_milestone_android_start'],
   },
 
   'ot_milestone_webview_start': {
@@ -1048,8 +1049,10 @@ export const ALL_FIELDS = {
       First WebView milestone that will support an origin
       trial of this feature.`,
     check: (_value, getFieldValue) =>
-      checkMilestoneRanges([OT_MILESTONE_WEBVIEW_RANGE], getFieldValue),
-    dependents: ['ot_milestone_webview_end'],
+      checkMilestoneRanges([
+        OT_MILESTONE_WEBVIEW_RANGE,
+        OT_SHIPPED_MILESTONE_IOS_RANGE], getFieldValue),
+    dependents: ['ot_milestone_webview_end', 'shipped_ios_milestone'],
   },
 
   'ot_milestone_webview_end': {
@@ -1061,10 +1064,8 @@ export const ALL_FIELDS = {
       Last WebView milestone that will support an origin
       trial of this feature.`,
     check: (_value, getFieldValue) =>
-      checkMilestoneRanges([
-        OT_SHIPPED_MILESTONE_IOS_RANGE,
-        OT_MILESTONE_WEBVIEW_RANGE], getFieldValue),
-    dependents: ['ot_milestone_ios_end', 'shipped_ios_milestone'],
+      checkMilestoneRanges([OT_MILESTONE_WEBVIEW_RANGE], getFieldValue),
+    dependents: ['ot_milestone_ios_start'],
   },
 
   'experiment_risks': {
@@ -1301,8 +1302,11 @@ export const ALL_FIELDS = {
       First milestone that will support an origin
       trial of this feature.`,
     check: (_value, getFieldValue) =>
-      checkMilestoneRanges([OT_MILESTONE_DESKTOP_RANGE], getFieldValue),
-    dependents: ['ot_milestone_desktop_end'],
+      checkMilestoneRanges([
+        OT_MILESTONE_DESKTOP_RANGE,
+        OT_SHIPPED_MILESTONE_DESKTOP_RANGE,
+      ], getFieldValue),
+    dependents: ['ot_milestone_desktop_end', 'shipped_milestone'],
   },
 
   'ot_creation__milestone_desktop_last': {
@@ -1315,10 +1319,8 @@ export const ALL_FIELDS = {
       Last milestone that will support an origin
       trial of this feature.`,
     check: (_value, getFieldValue) =>
-      checkMilestoneRanges([
-        OT_SHIPPED_MILESTONE_DESKTOP_RANGE,
-        OT_MILESTONE_DESKTOP_RANGE], getFieldValue),
-    dependents: ['ot_milestone_desktop_start', 'shipped_milestone'],
+      checkMilestoneRanges([OT_MILESTONE_DESKTOP_RANGE], getFieldValue),
+    dependents: ['ot_milestone_desktop_start'],
   },
 
   'anticipated_spec_changes': {
@@ -1481,7 +1483,8 @@ export const ALL_FIELDS = {
       checkMilestoneRanges([
         OT_SHIPPED_MILESTONE_DESKTOP_RANGE,
         DT_SHIPPED_MILESTONE_DESKTOP_RANGE], getFieldValue),
-    dependents: ['dt_milestone_desktop_start', 'ot_milestone_desktop_end', 'shipped_milestone'],
+    dependents: [
+      'dt_milestone_desktop_start', 'ot_milestone_desktop_start', 'shipped_milestone'],
   },
 
   'shipped_android_milestone': {
@@ -1493,8 +1496,8 @@ export const ALL_FIELDS = {
     check: (_value, getFieldValue) =>
       checkMilestoneRanges([OT_SHIPPED_MILESTONE_ANDROID_RANGE,
         DT_SHIPPED_MILESTONE_ANDROID_RANGE], getFieldValue),
-    dependents: ['dt_milestone_android_start', 'ot_milestone_android_end',
-      'shipped_android_milestone'],
+    dependents: [
+      'dt_milestone_android_start', 'ot_milestone_android_start', 'shipped_android_milestone'],
   },
 
   'shipped_ios_milestone': {
@@ -1507,8 +1510,8 @@ export const ALL_FIELDS = {
       checkMilestoneRanges([
         OT_SHIPPED_MILESTONE_IOS_RANGE,
         DT_SHIPPED_MILESTONE_IOS_RANGE], getFieldValue),
-    dependents: ['dt_milestone_ios_start', 'ot_milestone_ios_end',
-      'shipped_ios_milestone'],
+    dependents: [
+      'dt_milestone_ios_start', 'ot_milestone_ios_start', 'shipped_ios_milestone'],
   },
 
   'shipped_webview_milestone': {
@@ -1521,8 +1524,8 @@ export const ALL_FIELDS = {
       checkMilestoneRanges([
         OT_SHIPPED_MILESTONE_WEBVIEW_RANGE,
         DT_SHIPPED_MILESTONE_WEBVIEW_RANGE], getFieldValue),
-    dependents: ['dt_milestone_webview_start', 'ot_milestone_webview_end',
-      'shipped_webview_milestone'],
+    dependents: [
+      'dt_milestone_webview_start', 'ot_milestone_webview_start', 'shipped_webview_milestone'],
   },
 
   'requires_embedder_support': {

--- a/client-src/elements/utils.js
+++ b/client-src/elements/utils.js
@@ -369,14 +369,14 @@ export function handleSaveChangesResponse(response) {
 /**
  * Returns value for fieldName, retrieved from fieldValues.
   * @param {string} fieldName
-  * @param {Array<Object>} fieldValues
+  * @param {Array<Object>} formFieldValues, with allFields property for everything else
   * @return {*} The value of the named field.
  */
-export function getFieldValue(fieldName, fieldValues) {
-  let fieldValue = null;
-  fieldValues.some((valueObj) => {
-    if (valueObj.name === fieldName) {
-      fieldValue = valueObj.value;
+export function getFieldValue(fieldName, formFieldValues) {
+  let fieldValue = formFieldValues.allFields ? formFieldValues[fieldName] : null;
+  formFieldValues.some((fieldObj) => {
+    if (fieldObj.name === fieldName) {
+      fieldValue = fieldObj.value;
       return true;
     }
   });


### PR DESCRIPTION
This PR does the following:

- Don't constrain the origin trial end milestone relative to shipped milestone.
- Add 'allFields' to formFieldValues, so checks on any form can get access to any other field of the feature.
- 