### PR TITLE
Make one Approve vote on an I2S activate that gate.

### DIFF
--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -377,6 +377,11 @@ def _calc_gate_state(votes: list[Vote], rule: str) -> int:
         Vote.DENIED, Vote.INTERNAL_REVIEW, Vote.NA_REQUESTED):
       return vote.state
 
+  # An API Owner can kick off review of an I2S thread that was not detected
+  # by voting Approve for their "LGTM1".
+  if rule == THREE_LGTM and num_lgtms >= 1:
+    return Vote.REVIEW_REQUESTED
+
   # The feature owner has not requested review yet, or the request was
   # withdrawn.
   return Gate.PREPARING

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -322,6 +322,11 @@ class CalcGateStateTest(testing_config.CustomTestCase):
     self.assertEqual(('approved', 'review_requested'),
                      self.do_calc(RR, AP))
 
+  def test_request_one_approved__no_request(self):
+    """An API Owner gave LGTM1 Approval on an intent that was not detected."""
+    self.assertEqual(('approved', 'review_requested'),
+                     self.do_calc(AP))
+
   def test_request_three_approved(self):
     """The user has requested a review and it got 3 approvals."""
     self.assertEqual(('approved', 'approved'),


### PR DESCRIPTION
This change addresses feedback from one of the API Owners.  There was a case where a feature sent an initial I2S in 2021, which is before our review functionality was implemented.  That thread concluded, but the feature never actually shipped.  In 2023, the thread continued and the API Owners wanted to mark their approval in ChromeStatus, however there was no way to start the review without creating a new blink-dev thread.  In general, there are occasional needs to make a review gate active even through the thread was not detected (which is the normal way for an API Owners gate to become active).

The API Owners suggestion was that voting Approved on a I2S gate should make it active.

In this PR:
* Add logic to make the gate active (i.e., state review_requested) whenever we detect the case where: (a) the gate has not already been resolved in any way, and (b) there are one or two Approve votes on a gate that requires three votes.