### PR TITLE
OT Extension - Add endpoint to submit origin trial extension

### DIFF
--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -68,7 +68,7 @@ class OriginTrialsAPI(basehandlers.APIHandler):
     feature_id = int(kwargs['feature_id'])
     extension_stage_id = int(kwargs['extension_stage_id'])
     # Check that feature ID is valid.
-    if feature_id is None or feature_id == 0:
+    if not feature_id:
       self.abort(404, msg='No feature specified.')
     feature: FeatureEntry | None = FeatureEntry.get_by_id(feature_id)
     if feature is None:
@@ -76,7 +76,7 @@ class OriginTrialsAPI(basehandlers.APIHandler):
 
     # Check that stage ID is valid.
     extension_stage_id = int(kwargs['extension_stage_id'])
-    if extension_stage_id is None or extension_stage_id == 0:
+    if not extension_stage_id:
       self.abort(404, msg='No stage specified.')
     extension_stage: Stage | None = Stage.get_by_id(extension_stage_id)
     if extension_stage is None:

--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -59,7 +59,7 @@ class OriginTrialsAPI(basehandlers.APIHandler):
     if end_milestone is None or not end_milestone.isnumeric():
       self.abort(400, f'Invalid argument for end_milestone: {end_milestone}')
     intent_url = body.get('intent_thread_url')
-    if not validators.url(intent_url):
+    if intent_url is None or not validators.url(intent_url):
       self.abort(400, ('Invalid argument for extension_intent_url: '
                        f'{intent_url}'))
 

--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -38,14 +38,15 @@ class OriginTrialsAPI(basehandlers.APIHandler):
 
     return trials_list
 
-  def _validate_extension_args(self, feature_id: int, stage: Stage, body) -> None:
-    """Validates the given arguments used for origin trial extension."""
+  def _validate_extension_args(
+        self, feature_id: int, stage: Stage, body: dict) -> None:
+    """Abort if any arguments used for origin trial extension are invalid."""
     # The stage should belong to the feature.
     if feature_id != stage.feature_id:
       self.abort(400, ('Stage does not belong to feature. '
-                       f'feature_id: {trial_id}, '
+                       f'feature_id: {feature_id}, '
                        f'stage_id: {stage.key.integer_id()}'))
-    trial_id = body['origin_trial_id']
+    trial_id = body.get('origin_trial_id')
     if (trial_id is None
         or not (all(char.isdigit() or char == '-' for char in trial_id))):
       self.abort(400, f'Invalid argument for trial_id: {trial_id}')
@@ -54,10 +55,10 @@ class OriginTrialsAPI(basehandlers.APIHandler):
       self.abort(400, ('Origin trial does not belong to stage.'
                        f'origin trial ID: {trial_id}',
                        f'stage\'s origin trial ID: {trial_id}'))
-    end_milestone = body['end_milestone']
+    end_milestone = body.get('end_milestone')
     if end_milestone is None or not end_milestone.isnumeric():
       self.abort(400, f'Invalid argument for end_milestone: {end_milestone}')
-    intent_url = body['intent_thread_url']
+    intent_url = body.get('intent_thread_url')
     if not validators.url(intent_url):
       self.abort(400, ('Invalid argument for extension_intent_url: '
                        f'{intent_url}'))

--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -13,8 +13,12 @@
 # limitations under the License.
 
 import requests
+import validators
+
 from framework import basehandlers
+from framework import permissions
 from framework import origin_trials_client
+from internals.core_models import FeatureEntry, Stage
 
 
 class OriginTrialsAPI(basehandlers.APIHandler):
@@ -33,3 +37,55 @@ class OriginTrialsAPI(basehandlers.APIHandler):
       self.abort(500, 'Malformed response from origin trials API')
 
     return trials_list
+
+  def _validate_extension_args(self, feature_id: int, stage: Stage, body) -> None:
+    """Validates the given arguments used for origin trial extension."""
+    # The stage should belong to the feature.
+    if feature_id != stage.feature_id:
+      self.abort(400, ('Stage does not belong to feature. '
+                       f'feature_id: {trial_id}, '
+                       f'stage_id: {stage.key.integer_id()}'))
+    trial_id = body['trial_id']
+    if (trial_id is None
+        or not (all(char.isdigit() or char == '-' for char in trial_id))):
+      self.abort(400, f'Invalid argument for trial_id: {trial_id}')
+    # The origin trial should belong to the stage.
+    if trial_id != stage.origin_trial_id:
+      self.abort(400, ('Origin trial does not belong to stage.'
+                       f'origin trial ID: {trial_id}',
+                       f'stage\'s origin trial ID: {trial_id}'))
+    end_milestone = body['end_milestone']
+    if end_milestone is None or not end_milestone.isnumeric():
+      self.abort(400, f'Invalid argument for end_milestone: {end_milestone}')
+    intent_url = body['extension_intent_url']
+    if not validators.url(intent_url):
+      self.abort(400, ('Invalid argument for extension_intent_url: '
+                       f'{intent_url}'))
+
+
+  def do_post(self, **kwargs):
+    """Extends an existing origin trial"""
+    feature_id = int(kwargs['feature_id'])
+
+    feature: FeatureEntry | None = FeatureEntry.get_by_id(feature_id)
+    if feature is None:
+      self.abort(404, msg=f'Feature {feature_id} not found')
+
+    stage: Stage | None = Stage.get_by_id(stage_id)
+    stage_id = int(kwargs['stage_id'])
+    if stage is None:
+      self.abort(404, msg=f'Stage {stage_id} not found')
+
+    redirect_resp = permissions.validate_feature_edit_permission(
+        self, feature_id)
+    if redirect_resp:
+      return redirect_resp
+
+    body = self.get_json_param_dict()
+    self._validate_extension_args(feature_id, stage, body)
+
+    try:
+      origin_trials_client.extend_origin_trial(
+        body['trial_id'], body['end_milestone'], body['extension_intent_url'])
+    except requests.exceptions.RequestException:
+      self.abort(500, 'Error in request to origin trials API')

--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -46,14 +46,14 @@ class OriginTrialsAPI(basehandlers.APIHandler):
                        f'feature_id: {trial_id}, '
                        f'stage_id: {stage.key.integer_id()}'))
     trial_id = body['origin_trial_id']
-    # if (trial_id is None
-    #     or not (all(char.isdigit() or char == '-' for char in trial_id))):
-    #   self.abort(400, f'Invalid argument for trial_id: {trial_id}')
-    # # The origin trial should belong to the stage.
-    # if trial_id != stage.origin_trial_id:
-    #   self.abort(400, ('Origin trial does not belong to stage.'
-    #                    f'origin trial ID: {trial_id}',
-    #                    f'stage\'s origin trial ID: {trial_id}'))
+    if (trial_id is None
+        or not (all(char.isdigit() or char == '-' for char in trial_id))):
+      self.abort(400, f'Invalid argument for trial_id: {trial_id}')
+    # The origin trial should belong to the stage.
+    if trial_id != stage.origin_trial_id:
+      self.abort(400, ('Origin trial does not belong to stage.'
+                       f'origin trial ID: {trial_id}',
+                       f'stage\'s origin trial ID: {trial_id}'))
     end_milestone = body['end_milestone']
     if end_milestone is None or not end_milestone.isnumeric():
       self.abort(400, f'Invalid argument for end_milestone: {end_milestone}')
@@ -93,3 +93,5 @@ class OriginTrialsAPI(basehandlers.APIHandler):
         body['intent_thread_url'])
     except requests.exceptions.RequestException:
       self.abort(500, 'Error in request to origin trials API')
+    except KeyError:
+      self.abort(500, 'Malformed response from Schedule API')

--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -19,7 +19,7 @@ from framework import basehandlers
 from framework import permissions
 from framework import origin_trials_client
 from internals.core_models import FeatureEntry, Stage
-
+from internals.review_models import Gate, Vote
 
 class OriginTrialsAPI(basehandlers.APIHandler):
 
@@ -58,6 +58,10 @@ class OriginTrialsAPI(basehandlers.APIHandler):
     if intent_url is None or not validators.url(intent_url):
       self.abort(400, ('Invalid argument for extension_intent_url: '
                        f'{intent_url}'))
+
+    gate = Gate.query(Gate.stage_id == extension_stage.key.integer_id()).get()
+    if not gate or gate.state != Vote.APPROVED:
+      self.abort(400, 'Extension has not received the required approvals.')
 
   def do_post(self, **kwargs):
     """Extends an existing origin trial"""

--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -67,12 +67,14 @@ class OriginTrialsAPI(basehandlers.APIHandler):
   def do_post(self, **kwargs):
     """Extends an existing origin trial"""
     feature_id = int(kwargs['feature_id'])
+    # Check that feature ID is valid.
     if feature_id is None or feature_id == 0:
       self.abort(404, msg='No feature specified.')
     feature: FeatureEntry | None = FeatureEntry.get_by_id(feature_id)
     if feature is None:
       self.abort(404, msg=f'Feature {feature_id} not found')
 
+    # Check that stage ID is valid.
     stage_id = int(kwargs['stage_id'])
     if stage_id is None or stage_id == 0:
       self.abort(404, msg='No stage specified.')
@@ -80,6 +82,8 @@ class OriginTrialsAPI(basehandlers.APIHandler):
     if stage is None:
       self.abort(404, msg=f'Stage {stage_id} not found')
 
+    # Check that user has permission to edit the feature
+    # associated with the origin trial.
     redirect_resp = permissions.validate_feature_edit_permission(
         self, feature_id)
     if redirect_resp:
@@ -96,3 +100,5 @@ class OriginTrialsAPI(basehandlers.APIHandler):
       self.abort(500, 'Error in request to origin trials API')
     except KeyError:
       self.abort(500, 'Malformed response from Schedule API')
+
+    return {'message': 'Origin trial extended successfully.'}

--- a/api/origin_trials_api_test.py
+++ b/api/origin_trials_api_test.py
@@ -44,7 +44,7 @@ class OriginTrialsAPITest(testing_config.CustomTestCase):
     self.handler = origin_trials_api.OriginTrialsAPI()
     self.request_path = (
         '/api/v0/origintrials/'
-        f'{self.feature_1_id}/{self.ot_stage_1.key.integer_id()}')
+        f'{self.feature_1_id}/{self.ot_stage_1.key.integer_id()}/extend')
 
   def tearDown(self):
     for kind in [FeatureEntry, Stage]:

--- a/api/origin_trials_api_test.py
+++ b/api/origin_trials_api_test.py
@@ -31,14 +31,14 @@ class OriginTrialsAPITest(testing_config.CustomTestCase):
     self.feature_1.put()
     self.feature_1_id = self.feature_1.key.integer_id()
     self.ot_stage_1 = Stage(
-        feature_id=self.feature_1_id, stage_type=151,
+        feature_id=self.feature_1_id, stage_type=150,
         origin_trial_id='-1234567890')
     self.ot_stage_1.put()
     self.feature_2 = FeatureEntry(
         feature_type=1, name='feature two', summary='sum', category=1)
     self.feature_2.put()
     self.ot_stage_2 = Stage(
-        feature_id=self.feature_2.key.integer_id(), stage_type=151,
+        feature_id=self.feature_2.key.integer_id(), stage_type=150,
         origin_trial_id='9876543210')
     self.ot_stage_2.put()
     self.handler = origin_trials_api.OriginTrialsAPI()

--- a/api/origin_trials_api_test.py
+++ b/api/origin_trials_api_test.py
@@ -1,0 +1,145 @@
+# Copyright 2024 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config  # Must be imported before the module under test.
+
+import flask
+import werkzeug.exceptions  # Flask HTTP stuff.
+
+from api import origin_trials_api
+from internals.core_models import FeatureEntry, Stage
+
+test_app = flask.Flask(__name__)
+
+
+class OriginTrialsAPITest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.feature_1 = FeatureEntry(
+        feature_type=1, name='feature one', summary='sum', category=1)
+    self.feature_1.put()
+    self.feature_1_id = self.feature_1.key.integer_id()
+    self.ot_stage_1 = Stage(
+        feature_id=self.feature_1_id, stage_type=151,
+        origin_trial_id='-1234567890')
+    self.ot_stage_1.put()
+    self.feature_2 = FeatureEntry(
+        feature_type=1, name='feature two', summary='sum', category=1)
+    self.feature_2.put()
+    self.ot_stage_2 = Stage(
+        feature_id=self.feature_2.key.integer_id(), stage_type=151,
+        origin_trial_id='9876543210')
+    self.ot_stage_2.put()
+    self.handler = origin_trials_api.OriginTrialsAPI()
+    self.request_path = (
+        '/api/v0/origintrials/'
+        f'{self.feature_1_id}/{self.ot_stage_1.key.integer_id()}')
+
+  def tearDown(self):
+    for kind in [FeatureEntry, Stage]:
+      for entity in kind.query():
+        entity.key.delete()
+
+  def test_validate_extension_args__valid(self):
+    body = {
+      'origin_trial_id': '-1234567890',
+      'end_milestone': '150',
+      'intent_thread_url': 'https://example.com/intent',
+    }
+    # No exception should be raised.
+    with test_app.test_request_context(self.request_path):
+      self.handler._validate_extension_args(
+          self.feature_1_id, self.ot_stage_1, body)
+  
+  def test_validate_extension_args__mismatched_stage(self):
+    body = {
+      'origin_trial_id': '-1234567890',
+      'end_milestone': '150',
+      'intent_thread_url': 'https://example.com/intent',
+    }
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        # Stage doesn't belong to feature.
+        self.handler._validate_extension_args(
+            self.feature_1_id, self.ot_stage_2, body)
+  
+  def test_validate_extension_args__invalid_ot_id(self):
+    body = {
+      # Invalid trial ID.
+      'origin_trial_id': '1111111111',
+      'end_milestone': '150',
+      'intent_thread_url': 'https://example.com/intent',
+    }
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler._validate_extension_args(
+            self.feature_1_id, self.ot_stage_1, body)
+
+  def test_validate_extension_args__missing_ot_id(self):
+    body = {
+      # Missing trial ID.
+      'end_milestone': '150',
+      'intent_thread_url': 'https://example.com/intent',
+    }
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler._validate_extension_args(
+            self.feature_1_id, self.ot_stage_1, body)
+
+  def test_validate_extension_args__invalid_end_milestone(self):
+    body = {
+      'origin_trial_id': '-1234567890',
+      # Invalid end milestone.
+      'end_milestone': 'abc',
+      'intent_thread_url': 'https://example.com/intent',
+    }
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler._validate_extension_args(
+            self.feature_1_id, self.ot_stage_1, body)
+
+  def test_validate_extension_args__missing_end_milestone(self):
+    body = {
+      'origin_trial_id': '-1234567890',
+      # Missing end milestone.
+      'intent_thread_url': 'https://example.com/intent',
+    }
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler._validate_extension_args(
+            self.feature_1_id, self.ot_stage_1, body)
+
+  def test_validate_extension_args__invalid_intent_url(self):
+    body = {
+      'origin_trial_id': '-1234567890',
+      'end_milestone': '150',
+      # Invalid intent thread URL.
+      'intent_thread_url': 'This can\'t be right.',
+    }
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler._validate_extension_args(
+            self.feature_1_id, self.ot_stage_1, body)
+
+  def test_validate_extension_args__missing_intent_url(self):
+    body = {
+      'origin_trial_id': '-1234567890',
+      'end_milestone': '150',
+      # Missing intent thread URL.
+    }
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.BadRequest):
+        self.handler._validate_extension_args(
+            self.feature_1_id, self.ot_stage_1, body)
+

--- a/client-src/elements/chromedash-ot-extension-page.js
+++ b/client-src/elements/chromedash-ot-extension-page.js
@@ -1,7 +1,6 @@
 import {LitElement, css, html} from 'lit';
 import {ref} from 'lit/directives/ref.js';
 import {
-  formatFeatureChanges,
   showToastMessage,
   setupScrollToHash} from './utils.js';
 import './chromedash-form-table.js';
@@ -102,13 +101,24 @@ export class ChromedashOTExtensionPage extends LitElement {
     setupScrollToHash(this);
   }
 
+  getFieldValueForRequestBody(fieldName) {
+    return this.fieldValues.find(field => field.name === fieldName).value;
+  }
+
+  formatRequestBody() {
+    return {
+      end_milestone: this.getFieldValueForRequestBody(
+        'ot_extension__milestone_desktop_last'),
+      intent_thread_url: this.getFieldValueForRequestBody(
+        'ot_extension__intent_to_extend_experiment_url'),
+      origin_trial_id: this.stage.origin_trial_id,
+    };
+  }
+
   handleFormSubmit(e) {
     e.preventDefault();
-    const featureSubmitBody = formatFeatureChanges(this.fieldValues, this.featureId);
-    // We only need the single stage changes.
-    const stageSubmitBody = featureSubmitBody.stages[0];
-
-    window.csClient.createStage(this.featureId, stageSubmitBody).then(() => {
+    const requestBody = this.formatRequestBody();
+    window.csClient.extendOriginTrial(this.featureId, this.stageId, requestBody).then(() => {
       showToastMessage('Extension request submitted!');
       setTimeout(() => {
         window.location.href = this.nextPage || `/feature/${this.featureId}`;

--- a/client-src/elements/chromedash-ot-extension-page.js
+++ b/client-src/elements/chromedash-ot-extension-page.js
@@ -117,12 +117,26 @@ export class ChromedashOTExtensionPage extends LitElement {
 
   handleFormSubmit(e) {
     e.preventDefault();
-    const requestBody = this.formatRequestBody();
-    window.csClient.extendOriginTrial(this.featureId, this.stageId, requestBody).then(() => {
-      showToastMessage('Extension request submitted!');
-      setTimeout(() => {
-        window.location.href = this.nextPage || `/feature/${this.featureId}`;
-      }, 1000);
+    const featureSubmitBody = formatFeatureChanges(this.fieldValues, this.featureId);
+    // We only need the single stage changes.
+    const stageSubmitBody = featureSubmitBody.stages[0];
+
+    let newStageId = null;
+    window.csClient.createStage(this.featureId, stageSubmitBody).then(resp => {
+      newStageId = resp.stage_id;
+      return window.csClient.getGates(this.featureId);
+    }).then(resp => {
+      const gate = resp.gates.find(gate => gate.stage_id === newStageId);
+      showToastMessage('Extension request started!');
+      if (!newStageId || !gate) {
+        setTimeout(() => {
+          window.location.href = this.nextPage || `/feature/${this.featureId}`;
+        }, 1000);
+      } else {
+        setTimeout(() => {
+          window.location.href = this.nextPage || `/feature/${this.featureId}?gate=${gate.id}`;
+        }, 1000);
+      }
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });

--- a/client-src/elements/chromedash-ot-extension-page.js
+++ b/client-src/elements/chromedash-ot-extension-page.js
@@ -101,20 +101,6 @@ export class ChromedashOTExtensionPage extends LitElement {
     setupScrollToHash(this);
   }
 
-  getFieldValueForRequestBody(fieldName) {
-    return this.fieldValues.find(field => field.name === fieldName).value;
-  }
-
-  formatRequestBody() {
-    return {
-      end_milestone: this.getFieldValueForRequestBody(
-        'ot_extension__milestone_desktop_last'),
-      intent_thread_url: this.getFieldValueForRequestBody(
-        'ot_extension__intent_to_extend_experiment_url'),
-      origin_trial_id: this.stage.origin_trial_id,
-    };
-  }
-
   handleFormSubmit(e) {
     e.preventDefault();
     const featureSubmitBody = formatFeatureChanges(this.fieldValues, this.featureId);

--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -546,7 +546,6 @@ export const ORIGIN_TRIAL_EXTENSION_FIELDS = {
       fields: [
         'ot_extension__intent_to_extend_experiment_url',
         'ot_extension__milestone_desktop_last',
-        'ot_request_note',
       ],
     },
   ],

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -813,7 +813,6 @@ export const ALL_FIELDS = {
   },
 
   'ot_extension__intent_to_extend_experiment_url': {
-    name: 'intent_to_extend_experiment_url',
     type: 'input',
     attrs: URL_FIELD_ATTRS,
     required: true,

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -343,6 +343,11 @@ class ChromeStatusClient {
         `/features/${featureId}/stages/${stageId}/addXfnGates`);
   }
 
+  // Origin trials API
+  async extendOriginTrial(featureId, stageId, body) {
+    return this.doPost(`/origintrials/${featureId}/${stageId}/extend`, body);
+  }
+
   // Processes API
   async getFeatureProcess(featureId) {
     return this.doGet(`/features/${featureId}/process`);

--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -125,8 +125,7 @@ def extend_origin_trial(trial_id: str, end_milestone: str, intent_url: str):
 
   end_seconds = _get_trial_end_time(end_milestone)
   access_token = _get_ot_access_token()
-  url = (f'{settings.OT_API_URL}/v1/trials/{trial_id}:add_extension'
-         f'key={key}')
+  url = (f'{settings.OT_API_URL}/v1/trials/{trial_id}:add_extension')
   headers = {'Authorization': f'Bearer {access_token}'}
   json = {
     'trial_id': trial_id,
@@ -138,7 +137,8 @@ def extend_origin_trial(trial_id: str, end_milestone: str, intent_url: str):
   }
 
   try:
-    response = requests.post(url, headers=headers, json=json)
+    response = requests.post(
+        url, headers=headers, params={'key': key}, json=json)
     response.raise_for_status()
   except requests.exceptions.RequestException as e:
     logging.exception('Failed to get response from origin trials API.')

--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -71,7 +71,8 @@ def _get_trial_end_time(end_milestone: str) -> int:
   Raises:
     requests.exceptions.RequestException: If the request fails to connect or
       the HTTP status code is not successful.
-    KeyError: If the response from Chromium API is not in the expected format.
+    KeyError: If the response from Chromium schedule API is not in the expected
+      format.
   """
   milestone_plus_two = int(end_milestone) + 2
   try:
@@ -80,11 +81,11 @@ def _get_trial_end_time(end_milestone: str) -> int:
       f'?mstone={milestone_plus_two}')
     response.raise_for_status()
   except requests.exceptions.RequestException as e:
-    logging.exception('Failed to get response from Chromium Schedule API.')
+    logging.exception('Failed to get response from Chromium schedule API.')
     raise e
   response_json = response.json()
 
-  # Raise error if the response is in the expected format.
+  # Raise error if the response is not in the expected format.
   if ('mstones' not in response_json
       or len(response_json['mstones']) == 0
       or 'late_stable_date' not in response_json['mstones'][0]):

--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -118,6 +118,10 @@ def extend_origin_trial(trial_id: str, end_milestone: str, intent_url: str):
     requests.exceptions.RequestException: If the request fails to connect or
       the HTTP status code is not successful.
   """
+  if settings.DEV_MODE:
+    logging.info('Extension request will not be sent to origin trials API in '
+                 'local environment.')
+    return
   key = secrets.get_ot_api_key()
   # Return if no API key is found.
   if key == None:

--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import google.auth
+from google.auth.transport.requests import Request
 
 from dataclasses import asdict
 import logging
@@ -21,9 +23,6 @@ import requests
 from framework import secrets
 from internals.data_types import OriginTrialInfo
 import settings
-
-
-
 
 
 def get_trials_list() -> list[dict[str, Any]]:
@@ -42,13 +41,34 @@ def get_trials_list() -> list[dict[str, Any]]:
   if key == None:
     return []
 
+  credentials, project_id = google.auth.default(scopes=[
+      "https://www.googleapis.com/auth/chromeorigintrials"])
+  credentials.refresh(Request())
+  # credentials = app_engine.Credentials(scopes=[
+  #     "https://www.googleapis.com/auth/chromeorigintrials"], service_account_id='113400961428040496994', quota_project_id='cr-status-staging')
+  token_header = f'Bearer {credentials.token}'
+  response = requests.post(
+      f'{settings.OT_API_URL}/v1/trials/4544132024016830465:add_extension?key={key}',
+      headers={'Authorization': token_header},
+      json={
+        "trial_id": "4544132024016830465",
+        "end_date": {
+            "seconds": 2008384422
+        },
+        "milestone_end": "250",
+        "extension_intent_url": "https://example.com/from_chromestatus2"
+      })
+  return str({
+    'token_header': token_header,
+    'response': response.json()})
+  # return str(credentials.__dict__)
   try:
     response = requests.get(
         f'{settings.OT_API_URL}/v1/trials',
         params={'prettyPrint': 'false', 'key': key})
     response.raise_for_status()
   except requests.exceptions.RequestException as e:
-    logging.exception("Failed to get response from origin trials API.")
+    logging.exception('Failed to get response from origin trials API.')
     raise e
 
   response_json = response.json()
@@ -57,3 +77,44 @@ def get_trials_list() -> list[dict[str, Any]]:
                  for api_trial in response_json['trials']
                  if api_trial['isPublic']]
   return trials_list
+
+
+def extend_origin_trial(trial_id: str, milestone_end: str, intent_url: str):
+  """Extend an existing origin trial.
+
+  Returns:
+    Boolean value if the extension request was successful.
+
+  Raises:
+    requests.exceptions.RequestException: If the request fails to connect or
+      the HTTP status code is not successful.
+  """
+  key = secrets.get_ot_api_key()
+  # Return False if no API key is found.
+  if key == None:
+    return False
+
+  end_seconds = 0
+  # Obtain the service account credentials to be used in the request
+  # using the origin trials auth scope.
+  credentials, _ = google.auth.default(scopes=[
+      'https://www.googleapis.com/auth/chromeorigintrials'])
+  credentials.refresh(Request())
+  url = (f'{settings.OT_API_URL}/v1/trials/{trial_id}:add_extension'
+         f'key={key}')
+  headers = {'Authorization': f'Bearer {credentials.token}'}
+  json = {
+    'trial_id': trial_id,
+    'end_date': {
+      'seconds': end_seconds
+    },
+    'extension_intent_url': intent_url,
+  }
+
+  try:
+    response = requests.post(url, headers=headers, json=json)
+  except requests.exceptions.RequestException as e:
+    logging.exception('Failed to get response from origin trials API.')
+    raise e
+
+  return response.status_code == 200

--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -17,7 +17,6 @@ from google.auth.transport.requests import Request
 
 from dataclasses import asdict
 from datetime import datetime, timezone
-from dateutil import parser
 import logging
 from typing import Any
 import requests

--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -93,7 +93,7 @@ def _get_trial_end_time(end_milestone: str) -> int:
   date = datetime.strptime(
       response_json['mstones'][0]['late_stable_date'],
       CHROMIUM_SCHEDULE_DATE_FORMAT)
-  return int(date.replace(tzinfo=timezone.utc).strftime('%s'))
+  return int(date.replace(tzinfo=timezone.utc).timestamp())
 
 
 def _get_ot_access_token() -> str:

--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -17,6 +17,7 @@ from google.auth.transport.requests import Request
 
 from dataclasses import asdict
 from datetime import datetime, timezone
+from dateutil import parser
 import logging
 from typing import Any
 import requests
@@ -93,7 +94,7 @@ def _get_trial_end_time(end_milestone: str) -> int:
   date = datetime.strptime(
       response_json['mstones'][0]['late_stable_date'],
       CHROMIUM_SCHEDULE_DATE_FORMAT)
-  return int(date.astimezone(timezone.utc).strftime('%s'))
+  return int(date.replace(tzinfo=timezone.utc).strftime('%s'))
 
 
 def _get_ot_access_token() -> str:
@@ -121,7 +122,6 @@ def extend_origin_trial(trial_id: str, end_milestone: str, intent_url: str):
   key = secrets.get_ot_api_key()
   # Return if no API key is found.
   if key == None:
-    logging.warning('Trial extension was not requested.')
     return
 
   end_seconds = _get_trial_end_time(end_milestone)

--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -16,7 +16,7 @@ import google.auth
 from google.auth.transport.requests import Request
 
 from dataclasses import asdict
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 from typing import Any
 import requests
@@ -93,7 +93,7 @@ def _get_trial_end_time(end_milestone: str) -> int:
   date = datetime.strptime(
       response_json['mstones'][0]['late_stable_date'],
       CHROMIUM_SCHEDULE_DATE_FORMAT)
-  return int(date.strftime('%s'))
+  return int(date.astimezone(timezone.utc).strftime('%s'))
 
 
 def _get_ot_access_token() -> str:

--- a/framework/origin_trials_client_test.py
+++ b/framework/origin_trials_client_test.py
@@ -117,10 +117,9 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
       self, mock_requests_post, mock_api_key_get):
     """If no API key is available, do not send extension request."""
     mock_api_key_get.return_value = None
-    return_result = origin_trials_client.extend_origin_trial(
+    origin_trials_client.extend_origin_trial(
         '1234567890', '123', 'https://example.com/intent')
 
-    self.assertFalse(return_result)
     mock_api_key_get.assert_called_once()
     # POST request should not be executed with no API key.
     mock_requests_post.assert_not_called()
@@ -129,7 +128,7 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
   @mock.patch('framework.origin_trials_client._get_ot_access_token')
   @mock.patch('framework.origin_trials_client._get_trial_end_time')
   @mock.patch('requests.post')
-  def test_get_trials_list__with_api_key(
+  def test_extend_origin_trial__with_api_key(
       self, mock_requests_post, mock_get_trial_end_time,
       mock_get_ot_access_token, mock_api_key_get):
     """If an API key is available, POST should extend trial and return true."""
@@ -139,9 +138,8 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
     mock_get_ot_access_token.return_value = mock.MagicMock('access_token')
     mock_api_key_get.return_value = 'api_key_value'
 
-    return_result = origin_trials_client.extend_origin_trial(
+    origin_trials_client.extend_origin_trial(
         '1234567890', '123', 'https://example.com/intent')
-    self.assertTrue(return_result)
 
     mock_api_key_get.assert_called_once()
     mock_get_ot_access_token.assert_called_once()
@@ -152,7 +150,11 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
     """Should return an int value based on the date from the request."""
     mock_requests_get.return_value = mock.MagicMock(
         status_code=200,
-        json=lambda : {'late_stable_date': '2023-04-30T00:00:00'})
+        json=lambda : {
+          'mstones': [
+            {'late_stable_date': '2023-04-30T00:00:00'}
+          ]
+        })
 
     return_result = origin_trials_client._get_trial_end_time('123')
     self.assertEqual(return_result, 1682838000)

--- a/framework/origin_trials_client_test.py
+++ b/framework/origin_trials_client_test.py
@@ -110,3 +110,50 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
 
     mock_api_key_get.assert_called_once()
     mock_requests_get.assert_called_once()
+
+  @mock.patch('framework.secrets.get_ot_api_key')
+  @mock.patch('requests.post')
+  def test_extend_origin_trial__no_api_key(
+      self, mock_requests_post, mock_api_key_get):
+    """If no API key is available, do not send extension request."""
+    mock_api_key_get.return_value = None
+    return_result = origin_trials_client.extend_origin_trial(
+        '1234567890', '123', 'https://example.com/intent')
+
+    self.assertFalse(return_result)
+    mock_api_key_get.assert_called_once()
+    # POST request should not be executed with no API key.
+    mock_requests_post.assert_not_called()
+
+  @mock.patch('framework.secrets.get_ot_api_key')
+  @mock.patch('framework.origin_trials_client._get_ot_access_token')
+  @mock.patch('framework.origin_trials_client._get_trial_end_time')
+  @mock.patch('requests.post')
+  def test_get_trials_list__with_api_key(
+      self, mock_requests_post, mock_get_trial_end_time,
+      mock_get_ot_access_token, mock_api_key_get):
+    """If an API key is available, POST should extend trial and return true."""
+    mock_requests_post.return_value = mock.MagicMock(
+        status_code=200, json=lambda : {})
+    mock_get_trial_end_time.return_value = 111222333
+    mock_get_ot_access_token.return_value = mock.MagicMock('access_token')
+    mock_api_key_get.return_value = 'api_key_value'
+
+    return_result = origin_trials_client.extend_origin_trial(
+        '1234567890', '123', 'https://example.com/intent')
+    self.assertTrue(return_result)
+
+    mock_api_key_get.assert_called_once()
+    mock_get_ot_access_token.assert_called_once()
+    mock_requests_post.assert_called_once()
+
+  @mock.patch('requests.get')
+  def test_get_trial_end_time(self, mock_requests_get):
+    """Should return an int value based on the date from the request."""
+    mock_requests_get.return_value = mock.MagicMock(
+        status_code=200,
+        json=lambda : {'late_stable_date': '2023-04-30T00:00:00'})
+
+    return_result = origin_trials_client._get_trial_end_time('123')
+    self.assertEqual(return_result, 1682838000)
+    mock_requests_get.assert_called_once()

--- a/framework/origin_trials_client_test.py
+++ b/framework/origin_trials_client_test.py
@@ -157,5 +157,5 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
         })
 
     return_result = origin_trials_client._get_trial_end_time('123')
-    self.assertEqual(return_result, 1682863200)
+    self.assertEqual(return_result, 1682838000)
     mock_requests_get.assert_called_once()

--- a/framework/origin_trials_client_test.py
+++ b/framework/origin_trials_client_test.py
@@ -157,5 +157,5 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
         })
 
     return_result = origin_trials_client._get_trial_end_time('123')
-    self.assertEqual(return_result, 1682838000)
+    self.assertEqual(return_result, 1682863200)
     mock_requests_get.assert_called_once()

--- a/framework/origin_trials_client_test.py
+++ b/framework/origin_trials_client_test.py
@@ -157,5 +157,5 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
         })
 
     return_result = origin_trials_client._get_trial_end_time('123')
-    self.assertEqual(return_result, 1682838000)
+    self.assertEqual(return_result, 1682812800)
     mock_requests_get.assert_called_once()

--- a/main.py
+++ b/main.py
@@ -161,6 +161,8 @@ api_routes: list[Route] = [
     # (f'{API_BASE}/metrics/<str:kind>', TODO),  # uma-export data
     # (f'{API_BASE}/metrics/<str:kind>/<int:bucket_id>', TODO),
     Route(f'{API_BASE}/origintrials', origin_trials_api.OriginTrialsAPI),
+    Route(f'{API_BASE}/origintrials/<int:feature_id>/<int:stage_id>/extend',
+          origin_trials_api.OriginTrialsAPI),
 ]
 
 # The Routes below that have no handler specified use SPAHandler.


### PR DESCRIPTION
This change adds a new endpoint to the Chromestatus API in order to submit approved extension requests to be processed. Additionally, this change will redirect the user directly to the feature detail page with the extension gate open when the user submits an extension request.

More changes to actually use this endpoint in the UI will come in a subsequent PR.