### PR TITLE
Make the editing forms "Cancel" button navigate to feature detail page.

### DIFF
--- a/client-src/elements/chromedash-guide-editall-page.js
+++ b/client-src/elements/chromedash-guide-editall-page.js
@@ -132,7 +132,7 @@ export class ChromedashGuideEditallPage extends LitElement {
   };
 
   handleCancelClick() {
-    window.location.href = `/guide/edit/${this.featureId}`;
+    window.location.href = `/feature/${this.featureId}`;
   }
 
   renderSkeletons() {

--- a/client-src/elements/chromedash-guide-stage-page.js
+++ b/client-src/elements/chromedash-guide-stage-page.js
@@ -151,7 +151,7 @@ export class ChromedashGuideStagePage extends LitElement {
   }
 
   handleCancelClick() {
-    window.location.href = `/guide/edit/${this.featureId}`;
+    window.location.href = `/feature/${this.featureId}`;
   }
 
   // get a comma-spearated list of field names


### PR DESCRIPTION
Back when the Guide UX was the only way to edit a feature, the "Cancel" button naturally navigated the user back to the guide process overview page.   

When we introduced editing directly on the feature detail page, the Cancel buttons should have been changed to navigate back to whatever page the user started on, but we missed that opportunity. 

Now, that we are taking steps toward phasing out the Guide UX, I think that it makes sense to always navigate back to the feature detail page.  It will be a minor annoyance to Guide UX users who want to get back into the Guide UX, but it will help train them to edit directly from the feature detail page.