### PR TITLE
Check images are actual images

### DIFF
--- a/client-src/elements/chromedash-form-field.js
+++ b/client-src/elements/chromedash-form-field.js
@@ -130,11 +130,11 @@ export class ChromedashFormField extends LitElement {
     }
   }
 
-  doSemanticCheck() {
+  async doSemanticCheck() {
     const checkFunction = this.fieldProps.check;
     if (checkFunction) {
       const fieldValue = this.getValue();
-      const checkResult = checkFunction(fieldValue,
+      const checkResult = await checkFunction(fieldValue,
         (name) => getFieldValue(name, this.fieldValues));
       if (checkResult == null) {
         this.checkMessage = '';

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -414,6 +414,25 @@ export const ALL_FIELDS = {
     label: 'Screenshots link(s)',
     help_text: html`
         Optional: Link to screenshots showcasing this feature (one URL per line). These will be shared publicly.`,
+    check: async (value) => {
+      const urls = value.split('\n').filter(x => !!x);
+      if (!urls.length) {
+        return undefined;
+      }
+      const urlTypes = await Promise.all(
+        urls
+          .map(url => fetch(url, {method: 'HEAD'})
+            .then(response => response.blob())
+            .then(blob => blob.type)
+            .catch(() => 'error')));
+      // All urls must link to an image.
+      if (urlTypes.some(type => !type.startsWith('image'))) {
+        return {
+          error: 'One or more urls are not actual images. Use a valid link to an actual image.',
+        };
+      }
+      return undefined;
+    },
   },
 
   'motivation': {


### PR DESCRIPTION
- Make form field semantic checks asynchronous
- Add a check function to the screenshot_links field to verify that all the urls point to an actual image