### PR TITLE
fix incorrect email notification

### DIFF
--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -148,7 +148,9 @@ def notify_subscribers_of_vote_changes(fe: 'FeatureEntry', gate: Gate,
     'changes': [changed_props],
     # Subscribers are only notified on feature update.
     'is_update': True,
-    'feature': converters.feature_entry_to_json_verbose(fe)
+    'feature': converters.feature_entry_to_json_verbose(fe),
+    'local_updater_email': email,
+    
   }
 
   # Create task to email subscribers.
@@ -184,7 +186,6 @@ def notify_subscribers_of_new_comments(fe: 'FeatureEntry', gate: Gate,
     'gate_url': gate_url,
     'gate_type': gate.gate_type,
     'feature': converters.feature_entry_to_json_verbose(fe),
-    'local_updater_email': email,
   }
 
   cloud_tasks_helpers.enqueue_task('/tasks/email-comments', params)

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -183,7 +183,8 @@ def notify_subscribers_of_new_comments(fe: 'FeatureEntry', gate: Gate,
     'content': content,
     'gate_url': gate_url,
     'gate_type': gate.gate_type,
-    'feature': converters.feature_entry_to_json_verbose(fe)
+    'feature': converters.feature_entry_to_json_verbose(fe),
+    'local_updater_email': email,
   }
 
   cloud_tasks_helpers.enqueue_task('/tasks/email-comments', params)


### PR DESCRIPTION
Issue: #3393

Description: Incorrect email used when creating an update feature email

The issue arises from the use of fe.updater_email which results in the owner's email being used. This happens because fe.updater_email corresponds to the owner's email, as the owner is considered the updater when they create the feature.

In the code snippet, updater_email is not passed as a parameter, causing it to default to fe.updater_email.
https://github.com/GoogleChrome/chromium-dashboard/blob/a09e8cb0a04bea37a68e635ff91e68b83fc85c37/internals/notifier.py#L94-L96

The issue was resolved by passing the correct email obtained while creating the `Changes:` part of the email as a parameter. This ensures that the appropriate email is used in the update feature email.

https://github.com/GoogleChrome/chromium-dashboard/blob/a09e8cb0a04bea37a68e635ff91e68b83fc85c37/internals/notifier_helpers.py#L141-L145