### PR TITLE
Fix first notification milestone not being updated on non-enterprise features

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -247,6 +247,9 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
     if is_update_first_notification_milestone(feature, feature_changes):
       feature.first_enterprise_notification_milestone = int(feature_changes['first_enterprise_notification_milestone'])
       has_updated = True
+    elif needs_default_first_notification_milestone(feature, feature_changes):
+      feature.first_enterprise_notification_milestone = get_default_first_notice_milestone_for_feature()
+      has_updated = True
     if should_remove_first_notice_milestone(feature, feature_changes):
       feature.first_enterprise_notification_milestone = None
 

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -796,11 +796,14 @@ class FeaturesAPITest(testing_config.CustomTestCase):
     self.assertIsNotNone(self.feature_1.updated)
     self.assertEqual(self.feature_1.updater_email, 'admin@example.com')
 
+
+  @mock.patch('api.channels_api.construct_chrome_channels_details')
   @mock.patch('api.channels_api.construct_specified_milestones_details')
-  def test_patch__enterprise_first_notice_in_the_past(self, mock_call):
+  def test_patch__enterprise_first_notice_in_the_past(self, specified_mock, chrome_mock):
     """PATCH request successful with newer default first_enterprise_notification_milestone."""
     stable_date = _datetime_to_str(datetime.now().replace(year=datetime.now().year - 2, day=1))
-    mock_call.return_value = { 100: { 'version': 100, 'stable_date': stable_date } }
+    specified_mock.return_value = { 100: { 'version': 100, 'stable_date': stable_date } }
+    chrome_mock.return_value = { 'beta': { 'version': 420 } }
 
     # Signed-in user with permissions.
     testing_config.sign_in('admin@example.com', 123567890)
@@ -821,10 +824,10 @@ class FeaturesAPITest(testing_config.CustomTestCase):
     # Success response should be returned.
     self.assertEqual({'message': f'Feature {self.feature_1_id} updated.'}, response)
     # Assert that changes were made.
-    self.assertEqual(getattr(self.feature_1, 'first_enterprise_notification_milestone'), None)
+    self.assertEqual(getattr(self.feature_1, 'first_enterprise_notification_milestone'), 420)
     # Updater email field should be changed.
     self.assertIsNotNone(self.feature_1.updated)
-    self.assertIsNone(self.feature_1.updater_email)
+    self.assertEqual(self.feature_1.updater_email, 'admin@example.com')
 
 
   @mock.patch('api.channels_api.construct_specified_milestones_details')

--- a/internals/enterprise_helpers.py
+++ b/internals/enterprise_helpers.py
@@ -44,13 +44,18 @@ def needs_default_first_notification_milestone(
       milestone in channel_details and
       _str_to_datetime(channel_details[milestone]['stable_date']) > datetime.now())
 
+  existing_impact = ENTERPRISE_IMPACT_NONE
+  if existing_feature is not None and existing_feature.enterprise_impact is not None:
+    existing_impact = existing_feature.enterprise_impact
+  new_impact = int(new_fields.get('enterprise_impact', existing_impact))
+
   # We are creating a new feature
   if existing_feature is None:
     # All enterprise features need this
     if new_fields['feature_type'] == FEATURE_TYPE_ENTERPRISE_ID:
       return not has_valid_milestone_in_new_fields
     # All breaking changes need this
-    if new_fields.get('enterprise_impact', ENTERPRISE_IMPACT_NONE) > ENTERPRISE_IMPACT_NONE:
+    if new_impact > ENTERPRISE_IMPACT_NONE:
       return not has_valid_milestone_in_new_fields
     return False
 
@@ -63,8 +68,7 @@ def needs_default_first_notification_milestone(
     return not has_valid_milestone_in_new_fields
 
   # The breaking change stays a breaking change
-  if new_fields.get('enterprise_impact',
-                    existing_feature.enterprise_impact) > ENTERPRISE_IMPACT_NONE:
+  if new_impact > ENTERPRISE_IMPACT_NONE:
     return not has_valid_milestone_in_new_fields
 
   return False
@@ -100,8 +104,9 @@ def is_update_first_notification_milestone(feature: FeatureEntry, new_fields: di
     return True
 
   # The breaking change stays a breaking change or becomes a breaking change
-  return new_fields.get('enterprise_impact',
-                        feature.enterprise_impact) > ENTERPRISE_IMPACT_NONE
+  existing_impact = feature.enterprise_impact or ENTERPRISE_IMPACT_NONE
+  new_impact = int(new_fields.get('enterprise_impact', existing_impact))
+  return new_impact > ENTERPRISE_IMPACT_NONE
 
 
 def get_default_first_notice_milestone_for_feature() -> int:

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -111,7 +111,7 @@ class FeatureCreateTest(testing_config.CustomTestCase):
     mock_notify.assert_called_once()
 
   @mock.patch('api.channels_api.construct_chrome_channels_details')
-  def test_post__enterprise_impact_missing_first_notice(self, mock_channel_details):
+  def test_post__feature_impact_missing_first_notice(self, mock_channel_details):
     """Create a feature, first_enterprise_notification_milestone not added."""
     stable_date = self.now.replace(year=self.now.year + 1, day=1).strftime(DATE_FORMAT)
     mock_channel_details.return_value = {'beta': { 'version': 120, 'stable_date': stable_date } }

--- a/pages/guide_test.py
+++ b/pages/guide_test.py
@@ -99,6 +99,7 @@ class FeatureCreateTest(testing_config.CustomTestCase):
     self.assertEqual('user1@google.com', feature_entry.creator_email)
     self.assertEqual(['devrel-chromestatus-all@google.com'],
                      feature_entry.devrel_emails)
+    self.assertEqual(None, feature_entry.first_enterprise_notification_milestone)
 
     # Ensure Stage and Gate entities were created.
     stages = Stage.query().fetch()
@@ -108,6 +109,38 @@ class FeatureCreateTest(testing_config.CustomTestCase):
 
     # Ensure notifications are sent.
     mock_notify.assert_called_once()
+
+  @mock.patch('api.channels_api.construct_chrome_channels_details')
+  def test_post__enterprise_impact_missing_first_notice(self, mock_channel_details):
+    """Create a feature, first_enterprise_notification_milestone not added."""
+    stable_date = self.now.replace(year=self.now.year + 1, day=1).strftime(DATE_FORMAT)
+    mock_channel_details.return_value = {'beta': { 'version': 120, 'stable_date': stable_date } }
+
+    testing_config.sign_in('user1@google.com', 1234567890)
+    with test_app.test_request_context(
+        '/guide/new', data={
+            'category': '1',
+            'name': 'Feature name',
+            'summary': 'Feature summary',
+            'feature_type': '1',
+            'enterprise_impact': '2'
+        },
+        method='POST'):
+      actual_response = self.handler.process_post_data()
+
+    self.assertEqual('302 FOUND', actual_response.status)
+    location = actual_response.headers['location']
+    self.assertTrue(location.startswith('/feature/'))
+    new_feature_id = int(location.split('/')[-1])
+
+    # Ensure FeatureEntry entity was created.
+    feature_entry = FeatureEntry.get_by_id(new_feature_id)
+    self.assertEqual(1, feature_entry.category)
+    self.assertEqual(1, feature_entry.feature_type)
+    self.assertEqual('Feature name', feature_entry.name)
+    self.assertEqual('Feature summary', feature_entry.summary)
+    self.assertEqual('user1@google.com', feature_entry.creator_email)
+    self.assertEqual(120, feature_entry.first_enterprise_notification_milestone)
 
   @mock.patch('api.channels_api.construct_chrome_channels_details')
   def test_post__enterprise_impact_missing_first_notice(self, mock_channel_details):


### PR DESCRIPTION
When a feature becomes breaking change, we should update the first notification milestone