### PR TITLE
docs: fix the version of python

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For a one-click setup that leverages devcontainers, check out the devcontainer
 1. Install other developer tools commands
     1. node and npm.
     1. Gulp: `npm install --global gulp-cli`
-    1. Python virtual environment: `sudo apt install python3.10-venv`
+    1. Python virtual environment: `sudo apt install python3.11-venv`
 1. We recommend using an older node version, e.g. node 18
     1. Use `node -v` to check the default node version
     2. `nvm use 18` to switch to node 18


### PR DESCRIPTION
README.md file has the wrong Python version causing `npm run setup` to fail.

This is happening because "setup" script in `package.json` uses python3.11 while the README tells us to install `python3.10-venv`: 

https://github.com/GoogleChrome/chromium-dashboard/blob/b6d1c554ff47e39e8a893548963d9aadf339eca4/package.json#L15