### PR TITLE
Notify reviewers of overdue reviews

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -20,6 +20,9 @@ cron:
 - description: Send reminder to check summary before publication.
   url: /cron/send_prepublication
   schedule: every tuesday 09:00
+- description: Send reminders to reviewers of overdue reviews.
+  url: /cron/send_overdue_reviews
+  schedule: every day 09:00
 - description: Notify any users that have been inactive for 6 months.
   url: /cron/warn_inactive_users
   schedule: 1st monday of month 9:00

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -401,4 +401,7 @@ class SLOOverdueHandler(basehandlers.FlaskHandler):
     """Decide who to notify that a review is overdue."""
     if not is_escalated and gate.assignee_emails:
       return gate.assignee_emails
-    return approval_defs.get_approvers(gate.gate_type)
+
+    review_team = approval_defs.get_approvers(gate.gate_type)
+    assignees = gate.assignee_emails or []
+    return list(set(assignees + review_team))

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -315,7 +315,7 @@ class SLOReportHandler(basehandlers.FlaskHandler):
 class SLOOverdueHandler(basehandlers.FlaskHandler):
   JSONIFY = True
   SUBJECT_FORMAT = 'Review due for: %s'
-  BODY_TEMPLATE_PATH = 'slo_exipred_email.html'
+  BODY_TEMPLATE_PATH = 'slo_overdue_email.html'
 
   def get_template_data(self, **kwargs):
     """Sends notifications to reviewers of newly overdue reviews."""
@@ -326,7 +326,8 @@ class SLOOverdueHandler(basehandlers.FlaskHandler):
         newly_overdue_gates, relevant_features, False)
     long_email_tasks = self.build_gate_email_tasks(
         long_overdue_gates, relevant_features, True)
-    notifier.send_emails(newly_email_tasks + long_email_tasks)
+    email_tasks = newly_email_tasks + long_email_tasks
+    notifier.send_emails(email_tasks)
 
     recipients_str = ''
     # Add an alphabetical list of unique recipients to the return message.
@@ -341,16 +342,16 @@ class SLOOverdueHandler(basehandlers.FlaskHandler):
 
   def get_overdue_gates_and_features(self):
     """Return lists of newly and long overdue review gates, and their FEs."""
-    overdue_gates = slo.get_overdue_gates(
+    overdue_gates: list[Gate] = slo.get_overdue_gates(
         approval_defs.APPROVAL_FIELDS_BY_ID, approval_defs.DEFAULT_SLO_LIMIT)
-    newly_overdue_gates = []
-    long_overdue_gates = []
-    relevant_feature_ids = set()
+    newly_overdue_gates: list[Gate] = []
+    long_overdue_gates: list[Gate] = []
+    relevant_feature_ids: set[int] = set()
     for og in overdue_gates:
       appr_def = approval_defs.APPROVAL_FIELDS_BY_ID.get(og.gate_type)
       slo_limit = (appr_def.slo_initial_response
                    if appr_def else approval_defs.DEFAULT_SLO_LIMIT)
-      remaining = slo.remaining_days(og, slo_limit)
+      remaining = slo.remaining_days(og.requested_on, slo_limit)
       if remaining == -1:
         newly_overdue_gates.append(og)
         relevant_feature_ids.add(og.feature_id)
@@ -367,15 +368,19 @@ class SLOOverdueHandler(basehandlers.FlaskHandler):
       self,
       gates_to_notify: list[Gate],
       relevant_features: dict[int, FeatureEntry],
-      is_escalation: bool
+      is_escalated: bool
   ) -> list[dict[str, Any]]:
     email_tasks: list[dict[str, Any]] = []
     for gate in gates_to_notify:
+      gate_id = gate.key.integer_id()
+      appr_def = approval_defs.APPROVAL_FIELDS_BY_ID[gate.gate_type]
       fe = relevant_features[gate.feature_id]
+      feature_id = fe.key.integer_id()
+      gate_url = settings.SITE_URL + f'feature/{feature_id}?gate={gate_id}'
       body_data = {
-          'id': fe.key.integer_id(),
           'feature': fe,
-          'site_url': settings.SITE_URL,
+          'appr_def': appr_def,
+          'gate_url': gate_url,
           'is_escalated': is_escalated,
       }
       html = render_template(self.BODY_TEMPLATE_PATH, **body_data)

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -310,3 +310,90 @@ class SLOReportHandler(basehandlers.FlaskHandler):
 
     return {'message': 'OK',
             'gates_by_reviewer': gates_by_reviewer}
+
+
+class SLOOverdueHandler(basehandlers.FlaskHandler):
+  JSONIFY = True
+  SUBJECT_FORMAT = 'Review due for: %s'
+  BODY_TEMPLATE_PATH = 'slo_exipred_email.html'
+
+  def get_template_data(self, **kwargs):
+    """Sends notifications to reviewers of newly overdue reviews."""
+    self.require_cron_header()
+    newly_overdue_gates, long_overdue_gates, relevant_features = (
+        self.get_overdue_gates_and_features())
+    newly_email_tasks = self.build_gate_email_tasks(
+        newly_overdue_gates, relevant_features, False)
+    long_email_tasks = self.build_gate_email_tasks(
+        long_overdue_gates, relevant_features, True)
+    notifier.send_emails(newly_email_tasks + long_email_tasks)
+
+    recipients_str = ''
+    # Add an alphabetical list of unique recipients to the return message.
+    if len(email_tasks):
+      recipients = '\n'.join(
+          sorted(list(set([task['to'] for task in email_tasks]))))
+      recipients_str = f'\nRecipients:\n{recipients}'
+    message =  f'{len(email_tasks)} email(s) sent or logged.{recipients_str}'
+    logging.info(message)
+
+    return {'message': message}
+
+  def get_overdue_gates_and_features(self):
+    """Return lists of newly and long overdue review gates, and their FEs."""
+    overdue_gates = slo.get_overdue_gates(
+        approval_defs.APPROVAL_FIELDS_BY_ID, approval_defs.DEFAULT_SLO_LIMIT)
+    newly_overdue_gates = []
+    long_overdue_gates = []
+    relevant_feature_ids = set()
+    for og in overdue_gates:
+      appr_def = approval_defs.APPROVAL_FIELDS_BY_ID.get(og.gate_type)
+      slo_limit = (appr_def.slo_initial_response
+                   if appr_def else approval_defs.DEFAULT_SLO_LIMIT)
+      remaining = slo.remaining_days(og, slo_limit)
+      if remaining == -1:
+        newly_overdue_gates.append(og)
+        relevant_feature_ids.add(og.feature_id)
+      elif remaining == -slo_limit:
+        long_overdue_gates.append(og)
+        relevant_feature_ids.add(og.feature_id)
+
+    relevant_features = {
+        fe_id: FeatureEntry.get_by_id(fe_id)
+        for fe_id in relevant_feature_ids}
+    return newly_overdue_gates, long_overdue_gates, relevant_features
+
+  def build_gate_email_tasks(
+      self,
+      gates_to_notify: list[Gate],
+      relevant_features: dict[int, FeatureEntry],
+      is_escalation: bool
+  ) -> list[dict[str, Any]]:
+    email_tasks: list[dict[str, Any]] = []
+    for gate in gates_to_notify:
+      fe = relevant_features[gate.feature_id]
+      body_data = {
+          'id': fe.key.integer_id(),
+          'feature': fe,
+          'site_url': settings.SITE_URL,
+          'is_escalated': is_escalated,
+      }
+      html = render_template(self.BODY_TEMPLATE_PATH, **body_data)
+      subject = self.SUBJECT_FORMAT % fe.name
+      if is_escalated:
+        subject = f'ESCALATED: {subject}'
+      recipients = self.choose_reviewers(gate, is_escalated)
+      for recipient in recipients:
+        email_tasks.append({
+            'to': recipient,
+            'subject': subject,
+            'reply_to': None,
+            'html': html
+        })
+    return email_tasks
+
+  def choose_reviewers(self, gate: Gate, is_escalated: bool) -> list[str]:
+    """Decide who to notify that a review is overdue."""
+    if not is_escalated and gate.assignee_emails:
+      return gate.assignee_emails
+    return approval_defs.get_approvers(gate.gate_type)

--- a/internals/slo.py
+++ b/internals/slo.py
@@ -104,7 +104,7 @@ def is_gate_overdue(gate, appr_fields, default_slo_limit) -> bool:
   return remaining_days(gate.requested_on, slo_limit) < 0
 
 
-def get_overdue_gates(appr_fields, default_slo_limit):
+def get_overdue_gates(appr_fields, default_slo_limit) -> list[Gate]:
   """Return a list of gates with overdue reviews."""
   active_gates = Gate.query(Gate.state.IN(Gate.PENDING_STATES))
   overdue_gates = [g for g in active_gates

--- a/main.py
+++ b/main.py
@@ -247,6 +247,7 @@ internals_routes: list[Route] = [
   Route('/cron/export_backup', data_backup.BackupExportHandler),
   Route('/cron/send_accuracy_notifications', reminders.FeatureAccuracyHandler),
   Route('/cron/send_prepublication', reminders.PrepublicationHandler),
+  Route('/cron/send_overdue_reviews', reminders.SLOOverdueHandler),
   Route('/cron/warn_inactive_users', notifier.NotifyInactiveUsersHandler),
   Route('/cron/remove_inactive_users',
       inactive_users.RemoveInactiveUsersHandler),

--- a/templates/slo_overdue_email.html
+++ b/templates/slo_overdue_email.html
@@ -1,0 +1,18 @@
+{% if is_escalated %}
+
+  <p><a href="{{gate_url}}"
+      >The {{appr_def.team_name}} review</a>
+  of <b>{{feature.name}}</b>
+  is now overdue.</p>
+
+  <p>All potential reviewers are being notified,
+  even if the review was previously assigned to one reviewer.</p>
+
+{% else %}
+
+  <p><a href="{{gate_url}}"
+      >The {{appr_def.team_name}} review</a>
+  of <b>{{feature.name}}</b>
+  is now due.</p>
+
+{% endif %}


### PR DESCRIPTION
This resolves #3023.

In this PR:
* Set up a daily cron and cron task handler
* In that handler, find overdue reviews and classify them as `due` or `overdue`
* Calculate the recipients to be the assigned reviewers, all reviewers, or the union of those (because an assignee could be set by a rotation to a value that is not in the list of all reviewers)
* Generate a brief email notification from a template