### PR TITLE
Intent detection for gates in Chromestatus URLs

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -77,19 +77,19 @@ def detect_field(subject):
 
   return None
 
-
-CHROMESTATUS_LINK_GENERATED_RE = re.compile(
+CHROMESTATUS_LINK_GENERATED_PATTERN = (
     r'Chrome( Platform)? ?Status(.com)?[ \w]*:?\s+'
     r'[> ]*https?://(www\.)?chromestatus\.com/'
-    r'(feature|guide/edit)/(?P<id>\d+)', re.I)
+    r'(feature|guide/edit)/(?P<id>\d+)')
+
+CHROMESTATUS_LINK_GENERATED_RE = re.compile(
+    CHROMESTATUS_LINK_GENERATED_PATTERN, re.I)
+CHROMESTATUS_LINK_GENERATED_GATE_RE = re.compile(
+    CHROMESTATUS_LINK_GENERATED_PATTERN + r'\?gate=(?P<gate_id>\d+)', re.I)
 CHROMESTATUS_LINK_ALTERNATE_RE = re.compile(
     r'entry on the feature dashboard.*\s+'
     r'[> ]*https?://(www\.)?chromestatus\.com/'
     r'(feature|guide/edit)/(?P<id>\d+)', re.I)
-CHROMESTATUS_LINK_GENERATED_GATE_RE = re.compile(
-    r'Chrome( Platform)? ?Status(.com)?[ \w]*:?\s+'
-    r'[> ]*https?://(www\.)?chromestatus\.com/'
-    r'(feature|guide/edit)/(\d+)\?gate=(?P<id>\d+)', re.I)
 NOT_LGTM_RE = re.compile(
     r'\b(not|almost|need|want|missing) (a |an )?LGTM\b',
     re.I)
@@ -109,7 +109,7 @@ def detect_gate_id(body) -> int | None:
   """Detect the gate ID within the chromestatus URL."""
   match = CHROMESTATUS_LINK_GENERATED_GATE_RE.search(body)
   if match:
-    return int(match.group('id'))
+    return int(match.group('gate_id'))
   return None
 
 

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -212,17 +212,20 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     gate, stage = self.get_gate_and_stage(
         feature, approval_field, gate_id, thread_url)
     if stage is None:
-      message = (f'Stage not found for intent type {approval_field.field_id}')
+      message = (f'Stage not found for intent type {approval_field.field_id} '
+                 f'of feature {feature_id}')
       logging.info(message)
       return {'message': message}
     if gate is None:
-      message = (f'Gate not found for gate type {approval_field.field_id}')
+      message = (f'Gate not found for intent type {approval_field.field_id} '
+                 f'of feature {feature_id}')
       logging.info(message)
       return {'message': message}
     if gate.gate_type != approval_field.field_id:
-      message = 'Gate type does not match approval field gate type'
-      logging.info(f'{message}. gate_type={gate.gate_type}'
-                   f', approval_field.field_id={approval_field.field_id}')
+      message = (f'Gate {gate.key.integer_id()} has gate type {gate.gate_type} '
+                 'and does not match approval field gate type '
+                 f'{approval_field.field_id}')
+      logging.info(message)
       return {'message': message}
 
     self.set_intent_thread_url(stage, thread_url, subject)

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -86,6 +86,10 @@ CHROMESTATUS_LINK_ALTERNATE_RE = re.compile(
     r'entry on the feature dashboard.*\s+'
     r'[> ]*https?://(www\.)?chromestatus\.com/'
     r'(feature|guide/edit)/(?P<id>\d+)', re.I)
+CHROMESTATUS_LINK_GENERATED_GATE_RE = re.compile(
+    r'Chrome( Platform)? ?Status(.com)?[ \w]*:?\s+'
+    r'[> ]*https?://(www\.)?chromestatus\.com/'
+    r'(feature|guide/edit)/(\d+)\?gate=(?P<id>\d+)', re.I)
 NOT_LGTM_RE = re.compile(
     r'\b(not|almost|need|want|missing) (a |an )?LGTM\b',
     re.I)
@@ -96,6 +100,14 @@ def detect_feature_id(body):
   """Look for the link to a chromestatus entry."""
   match = (CHROMESTATUS_LINK_GENERATED_RE.search(body) or
            CHROMESTATUS_LINK_ALTERNATE_RE.search(body))
+  if match:
+    return int(match.group('id'))
+  return None
+
+
+def detect_gate_id(body) -> int | None:
+  """Detect the gate ID within the chromestatus URL."""
+  match = CHROMESTATUS_LINK_GENERATED_GATE_RE.search(body)
   if match:
     return int(match.group('id'))
   return None
@@ -186,6 +198,7 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
       return {'message': 'Not an intent'}
 
     feature_id = detect_feature_id(body)
+    gate_id = detect_gate_id(body)
     thread_url = detect_thread_url(body)
     feature, message = self.load_detected_feature(
         feature_id, thread_url)
@@ -196,19 +209,20 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
       logging.info('Could not retrieve feature')
       return {'message': 'Feature not found'}
 
-    stage = self.find_matching_stage(feature, approval_field, thread_url)
+    gate, stage = self.get_gate_and_stage(
+        feature, approval_field, gate_id, thread_url)
     if stage is None:
-      message = ('No matching stage found for intent type '
-                 f'{approval_field.field_id}')
+      message = (f'Stage not found for intent type {approval_field.field_id}')
       logging.info(message)
       return {'message': message}
-
-    gate = Gate.query(Gate.stage_id == stage.key.integer_id(),
-                      Gate.gate_type == approval_field.field_id).get()
     if gate is None:
-      message = (f'Gate not found for stage {stage.key.integer_id()} '
-                    f' and gate type {approval_field.field_id}')
+      message = (f'Gate not found for gate type {approval_field.field_id}')
       logging.info(message)
+      return {'message': message}
+    if gate.gate_type != approval_field.field_id:
+      message = 'Gate type does not match approval field gate type'
+      logging.info(f'{message}. gate_type={gate.gate_type}'
+                   f', approval_field.field_id={approval_field.field_id}')
       return {'message': message}
 
     self.set_intent_thread_url(stage, thread_url, subject)
@@ -242,6 +256,31 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
       return None, 'Ambiguous feature entries %r' % fe_ids
 
     return FeatureEntry.get_by_id(fe_ids[0]), None
+
+  def get_gate_and_stage(
+      self,
+      feature: FeatureEntry,
+      approval_field: approval_defs.ApprovalFieldDef,
+      gate_id: int | None,
+      thread_url: str) -> tuple[Gate | None, Stage | None]:
+    # If a gate ID is detected, query for the gate.
+    if gate_id:
+      logging.info(f'Using detected gate ID {gate_id}')
+      gate = Gate.get_by_id(gate_id)
+      # Return nulls if the gate ID is invalid.
+      if gate is None:
+        logging.info('Gate not found')
+        return None, None
+      stage = Stage.get_by_id(gate.stage_id)
+    # Otherwise, try to find the matching gate based on other feature info.
+    else:
+      logging.info('Attempting to find stage/gate without detected gate ID')
+      stage = self.find_matching_stage(feature, approval_field, thread_url)
+      if stage is None:
+        return None, None
+      gate = Gate.query(Gate.stage_id == stage.key.integer_id(),
+                        Gate.gate_type == approval_field.field_id).get()
+    return gate, stage
 
   def find_matching_stage(self, feature: FeatureEntry,
       approval_field: approval_defs.ApprovalFieldDef,

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -309,11 +309,10 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
                    f'{feature.key.integer_id()}, stage_type: {stage_type}')
       return None
 
-    # Check if this intent URL already belongs to a stage.
-    # TODO(DanielRyanSmith): The intent thread URLs contain the message ID
-    # and won't match up perfectly when comparing them.
-    # Update to instead detect by gate ID.
-    # See https://github.com/GoogleChrome/chromium-dashboard/pull/3678#discussion_r1513361281
+    # If only 1 stage is found, it's assumed to be the correct stage.
+    if len(stages_of_type_in_feature) == 1:
+      return stages_of_type_in_feature[0]
+
     matching_stage = next((s for s in stages_of_type_in_feature
                             if s.intent_thread_url == thread_url), None)
     if matching_stage:
@@ -321,6 +320,9 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
                    matching_stage.intent_thread_url)
       return matching_stage
 
+    # TODO(DanielRyanSmith): This logic could still fail in some circumstances.
+    # Move to a guaranteed gate ID detection method, or post intent threads
+    # on behalf of the user with a unique identifier.
     # If only 1 stage exists without a set intent URL, we can assume that
     # this thread is associated with that stage.
     stages_with_no_intent_thread_url = list(filter(

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -559,8 +559,11 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
     with test_app.test_request_context(
         self.request_path, json=extend_json_data):
       actual = self.handler.process_post_data()
+    created_votes = list(Vote.query().fetch(None))
+    self.assertEqual(0, len(created_votes))
 
-    self.assertEqual(actual, {'message': 'Stage not found for intent type 3'})
+    self.assertEqual(actual, {'message': ('Stage not found for intent type 3 '
+                                          f'of feature {self.feature_id}')})
 
   @mock.patch('logging.info')
   def test_process_post_data__incorrect_gate_type(self, mock_info):
@@ -574,9 +577,13 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
     with test_app.test_request_context(
         self.request_path, json=extend_json_data):
       actual = self.handler.process_post_data()
+    created_votes = list(Vote.query().fetch(None))
+    self.assertEqual(0, len(created_votes))
 
     self.assertEqual(actual, {
-        'message': 'Gate type does not match approval field gate type'})
+        'message': (f'Gate {self.gate_with_experiment_type.key.integer_id()} '
+                    'has gate type 2 and does not match approval field '
+                    'gate type 3')})
 
   def test_process_post_data__new_thread_already_empty_str(self):
     """We still set intent_thread_url if it was previously an empty string."""


### PR DESCRIPTION
This PR allows the detection of gate IDs in intent threads to ensure we correlate the correct approvals and review requests with the correct gate and stage.

- The intent detection logic will still function as it previously did if no gate ID is detected.
- A check will occur to ensure the detected gate matches the intent type (e.g. an "Intent to Extend Experiment" intent thread should only update an origin trial extension gate).