### PR TITLE
Add "OT extended" notification template

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -722,6 +722,44 @@ class OriginTrialExtensionRequestHandler(basehandlers.FlaskHandler):
       'html': email_body,
     }
 
+
+class OriginTrialExtendedHandler(basehandlers.FlaskHandler):
+  """Notify about an origin trial extension being completed."""
+
+  IS_INTERNAL_HANDLER = True
+
+  def process_post_data(self, **kwargs):
+    extension_stage = self.get_param('stage')
+    ot_stage = self.get_param('ot_stage')
+    logging.info('Starting to notify about successful origin triale extension.')
+    send_emails([self.build_email(self, extension_stage, ot_stage)])
+
+  def build_email(self, extension_stage, ot_stage):
+    email_body = f"""
+<p>
+  A recent extension request was finalized and processed.
+  <br>
+  Requested by: {extension_stage["ot_owner_email"]}
+  <br>
+  Feature name: {ot_stage["ot_display_name"]}
+  <br>
+  Intent to Extend Experiment URL: {extension_stage["intent_thread_url"]}
+  <br>
+  New end milestone: {extension_stage["desktop_last"]}
+  <br>
+  <br>
+  No additional action needs to be taken if this information looks correct.
+</p>
+"""
+    return {
+      'to': OT_SUPPORT_EMAIL,
+      'subject': ('Origin trial extension processed: '
+                  f'{ot_stage["ot_display_name"]}'),
+      'reply_to': None,
+      'html': email_body,
+    }
+
+
 BLINK_DEV_ARCHIVE_URL_PREFIX = (
     'https://groups.google.com/a/chromium.org/d/msgid/blink-dev/')
 TEST_ARCHIVE_URL_PREFIX = (

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -727,36 +727,27 @@ class OriginTrialExtendedHandler(basehandlers.FlaskHandler):
   """Notify about an origin trial extension being completed."""
 
   IS_INTERNAL_HANDLER = True
+  EMAIL_TEMPLATE_PATH = 'origintrials/ot-extended-email.html'
 
   def process_post_data(self, **kwargs):
     extension_stage = self.get_param('stage')
     ot_stage = self.get_param('ot_stage')
-    logging.info('Starting to notify about successful origin triale extension.')
+    logging.info('Starting to notify about successful origin trial extension.')
     send_emails([self.build_email(self, extension_stage, ot_stage)])
 
   def build_email(self, extension_stage, ot_stage):
-    email_body = f"""
-<p>
-  A recent extension request was finalized and processed.
-  <br>
-  Requested by: {extension_stage["ot_owner_email"]}
-  <br>
-  Feature name: {ot_stage["ot_display_name"]}
-  <br>
-  Intent to Extend Experiment URL: {extension_stage["intent_thread_url"]}
-  <br>
-  New end milestone: {extension_stage["desktop_last"]}
-  <br>
-  <br>
-  No additional action needs to be taken if this information looks correct.
-</p>
-"""
+    body_data = {
+      'extension_stage': extension_stage,
+      'ot_stage': ot_stage
+    }
+    body = render_template(self.EMAIL_TEMPLATE_PATH, **body_data)
+
     return {
       'to': OT_SUPPORT_EMAIL,
       'subject': ('Origin trial extension processed: '
                   f'{ot_stage["ot_display_name"]}'),
       'reply_to': None,
-      'html': email_body,
+      'html': body,
     }
 
 

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -212,7 +212,7 @@ def send_ot_notification(stage: Stage):
 
 
 def send_trial_extended_notification(stage: Stage):
-  """Notify about """
+  """Notify about a successful automatic trial extension."""
   stage_dict = converters.stage_to_json_dict(stage)
   params = {'stage': stage_dict}
   ot_stage = Stage.get_by_id(stage.ot_stage_id)

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -192,7 +192,7 @@ def notify_subscribers_of_new_comments(fe: 'FeatureEntry', gate: Gate,
 
 
 def send_ot_notification(stage: Stage):
-  """Notify about new trial creation request."""
+  """Notify about new trial creation/extension request."""
   stage_dict = converters.stage_to_json_dict(stage)
   # Add the OT request note, which is usually not publicly visible.
   stage_dict['ot_request_note'] = stage.ot_request_note
@@ -209,3 +209,12 @@ def send_ot_notification(stage: Stage):
   else:
     cloud_tasks_helpers.enqueue_task(
         '/tasks/email-ot-creation-request',params)
+
+
+def send_trial_extended_notification(stage: Stage):
+  """Notify about """
+  stage_dict = converters.stage_to_json_dict(stage)
+  params = {'stage': stage_dict}
+  ot_stage = Stage.get_by_id(stage.ot_stage_id)
+  params['ot_stage'] = converters.stage_to_json_dict(ot_stage)
+  cloud_tasks_helpers.enqueue_task('/tasks/email-ot-extended', params)

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -1062,33 +1062,12 @@ class OriginTrialExtendedHandlerTest(testing_config.CustomTestCase):
   def test_make_extended_request_email(self):
     ot_stage_dict = converters.stage_to_json_dict(self.ot_stage)
     extension_stage_dict = converters.stage_to_json_dict(self.extension_stage)
-    handler = notifier.OriginTrialExtendedHandler()
-    email_task = handler.build_email(extension_stage_dict, ot_stage_dict)
-
-    expected_body = """
-<p>
-  A recent extension request was finalized and processed.
-  <br>
-  Requested by: user2@example.com
-  <br>
-  Feature name: An existing origin trial
-  <br>
-  Intent to Extend Experiment URL: https://example.com/intent
-  <br>
-  New end milestone: 106
-  <br>
-  <br>
-  No additional action needs to be taken if this information looks correct.
-</p>
-"""
-    expected = {
-      'to': 'origin-trials-support@google.com',
-      'subject': 'Origin trial extension processed: An existing origin trial',
-      'reply_to': None,
-      'html': expected_body,
-    }
-
-    self.assertEqual(email_task, expected)
+    with test_app.app_context():
+      handler = notifier.OriginTrialExtendedHandler()
+      email_task = handler.build_email(extension_stage_dict, ot_stage_dict)
+      # TESTDATA.make_golden(email_task['html'], 'test_make_extended_request_email.html')
+      self.assertEqual(email_task['html'],
+        TESTDATA['test_make_extended_request_email.html'])
 
 
 class OriginTrialExtensionRequestHandlerTest(testing_config.CustomTestCase):

--- a/internals/testdata/notifier_test/test_make_extended_request_email.html
+++ b/internals/testdata/notifier_test/test_make_extended_request_email.html
@@ -1,0 +1,14 @@
+<p>
+  A recent extension request was finalized and processed.
+  <br>
+  Requested by: user2@example.com
+  <br>
+  Feature name: An existing origin trial
+  <br>
+  Intent to Extend Experiment URL: https://example.com/intent
+  <br>
+  New end milestone: 106
+  <br>
+  <br>
+  No additional action needs to be taken if this information looks correct.
+</p>

--- a/main.py
+++ b/main.py
@@ -273,6 +273,8 @@ internals_routes: list[Route] = [
         notifier.OriginTrialCreationRequestHandler),
   Route('/tasks/email-ot-extension-request',
         notifier.OriginTrialExtensionRequestHandler),
+  Route('/tasks/email-ot-extended',
+        notifier.OriginTrialCreationRequestHandler),
 
   # Maintenance scripts.
   Route('/scripts/evaluate_gate_status',

--- a/templates/origintrials/ot-extended-email.html
+++ b/templates/origintrials/ot-extended-email.html
@@ -1,0 +1,14 @@
+<p>
+  A recent extension request was finalized and processed.
+  <br>
+  Requested by: {{extension_stage.ot_owner_email}}
+  <br>
+  Feature name: {{ot_stage.ot_display_name}}
+  <br>
+  Intent to Extend Experiment URL: {{extension_stage.intent_thread_url}}
+  <br>
+  New end milestone: {{extension_stage.desktop_last}}
+  <br>
+  <br>
+  No additional action needs to be taken if this information looks correct.
+</p>


### PR DESCRIPTION
This PR adds a new notification template that will be sent to the OT team when an origin trial is successfully extended. The template is not yet used, and will be implemented when the new automatic origin trial extension work has landed.