### PR TITLE
Update our use of Sign In With Google to use FedCM.

### DIFF
--- a/client-src/elements/chromedash-header.js
+++ b/client-src/elements/chromedash-header.js
@@ -205,6 +205,7 @@ export class ChromedashHeader extends LitElement {
     google.accounts.id.initialize({
       client_id: this.googleSignInClientId,
       callback: this.handleCredentialResponse,
+      use_fedcm_for_prompt: true,
     });
     google.accounts.id.prompt();
 

--- a/framework/csp.py
+++ b/framework/csp.py
@@ -31,6 +31,7 @@ NONCE_LENGTH = 30
 # Note: This is an addition beyond the reference csp.py example code.
 HOST_SOURCES = [
     'https://www.gstatic.com',
+    'https://accounts.google.com/gsi/client',
     ]
 
 DEFAULT_POLICY = {


### PR DESCRIPTION
I got an email from GoogleDevelopers-noreply@ advising that we follow the steps listed below to keep our sign-in button working after third-party cookies are restricted.

https://developers.google.com/identity/gsi/web/guides/fedcm-migration

In this PR:
* Add the JS parameter as recommended
* Add a script-src host as recommended