### PR TITLE
Send verify accuracy emails to enterprise users

### DIFF
--- a/client-src/elements/form-definition.js
+++ b/client-src/elements/form-definition.js
@@ -695,6 +695,21 @@ const VERIFY_ACCURACY_PREPARE_TO_SHIP_FIELDS = {
   ],
 };
 
+const VERIFY_ACCURACY_ENTERPRISE_PREPARE_TO_SHIP_FIELDS = {
+  name: 'Rollout step',
+  sections: [
+    {
+      name: 'Rollout milestones',
+      fields: [
+        'rollout_milestone',
+        'rollout_platforms',
+        'rollout_details',
+        'enterprise_policies',
+      ],
+    },
+  ],
+};
+
 // A single form to display the checkbox for verifying accuracy at the end.
 export const VERIFY_ACCURACY_CONFIRMATION_FIELD = {
   name: 'Verify Accuracy',
@@ -776,6 +791,7 @@ export const VERIFY_ACCURACY_FORMS_BY_STAGE_TYPE = {
   [enums.STAGE_DEP_DEPRECATION_TRIAL]: VERIFY_ACCURACY_ORIGIN_TRIAL_FIELDS,
   [enums.STAGE_DEP_SHIPPING]: VERIFY_ACCURACY_PREPARE_TO_SHIP_FIELDS,
 
+  [enums.STAGE_ENT_ROLLOUT]: VERIFY_ACCURACY_ENTERPRISE_PREPARE_TO_SHIP_FIELDS,
   [enums.STAGE_ENT_SHIPPED]: VERIFY_ACCURACY_PREPARE_TO_SHIP_FIELDS,
 };
 

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -204,7 +204,7 @@ STAGE_DEP_REMOVE_CODE = 470
 # Note STAGE_* enum values 500-999 are reseverd for future WP processes.
 
 # Define enterprise feature processes.
-# Note: This stage can ge added to any feature that is following any process.
+# Note: This stage can be added to any feature that is following any process.
 STAGE_ENT_ROLLOUT = 1061
 STAGE_ENT_SHIPPED = 1070
 

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -171,10 +171,13 @@ class AbstractReminderHandler(basehandlers.FlaskHandler):
         relevant_stages = stages.get(
             STAGE_TYPES_BY_FIELD_MAPPING[field][feature.feature_type] or -1, [])
         for stage in relevant_stages:
-          milestones = stage.milestones
-          m = (None if milestones is None
-              else getattr(milestones,
-                  MilestoneSet.MILESTONE_FIELD_MAPPING[field]))
+          if field == 'rollout_milestone':
+            m = getattr(stage, field)
+          else:
+            milestones = stage.milestones
+            m = (None if milestones is None
+                else getattr(milestones,
+                    MilestoneSet.MILESTONE_FIELD_MAPPING[field]))
           if m is not None and m >= min_mstone and m <= max_mstone:
             if min_milestone is None:
               min_milestone = m
@@ -228,7 +231,8 @@ class FeatureAccuracyHandler(AbstractReminderHandler):
       'shipped_android_milestone',
       'shipped_ios_milestone',
       'shipped_milestone',
-      'shipped_webview_milestone']
+      'shipped_webview_milestone',
+      'rollout_milestone']
 
   def prefilter_features(
       self,

--- a/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy_enterprise.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy_enterprise.html
@@ -1,0 +1,112 @@
+
+<div style="background: #eee; padding: 0 16px 16px">
+<div style="color: #666; padding: 8px 0 0 16px;"></div>
+
+<div style="padding: 8px; background: white; border-top: 4px solid #888; border-color: #d32f2f;">
+<section id="context" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
+  <table>
+    <tr>
+      <td rowspan=2>
+  
+<div style="border: 4px solid #d32f2f; border-radius: 50%; width: 32px; height: 32px; margin-right: 8px;">
+  </div>
+
+</td>
+      <td><b>Your update is needed</b> on feature entry:</td>
+    </tr>
+    <tr>
+      <td><a style="font-size: 140%;"
+             href="http://127.0.0.1:8888/feature/123"
+             >feature one</a>
+      </td>
+    </tr>
+  </table>
+</section>
+
+
+<section id="why-triggered" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
+  
+
+  <p>
+    You are receiving this notification because you are listed as
+    an owner
+     of the ChromeStatus feature entry.
+  </p>
+</section>
+
+
+<section id="details" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
+  <p>Your feature is slated to launch soon for m110:</p>
+  <p>
+    
+
+  <table>
+
+    
+    
+      <tr><td>Origin trial desktop first</td>
+      <td>100</td></tr>
+    
+      <tr><td>Origin trial desktop last</td>
+      <td>105</td></tr>
+
+    
+    
+      <tr><td>Origin trial extension 1 end milestone</td>
+      <td>108</td></tr>
+
+    
+    
+
+  </table>
+
+  <table>
+
+    
+    
+    
+
+  </table>
+
+
+  <table>
+
+    
+    
+
+  </table>
+
+
+  <table>
+
+    
+    
+
+  </table>
+
+
+  </p>
+  <p>
+    Your feature entry is an important resource for
+    cross functional teams that help drive adoption of new features and
+    enterprise IT admins who might be affected by web platform changes.
+  </p>
+
+  <p>
+    We need to know whether your plans are changing or staying
+    the same. <strong>Please click the link below to update and confirm key
+    fields of your feature entry.</strong>
+  </p>
+</section>
+
+
+<section id="next-steps" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
+  <div><b>Your next steps:</b></div>
+
+  <div style="margin: 16px;">
+    <a href="http://127.0.0.1:8888/guide/verify_accuracy/123" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; "
+     >Verify feature accuracy</a></div>
+</section>
+
+</div>
+</div>


### PR DESCRIPTION
This change updates the logic for sending accuracy verification emails to ensure that owners of enterprise features also receive reminder emails.