### PR TITLE
Disable monorail feature_links due to CoB migration.

### DIFF
--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -314,9 +314,12 @@ class Link():
         # if the link is not valid, return early
         self.is_parsed = True
         return
-      if self.type == LINK_TYPE_CHROMIUM_BUG:
-        self.information = self._parse_chromium_bug()
-      elif self.type == LINK_TYPE_GITHUB_ISSUE:
+
+      # TODO(jrobbins): Re-enable after issues.chromium.org has an API
+      # if self.type == LINK_TYPE_CHROMIUM_BUG:
+      #  self.information = self._parse_chromium_bug()
+
+      if self.type == LINK_TYPE_GITHUB_ISSUE:
         self.information = self._parse_github_issue()
       elif self.type == LINK_TYPE_GITHUB_PULL_REQUEST:
         # we can also use github issue api to get pull request information

--- a/internals/link_helpers_test.py
+++ b/internals/link_helpers_test.py
@@ -15,6 +15,7 @@
 
 import testing_config
 from unittest import mock
+from unittest import skip
 from internals.link_helpers import (
     Link,
     LINK_TYPE_CHROMIUM_BUG,
@@ -217,6 +218,7 @@ class LinkHelperTest(testing_config.CustomTestCase):
     link = Link("https://bugs0chromium.org/p/chromium/issues/detail?id=100000")
     self.assertNotEqual(link.type, LINK_TYPE_CHROMIUM_BUG)
 
+  @skip('Until issues.chromium.org has an API')
   def test_parse_chromium_tracker(self):
     link = Link("https://bugs.chromium.org/p/chromium/issues/detail?id=100000")
     link.parse()
@@ -227,6 +229,7 @@ class LinkHelperTest(testing_config.CustomTestCase):
     self.assertEqual(info["statusRef"]["status"], "Fixed")
     self.assertEqual(info["ownerRef"]["displayName"], "backer@chromium.org")
 
+  @skip('Until issues.chromium.org has an API')
   @mock.patch("logging.error")
   def test_parse_chromium_tracker_fail_wrong_id(self, mock_error):
     link = Link(
@@ -238,6 +241,7 @@ class LinkHelperTest(testing_config.CustomTestCase):
     self.assertEqual(link.is_error, True)
     self.assertEqual(link.information, None)
 
+  @skip('Until issues.chromium.org has an API')
   @mock.patch("logging.error")
   def test_parse_chromium_tracker_fail_no_permission(self, mock_error):
     link = Link("https://bugs.chromium.org/p/chromium/issues/detail?id=1")


### PR DESCRIPTION
Since bugs.chromium.org is now switched to issues.chromium.org, our old approach to getting issue data no longer works.  I have sent a question to the CoB team to ask about the simplest way to access the new tool, but until then, we can just disable the monorail feature_links functionality.  That should get our CI passing again.