### PR TITLE
Add gate ID to Chromestatus URL in Intent drafts

### DIFF
--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -402,7 +402,7 @@ export class ChromedashGateColumn extends LitElement {
     const label = action.name;
     const url = action.url
       .replace('{feature_id}', this.feature.id)
-      .replace('{outgoing_stage}', processStage.outgoing_stage);
+      .replace('{gate_id}', this.gate.id);
 
     const checkCompletion = () => {
       if (somePendingPrereqs(action, this.progress) ||
@@ -410,7 +410,7 @@ export class ChromedashGateColumn extends LitElement {
         // Open the dialog.
         openPreflightDialog(
           this.feature, this.progress, this.process, action,
-          processStage, this.stage, this.featureGates);
+          processStage, this.stage, this.featureGates, this.gate);
         return;
       } else {
         // Act like user clicked left button to go to the draft email window.

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -402,6 +402,7 @@ export class ChromedashGateColumn extends LitElement {
     const label = action.name;
     const url = action.url
       .replace('{feature_id}', this.feature.id)
+      .replace('{intent_stage}', processStage.outgoing_stage)
       .replace('{gate_id}', this.gate.id);
 
     const checkCompletion = () => {
@@ -410,7 +411,7 @@ export class ChromedashGateColumn extends LitElement {
         // Open the dialog.
         openPreflightDialog(
           this.feature, this.progress, this.process, action,
-          processStage, this.stage, this.featureGates, this.gate);
+          processStage, this.stage, this.featureGates, url);
         return;
       } else {
         // Act like user clicked left button to go to the draft email window.

--- a/client-src/elements/chromedash-preflight-dialog.js
+++ b/client-src/elements/chromedash-preflight-dialog.js
@@ -11,14 +11,14 @@ import {SHARED_STYLES} from '../css/shared-css.js';
 let preflightDialogEl;
 
 export async function openPreflightDialog(
-  feature, progress, process, action, stage, feStage, featureGates) {
+  feature, progress, process, action, stage, feStage, featureGates, selectedGate) {
   if (!preflightDialogEl) {
     preflightDialogEl = document.createElement('chromedash-preflight-dialog');
     document.body.appendChild(preflightDialogEl);
     await preflightDialogEl.updateComplete;
   }
   preflightDialogEl.openWithContext(
-    feature, progress, process, action, stage, feStage, featureGates);
+    feature, progress, process, action, stage, feStage, featureGates, selectedGate);
 }
 
 
@@ -113,7 +113,7 @@ export class ChromedashPreflightDialog extends LitElement {
   }
 
   openWithContext(
-    feature, progress, process, action, stage, feStage, featureGates) {
+    feature, progress, process, action, stage, feStage, featureGates, selectedGate) {
     this.feature = feature;
     this.progress = progress;
     this.process = process;
@@ -121,6 +121,7 @@ export class ChromedashPreflightDialog extends LitElement {
     this.stage = stage;
     this.feStage = feStage;
     this.featureGates = featureGates;
+    this.selectedGate = selectedGate;
     this.shadowRoot.querySelector('sl-dialog').show();
   }
 
@@ -170,7 +171,7 @@ export class ChromedashPreflightDialog extends LitElement {
 
     const url = this.action.url
       .replace('{feature_id}', this.feature.id)
-      .replace('{outgoing_stage}', this.stage.outgoing_stage);
+      .replace('{gate_id}', this.selectedGate.id);
 
     return html`
       Before you ${this.action.name}, it is strongly recommended that you do the following:

--- a/client-src/elements/chromedash-preflight-dialog.js
+++ b/client-src/elements/chromedash-preflight-dialog.js
@@ -11,14 +11,14 @@ import {SHARED_STYLES} from '../css/shared-css.js';
 let preflightDialogEl;
 
 export async function openPreflightDialog(
-  feature, progress, process, action, stage, feStage, featureGates, selectedGate) {
+  feature, progress, process, action, stage, feStage, featureGates, url) {
   if (!preflightDialogEl) {
     preflightDialogEl = document.createElement('chromedash-preflight-dialog');
     document.body.appendChild(preflightDialogEl);
     await preflightDialogEl.updateComplete;
   }
   preflightDialogEl.openWithContext(
-    feature, progress, process, action, stage, feStage, featureGates, selectedGate);
+    feature, progress, process, action, stage, feStage, featureGates, url);
 }
 
 
@@ -113,7 +113,7 @@ export class ChromedashPreflightDialog extends LitElement {
   }
 
   openWithContext(
-    feature, progress, process, action, stage, feStage, featureGates, selectedGate) {
+    feature, progress, process, action, stage, feStage, featureGates, url) {
     this.feature = feature;
     this.progress = progress;
     this.process = process;
@@ -121,7 +121,7 @@ export class ChromedashPreflightDialog extends LitElement {
     this.stage = stage;
     this.feStage = feStage;
     this.featureGates = featureGates;
-    this.selectedGate = selectedGate;
+    this.url = url;
     this.shadowRoot.querySelector('sl-dialog').show();
   }
 
@@ -169,10 +169,6 @@ export class ChromedashPreflightDialog extends LitElement {
     }
     const pendingGates = findPendingGates(this.featureGates, this.feStage);
 
-    const url = this.action.url
-      .replace('{feature_id}', this.feature.id)
-      .replace('{gate_id}', this.selectedGate.id);
-
     return html`
       Before you ${this.action.name}, it is strongly recommended that you do the following:
       <ol class="missing-prereqs-list">
@@ -197,7 +193,7 @@ export class ChromedashPreflightDialog extends LitElement {
          `)}
       </ol>
 
-      <sl-button href="${url}" target="_blank" size="small">
+      <sl-button href="${this.url}" target="_blank" size="small">
         Proceed anyway
       </sl-button>
       <sl-button size="small" variant="warning"

--- a/client-src/elements/chromedash-process-overview.js
+++ b/client-src/elements/chromedash-process-overview.js
@@ -164,7 +164,9 @@ export class ChromedashProcessOverview extends LitElement {
     const label = action.name;
     const url = action.url
       .replace('{feature_id}', this.feature.id)
-      .replace('{outgoing_stage}', stage.outgoing_stage);
+      .replace('{intent_stage}', stage.outgoing_stage)
+      // No gate_id for this URL.
+      .replace('/{gate_id}', '');
 
     const checkCompletion = () => {
       if (somePendingPrereqs(action, this.progress) ||
@@ -172,7 +174,7 @@ export class ChromedashProcessOverview extends LitElement {
         // Open the dialog.
         openPreflightDialog(
           this.feature, this.progress, this.process, action, stage, feStage,
-          this.featureGates);
+          this.featureGates, url);
         return;
       } else {
         // Act like user clicked left button to go to the draft email window.

--- a/internals/processes.py
+++ b/internals/processes.py
@@ -68,12 +68,12 @@ def process_to_dict(process):
 
 # This page generates a preview of an email that can be sent
 # to a mailing list to announce an intent.
-# {feature_id} and {outgoing_stage} are filled in by JS code.
+# {feature_id} and {stage_id} are filled in by JS code.
 # The param "intent" adds clauses the template to include details
 # needed for an intent email.  The param "launch" causes those
 # details to be omitted and a link to create a launch bug shown instead.
 INTENT_EMAIL_URL = ('/admin/features/launch/{feature_id}'
-                    '/{outgoing_stage}'
+                    '/{gate_id}'
                     '?intent=1')
 LAUNCH_BUG_TEMPLATE_URL = '/admin/features/launch/{feature_id}?launch=1'
 # TODO(jrobbins): Creation of the launch bug has been a TODO for 5 years.

--- a/internals/processes.py
+++ b/internals/processes.py
@@ -68,12 +68,12 @@ def process_to_dict(process):
 
 # This page generates a preview of an email that can be sent
 # to a mailing list to announce an intent.
-# {feature_id} and {stage_id} are filled in by JS code.
+# {feature_id}, {intent_stage}, and {gate_id} are filled in by JS code.
 # The param "intent" adds clauses the template to include details
 # needed for an intent email.  The param "launch" causes those
 # details to be omitted and a link to create a launch bug shown instead.
 INTENT_EMAIL_URL = ('/admin/features/launch/{feature_id}'
-                    '/{gate_id}'
+                    '/{intent_stage}/{gate_id}'
                     '?intent=1')
 LAUNCH_BUG_TEMPLATE_URL = '/admin/features/launch/{feature_id}?launch=1'
 # TODO(jrobbins): Creation of the launch bug has been a TODO for 5 years.

--- a/main.py
+++ b/main.py
@@ -227,7 +227,9 @@ mpa_page_routes: list[Route] = [
 
     Route('/admin/features/launch/<int:feature_id>',
         intentpreview.IntentEmailPreviewHandler),
-    Route('/admin/features/launch/<int:feature_id>/<int:gate_id>',
+    Route('/admin/features/launch/<int:feature_id>/<int:intent_stage>',
+        intentpreview.IntentEmailPreviewHandler),
+    Route('/admin/features/launch/<int:feature_id>/<int:intent_stage>/<int:gate_id>',
         intentpreview.IntentEmailPreviewHandler),
 
     # Note: The only requests being made now hit /features.json and

--- a/main.py
+++ b/main.py
@@ -227,7 +227,7 @@ mpa_page_routes: list[Route] = [
 
     Route('/admin/features/launch/<int:feature_id>',
         intentpreview.IntentEmailPreviewHandler),
-    Route('/admin/features/launch/<int:feature_id>/<int:stage_id>',
+    Route('/admin/features/launch/<int:feature_id>/<int:gate_id>',
         intentpreview.IntentEmailPreviewHandler),
 
     # Note: The only requests being made now hit /features.json and


### PR DESCRIPTION
This change adds the corresponding gate ID to intent drafts so that it can be detected and referenced for intent thread detection. These changes ensure that old intent draft links in Chromestatus will still be functional, but will not contain a gate ID in the intent draft.

A subsequent PR will add detection of gate IDs to intent detection.