### PR TITLE
Reimplement input mirroring for OT milestone fields

### DIFF
--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -887,3 +887,10 @@ export const GATE_QUESTIONNAIRES = {
   [enums.GATE_TYPES.TESTING_SHIP]: TESTING_SHIP_QUESTIONNAIRE,
   [enums.GATE_TYPES.TESTING_PLAN]: TESTING_SHIP_QUESTIONNAIRE,
 };
+
+/** Copy field SRC to DST if SRC is edited and DST was empty and has not been edited */
+export const COPY_ON_EDIT = Object.freeze({
+  'ot_milestone_desktop_start': ['ot_milestone_android_start', 'ot_milestone_webview_start'],
+  'ot_milestone_desktop_end': ['ot_milestone_android_end', 'ot_milestone_webview_end'],
+  'dt_milestone_desktop_start': ['dt_milestone_android_start', 'dt_milestone_webview_start'],
+});


### PR DESCRIPTION
Fixes #3173

- If the value in the text box for the OT/DT desktop milestone start/end field is changed, and the other android/webview milestone start fields are empty or were the same value as the desktop milestone previously, their values are also changed to match.
- If this value mirroring occurs, the touched property on these fields are all changed to "true" (which is how we know to update the field once the form is submitted).

Demo:

https://github.com/GoogleChrome/chromium-dashboard/assets/23418428/9a00fe12-47b8-4bab-88b7-1445f89b27b0