### PR TITLE
Recommend the Ruff extension to everyone

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,7 @@
 				"pylint.args": ["--indent-string=\"  \""],
 				"python.defaultInterpreterPath": "/workspace/cs-env/bin/python",
 				"python.editor.tabSize": 2,
+				"python.languageServer": "Jedi",
 				"python.testing.pytestEnabled": false,
 				"python.testing.unittestArgs": [
 					"-v",
@@ -27,19 +28,18 @@
 					"-p",
 					"*_test.py"
 				],
-				"python.languageServer": "Jedi",
 				"python.testing.unittestEnabled": true
 			},
 
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
-				"ms-python.python",
+				"42Crunch.vscode-openapi",
+				"bierner.lit-html",
 				"eeyore.yapf",
+				"ms-playwright.playwright",
 				"ms-python.mypy-type-checker",
 				"ms-python.pylint",
-				"bierner.lit-html",
-				"42Crunch.vscode-openapi",
-				"ms-playwright.playwright"
+				"ms-python.python"
 			]
 		}
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,9 +16,7 @@
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
 				"mypy-type-checker.args": ["--ignore-missing-imports --exclude cs-env/ --exclude gen/ --exclude appengine_config.py --disable-error-code \"annotation-unchecked\""],
-				"pylint.args": ["--indent-string=\"  \""],
 				"python.defaultInterpreterPath": "/workspace/cs-env/bin/python",
-				"python.editor.tabSize": 2,
 				"python.languageServer": "Jedi",
 				"python.testing.pytestEnabled": false,
 				"python.testing.unittestArgs": [
@@ -35,11 +33,11 @@
 			"extensions": [
 				"42Crunch.vscode-openapi",
 				"bierner.lit-html",
-				"eeyore.yapf",
 				"ms-playwright.playwright",
+				"charliermarsh.ruff",
 				"ms-python.mypy-type-checker",
-				"ms-python.pylint",
-				"ms-python.python"
+				"ms-python.python",
+				"EditorConfig.EditorConfig"
 			]
 		}
 	},

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,19 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": [
+    "42Crunch.vscode-openapi",
+    "bierner.lit-html",
+    "charliermarsh.ruff",
+    "ms-playwright.playwright",
+    "ms-python.mypy-type-checker",
+    "ms-python.python",
+    "EditorConfig.EditorConfig",
+  ],
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": [
+
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.ruff]
+indent-width = 2
+
+[tool.ruff.format]
+quote-style = "single"


### PR DESCRIPTION
I removed the pylint and yapf extensions, which Ruff replaces, and I
added a pyproject.toml to hold Python tool configuration.

I also added a .vscode/extensions.json to recommend the same list of
extensions to people who don't use devcontainers.