### PR TITLE
Preserve casing in the OpenAPI JS bindings.

### DIFF
--- a/client-src/elements/chromedash-admin-blink-page.js
+++ b/client-src/elements/chromedash-admin-blink-page.js
@@ -114,11 +114,11 @@ export class ChromedashAdminBlinkPage extends LitElement {
 
     // If the user is already a subscriber, we do not want to append it.
     // We can get here if we are adding the user the owner list.
-    if (!component.subscriberIds.includes(e.detail.userId)) {
-      component.subscriberIds = [...component.subscriberIds, e.detail.userId];
+    if (!component.subscriber_ids.includes(e.detail.userId)) {
+      component.subscriber_ids = [...component.subscriber_ids, e.detail.userId];
     }
     if (e.detail.toggleAsOwner) {
-      component.ownerIds = [...component.ownerIds, e.detail.userId];
+      component.owner_ids = [...component.owner_ids, e.detail.userId];
     }
     showToastMessage(`"${this.usersMap.get(e.detail.userId).name} added to ${component.name}".`);
     this.components[e.detail.index] = component;
@@ -132,10 +132,10 @@ export class ChromedashAdminBlinkPage extends LitElement {
       return;
     }
 
-    component.subscriberIds = component.subscriberIds.filter(
+    component.subscriber_ids = component.subscriber_ids.filter(
       (currentUserId) => e.detail.userId !== currentUserId);
     if (e.detail.toggleAsOwner) {
-      component.ownerIds = component.ownerIds.filter(
+      component.owner_ids = component.owner_ids.filter(
         (currentUserId) => e.detail.userId !== currentUserId);
     }
     showToastMessage(`"${this.usersMap.get(e.detail.userId).name} removed from ${component.name}".`);
@@ -180,8 +180,8 @@ export class ChromedashAdminBlinkPage extends LitElement {
             <chromedash-admin-blink-component-listing
               .id=${component.id}
               .name=${component.name}
-              .subscriberIds=${component.subscriberIds ?? []}
-              .ownerIds=${component.ownerIds ?? []}
+              .subscriberIds=${component.subscriber_ids ?? []}
+              .ownerIds=${component.owner_ids ?? []}
               .index=${index}
               .usersMap=${this.usersMap}
               ?editing=${this._editMode}

--- a/client-src/elements/chromedash-admin-blink-page_test.js
+++ b/client-src/elements/chromedash-admin-blink-page_test.js
@@ -34,7 +34,7 @@ describe('chromedash-admin-blink-page', () => {
         {id: 0, name: 'user0', email: 'user0@example.com'},
       ],
       components: [
-        {id: 0, name: 'component0', subscriberIds: [0], ownerIds: [0]},
+        {id: 0, name: 'component0', subscriber_ids: [0], owner_ids: [0]},
       ],
     };
     window.csOpenApiClient = sinon.createStubInstance(DefaultApi, {

--- a/gen/js/chromestatus-openapi/src/models/OwnersAndSubscribersOfComponent.ts
+++ b/gen/js/chromestatus-openapi/src/models/OwnersAndSubscribersOfComponent.ts
@@ -36,13 +36,13 @@ export interface OwnersAndSubscribersOfComponent {
      * @type {Array<number>}
      * @memberof OwnersAndSubscribersOfComponent
      */
-    subscriberIds?: Array<number>;
+    subscriber_ids?: Array<number>;
     /**
      * 
      * @type {Array<number>}
      * @memberof OwnersAndSubscribersOfComponent
      */
-    ownerIds?: Array<number>;
+    owner_ids?: Array<number>;
 }
 
 /**
@@ -68,8 +68,8 @@ export function OwnersAndSubscribersOfComponentFromJSONTyped(json: any, ignoreDi
         
         'id': json['id'],
         'name': json['name'],
-        'subscriberIds': !exists(json, 'subscriber_ids') ? undefined : json['subscriber_ids'],
-        'ownerIds': !exists(json, 'owner_ids') ? undefined : json['owner_ids'],
+        'subscriber_ids': !exists(json, 'subscriber_ids') ? undefined : json['subscriber_ids'],
+        'owner_ids': !exists(json, 'owner_ids') ? undefined : json['owner_ids'],
     };
 }
 
@@ -84,8 +84,8 @@ export function OwnersAndSubscribersOfComponentToJSON(value?: OwnersAndSubscribe
         
         'id': value.id,
         'name': value.name,
-        'subscriber_ids': value.subscriberIds,
-        'owner_ids': value.ownerIds,
+        'subscriber_ids': value.subscriber_ids,
+        'owner_ids': value.owner_ids,
     };
 }
 

--- a/gen/py/chromestatus_openapi/requirements.txt
+++ b/gen/py/chromestatus_openapi/requirements.txt
@@ -4,8 +4,8 @@ connexion[swagger-ui] <= 2.3.0; python_version=="3.5" or python_version=="3.4"
 # connexion requires werkzeug but connexion < 2.4.0 does not install werkzeug
 # we must peg werkzeug versions below to fix connexion
 # https://github.com/zalando/connexion/pull/1044
-werkzeug == 2.3.8; python_version=="3.5" or python_version=="3.4"
+werkzeug == 0.16.1; python_version=="3.5" or python_version=="3.4"
 swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
-Flask == 2.2.5
+Flask == 2.1.1

--- a/openapi/js-config.yaml
+++ b/openapi/js-config.yaml
@@ -1,0 +1,7 @@
+additionalProperties:
+  enumPropertyNaming: original
+  modelPropertyNaming: original
+  npmName: chromestatus-openapi
+  paramNaming: camelCase
+  supportsES6: true
+  withInterfaces: true

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "deploy": "./scripts/deploy_site.sh `git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted'`",
     "deploy-rc": "./scripts/deploy_site.sh rc",
     "openapi": "npm run openapi-backend && npm run openapi-frontend",
-    "openapi-frontend": "rm -rf gen/js/chromestatus-openapi && openapi-generator-cli generate -i openapi/api.yaml -g typescript-fetch  -o gen/js/chromestatus-openapi --additional-properties=npmName=chromestatus-openapi,withInterfaces=true,supportsES6=true && npm install",
+    "openapi-frontend": "rm -rf gen/js/chromestatus-openapi && openapi-generator-cli generate -i openapi/api.yaml -g typescript-fetch  -o gen/js/chromestatus-openapi --config openapi/js-config.yaml && npm install",
     "openapi-backend": "rm -rf gen/py/chromestatus_openapi && openapi-generator-cli generate -i openapi/api.yaml -g python-flask  -o gen/py/chromestatus_openapi --additional-properties=packageName=chromestatus_openapi && pip install -r requirements.txt",
     "openapi-validate": "openapi-generator-cli validate -i openapi/api.yaml"
   },


### PR DESCRIPTION
It seems like it'll be confusing to have the API documentation use a different casing from the code we actually write. If we want a particular casing, we should use it in the API spec. (Do we want camelCase for these two fields?)

I left the paramNaming as camelCase because it doesn't seem to react to changes in the API casing (a bug in the generator?), and we don't want "ComponentUsersRequest" to start with a capital when used as an object member.