### PR TITLE
Avoid race condition after requesting N/A.

### DIFF
--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -213,7 +213,9 @@ export class ChromedashGateColumn extends LitElement {
 
   reloadComments() {
     const commentArea = this.commentAreaRef.value;
-    commentArea.value = '';
+    if (commentArea) {
+      commentArea.value = '';
+    }
     this.needsPost = false;
     Promise.all([
       // TODO(jrobbins): Include activities for this gate
@@ -274,10 +276,10 @@ export class ChromedashGateColumn extends LitElement {
     this.postComment(commentText, postToThreadType);
   }
 
-  postComment(commentText, postToThreadType=0) {
+  async postComment(commentText, postToThreadType=0) {
     this.submittingVote = true;
     if (commentText != '') {
-      window.csClient.postComment(
+      await window.csClient.postComment(
         this.feature.id, this.gate.id, commentText,
         Number(postToThreadType))
         .then(() => {


### PR DESCRIPTION
I noticed that when submitting at "Request N/A" request, the app would display a "Some errors occurred" toast.  It only happened immediately after a page reload on the feature detail page.

I believe the problem was that the call to `postComment()` on line 384 returned immediately and so line 386 started the process of reloading data to be displayed on the page.  That reloading process sets `this.loading = true` and the rendering code generates a shimmering shape while loading rather than the text area for entering a comment.    That means that the text area cannot be found when `postComment()` tries to clear it out.

The fix is to mark `postComment()` as async and make it await the requests that it makes inside.  That way the existing `await` on the call to it is actually blocking.  Also, just for safety, we check that the text area element is found before trying to clear it out.