### PR TITLE
Add back sans-serif for chromeos

### DIFF
--- a/client-src/sass/theme.scss
+++ b/client-src/sass/theme.scss
@@ -43,7 +43,7 @@
 // throughout the app.
 :root {
   --page-background: var(--md-gray-50);
-  --default-font: 14px system-ui;
+  --default-font: 14px system-ui, sans-serif;
   --form-element-font: system-ui;
   --default-color: var(--md-gray-900-alpha);
   --unimportant-text-color: var(--md-gray-700-alpha);

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -313,7 +313,7 @@ sl-skeleton {
 
 :root {
   --page-background: var(--md-gray-50);
-  --default-font: 14px system-ui;
+  --default-font: 14px system-ui, sans-serif;
   --form-element-font: system-ui;
   --default-color: var(--md-gray-900-alpha);
   --unimportant-text-color: var(--md-gray-700-alpha);


### PR DESCRIPTION
Apparently chromeos does not have system-ui.