### PR TITLE
Fetch all review gates together (w/ new index).

### DIFF
--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -163,6 +163,52 @@ class GatesAPI(basehandlers.APIHandler):
         self.abort(400, 'Assignee is not a reviewer')
 
 
+class PendingGatesAPI(basehandlers.APIHandler):
+
+  def get_stage_ids_of_gates_pending_my_approval(self) -> list[int]:
+    """Return a list of stage_id needing approval by current user."""
+    user = self.get_current_user()
+    if not user:
+      return []
+
+    approvable_gate_types = approval_defs.fields_approvable_by(user)
+    if not approvable_gate_types:
+      logging.info('User has no approvable_gate_types')
+      return []
+    query = Gate.query(
+        Gate.state.IN(Gate.PENDING_STATES),
+        Gate.gate_type.IN(approvable_gate_types))
+    future_stage_ids = query.fetch_async(projection=['stage_id'])
+    return future_stage_ids
+
+  def do_get(self, **kwargs):
+    """Return a list of gates on features that have some active gates."""
+    # 1. Get the feature IDs of any active gates.  Also, prefetch approvers.
+    future_projections = self.get_stage_ids_of_gates_pending_my_approval()
+    prefetched_approvers = {
+        gate_type: approval_defs.get_approvers(gate_type)
+        for gate_type in approval_defs.APPROVAL_FIELDS_BY_ID}
+    if type(future_projections) == list:
+      stage_ids = set(future_projections)
+    else:
+      projections = future_projections.get_result()
+      stage_ids = set(proj.stage_id for proj in projections)
+    if not stage_ids:
+      return {'gates': []}
+
+    # 2. Fetch all the gates on those stages.
+    gates: list[Gate] = Gate.query(Gate.stage_id.IN(stage_ids)).fetch()
+
+    # 3. Convert to dicts and add possible assignees.
+    dicts = [converters.gate_value_to_json_dict(g) for g in gates]
+    for g in dicts:
+      g['possible_assignee_emails'] = prefetched_approvers.get(g['gate_type'], [])
+
+    return {
+        'gates': dicts,
+        }
+
+
 class XfnGatesAPI(basehandlers.APIHandler):
 
   def do_get(self, **kwargs):

--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -18,6 +18,7 @@ import logging
 import re
 from typing import Any, Optional, Tuple
 from google.cloud import ndb
+from google.cloud.ndb.tasklets import Future  # for type checking only
 
 from api import converters
 from framework import basehandlers
@@ -165,7 +166,7 @@ class GatesAPI(basehandlers.APIHandler):
 
 class PendingGatesAPI(basehandlers.APIHandler):
 
-  def get_stage_ids_of_gates_pending_my_approval(self) -> list[int]:
+  def get_stage_ids_of_gates_pending_my_approval(self) -> list[int] | Future:
     """Return a list of stage_id needing approval by current user."""
     user = self.get_current_user()
     if not user:
@@ -204,9 +205,7 @@ class PendingGatesAPI(basehandlers.APIHandler):
     for g in dicts:
       g['possible_assignee_emails'] = prefetched_approvers.get(g['gate_type'], [])
 
-    return {
-        'gates': dicts,
-        }
+    return {'gates': dicts}
 
 
 class XfnGatesAPI(basehandlers.APIHandler):

--- a/client-src/elements/chromedash-feature-table.js
+++ b/client-src/elements/chromedash-feature-table.js
@@ -57,12 +57,12 @@ class ChromedashFeatureTable extends LitElement {
       this.features = resp.features;
       this.totalCount = resp.total_count;
       this.loading = false;
-      if (this.columns == 'approvals') {
-        this.loadGateData();
-      }
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });
+    if (this.columns == 'approvals') {
+      this.loadGateData();
+    }
   }
 
   refetch() {
@@ -70,13 +70,18 @@ class ChromedashFeatureTable extends LitElement {
   }
 
   loadGateData() {
-    for (const feature of this.features) {
-      window.csClient.getGates(feature.id).then(res => {
-        const newGates = {...this.gates};
-        newGates[feature.id] = res.gates;
-        this.gates = newGates;
-      });
-    }
+    window.csClient.getPendingGates().then(res => {
+      const gatesByFID = {};
+      for (const g of res.gates) {
+        if (!gatesByFID.hasOwnProperty(g.feature_id)) {
+          gatesByFID[g.feature_id] = [];
+        }
+        gatesByFID[g.feature_id].push(g);
+      }
+      this.gates = gatesByFID;
+    }).catch(() => {
+      showToastMessage('Some errors occurred. Please refresh the page or try again later.');
+    });
   }
 
   // For rerendering of the "Features I starred" section when a feature is starred

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -227,6 +227,10 @@ class ChromeStatusClient {
     return this.doGet(`/features/${featureId}/gates`);
   }
 
+  getPendingGates() {
+    return this.doGet(`/gates/pending`);
+  }
+
   updateGate(featureId, gateId, assignees) {
     return this.doPost(
         `/features/${featureId}/gates/${gateId}`,

--- a/index.yaml
+++ b/index.yaml
@@ -500,6 +500,11 @@ indexes:
   - name: feature_id
 - kind: Gate
   properties:
+  - name: gate_type
+  - name: state
+  - name: stage_id
+- kind: Gate
+  properties:
   - name: state
   - name: requested_on
     direction: desc

--- a/internals/search.py
+++ b/internals/search.py
@@ -35,7 +35,7 @@ MAX_TERMS = 6
 DEFAULT_RESULTS_PER_PAGE = 100
 
 
-def process_pending_approval_me_query() -> list[int]:
+def process_pending_approval_me_query() -> list[int] | Future:
   """Return a list of features needing approval by current user."""
   user = users.get_current_user()
   if not user:
@@ -62,7 +62,7 @@ def process_starred_me_query() -> list[int]:
   return feature_ids
 
 
-def process_recent_reviews_query() -> list[int]:
+def process_recent_reviews_query() -> list[int] | Future:
   """Return features that were reviewed recently."""
   query = Gate.query(
       Gate.state.IN(Gate.FINAL_STATES))

--- a/internals/search_queries.py
+++ b/internals/search_queries.py
@@ -30,7 +30,7 @@ from internals.review_models import Gate
 
 def single_field_query_async(
     field_name: str, operator: str, val: Union[str, int, datetime.datetime],
-    limit: int|None = None) -> Union[list[int], Future]:
+    limit: int|None = None) -> list[int] | Future:
   """Create a query for one FeatureEntry field and run it, returning a promise."""
   # Note: We don't exclude deleted features, that's done by process_query.
   field_name = field_name.lower()
@@ -118,7 +118,7 @@ def negate_operator(operator: str) -> str:
   return operator
 
 
-def handle_me_query_async(field_name: str) -> Future:
+def handle_me_query_async(field_name: str) -> list[int] | Future:
   """Return a future for feature IDs that reference the current user."""
   user = users.get_current_user()
   if not user:
@@ -126,7 +126,7 @@ def handle_me_query_async(field_name: str) -> Future:
   return single_field_query_async(field_name, '=', user.email())
 
 
-def handle_can_edit_me_query_async() -> Future:
+def handle_can_edit_me_query_async() -> list[int] | Future:
   """Return a future for features that the current user can edit."""
   user = users.get_current_user()
   if not user:
@@ -140,7 +140,7 @@ def handle_can_edit_me_query_async() -> Future:
   return keys_promise
 
 
-def total_order_query_async(sort_spec: str) -> Union[list[int], Future]:
+def total_order_query_async(sort_spec: str) -> list[int] | Future:
   """Create a query promise for all FeatureEntry IDs sorted by sort_spec."""
   # TODO(jrobbins): Support multi-column sort.
   descending = False

--- a/internals/slo.py
+++ b/internals/slo.py
@@ -22,7 +22,7 @@ from internals.core_models import FeatureEntry
 from internals.review_models import Gate, Vote
 
 PACIFIC_TZ = pytz.timezone('US/Pacific')
-MAX_DAYS = 9999
+MAX_DAYS = 30
 
 
 def is_weekday(d: datetime.datetime) -> bool:
@@ -32,6 +32,11 @@ def is_weekday(d: datetime.datetime) -> bool:
 
 def weekdays_between(start: datetime.datetime, end: datetime.datetime) -> int:
   """Return the number of Pacific timezone weekdays between two UTC dates."""
+  # If the difference is big, just approximate.
+  calendar_days = (end - start).days
+  if calendar_days > MAX_DAYS:
+    return calendar_days * 5 // 7
+
   d_ptz = start.astimezone(PACIFIC_TZ)
   # The day of the request does not count.
   d_ptz = d_ptz.replace(hour=23, minute=59, second=59)

--- a/internals/slo_test.py
+++ b/internals/slo_test.py
@@ -73,11 +73,11 @@ class SLOFunctionTests(testing_config.CustomTestCase):
     self.assertEqual(0, actual)
 
   def test_weekdays_between__huge(self):
-    """We can stop counting at 9999 days."""
+    """For huge differences, we approximate."""
     start = datetime.datetime(1970, 6, 7, 12, 30, 0)
     end = datetime.datetime(2111, 6, 9, 14, 15, 10)
     actual = slo.weekdays_between(start, end)
-    self.assertEqual(9999, actual)
+    self.assertEqual(36786, actual)
 
   def test_now_utc(self):
     """This function returns a datetime."""

--- a/main.py
+++ b/main.py
@@ -120,6 +120,8 @@ api_routes: list[Route] = [
         reviews_api.GatesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/gates/<int:gate_id>',
         reviews_api.GatesAPI),
+    Route(f'{API_BASE}/gates/pending',
+        reviews_api.PendingGatesAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/approvals/comments',
         comments_api.CommentsAPI),
     Route(f'{API_BASE}/features/<int:feature_id>/approvals/<int:gate_id>/comments',


### PR DESCRIPTION
This should speed up the reviewer's dashboard loading time by reducing the variation in latency on the high end.

Previously, the way that the pending reviews box on the "my features" page was fetching data from the backend was to:
1. Run a feature query to get the features that should show up, and then after that,
2. Make N parallel API calls to get all the gates for each feature returned in step 1.
The performance was about 1s to 2s for the feature search, plus another 200ms to 500ms waiting for the majority of gate queries to return.  But, pretty often there was one gate query that took a whole second longer, maybe due to the request starting a new GAE instance.  It also led to a noticeable visual pop when it finally rendered.

In the new approach, the queries are both started immediately in parallel:
1. The features query performance is unchanged: it still takes 1s to 2s.
2. The /gates/pending query starts immediately and  takes 1.5s to 2.5s.
So, the overall average performance is about the same.  It's hard to tell because there is a lot of variation between trials.  However, doing the single larger request seems to have more consistent performance than the old approach, and much less of a visual pop.

In this PR:
* Define a new API endpoint to get pending gates.   It returns only the gates for the stages that have an active gate, which is about half of the total number of gates returned in the previous approach.  It requires a new index, I suppose that is so that the stage_id projection can be read from the index.
* Change the feature table to make the feature query request and the gates request in parallel.
* Add the new API endpoint to cs-client.js
* Change the logic for counting weekdays between the gate request and today.  Counting days one at a time in a loop was slow for a few long-abandoned gates.  Instead, now we keep the precise count up to 30 days and use a fast approximation for longer time ranges.
