### PR TITLE
Disable the eslint valid-jsdoc check.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
       { "outerIIFEBody": 0, "SwitchCase": 1, "ignoredNodes": ["TemplateLiteral > *"] }
     ],
     "require-jsdoc": 0,
+    "valid-jsdoc": "off",
     "no-var": 1,
     "arrow-parens": 0,
     "max-len": [2, 100, {

--- a/client-src/js-src/openapi-client.js
+++ b/client-src/js-src/openapi-client.js
@@ -38,7 +38,6 @@ class ChromeStatusOpenApiClient extends Api {
 }
 
 class ChromeStatusMiddlewares {
-  // eslint-disable-next-line valid-jsdoc
   /**
    * Refresh the XSRF Token, if needed. Add to headers.
    *
@@ -56,7 +55,6 @@ class ChromeStatusMiddlewares {
   }
 
 
-  // eslint-disable-next-line valid-jsdoc
   /**
    * Server sends XSSI prefix. Remove it and allow the client to parse.
    *


### PR DESCRIPTION
It's deprecated upstream
(https://eslint.org/blog/2018/11/jsdoc-end-of-life/), and it has
false-positives on some of the type expressions we need to accurately
describe our types.
