### PR TITLE
fix: missing edit icon on new features page for user editable features

### DIFF
--- a/client-src/elements/chromedash-all-features-page.js
+++ b/client-src/elements/chromedash-all-features-page.js
@@ -83,6 +83,13 @@ export class ChromedashAllFeaturesPage extends LitElement {
       });
   }
 
+  // Get all editable features of the user
+  getEditableFeatures() {
+    return this.user ?
+      new Set(this.user.editable_features) :
+      new Set();
+  }
+
   renderBox(query) {
     return html`
       <chromedash-feature-table
@@ -91,7 +98,8 @@ export class ChromedashAllFeaturesPage extends LitElement {
         .num=${this.num}
         showQuery
         ?signedIn=${Boolean(this.user)}
-        ?canEdit=${this.user && this.user.can_edit_all}
+        ?canEditAll=${this.user && this.user.can_edit_all}
+        .editableFeatures=${this.getEditableFeatures()}
         .starredFeatures=${this.starredFeatures}
         @star-toggle-event=${this.handleStarToggle}
         alwaysOfferPagination columns="normal">

--- a/client-src/elements/chromedash-feature-table.js
+++ b/client-src/elements/chromedash-feature-table.js
@@ -19,7 +19,8 @@ class ChromedashFeatureTable extends LitElement {
       alwaysOfferPagination: {type: Boolean},
       columns: {type: String},
       signedIn: {type: Boolean},
-      canEdit: {type: Boolean},
+      canEditAll: {type: Boolean},
+      editableFeatures: {type: Object},
       starredFeatures: {type: Object},
       noResultsMessage: {type: String},
       gates: {type: Object},
@@ -34,13 +35,14 @@ class ChromedashFeatureTable extends LitElement {
     this.showQuery = false;
     this.loading = true;
     this.starredFeatures = new Set();
+    this.editableFeatures = new Set();
     this.features = [];
     this.totalCount = 0;
     this.start = 0;
     this.num = 100;
     this.alwaysOfferPagination = false;
     this.noResultsMessage = 'No results';
-    this.canEdit = false;
+    this.canEditAll = false;
     this.gates = {};
     this.selectedGateId = 0;
   }
@@ -229,13 +231,19 @@ class ChromedashFeatureTable extends LitElement {
     `;
   }
 
+  // Feature is editable if the user can "edit all" features or if the user
+  // specifically has edit permissions on that feature
+  userCanEditFeature(featureId) {
+    return this.canEditAll || this.editableFeatures.has(featureId);
+  }
+
   renderFeature(feature) {
     return html`
       <chromedash-feature-row
          .feature=${feature}
          columns=${this.columns}
          ?signedIn=${this.signedIn}
-         ?canEdit=${this.canEdit}
+         ?canEdit=${this.userCanEditFeature(feature.id)}
          .starredFeatures=${this.starredFeatures}
          .gates=${this.gates}
          selectedGateId=${this.selectedGateId}


### PR DESCRIPTION
### Overview:

Added a new property to `chromedash-feature-table` that now takes in `editableFeatures` along with other existing props like `starredFeatures` etc. When rendering the rows for the table, this property will be used to decide if the user can edit the feature or not (along with the existing check if user has "all edit" permissions)

Fixes #3569 

