### PR TITLE
Avoid getting permissions twice when signed out.

### DIFF
--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -114,7 +114,7 @@ class ChromedashApp extends LitElement {
 
   constructor() {
     super();
-    this.user = {};
+    this.user = undefined;
     this.loading = true;
     this.appTitle = '';
     this.googleSignInClientId = '',

--- a/client-src/elements/chromedash-drawer.js
+++ b/client-src/elements/chromedash-drawer.js
@@ -108,7 +108,7 @@ export class ChromedashDrawer extends LitElement {
     this.currentPage = '';
     this.devMode = 'False';
     this.googleSignInClientId = '',
-    this.user = {};
+    this.user = undefined;
     this.loading = false;
     this.defaultOpen = false;
   }
@@ -117,7 +117,7 @@ export class ChromedashDrawer extends LitElement {
     super.connectedCallback();
 
     // user is passed in from chromedash-app
-    if (this.user && this.user.email) return;
+    if (this.user !== undefined) return;
 
     // Try to load user.
     this.loading = true;

--- a/client-src/elements/chromedash-header.js
+++ b/client-src/elements/chromedash-header.js
@@ -151,7 +151,7 @@ export class ChromedashHeader extends LitElement {
     this.googleSignInClientId = '',
     this.devMode = '';
     this.currentPage = '';
-    this.user = {};
+    this.user = undefined;
     this.loading = false;
   }
 
@@ -164,10 +164,10 @@ export class ChromedashHeader extends LitElement {
     }
 
     // user is passed in from chromedash-app
-    if (this.user && this.user.email) return;
+    if (this.user !== undefined) return;
 
     // user is passed in from chromedash-app, but the user is not logged in
-    if (!this.user) {
+    if (this.user === null) {
       if (!window['isPlaywright']) {
         // Insert the google signin button first.
         // Only insert if not running playwright.


### PR DESCRIPTION
When looking into chromestatus performance I noticed that the permissions API call was being done twice on some page loads.  It was only happening for signed-out users.  I think the cause was just the way that these comparisons are done.  This fix should make the site a bit faster for signed-out users, and also eliminate a potential distraction as I continue to work on performance for signed-in users.