### PR TITLE
Fetch paired_user separately.

### DIFF
--- a/api/permissions_api.py
+++ b/api/permissions_api.py
@@ -33,10 +33,12 @@ class PermissionsAPI(basehandlers.APIHandler):
     # get user permission data if signed in
     user = self.get_current_user()
     if user:
-      user_data = self.get_all_perms(user)
-      paired_user = self.find_paired_user(user)
-      if paired_user:
-        user_data['paired_user'] = self.get_all_perms(paired_user)
+      if not self.get_bool_arg('returnPairedUser'):
+        user_data = self.get_all_perms(user)
+      else:
+        paired_user = self.find_paired_user(user)
+        if paired_user:
+          user_data = self.get_all_perms(paired_user)
 
     return {'user': user_data}
 

--- a/api/permissions_api_test.py
+++ b/api/permissions_api_test.py
@@ -69,14 +69,22 @@ class PermissionsAPITest(testing_config.CustomTestCase):
         'is_admin': False,
         'email': 'one@google.com',
         'editable_features': [],
-        'paired_user': {
-            'can_create_feature': True,
-            'approvable_gate_types': [],
-            'can_comment': True,
-            'can_edit_all': False,
-            'is_admin': False,
-            'email': 'one@chromium.org',
-            'editable_features': []
-          }
         }}
+    self.assertEqual(expected, actual)
+
+  def test_get__googler_paired_user(self):
+    """Googlers have default permissions to create features."""
+    testing_config.sign_in('one@google.com', 67890)
+    with test_app.test_request_context(self.request_path + '?returnPairedUser'):
+      actual = self.handler.do_get()
+    expected = {
+      'user': {
+          'can_create_feature': True,
+          'approvable_gate_types': [],
+          'can_comment': True,
+          'can_edit_all': False,
+          'is_admin': False,
+          'email': 'one@chromium.org',
+          'editable_features': []
+      }}
     self.assertEqual(expected, actual)

--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -153,7 +153,8 @@ class ChromedashApp extends LitElement {
   fetchPairedUser() {
     if (this.paired_user !== undefined) {
       if (this.pageComponent) {
-        this.pageComponent.paired_user = pu;
+        this.pageComponent.paired_user = this.paired_user;
+        return;
       }
     }
     window.csClient.getPermissions(true).then((pu) => {

--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -97,6 +97,7 @@ class ChromedashApp extends LitElement {
   static get properties() {
     return {
       user: {type: Object},
+      paired_user: {type: Object},
       loading: {type: Boolean},
       appTitle: {type: String},
       googleSignInClientId: {type: String},
@@ -115,6 +116,7 @@ class ChromedashApp extends LitElement {
   constructor() {
     super();
     this.user = {};
+    this.paired_user = undefined;
     this.loading = true;
     this.appTitle = '';
     this.googleSignInClientId = '',
@@ -145,6 +147,22 @@ class ChromedashApp extends LitElement {
     }).finally(() => {
       this.setUpRoutes();
       this.loading = false;
+    });
+  }
+
+  fetchPairedUser() {
+    if (this.paired_user !== undefined) {
+      if (this.pageComponent) {
+        this.pageComponent.paired_user = pu;
+      }
+    }
+    window.csClient.getPermissions(true).then((pu) => {
+      this.paired_user = pu;
+      if (this.pageComponent) {
+        this.pageComponent.paired_user = pu;
+      }
+    }).catch(() => {
+      showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });
   }
 
@@ -301,6 +319,7 @@ class ChromedashApp extends LitElement {
       if (!this.setupNewPage(ctx, 'chromedash-feature-page')) return;
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.user = this.user;
+      this.fetchPairedUser();
       this.pageComponent.contextLink = this.contextLink;
       this.pageComponent.selectedGateId = this.selectedGateId;
       this.pageComponent.appTitle = this.appTitle;

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -99,6 +99,7 @@ export class ChromedashFeaturePage extends LitElement {
   static get properties() {
     return {
       user: {attribute: false},
+      paired_user: {attribute: false},
       featureId: {type: Number},
       feature: {type: Object},
       featureLinks: {type: Array},
@@ -301,9 +302,8 @@ export class ChromedashFeaturePage extends LitElement {
   }
 
   pairedUserCanEdit() {
-    return (this.user?.paired_user &&
-            (this.user.paired_user.can_edit_all ||
-             this.user.paired_user.editable_features.includes(this.featureId)));
+    return (this.paired_user?.can_edit_all ||
+            this.paired_user?.editable_features.includes(this.featureId));
   }
 
   renderSubHeader() {
@@ -379,18 +379,18 @@ export class ChromedashFeaturePage extends LitElement {
       warnings.push(html`
         <div id="switch_to_edit" class="warning">
           User ${this.user.email} cannot edit this feature or request reviews.
-          But, ${this.user.paired_user.email} can do that.
+          But, ${this.paired_user.email} can do that.
           <br>
           To switch users: sign out and then sign in again.
         </div>
       `);
     }
     if (this.user?.approvable_gate_types.length == 0 &&
-        this.user?.paired_user?.approvable_gate_types.length > 0) {
+        this.paired_user?.approvable_gate_types.length > 0) {
       warnings.push(html`
         <div id="switch_to_review" class="warning">
           User ${this.user.email} cannot review this feature.
-          But, ${this.user.paired_user.email} can do that.
+          But, ${this.paired_user.email} can do that.
           <br>
           To switch users: sign out and then sign in again.
         </div>

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -163,8 +163,12 @@ class ChromeStatusClient {
   }
 
   // Permissions API
-  getPermissions() {
-    return this.doGet('/currentuser/permissions')
+  getPermissions(returnPairedUser=false) {
+    let url = '/currentuser/permissions';
+    if (returnPairedUser) {
+      url += '?returnPairedUser';
+    }
+    return this.doGet(url)
       .then((res) => res.user);
   }
 

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -62,9 +62,8 @@ def can_create_feature(user: User) -> bool:
   if user.email().endswith(('@chromium.org', '@google.com')):
     return True
 
-  query = AppUser.query(AppUser.email == user.email())
-  found_user = query.get(keys_only=True)
-  if found_user is not None:
+  app_user = AppUser.get_app_user(user.email())
+  if app_user:
     return True
 
   return False


### PR DESCRIPTION
This speeds up API calls to get permissions by about 200ms.

ChromeStatus has a UI detail that helps @google.com and @chromium.org users notice when they are signed into the wrong account.  If they are viewing a feature that has an owner with one account, but they are signed into the other account (called the "paired_user") then they see a warning.  This was implemented inefficiently in that the paired user is always looked up even when it is not needed.

In this PR:
* Change the permissions_api to only return permissions for the signed in user, not both users.  Add a `?returnPairedUser` mode that only returns the paired user.
* Change the JS code to explicitly fetch the paired user, but only on the feature detail page.
* Also, change permissions.py to use cached user objects in one function that was previously doing a direct NDB query.

When reloading the roadmap page or "my features page", the app currently spends about 400ms in the permissions call.   With this PR, those pages spend only about 180ms in that call. 

When reloading the feature detail page, the same savings are seen.  That is because even though the second call is made to get permissions for the paired user, and that call also takes about 180ms, it is done asynchronously.  So, the main page content loads sooner and the warning is the only part that is slightly delayed while waiting for the paired user.

The app does not repeatedly request permissions as the user is navigating around the site.  However, API Owners do frequently reload the page to get an updated list when they are all entering vote during their meeting.