### PR TITLE
Add escalation email for the debuggability team.

### DIFF
--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -132,13 +132,15 @@ DebuggabilityOriginTrialApproval = ApprovalFieldDef(
     'Debuggability OT Review',
     'Debuggability OT Review',
     core_enums.GATE_DEBUGGABILITY_ORIGIN_TRIAL, ONE_LGTM,
-    approvers=DEBUGGABILITY_APPROVERS, team_name='Debuggability')
+    approvers=DEBUGGABILITY_APPROVERS, team_name='Debuggability',
+    escalation_email='devtools-dev@chromium.org')
 
 DebuggabilityShipApproval = ApprovalFieldDef(
     'Debuggability Ship Review',
     'Debuggability Ship Review',
     core_enums.GATE_DEBUGGABILITY_SHIP, ONE_LGTM,
-    approvers=DEBUGGABILITY_APPROVERS, team_name='Debuggability')
+    approvers=DEBUGGABILITY_APPROVERS, team_name='Debuggability',
+    escalation_email='devtools-dev@chromium.org')
 
 TestingShipApproval = ApprovalFieldDef(
     'Testing Ship Review',


### PR DESCRIPTION
This one bit of the info that we have been trying to add for each of the review teams.  It appears as a mailto: link in the gate column.