### PR TITLE
Fix gate_url for staging emails.

### DIFF
--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -85,7 +85,7 @@ def notify_subscribers_and_save_amendments(
 
 
 def get_gate_url(gate: Gate) -> str:
-  """Reutrn a URL for the user to view the given gate."""
+  """Return a URL for the user to view the given gate."""
   gate_id = gate.key.integer_id()
   gate_url = '%sfeature/%s?gate=%s' % (
       settings.SITE_URL, gate.feature_id, gate_id)


### PR DESCRIPTION
We have been generating prod URLs to the gates in the email notifications.  That's correct from the users' point of view, but it makes it a bit of a hassle to test on staging.  This PR uses settings.SITE_URL to generate the correct gate_url.  Also, it DRYs up some redundant code and adds some missing whitespace.