### PR TITLE
Add notice explaining site admin review powers

### DIFF
--- a/client-src/elements/chromedash-myfeatures-page.js
+++ b/client-src/elements/chromedash-myfeatures-page.js
@@ -93,6 +93,9 @@ export class ChromedashMyFeaturesPage extends LitElement {
   }
 
   renderPendingAndRecentApprovals() {
+    const adminNotice = this.user?.is_admin ?
+      html`<p>You see all pending approvals because you're a site admin.</p>` :
+      nothing;
     // Use feature_type>=0 to include all types, even enterprise.
     const pendingBox = this.renderBox(
       'Features pending my approval',
@@ -102,7 +105,7 @@ export class ChromedashMyFeaturesPage extends LitElement {
       'Recently reviewed features',
       'is:recently-reviewed feature_type>=0',
       'normal', '-gate.reviewed_on', false);
-    return [pendingBox, recentBox];
+    return [adminNotice, pendingBox, recentBox];
   }
 
   renderIStarred() {


### PR DESCRIPTION
This week in the API Owners meeting, the usual presenter was out, so another member tried to present, but he was also a site admin, so his list included all of the features pending review by any team.  That caused some confusion, resulting in other members asking why they didn't have certain features on their list. Long term we might want to do more with filtering the pending review box, but for now I just want to make it clear why a site-admin presenter might have a longer list than others.