### PR TITLE
Speed up permissions check

### DIFF
--- a/api/permissions_api.py
+++ b/api/permissions_api.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from framework import basehandlers
 from framework import permissions
 from framework.users import User
@@ -40,15 +42,24 @@ class PermissionsAPI(basehandlers.APIHandler):
 
   def get_all_perms(self, user):
     """Return a dict of permissions for the given user."""
+    logging.info('In get_all_perms')
+    can_create_feature = permissions.can_create_feature(user)
+    approvable_gate_types = sorted(
+        approval_defs.fields_approvable_by(user))
+    can_comment = permissions.can_comment(user)
+    can_edit_all = permissions.can_edit_any_feature(user)
+    is_admin = permissions.can_admin_site(user)
+    editable_features = permissions.feature_edit_list(user)
+    logging.info('got editable_features')
+
     return {
-      'can_create_feature': permissions.can_create_feature(user),
-      'approvable_gate_types': sorted(
-          approval_defs.fields_approvable_by(user)),
-      'can_comment': permissions.can_comment(user),
-      'can_edit_all': permissions.can_edit_any_feature(user),
-      'is_admin': permissions.can_admin_site(user),
+      'can_create_feature': can_create_feature,
+      'approvable_gate_types': approvable_gate_types,
+      'can_comment': can_comment,
+      'can_edit_all': can_edit_all,
+      'is_admin': is_admin,
       'email': user.email(),
-      'editable_features': permissions.feature_edit_list(user)
+      'editable_features': editable_features,
     }
 
   def find_paired_user(self, user):

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -97,10 +97,10 @@ def feature_edit_list(user: User) -> list[int]:
     return []
 
   # Query features to find which can be edited.
-  features_editable = feature_helpers.get_all(
-    filterby=('can_edit', user.email()))
+  editable_feature_keys = feature_helpers.get_all(
+      filterby=('can_edit', user.email()), keys_only=True)
   # Return a list of unique ids of features that can be edited.
-  return list(set([f['id'] for f in features_editable]))
+  return list(set([fk.integer_id() for fk in editable_feature_keys]))
 
 
 def can_edit_feature(user: User, feature_id: int) -> bool:

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -17,6 +17,7 @@
 import logging
 from typing import Optional
 import flask
+from google.cloud import ndb  # type: ignore
 
 import settings
 from framework.users import User
@@ -97,7 +98,7 @@ def feature_edit_list(user: User) -> list[int]:
     return []
 
   # Query features to find which can be edited.
-  editable_feature_keys = feature_helpers.get_all(
+  editable_feature_keys: list[ndb.Key] = feature_helpers.get_all(
       filterby=('can_edit', user.email()), keys_only=True)
   # Return a list of unique ids of features that can be edited.
   return list(set([fk.integer_id() for fk in editable_feature_keys]))

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -287,7 +287,7 @@ def get_approvers(field_id) -> list[str]:
   else:
     owners = afd.approvers
 
-  rediscache.set(cache_key, owners)
+  rediscache.set(cache_key, owners, time=CACHE_EXPIRATION)
   return owners
 
 

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -18,6 +18,7 @@ import testing_config  # Must be imported before the module under test.
 
 from unittest import mock
 
+from framework import rediscache
 from internals import approval_defs
 from internals import core_enums
 from internals.review_models import Gate, GateDef, Vote
@@ -128,9 +129,18 @@ MOCK_APPROVALS_BY_ID = {
 
 class GetApproversTest(testing_config.CustomTestCase):
 
+  def setUp(self):
+    self.clearCache()
+
   def tearDown(self):
+    self.clearCache()
     for gate_def in GateDef.query():
       gate_def.key.delete()
+
+  def clearCache(self):
+    for gate_type in approval_defs.APPROVAL_FIELDS_BY_ID:
+      cache_key = '%s|%s' % (approval_defs.APPROVERS_CACHE_KEY, gate_type)
+      rediscache.delete(cache_key)
 
   @mock.patch('internals.approval_defs.APPROVAL_FIELDS_BY_ID',
               MOCK_APPROVALS_BY_ID)

--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -79,14 +79,14 @@ def get_features_in_release_notes(milestone: int):
           Stage.rollout_milestone >= milestone),
       Stage.stage_type.IN([STAGE_BLINK_SHIPPING, STAGE_PSA_SHIPPING,
           STAGE_FAST_SHIPPING, STAGE_DEP_SHIPPING, STAGE_ENT_ROLLOUT])).filter().fetch()
-  
+
   feature_ids = list(set({
       *[s.feature_id for s in stages]}))
   features = [dict(converters.feature_entry_to_json_verbose(f))
             for f in _get_future_results(_get_entries_by_id_async(feature_ids))]
-  features = [f for f in filter_unlisted(features) 
+  features = [f for f in filter_unlisted(features)
     if not f['deleted'] and
-      (f['enterprise_impact'] > ENTERPRISE_IMPACT_NONE or 
+      (f['enterprise_impact'] > ENTERPRISE_IMPACT_NONE or
        f['feature_type_int'] == FEATURE_TYPE_ENTERPRISE_ID) and
       (f['first_enterprise_notification_milestone'] == None or
        f['first_enterprise_notification_milestone'] <= milestone)]
@@ -285,7 +285,8 @@ def get_in_milestone(milestone: int,
 
 def get_all(limit: Optional[int]=None,
     order: str='-updated', filterby: Optional[tuple[str, Any]]=None,
-    update_cache: bool=False, keys_only: bool=False) -> list[dict]:
+    update_cache: bool=False, keys_only: bool=False
+ ) -> list[dict] | list[ndb.Key]:
   """Return JSON dicts for entities that fit the filterby criteria.
 
   Because the cache may rarely have stale data, this should only be


### PR DESCRIPTION
One of the API Owners complained that the review dashboard was loading slowly, and specifically that the call to get the user permissions was taking almost 1000ms.

In this PR:
* Log the start and end of computing permission data so that we can keep an eye on performance in the future.
* When getting the set of features that the user can edit, just get the IDs since that is all we need.
* Cache the list of users who can review a given gate type.  This replaces some ndb queries with reds queries. 

These changes reduce the latency of this call from my desktop browser from around 850ms to about 350ms.