### PR TITLE
Make buttons at top of gate column square.

### DIFF
--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -433,7 +433,7 @@ export class ChromedashGateColumn extends LitElement {
 
     return html`
       <sl-button @click=${loadThenCheckCompletion}
-       pill size=small variant=primary
+       size=small variant=primary
        >${label}</sl-button>
     `;
   }
@@ -469,10 +469,10 @@ export class ChromedashGateColumn extends LitElement {
     `;
 
     return html`
-     <sl-button pill size=small variant=primary
+     <sl-button size=small variant=primary
        @click=${this.handleReviewRequested}
        >Request review</sl-button>
-     <sl-button pill size=small
+     <sl-button size=small
        @click=${this.handleNARequested}
        >Request N/A</sl-button>
      ${dialog}


### PR DESCRIPTION
This is a small change that was mentioned at the team's in-person meetings last week.  Basically, we want to clarify to first-time users that the gate chips are something that they should click on to get to review info.  We will do that by adding some in-app help.  But before we do that, I want to make these buttons look more distinct from the gate chips.    

For now, we should consistently follow material design 2 which uses pill shapes for chips and rounded rectangles for buttons.   Someday we might change everything to the MD3 style which reverses those shapes, but we are not ready to do that yet.