### PR TITLE
Remove bad mention of feature updater in vote notifications.

### DIFF
--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -138,8 +138,9 @@ def notify_subscribers_of_vote_changes(fe: 'FeatureEntry', gate: Gate,
   activity.put()
 
   gate_url = get_gate_url(gate)
+  team_name = appr_def.team_name or 'Gate'
   changed_props = {
-      'prop_name': '%s set review status in %s' % (email, gate_url),
+      'prop_name': '%s review status %s' % (team_name, gate_url),
       'old_val': old_state_name,
       'new_val': state_name,
   }
@@ -148,6 +149,7 @@ def notify_subscribers_of_vote_changes(fe: 'FeatureEntry', gate: Gate,
     'changes': [changed_props],
     # Subscribers are only notified on feature update.
     'is_update': True,
+    'triggering_user_email': email,
     'feature': converters.feature_entry_to_json_verbose(fe)
   }
 

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -319,7 +319,8 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.assertEqual('watcher_1@example.com', watcher_task['to'])
 
     mock_f_e_b.assert_called_once_with(
-        'new-feature-email.html', self.fe_1, [])
+        'new-feature-email.html', self.fe_1, [],
+        updater_email='creator1@gmail.com')
 
   @mock.patch('internals.notifier.format_email_body')
   def test_make_feature_changes_email__update(self, mock_f_e_b):
@@ -380,7 +381,8 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.assertEqual('watcher_1@example.com', watcher_task['to'])
 
     mock_f_e_b.assert_called_once_with(
-        'update-feature-email.html', self.fe_1, self.changes)
+        'update-feature-email.html', self.fe_1, self.changes,
+        updater_email='editor1@gmail.com')
 
   @mock.patch('internals.notifier.format_email_body')
   def test_make_feature_changes_email__starrer(self, mock_f_e_b):
@@ -450,7 +452,8 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.assertEqual('watcher_1@example.com', watcher_task['to'])
 
     mock_f_e_b.assert_called_once_with(
-        'update-feature-email.html', self.fe_1, self.changes)
+        'update-feature-email.html', self.fe_1, self.changes,
+        updater_email='editor1@gmail.com')
 
 
   @mock.patch('internals.notifier.format_email_body')
@@ -474,7 +477,8 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.assertEqual('owner_1@example.com', component_owner_task['to'])
     self.assertEqual('watcher_1@example.com', watcher_task['to'])
     mock_f_e_b.assert_called_once_with(
-        'update-feature-email.html', self.fe_2, self.changes)
+        'update-feature-email.html', self.fe_2, self.changes,
+        updater_email='editor2@example.com')
 
 
 class FeatureCommentHandlerTest(testing_config.CustomTestCase):


### PR DESCRIPTION
Fixes #3393.

Prior to this PR, the feature change notification email always included the address of the user who most recently edited the feature.  That is wrong in the case where we send a notification about a vote, because that user is not the reviewer.

In this PR:
* Include the voter email in the task parameters.
* Pass that through the handler to the point where it is used in the template to generate the email body.