### PR TITLE
Add style attributes to emails.

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -97,6 +97,7 @@ def format_email_body(
       'milestone': milestone_str,
       'status': core_enums.IMPLEMENTATION_STATUS[fe.impl_status_chrome],
       'formatted_changes': formatted_changes,
+      'APP_TITLE': settings.APP_TITLE,
       'SITE_URL': settings.SITE_URL,
   }
   body_data.update(additional_template_data or {})

--- a/internals/testdata/notifier_test/test_format_email_body__new.html
+++ b/internals/testdata/notifier_test/test_format_email_body__new.html
@@ -1,56 +1,75 @@
-<section id="context">
-  <div>
-    <b>New</b> feature entry:<br/>
-    <a class="feature-name" href="http://127.0.0.1:8888/feature/123"
-          >feature template</a>
-  </div>
-</section>
-<br/>
 
+<div style="background: #eee; padding: 0 16px 16px">
+<div style="color: #666; padding: 8px 0 0 16px;">Local testing</div>
 
-<section id="details">
-  <div><b>New details entered by creator_template@example.com:</div>
-
+<div style="padding: 8px; background: white; border-top: 4px solid #888; border-color: #388e3c;">
+<section id="context" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <table>
     <tr>
-      <td>Summary:</td>
-      <td>sum</td>
+      <td rowspan=2>
+  
+<div style="border: 4px solid #338e3c; border-radius: 50%; width: 32px; height: 32px; margin-right: 8px;">
+  </div>
+
+</td>
+      <td><b>New</b> feature entry:</td>
     </tr>
     <tr>
-      <td>Unlisted:</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <td>Breaking change:</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <td>Feature owners:</td>
-      <td>feature_owner@example.com</td>
-    </tr>
-    <tr>
-      <td>Cc:</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Blink component:</td>
-      <td>Blink</td>
-    </tr>
-    <tr>
-      <td>Category:</td>
-      <td>Web Components</td>
-    </tr>
-    <tr>
-      <td>Feature type:</td>
-      <td>New feature incubation</td>
+      <td><a style="font-size: 140%;"
+             href="http://127.0.0.1:8888/feature/123"
+             >feature template</a>
+      </td>
     </tr>
   </table>
 </section>
 
 
-<section id="next-steps">
+<section id="details" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
+  <div><b>New details entered by creator_template@example.com:</div>
+
+  <table>
+    <tr>
+      <td style="padding-left: 16px;">Summary:</td>
+      <td style="padding-left: 16px;">sum</td>
+    </tr>
+    <tr>
+      <td style="padding-left: 16px;">Unlisted:</td>
+      <td style="padding-left: 16px;">No</td>
+    </tr>
+    <tr>
+      <td style="padding-left: 16px;">Breaking change:</td>
+      <td style="padding-left: 16px;">No</td>
+    </tr>
+    <tr>
+      <td style="padding-left: 16px;">Feature owners:</td>
+      <td style="padding-left: 16px;">feature_owner@example.com</td>
+    </tr>
+    <tr>
+      <td style="padding-left: 16px;">Cc:</td>
+      <td style="padding-left: 16px;"></td>
+    </tr>
+    <tr>
+      <td style="padding-left: 16px;">Blink component:</td>
+      <td style="padding-left: 16px;">Blink</td>
+    </tr>
+    <tr>
+      <td style="padding-left: 16px;">Category:</td>
+      <td style="padding-left: 16px;">Web Components</td>
+    </tr>
+    <tr>
+      <td style="padding-left: 16px;">Feature type:</td>
+      <td style="padding-left: 16px;">New feature incubation</td>
+    </tr>
+  </table>
+</section>
+
+
+<section id="next-steps" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <div><b>Your next steps:</b></div>
-  <div><a href="http://127.0.0.1:8888/feature/123"
-     class="button-like"
+  <div style="margin: 16px;">
+    <a href="http://127.0.0.1:8888/feature/123" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; "
      >View feature details</a></div>
 </section>
+
+</div>
+</div>

--- a/internals/testdata/notifier_test/test_format_email_body__update_no_changes.html
+++ b/internals/testdata/notifier_test/test_format_email_body__update_no_changes.html
@@ -1,14 +1,30 @@
-<section id="context">
-  <div>
-    <b>Updated</b> feature entry:<br/>
-    <a class="feature-name" href="http://127.0.0.1:8888/feature/123"
-          >feature template</a>
+
+<div style="background: #eee; padding: 0 16px 16px">
+<div style="color: #666; padding: 8px 0 0 16px;">Local testing</div>
+
+<div style="padding: 8px; background: white; border-top: 4px solid #888; border-color: #01579b;">
+<section id="context" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
+  <table>
+    <tr>
+      <td rowspan=2>
+  
+<div style="border: 4px solid #01579b; border-radius: 50%; width: 32px; height: 32px; margin-right: 8px;">
   </div>
+
+</td>
+      <td><b>Updated</b> feature entry:</td>
+    </tr>
+    <tr>
+      <td><a style="font-size: 140%;"
+             href="http://127.0.0.1:8888/feature/123"
+             >feature template</a>
+      </td>
+    </tr>
+  </table>
 </section>
-<br/>
 
 
-<section id="details">
+<section id="details" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <div><b>Updates made by editor_template@example.com:</b></div>
   <ul>
     <li>None</li>
@@ -16,9 +32,12 @@
 </section>
 
 
-<section id="next-steps">
+<section id="next-steps" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <div><b>Your next steps:</b></div>
-  <div><a href="http://127.0.0.1:8888/feature/123"
-     class="button-like"
+  <div style="margin: 16px;">
+    <a href="http://127.0.0.1:8888/feature/123" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; "
      >View feature details</a></div>
 </section>
+
+</div>
+</div>

--- a/internals/testdata/notifier_test/test_format_email_body__update_with_changes.html
+++ b/internals/testdata/notifier_test/test_format_email_body__update_with_changes.html
@@ -1,14 +1,30 @@
-<section id="context">
-  <div>
-    <b>Updated</b> feature entry:<br/>
-    <a class="feature-name" href="http://127.0.0.1:8888/feature/123"
-          >feature template</a>
+
+<div style="background: #eee; padding: 0 16px 16px">
+<div style="color: #666; padding: 8px 0 0 16px;">Local testing</div>
+
+<div style="padding: 8px; background: white; border-top: 4px solid #888; border-color: #01579b;">
+<section id="context" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
+  <table>
+    <tr>
+      <td rowspan=2>
+  
+<div style="border: 4px solid #01579b; border-radius: 50%; width: 32px; height: 32px; margin-right: 8px;">
   </div>
+
+</td>
+      <td><b>Updated</b> feature entry:</td>
+    </tr>
+    <tr>
+      <td><a style="font-size: 140%;"
+             href="http://127.0.0.1:8888/feature/123"
+             >feature template</a>
+      </td>
+    </tr>
+  </table>
 </section>
-<br/>
 
 
-<section id="details">
+<section id="details" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <div><b>Updates made by editor_template@example.com:</b></div>
   <ul>
     <li><b>test_prop:</b> <br/><b>old:</b> test old value <br/><b>new:</b> test new value<br/></li><br/>
@@ -16,9 +32,12 @@
 </section>
 
 
-<section id="next-steps">
+<section id="next-steps" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <div><b>Your next steps:</b></div>
-  <div><a href="http://127.0.0.1:8888/feature/123"
-     class="button-like"
+  <div style="margin: 16px;">
+    <a href="http://127.0.0.1:8888/feature/123" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; "
      >View feature details</a></div>
 </section>
+
+</div>
+</div>

--- a/internals/testdata/reminders_test/test_build_email_tasks_escalated_feature_accuracy.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_escalated_feature_accuracy.html
@@ -1,14 +1,30 @@
-<section id="context">
-  <div>
-    <b>Your update is needed</b> on feature entry:<br/>
-    <a class="feature-name" href="http://127.0.0.1:8888/feature/123"
-          >feature one</a>
+
+<div style="background: #eee; padding: 0 16px 16px">
+<div style="color: #666; padding: 8px 0 0 16px;"></div>
+
+<div style="padding: 8px; background: white; border-top: 4px solid #888; border-color: #d32f2f;">
+<section id="context" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
+  <table>
+    <tr>
+      <td rowspan=2>
+  
+<div style="border: 4px solid #d32f2f; border-radius: 50%; width: 32px; height: 32px; margin-right: 8px;">
   </div>
+
+</td>
+      <td><b>Your update is needed</b> on feature entry:</td>
+    </tr>
+    <tr>
+      <td><a style="font-size: 140%;"
+             href="http://127.0.0.1:8888/feature/123"
+             >feature one</a>
+      </td>
+    </tr>
+  </table>
 </section>
-<br/>
 
 
-<section id="why-triggered">
+<section id="why-triggered" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   
   <p>
     In order to ensure feature data accuracy, this notification has been
@@ -22,10 +38,9 @@
      of the ChromeStatus feature entry.
   </p>
 </section>
-<br/>
 
 
-<section id="details">
+<section id="details" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <p>Your feature is slated to launch soon for m100:</p>
   <p>
     
@@ -82,9 +97,13 @@
 </section>
 
 
-<section id="next-steps">
+<section id="next-steps" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <div><b>Your next steps:</b></div>
-  <div><a href="http://127.0.0.1:8888/guide/verify_accuracy/123"
-          class="button-like">
-      Verify feature accuracy</a></div>
+
+  <div style="margin: 16px;">
+    <a href="http://127.0.0.1:8888/guide/verify_accuracy/123" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; "
+     >Verify feature accuracy</a></div>
 </section>
+
+</div>
+</div>

--- a/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy.html
@@ -1,14 +1,30 @@
-<section id="context">
-  <div>
-    <b>Your update is needed</b> on feature entry:<br/>
-    <a class="feature-name" href="http://127.0.0.1:8888/feature/123"
-          >feature one</a>
+
+<div style="background: #eee; padding: 0 16px 16px">
+<div style="color: #666; padding: 8px 0 0 16px;"></div>
+
+<div style="padding: 8px; background: white; border-top: 4px solid #888; border-color: #d32f2f;">
+<section id="context" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
+  <table>
+    <tr>
+      <td rowspan=2>
+  
+<div style="border: 4px solid #d32f2f; border-radius: 50%; width: 32px; height: 32px; margin-right: 8px;">
   </div>
+
+</td>
+      <td><b>Your update is needed</b> on feature entry:</td>
+    </tr>
+    <tr>
+      <td><a style="font-size: 140%;"
+             href="http://127.0.0.1:8888/feature/123"
+             >feature one</a>
+      </td>
+    </tr>
+  </table>
 </section>
-<br/>
 
 
-<section id="why-triggered">
+<section id="why-triggered" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   
 
   <p>
@@ -17,10 +33,9 @@
      of the ChromeStatus feature entry.
   </p>
 </section>
-<br/>
 
 
-<section id="details">
+<section id="details" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <p>Your feature is slated to launch soon for m100:</p>
   <p>
     
@@ -77,9 +92,13 @@
 </section>
 
 
-<section id="next-steps">
+<section id="next-steps" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <div><b>Your next steps:</b></div>
-  <div><a href="http://127.0.0.1:8888/guide/verify_accuracy/123"
-          class="button-like">
-      Verify feature accuracy</a></div>
+
+  <div style="margin: 16px;">
+    <a href="http://127.0.0.1:8888/guide/verify_accuracy/123" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; "
+     >Verify feature accuracy</a></div>
 </section>
+
+</div>
+</div>

--- a/internals/testdata/reminders_test/test_build_email_tasks_prepublication.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_prepublication.html
@@ -1,14 +1,30 @@
-<section id="context">
-  <div>
-    <b>Pre-publication notice</b> for feature entry:<br/>
-    <a class="feature-name" href="http://127.0.0.1:8888/feature/123"
-          >feature one</a>
+
+<div style="background: #eee; padding: 0 16px 16px">
+<div style="color: #666; padding: 8px 0 0 16px;"></div>
+
+<div style="padding: 8px; background: white; border-top: 4px solid #888; border-color: #d32f2f;">
+<section id="context" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
+  <table>
+    <tr>
+      <td rowspan=2>
+  
+<div style="border: 4px solid #d32f2f; border-radius: 50%; width: 32px; height: 32px; margin-right: 8px;">
   </div>
+
+</td>
+      <td><b>Prepublication notice</b> for feature entry:</td>
+    </tr>
+    <tr>
+      <td><a style="font-size: 140%;"
+             href="http://127.0.0.1:8888/feature/123"
+             >feature one</a>
+      </td>
+    </tr>
+  </table>
 </section>
-<br/>
 
 
-<section id="details">
+<section id="details" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <div><b>It's really happening:</b></div>
 
   <p>Your feature is slated to ship in M100 which will reach the
@@ -20,10 +36,9 @@
     web developers and IT admins, and they are sometimes used as the basis
     for popular press articles.</p>
 </section>
-<br/>
 
 
-<section id="next-steps">
+<section id="next-steps"  style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <div><b>Your next steps:</b></div>
 
   <h2>1. Locate your releases on the roadmap.</h2>
@@ -54,9 +69,9 @@
     <p>sum</p>
   </div>
 
-  <p><a href="http://127.0.0.1:8888/feature/123" class="button-like"
-        >Edit your feature</a></p>
-
+  <div style="margin: 16px;">
+    <a href="http://127.0.0.1:8888/feature/123" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; "
+       >View feature details</a></div>
 
   <p>Guidelines for writing the summary:</p>
   <ul>
@@ -109,3 +124,6 @@
     or email us at webstatus@google.com.</p>
 
 </section>
+
+</div>
+</div>

--- a/templates/accuracy_notice_email.html
+++ b/templates/accuracy_notice_email.html
@@ -1,14 +1,25 @@
-<section id="context">
-  <div>
-    <b>Your update is needed</b> on feature entry:<br/>
-    <a class="feature-name" href="{{SITE_URL}}feature/{{id}}"
-          >{{feature.name}}</a>
-  </div>
+{% import 'email-styles.html' as styles %}
+<div style="{{styles.body}}">
+<div style="{{styles.branding}}">{{APP_TITLE}}</div>
+
+<div style="{{styles.content}} {{styles.content_alert}}">
+<section id="context" style="{{styles.section}}">
+  <table>
+    <tr>
+      <td rowspan=2>{{styles.icon_alert()}}</td>
+      <td><b>Your update is needed</b> on feature entry:</td>
+    </tr>
+    <tr>
+      <td><a style="{{styles.feature_name}}"
+             href="{{SITE_URL}}feature/{{id}}"
+             >{{feature.name}}</a>
+      </td>
+    </tr>
+  </table>
 </section>
-<br/>
 
 
-<section id="why-triggered">
+<section id="why-triggered" style="{{styles.section}}">
   {% if is_escalated %}
   <p>
     In order to ensure feature data accuracy, this notification has been
@@ -22,10 +33,9 @@
      of the ChromeStatus feature entry.
   </p>
 </section>
-<br/>
 
 
-<section id="details">
+<section id="details" style="{{styles.section}}">
   <p>Your feature is slated to launch soon for m{{milestone}}:</p>
   <p>
     {% include "estimated-milestones-table.html" %}
@@ -44,9 +54,13 @@
 </section>
 
 
-<section id="next-steps">
+<section id="next-steps" style="{{styles.section}}">
   <div><b>Your next steps:</b></div>
-  <div><a href="{{SITE_URL}}guide/verify_accuracy/{{id}}"
-          class="button-like">
-      Verify feature accuracy</a></div>
+
+  <div style="{{styles.button_div}}">
+    <a href="{{SITE_URL}}guide/verify_accuracy/{{id}}" style="{{styles.button_a}}"
+     >Verify feature accuracy</a></div>
 </section>
+
+</div>
+</div>

--- a/templates/email-styles.html
+++ b/templates/email-styles.html
@@ -1,0 +1,57 @@
+{# This file is imported into other email teamplates to share style="..."
+attributes because email clients do not consistently support <style>. #}
+
+{% set body =
+ 'background: #eee; padding: 0 16px 16px'
+%}
+
+{% set branding =
+ 'color: #666; padding: 8px 0 0 16px;'
+%}
+
+{% set content =
+ 'padding: 8px; background: white; border-top: 4px solid #888;'
+%}
+
+{% set content_new = 'border-color: #388e3c;' %}
+{% set content_updated = 'border-color: #01579b;' %}
+{% set content_alert = 'border-color: #d32f2f;' %}
+
+{# TODO(jrobbins): Replace these colored circles with actual icons. #}
+{% macro icon(color) %}
+<div style="border: 4px solid {{color}}; border-radius: 50%; width: 32px; height: 32px; margin-right: 8px;">
+  </div>
+{% endmacro %}
+
+{% macro icon_new() %}
+  {{icon('#338e3c')}}
+{% endmacro %}
+
+{% macro icon_updated() %}
+  {{icon('#01579b')}}
+{% endmacro %}
+
+{% macro icon_alert() %}
+  {{icon('#d32f2f')}}
+{% endmacro %}
+
+
+{% set feature_name =
+ 'font-size: 140%;'
+%}
+
+{% set section =
+ 'margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;'
+%}
+
+{% set td =
+ 'padding-left: 16px;'
+%}
+
+{% set button_div =
+ 'margin: 16px;'
+%}
+
+{% set button_a =
+ 'text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; '
+%}

--- a/templates/new-feature-email.html
+++ b/templates/new-feature-email.html
@@ -1,56 +1,70 @@
-<section id="context">
-  <div>
-    <b>New</b> feature entry:<br/>
-    <a class="feature-name" href="{{SITE_URL}}feature/{{id}}"
-          >{{feature.name}}</a>
-  </div>
-</section>
-<br/>
+{% import 'email-styles.html' as styles %}
+<div style="{{styles.body}}">
+<div style="{{styles.branding}}">{{APP_TITLE}}</div>
 
-
-<section id="details">
-  <div><b>New details entered by {{feature.creator_email}}:</div>
-
+<div style="{{styles.content}} {{styles.content_new}}">
+<section id="context" style="{{styles.section}}">
   <table>
     <tr>
-      <td>Summary:</td>
-      <td>{{feature.summary}}</td>
+      <td rowspan=2>{{styles.icon_new()}}</td>
+      <td><b>New</b> feature entry:</td>
     </tr>
     <tr>
-      <td>Unlisted:</td>
-      <td>{% if feature.unlisted %}Yes{% else %}No{% endif %}</td>
-    </tr>
-    <tr>
-      <td>Breaking change:</td>
-      <td>{% if feature.breaking_change %}Yes{% else %}No{% endif %}</td>
-    </tr>
-    <tr>
-      <td>Feature owners:</td>
-      <td>{{feature.owner_emails|join(", ")}}</td>
-    </tr>
-    <tr>
-      <td>Cc:</td>
-      <td>{{feature.cc_emails|join(", ")}}</td>
-    </tr>
-    <tr>
-      <td>Blink component:</td>
-      <td>{{feature.blink_components|join(", ")}}</td>
-    </tr>
-    <tr>
-      <td>Category:</td>
-      <td>{{category}}</td>
-    </tr>
-    <tr>
-      <td>Feature type:</td>
-      <td>{{feature_type}}</td>
+      <td><a style="{{styles.feature_name}}"
+             href="{{SITE_URL}}feature/{{id}}"
+             >{{feature.name}}</a>
+      </td>
     </tr>
   </table>
 </section>
 
 
-<section id="next-steps">
+<section id="details" style="{{styles.section}}">
+  <div><b>New details entered by {{feature.creator_email}}:</div>
+
+  <table>
+    <tr>
+      <td style="{{styles.td}}">Summary:</td>
+      <td style="{{styles.td}}">{{feature.summary}}</td>
+    </tr>
+    <tr>
+      <td style="{{styles.td}}">Unlisted:</td>
+      <td style="{{styles.td}}">{% if feature.unlisted %}Yes{% else %}No{% endif %}</td>
+    </tr>
+    <tr>
+      <td style="{{styles.td}}">Breaking change:</td>
+      <td style="{{styles.td}}">{% if feature.breaking_change %}Yes{% else %}No{% endif %}</td>
+    </tr>
+    <tr>
+      <td style="{{styles.td}}">Feature owners:</td>
+      <td style="{{styles.td}}">{{feature.owner_emails|join(", ")}}</td>
+    </tr>
+    <tr>
+      <td style="{{styles.td}}">Cc:</td>
+      <td style="{{styles.td}}">{{feature.cc_emails|join(", ")}}</td>
+    </tr>
+    <tr>
+      <td style="{{styles.td}}">Blink component:</td>
+      <td style="{{styles.td}}">{{feature.blink_components|join(", ")}}</td>
+    </tr>
+    <tr>
+      <td style="{{styles.td}}">Category:</td>
+      <td style="{{styles.td}}">{{category}}</td>
+    </tr>
+    <tr>
+      <td style="{{styles.td}}">Feature type:</td>
+      <td style="{{styles.td}}">{{feature_type}}</td>
+    </tr>
+  </table>
+</section>
+
+
+<section id="next-steps" style="{{styles.section}}">
   <div><b>Your next steps:</b></div>
-  <div><a href="{{SITE_URL}}feature/{{id}}"
-     class="button-like"
+  <div style="{{styles.button_div}}">
+    <a href="{{SITE_URL}}feature/{{id}}" style="{{styles.button_a}}"
      >View feature details</a></div>
 </section>
+
+</div>
+</div>

--- a/templates/prepublication-notice-email.html
+++ b/templates/prepublication-notice-email.html
@@ -1,14 +1,25 @@
-<section id="context">
-  <div>
-    <b>Pre-publication notice</b> for feature entry:<br/>
-    <a class="feature-name" href="{{SITE_URL}}feature/{{id}}"
-          >{{feature.name}}</a>
-  </div>
+{% import 'email-styles.html' as styles %}
+<div style="{{styles.body}}">
+<div style="{{styles.branding}}">{{APP_TITLE}}</div>
+
+<div style="{{styles.content}} {{styles.content_alert}}">
+<section id="context" style="{{styles.section}}">
+  <table>
+    <tr>
+      <td rowspan=2>{{styles.icon_alert()}}</td>
+      <td><b>Prepublication notice</b> for feature entry:</td>
+    </tr>
+    <tr>
+      <td><a style="{{styles.feature_name}}"
+             href="{{SITE_URL}}feature/{{id}}"
+             >{{feature.name}}</a>
+      </td>
+    </tr>
+  </table>
 </section>
-<br/>
 
 
-<section id="details">
+<section id="details" style="{{styles.section}}">
   <div><b>It's really happening:</b></div>
 
   <p>Your feature is slated to ship in M{{milestone}} which will reach the
@@ -20,10 +31,9 @@
     web developers and IT admins, and they are sometimes used as the basis
     for popular press articles.</p>
 </section>
-<br/>
 
 
-<section id="next-steps">
+<section id="next-steps"  style="{{styles.section}}">
   <div><b>Your next steps:</b></div>
 
   <h2>1. Locate your releases on the roadmap.</h2>
@@ -54,9 +64,9 @@
     <p>{{feature.summary}}</p>
   </div>
 
-  <p><a href="{{SITE_URL}}feature/{{id}}" class="button-like"
-        >Edit your feature</a></p>
-
+  <div style="{{styles.button_div}}">
+    <a href="{{SITE_URL}}feature/{{id}}" style="{{styles.button_a}}"
+       >View feature details</a></div>
 
   <p>Guidelines for writing the summary:</p>
   <ul>
@@ -109,3 +119,6 @@
     or email us at webstatus@google.com.</p>
 
 </section>
+
+</div>
+</div>

--- a/templates/review-request-email.html
+++ b/templates/review-request-email.html
@@ -1,22 +1,35 @@
-<section id="context">
-  <p>
-    <b>Review requested</b> for feature entry:<br/>
-    <a class="feature-name" href="{{SITE_URL}}feature/{{id}}"
-          >{{feature.name}}</a>
-  </p>
+{% import 'email-styles.html' as styles %}
+<div style="{{styles.body}}">
+<div style="{{styles.branding}}">{{APP_TITLE}}</div>
+
+<div style="{{styles.content}} {{styles.content_alert}}">
+<section id="context" style="{{styles.section}}">
+  <table>
+    <tr>
+      <td rowspan=2>{{styles.icon_alert()}}</td>
+      <td><b>Review requested</b> for feature entry:</td>
+    </tr>
+    <tr>
+      <td><a style="{{styles.feature_name}}"
+             href="{{SITE_URL}}feature/{{id}}"
+             >{{feature.name}}</a>
+      </td>
+    </tr>
+  </table>
 </section>
 
-
-<section id="details">
+<section id="details" style="{{styles.section}}">
   <p><b>Review requested{% if updater_email %} by {{updater_email}}{% endif %}:</b></p>
 
   <p>Please review this feature entry on behalf of {% if team_name %}{{team_name}}{% else %}your team{% endif %}.</p>
 </section>
 
-
-<section id="next-steps">
-  <p><b>Your next steps:</b></p>
-  <p><a href="{{gate_url}}"
-     class="button-like"
-     >Review feature details</a></p>
+<section id="next-steps" style="{{styles.section}}">
+  <div><b>Your next steps:</b></div>
+  <div style="{{styles.button_div}}">
+    <a href="{{gate_url}}" style="{{styles.button_a}}"
+     >Review feature details</a></div>
 </section>
+
+</div>
+</div>

--- a/templates/update-feature-email.html
+++ b/templates/update-feature-email.html
@@ -1,14 +1,25 @@
-<section id="context">
-  <div>
-    <b>Updated</b> feature entry:<br/>
-    <a class="feature-name" href="{{SITE_URL}}feature/{{id}}"
-          >{{feature.name}}</a>
-  </div>
+{% import 'email-styles.html' as styles %}
+<div style="{{styles.body}}">
+<div style="{{styles.branding}}">{{APP_TITLE}}</div>
+
+<div style="{{styles.content}} {{styles.content_updated}}">
+<section id="context" style="{{styles.section}}">
+  <table>
+    <tr>
+      <td rowspan=2>{{styles.icon_updated()}}</td>
+      <td><b>Updated</b> feature entry:</td>
+    </tr>
+    <tr>
+      <td><a style="{{styles.feature_name}}"
+             href="{{SITE_URL}}feature/{{id}}"
+             >{{feature.name}}</a>
+      </td>
+    </tr>
+  </table>
 </section>
-<br/>
 
 
-<section id="details">
+<section id="details" style="{{styles.section}}">
   <div><b>Updates made by {{updater_email}}:</b></div>
   <ul>
     {{formatted_changes|safe}}
@@ -16,9 +27,12 @@
 </section>
 
 
-<section id="next-steps">
+<section id="next-steps" style="{{styles.section}}">
   <div><b>Your next steps:</b></div>
-  <div><a href="{{SITE_URL}}feature/{{id}}"
-     class="button-like"
+  <div style="{{styles.button_div}}">
+    <a href="{{SITE_URL}}feature/{{id}}" style="{{styles.button_a}}"
      >View feature details</a></div>
 </section>
+
+</div>
+</div>


### PR DESCRIPTION
This adds significant visual polish to our email notifications.  Preceding PRs have updated the markup and content of our email templates, and now this one adds style.   The `<style>` element does not work on groups.google.com, so we need to use `style="..."` attributes instead.  

To avoid repeating style details many times, I have used jinja2 variables and macros.  I could have done the same thing with python code, but I felt that it was more clear to keep template content stuff in the template language rather than in python.

In this PR:
* Pass APP_TITLE because it is used in the "branding" line at the very top of each email notification body.
* Revise each email notification template:
    * Add grey "body" and white "content" divs to frame the content.  The "content" has a color-coded top border.
    * Style the `<sections>` to look like bubbles
    * Style the "context" header with a color-coded circle and large-font feature name
    * Style the "View feature details" or other main action link to look like buttons
