### PR TITLE
Add back import lost in merge

### DIFF
--- a/client-src/elements/chromedash-ot-extension-page.js
+++ b/client-src/elements/chromedash-ot-extension-page.js
@@ -1,6 +1,7 @@
 import {LitElement, css, html} from 'lit';
 import {ref} from 'lit/directives/ref.js';
 import {
+  formatFeatureChanges,
   showToastMessage,
   setupScrollToHash} from './utils.js';
 import './chromedash-form-table.js';


### PR DESCRIPTION
Adds back an import that was mistakenly removed while resolving merge issues, causing the OT extension form request to error out.