### PR TITLE
Update intent detection logic for multiple stages

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -198,14 +198,19 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     
     stage = self.find_matching_stage(feature, approval_field, thread_url)
     if stage is None:
-      return {'message': (
-        f'No matching stage found for intent type {approval_field.field_id}')}
+      message = ('No matching stage found for intent type '
+                 f'{approval_field.field_id}')
+      logging.info(message)
+      return {'message': message}
 
     gate = Gate.query(Gate.stage_id == stage.key.integer_id(),
                       Gate.gate_type == approval_field.field_id).get()
     if gate is None:
-      return {'message': (f'Gate not found for stage {stage.key.integer_id()} '
-                          f' and gate type {approval_field.field_id}')}
+      message = (f'Gate not found for stage {stage.key.integer_id()} '
+                    f' and gate type {approval_field.field_id}')
+      logging.info(message)
+      return {'message': message}
+
     self.set_intent_thread_url(stage, thread_url, subject)
     is_new_thread = detect_new_thread(feature_id, approval_field)
     self.create_approvals(feature, gate, approval_field, from_addr, body)

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -195,7 +195,7 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     if not feature:
       logging.info('Could not retrieve feature')
       return {'message': 'Feature not found'}
-    
+
     stage = self.find_matching_stage(feature, approval_field, thread_url)
     if stage is None:
       message = ('No matching stage found for intent type '
@@ -268,6 +268,10 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
       return None
 
     # Check if this intent URL already belongs to a stage.
+    # TODO(DanielRyanSmith): The intent thread URLs contain the message ID
+    # and won't match up perfectly when comparing them.
+    # Update to instead detect by gate ID.
+    # See https://github.com/GoogleChrome/chromium-dashboard/pull/3678#discussion_r1513361281
     matching_stage = next((s for s in stages_of_type_in_feature
                             if s.intent_thread_url == thread_url), None)
     if matching_stage:

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -37,19 +37,9 @@ class FunctionTest(testing_config.CustomTestCase):
         name='feature one', summary='detailed sum', category=1,
         intent_stage=core_enums.INTENT_IMPLEMENT)
     self.feature_1.put()
-    self.prototype_stage = Stage(feature_id=self.feature_1.key.integer_id(), stage_type=120)
-    self.prototype_stage.put()
-    self.ot_stage = Stage(feature_id=self.feature_1.key.integer_id(), stage_type=150)
-    self.ot_stage.put()
-    self.extend_stage = Stage(feature_id=self.feature_1.key.integer_id(), stage_type=151)
-    self.extend_stage.put()
-    self.ship_stage = Stage(feature_id=self.feature_1.key.integer_id(), stage_type=160)
-    self.ship_stage.put()
 
   def tearDown(self):
-    for kind in [FeatureEntry, Stage]:
-      for entity in kind.query():
-        entity.key.delete()
+    self.feature_1.key.delete()
 
   def test_detect_field(self):
     """We can detect intent thread type by subject line."""

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -403,22 +403,31 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
     self.feature_id = self.feature_1.key.integer_id()
 
     # Typical feature with two OT extension stages.
-    stage_types = [110, 120, 130, 140, 150, 151, 151, 160]
+    feature_stages_and_gates = core_enums.STAGES_AND_GATES_BY_FEATURE_TYPE[0]
     self.stages: list[Stage] = []
-    for s_type in stage_types:
+    for s_type, gate_types in feature_stages_and_gates:
       stage = Stage(feature_id=self.feature_id, stage_type=s_type)
       stage.put()
       self.stages.append(stage)
+      for gate_type in gate_types:
+        gate = Gate(feature_id=self.feature_id,
+                    stage_id=stage.key.integer_id(), gate_type=gate_type,
+                    state=Vote.NA)
+        gate.put()
+    extra_extension_stage = Stage(feature_id=self.feature_id, stage_type=151)
+    extra_extension_stage.put()
+    extra_extension_gate = Gate(feature_id=self.feature_id,
+                                stage_id=extra_extension_stage.key.integer_id(),
+                                gate_type=3, state=Vote.NA)
+    extra_extension_gate.put()
     self.stages_dict = stage_helpers.get_feature_stages(self.feature_id)
     # The intent thread url already exists for the first extension stage.
     self.stages_dict[151][0].intent_thread_url = 'https://example.com/exists'
+    self.stages_dict[151][0].put()
 
     self.gate_1 = Gate(feature_id=self.feature_id, stage_id=1,
         gate_type=1, state=Vote.NA)
     self.gate_1.put()
-    self.gate_2 = Gate(feature_id=self.feature_id, stage_id=2,
-        gate_type=4, state=Vote.NA)
-    self.gate_2.put()
 
     self.request_path = '/tasks/detect-intent'
 
@@ -544,6 +553,9 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
   def test_record_slo__gate_not_found(self, mock_info):
     """If we can't find the gate, exit early."""
     appr_field = approval_defs.TestingShipApproval
+    ship_gate: Gate = Gate.query(Gate.feature_id == self.feature_id,
+               Gate.gate_type == appr_field.field_id).get()
+    ship_gate.key.delete()
     self.handler.record_slo(self.feature_1, appr_field, 'from_addr', False)
     mock_info.assert_called_once_with('Did not find a gate')
 
@@ -566,8 +578,8 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
     """If an approver posted, count that as an initial response."""
     mock_now.return_value = datetime.datetime.now()
     appr_field = approval_defs.TestingShipApproval
-    gate = Gate(feature_id=self.feature_id, stage_id=2,
-        gate_type=appr_field.field_id, state=Vote.NA)
+    gate = Gate.query(Gate.feature_id == self.feature_id,
+                      Gate.gate_type == appr_field.field_id).get()
     gate.requested_on = mock_now.return_value
     gate.put()
     from_addr = approval_defs.TESTING_APPROVERS[0]


### PR DESCRIPTION
This change updates the intent detection logic to function even in the presence of multiple stages of the same type.

If multiple stages of the same type exist that correspond to a new intent thread, the logic will check if any of those stages have a set intent thread URL matching the detected thread URL. If no stages are associated with that intent thread URL and exactly one of those stages has an unset intent thread URL, it will be assumed that the newly detected intent thread is associated with that stage.

Additionally, the gate is always queried for before setting a vote, so that we definitively discern which gate the vote belongs to.