### PR TITLE
Speed up sorting of pending reviews.

### DIFF
--- a/internals/search_queries.py
+++ b/internals/search_queries.py
@@ -167,7 +167,7 @@ def total_order_query_async(sort_spec: str) -> Union[list[int], Future]:
 
 def _sorted_by_joined_model(
     joinable_model_class: Model, condition: FilterNode, descending: bool,
-    order_by: Property) -> list[int]:
+    order_by: Property) -> Future:
   """Return feature_ids sorted by a field in a joined entity kind."""
   query = joinable_model_class.query()
   if condition:
@@ -177,12 +177,11 @@ def _sorted_by_joined_model(
   else:
     query = query.order(order_by)
 
-  joined_models = query.fetch(projection=['feature_id'])
-  feature_ids = utils.dedupe(jm.feature_id for jm in joined_models)
-  return feature_ids
+  projection_future = query.fetch_async(projection=['feature_id'])
+  return projection_future
 
 
-def sorted_by_pending_request_date(descending: bool) -> list[int]:
+def sorted_by_pending_request_date(descending: bool) -> Future:
   """Return feature_ids of pending approvals sorted by request date."""
   return _sorted_by_joined_model(
       Gate,
@@ -190,7 +189,7 @@ def sorted_by_pending_request_date(descending: bool) -> list[int]:
       descending, Gate.requested_on)
 
 
-def sorted_by_review_date(descending: bool) -> list[int]:
+def sorted_by_review_date(descending: bool) -> Future:
   """Return feature_ids of reviewed approvals sorted by last review."""
   return _sorted_by_joined_model(
       Gate,

--- a/internals/search_queries_test.py
+++ b/internals/search_queries_test.py
@@ -278,14 +278,16 @@ class SearchFeaturesTest(testing_config.CustomTestCase):
 
   def test_total_order_query_async__requested_on(self):
     """We can get feature IDs sorted by gate review requests."""
-    actual = search_queries.total_order_query_async('gate.requested_on')
+    future = search_queries.total_order_query_async('gate.requested_on')
+    actual = search._resolve_promise_to_id_list(future)
     self.assertEqual(
         [self.feature_2_id],
         actual)
 
   def test_total_order_query_async__reviewed_on(self):
     """We can get feature IDs sorted by gate resolution times."""
-    actual = search_queries.total_order_query_async('gate.reviewed_on')
+    future = search_queries.total_order_query_async('gate.reviewed_on')
+    actual = search._resolve_promise_to_id_list(future)
     self.assertEqual(
         [self.feature_1_id],
         actual)


### PR DESCRIPTION
This improves the performance of feature search queries that are used on the chromestatus reviewers' dashboard.  

Specifically, it makes the step that gets sorted feature IDs use an async query rather than synchronous.  This allows some of the integer set union and intersection work to be done in parallel with the sorting query.  This is only a small improvement because the set logic stuff executes quickly anyway.

In this PR:
* Add more logging so that we can see where time is being spent during request processing.
* Make `sorted_by_pending_request_date()` and `sorted_by_review_date()` return futures rather than blocking while their query executes.  The ability to handle futures is already supported in the rest of the search pipeline.
* Make the final logging statement generate a shorter string