### PR TITLE
Use sl-dropdown for the comment menu.

### DIFF
--- a/client-src/elements/chromedash-activity-log.js
+++ b/client-src/elements/chromedash-activity-log.js
@@ -115,11 +115,6 @@ export class ChromedashActivity extends LitElement {
           margin-right: var(--content-padding);
         }
 
-        .edit-menu {
-          display: block;
-          float: right;
-        }
-
         .comment-menu-icon {
           float: right;
           margin-right: 8px;
@@ -160,20 +155,6 @@ export class ChromedashActivity extends LitElement {
     </div>`;
   }
 
-  toggleMenu() {
-    const menuEl = this.shadowRoot.querySelector(`#comment-menu`);
-    // Change the menu icon to represent open/closing on click.
-    const iconEl = this.shadowRoot.querySelector(`iron-icon`);
-    const isVisible = menuEl.style.display !== 'none';
-    if (isVisible) {
-      menuEl.style.display = 'none';
-      iconEl.icon = 'chromestatus:more-vert';
-    } else {
-      menuEl.style.display = 'inline-block';
-      iconEl.icon = 'chromestatus:close';
-    }
-  }
-
   // Add a dropdown menu to the activity header if the user can edit the activity.
   formatEditMenu() {
     // If the activity is not editable, don't show a menu.
@@ -182,23 +163,20 @@ export class ChromedashActivity extends LitElement {
     }
     // Show delete option if not deleted, else show undelete.
     let menuItem = html`
-    <sl-menu-item @click="${() => this.handleDeleteToggle(false)}"
+    <sl-menu-item @click="${() => this.handleDelete(false)}"
     >Delete Comment</sl-menu-item>`;
     if (this.activity.deleted_by) {
       menuItem = html`
-      <sl-menu-item @click="${() => this.handleDeleteToggle(true)}"
+      <sl-menu-item @click="${() => this.handleDelete(true)}"
       >Undelete Comment</sl-menu-item>`;
     }
 
     return html`
-      <iron-icon class="comment-menu-icon"
-      icon="chromestatus:more-vert"
-      @click=${() => this.toggleMenu()}></iron-icon>
-      <div class="edit-menu">
-        <div id="comment-menu" style="display: none;">
+       <sl-dropdown class="comment-menu-icon">
+         <sl-icon-button library="material" name="more_vert_24px"
+           label="Comment menu" slot="trigger"></sl-icon-button>
           <sl-menu>${menuItem}</sl-menu>
-        </div>
-      </div>`;
+       </sl-dropdown>`;
   }
 
   render() {
@@ -228,7 +206,7 @@ export class ChromedashActivity extends LitElement {
   }
 
   // Handle deleting or undeleting a comment.
-  async handleDeleteToggle(isUndelete) {
+  async handleDelete(isUndelete) {
     let resp;
     if (isUndelete) {
       resp = await window.csClient.undeleteComment(
@@ -239,7 +217,6 @@ export class ChromedashActivity extends LitElement {
     }
     if (resp && resp.message === 'Done') {
       this.activity.deleted_by = (isUndelete) ? null : this.user.email;
-      this.toggleMenu();
       this.requestUpdate();
     }
   }

--- a/client-src/elements/chromedash-activity-log_test.js
+++ b/client-src/elements/chromedash-activity-log_test.js
@@ -54,7 +54,7 @@ describe('chromedash-activity', () => {
     assert.include(commentDiv.innerHTML, 'hey, nice feature');
     // TODO: Fails on firefox.  See issue #2186.
     // assert.exists(component.shadowRoot.querySelector('sl-relative-time'));
-    assert.notExists(component.shadowRoot.querySelector('.edit-menu'));
+    assert.notExists(component.shadowRoot.querySelector('sl-dropdown'));
     assert.notExists(component.shadowRoot.querySelector('sl-menu'));
   });
 
@@ -67,7 +67,7 @@ describe('chromedash-activity', () => {
              </chromedash-activity>`);
     const commentDiv = component.shadowRoot.querySelector('.comment');
     assert.include(commentDiv.innerHTML, 'hey, nice feature');
-    assert.exists(component.shadowRoot.querySelector('#comment-menu'));
+    assert.exists(component.shadowRoot.querySelector('sl-menu'));
   });
 
   // Note: It does not hide or prefix a deleted comment for users who don't
@@ -91,7 +91,7 @@ describe('chromedash-activity', () => {
     const commentDiv = component.shadowRoot.querySelector('.comment');
     assert.include(commentDiv.innerHTML, '[Deleted]');
     assert.include(commentDiv.innerHTML, 'better left unsaid');
-    assert.exists(component.shadowRoot.querySelector('#comment-menu'));
+    assert.exists(component.shadowRoot.querySelector('sl-dropdown'));
     assert.exists(component.shadowRoot.querySelector('sl-menu'));
   });
 
@@ -117,7 +117,7 @@ describe('chromedash-activity', () => {
     assert.notInclude(before.innerHTML, '[Deleted]');
     assert.include(before.innerHTML, 'something off the cuff');
 
-    await component.handleDeleteToggle(false);
+    await component.handleDelete(false);
     assert.equal(doomedComment.deleted_by, nonAdminUser.email);
     const after = component.shadowRoot.querySelector('.comment');
     assert.include(after.innerHTML, '[Deleted]');
@@ -147,7 +147,7 @@ describe('chromedash-activity', () => {
     assert.include(before.innerHTML, '[Deleted]');
     assert.include(before.innerHTML, 'lucky guess');
 
-    await component.handleDeleteToggle(true);
+    await component.handleDelete(true);
     assert.equal(blessedComment.deleted_by, null);
     const after = component.shadowRoot.querySelector('.comment');
     assert.notInclude(after.innerHTML, '[Deleted]');


### PR DESCRIPTION
Change the comment "..." menu to use `sl-dropdown` rather than an `iron-icon` and custom logic. 

I don't recall why we did not use sl-dropdown for this menu before.  It seems to work fine for the stage menu that I added recently.  So, using it here too is consistent with that, has less code, and improves user functionality slightly in that (1) opening the menu does not shift other content and (2) clicking away from the menu now closes it.