### PR TITLE
fixed Toast is briefly displayed on page load

### DIFF
--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -130,6 +130,11 @@ class ChromedashApp extends LitElement {
     this.drawerOpen = !IS_MOBILE;
   }
 
+  firstUpdated() {
+    const toastEl = document.createElement('chromedash-toast');
+    document.body.appendChild(toastEl);
+  }
+
   connectedCallback() {
     super.connectedCallback();
     this.loading = true;

--- a/client-src/elements/chromedash-roadmap-page.js
+++ b/client-src/elements/chromedash-roadmap-page.js
@@ -57,6 +57,10 @@ export class ChromedashRoadmapPage extends LitElement {
 
   firstUpdated() {
     this.handleResize();
+
+    const toastEl = document.createElement('chromedash-toast');
+    document.body.appendChild(toastEl);
+    toastEl.showMessage("Welcome to chromestatus.com!");
   }
 
   handleResize() {

--- a/client-src/elements/chromedash-roadmap-page.js
+++ b/client-src/elements/chromedash-roadmap-page.js
@@ -57,10 +57,6 @@ export class ChromedashRoadmapPage extends LitElement {
 
   firstUpdated() {
     this.handleResize();
-
-    const toastEl = document.createElement('chromedash-toast');
-    document.body.appendChild(toastEl);
-    toastEl.showMessage("Welcome to chromestatus.com!");
   }
 
   handleResize() {

--- a/pages/testdata/featurelist_test/test_html_rendering.html
+++ b/pages/testdata/featurelist_test/test_html_rendering.html
@@ -158,8 +158,6 @@ limitations under the License.
     <chromedash-footer></chromedash-footer>
   </div>
 
-  <chromedash-toast msg="Welcome to chromestatus.com!"></chromedash-toast>
-
   
   <chromedash-legend></chromedash-legend>
 

--- a/pages/testdata/intentpreview_test/test_html_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_rendering.html
@@ -338,8 +338,6 @@ False
     <chromedash-footer></chromedash-footer>
   </div>
 
-  <chromedash-toast msg="Welcome to chromestatus.com!"></chromedash-toast>
-
   
 
   

--- a/pages/testdata/users_test/test_html_rendering.html
+++ b/pages/testdata/users_test/test_html_rendering.html
@@ -138,8 +138,6 @@ limitations under the License.
     <chromedash-footer></chromedash-footer>
   </div>
 
-  <chromedash-toast msg="Welcome to chromestatus.com!"></chromedash-toast>
-
   
 
   

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -126,7 +126,7 @@ limitations under the License.
     <chromedash-footer></chromedash-footer>
   </div>
 
-  <chromedash-toast msg="Welcome to chromestatus.com!"></chromedash-toast>
+  <!-- <chromedash-toast msg="Welcome to chromestatus.com!"></chromedash-toast> -->
 
   {% block overlay %}{% endblock %}
 

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -126,8 +126,6 @@ limitations under the License.
     <chromedash-footer></chromedash-footer>
   </div>
 
-  <!-- <chromedash-toast msg="Welcome to chromestatus.com!"></chromedash-toast> -->
-
   {% block overlay %}{% endblock %}
 
   {% block js %}{% endblock %}

--- a/templates/spa.html
+++ b/templates/spa.html
@@ -78,7 +78,7 @@ limitations under the License.
     bannerTime="{{banner_time}}">
   </chromedash-app>
 
-  <chromedash-toast msg="Welcome to chromestatus.com!"></chromedash-toast>
+  <!-- <chromedash-toast msg="Welcome to chromestatus.com!"></chromedash-toast> -->
 
   <script src="https://www.googletagmanager.com/gtag/js?id=UA-179341418-1" async nonce="{{nonce}}"></script>
 

--- a/templates/spa.html
+++ b/templates/spa.html
@@ -78,8 +78,6 @@ limitations under the License.
     bannerTime="{{banner_time}}">
   </chromedash-app>
 
-  <!-- <chromedash-toast msg="Welcome to chromestatus.com!"></chromedash-toast> -->
-
   <script src="https://www.googletagmanager.com/gtag/js?id=UA-179341418-1" async nonce="{{nonce}}"></script>
 
   {#


### PR DESCRIPTION
fixes #2512 

### Summary:
- Resolved the toast-display issue on page load in multiple pages like roadmap, myfeatures, newfeatures, and probably others.

### Tests
- [x] Tested the toast display on roadmap, myfeatures, newfeatures, etc. pages
- [x] Tested correct workflow of the toast popups like "Link copied", "Some errors occurred", etc.

### Screenshots

https://github.com/GoogleChrome/chromium-dashboard/assets/57730879/6961fbf7-d99e-4d8a-8260-e9ef3d9de299

This approach works on every page, but having a welcome toast on every page was not ideal. Previously, due to the <chromedash-toast> initialization, the toast used to appear briefly like that. Thus, I've commented out the toast initialization with the welcome text in the `spa` and `_base`.

For now, I've considered initializing the toast only where needed, thus solving this issue.

I'm open to discussing and implementing any other approach. I would appreciate a review of this! Thanks!

cc: @DanielRyanSmith @jrobbins