### PR TITLE
Enter the python venv before installing the generated openapi backend.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "deploy-rc": "./scripts/deploy_site.sh rc",
     "openapi": "npm run openapi-backend && npm run openapi-frontend",
     "openapi-frontend": "rm -rf gen/js/chromestatus-openapi && openapi-generator-cli generate -i openapi/api.yaml -g typescript-fetch  -o gen/js/chromestatus-openapi --config openapi/js-config.yaml && npm install",
-    "openapi-backend": "rm -rf gen/py/chromestatus_openapi && openapi-generator-cli generate -i openapi/api.yaml -g python-flask  -o gen/py/chromestatus_openapi --additional-properties=packageName=chromestatus_openapi && pip install -r requirements.txt",
+    "openapi-backend": ". cs-env/bin/activate; rm -rf gen/py/chromestatus_openapi && openapi-generator-cli generate -i openapi/api.yaml -g python-flask  -o gen/py/chromestatus_openapi --additional-properties=packageName=chromestatus_openapi && pip install -r requirements.txt",
     "openapi-validate": "openapi-generator-cli validate -i openapi/api.yaml"
   },
   "repository": {


### PR DESCRIPTION
Sometimes this gets run outside the venv, and then you mysteriously use
an old version of the generated code.