### PR TITLE
Reduce the number of parallel ndb queries (w/ new index).

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -92,7 +92,8 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
     num = self.get_int_arg('num', search.DEFAULT_RESULTS_PER_PAGE)
     start = self.get_int_arg('start', 0)
 
-    show_enterprise = 'feature_type' in user_query
+    show_enterprise = (
+        'feature_type' in user_query or self.get_bool_arg('showEnterprise'))
     try:
       features_on_page, total_count = search.process_query(
           user_query, sort_spec=sort_spec, show_unlisted=show_unlisted_features,
@@ -130,7 +131,7 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
       if field in body:
         fields_dict[field] = self.format_field_val(
             field, field_type, body[field])
-    
+
     # If no enterprise notification milestone was set, set one since it will be shown in the next
     # release notes by default. This is true for breaking changes and enterprise features only.
     if ('first_enterprise_notification_milestone' in body):

--- a/client-src/elements/chromedash-feature-table.js
+++ b/client-src/elements/chromedash-feature-table.js
@@ -9,6 +9,7 @@ class ChromedashFeatureTable extends LitElement {
   static get properties() {
     return {
       query: {type: String},
+      showEnterprise: {type: Boolean},
       sortSpec: {type: String},
       showQuery: {type: Boolean},
       features: {type: Array},
@@ -30,6 +31,7 @@ class ChromedashFeatureTable extends LitElement {
   constructor() {
     super();
     this.query = '';
+    this.showEnterprise = false;
     this.sortSpec = '';
     this.showQuery = false;
     this.loading = true;
@@ -53,7 +55,8 @@ class ChromedashFeatureTable extends LitElement {
   fetchFeatures() {
     this.loading = true;
     window.csClient.searchFeatures(
-      this.query, this.sortSpec, this.start, this.num).then((resp) => {
+      this.query, this.showEnterprise, this.sortSpec,
+      this.start, this.num).then((resp) => {
       this.features = resp.features;
       this.totalCount = resp.total_count;
       this.loading = false;

--- a/client-src/elements/chromedash-myfeatures-page.js
+++ b/client-src/elements/chromedash-myfeatures-page.js
@@ -80,6 +80,7 @@ export class ChromedashMyFeaturesPage extends LitElement {
 
         <chromedash-feature-table
           query="${query}"
+          showEnterprise
           sortSpec="${sortSpec}"
           ?signedIn=${Boolean(this.user)}
           ?canEdit=${this.user && this.user.can_edit_all}
@@ -96,14 +97,14 @@ export class ChromedashMyFeaturesPage extends LitElement {
     const adminNotice = this.user?.is_admin ?
       html`<p>You see all pending approvals because you're a site admin.</p>` :
       nothing;
-    // Use feature_type>=0 to include all types, even enterprise.
+
     const pendingBox = this.renderBox(
       'Features pending my approval',
-      'pending-approval-by:me feature_type>=0',
+      'pending-approval-by:me',
       'approvals', 'gate.requested_on');
     const recentBox = this.renderBox(
       'Recently reviewed features',
-      'is:recently-reviewed feature_type>=0',
+      'is:recently-reviewed',
       'normal', '-gate.reviewed_on', false);
     return [adminNotice, pendingBox, recentBox];
   }
@@ -111,14 +112,14 @@ export class ChromedashMyFeaturesPage extends LitElement {
   renderIStarred() {
     return this.renderBox(
       'Features I starred',
-      'starred-by:me feature_type>=0',
+      'starred-by:me',
       'normal');
   }
 
   renderICanEdit() {
     return this.renderBox(
       'Features I can edit',
-      'can_edit:me feature_type>=0',
+      'can_edit:me',
       'normal');
   }
 

--- a/client-src/elements/chromedash-myfeatures-page_test.js
+++ b/client-src/elements/chromedash-myfeatures-page_test.js
@@ -65,13 +65,13 @@ describe('chromedash-myfeatures-page', () => {
 
     // "Features I can edit" sl-details exists and has a correct query
     assert.exists(featureICanEdit);
-    assert.include(
-      featureICanEdit.innerHTML, 'query="can_edit:me feature_type>=0"');
+    assert.include(featureICanEdit.innerHTML, 'query="can_edit:me"');
+    assert.include(featureICanEdit.innerHTML, 'showenterprise');
 
     // Features I starred sl-details exists and has a correct query
     assert.exists(featureIStarred);
-    assert.include(
-      featureIStarred.innerHTML, 'query="starred-by:me feature_type>=0"');
+    assert.include(featureIStarred.innerHTML, 'query="starred-by:me"');
+    assert.include(featureIStarred.innerHTML, 'showenterprise');
   });
 
   it('user has approval permission', async () => {
@@ -105,24 +105,22 @@ describe('chromedash-myfeatures-page', () => {
 
     // "Recently reviewed features" exists and has a correct query
     assert.exists(pendingReview);
-    assert.include(
-      pendingReview.innerHTML,
-      'query="pending-approval-by:me feature_type>=0"');
+    assert.include(pendingReview.innerHTML, 'query="pending-approval-by:me"');
+    assert.include(pendingReview.innerHTML, 'showenterprise');
 
     // "Features pending my approval" exists and has a correct query
     assert.exists(recentReview);
-    assert.include(
-      recentReview.innerHTML,
-      'query="is:recently-reviewed feature_type>=0"');
+    assert.include(recentReview.innerHTML, 'query="is:recently-reviewed"');
+    assert.include(recentReview.innerHTML, 'showenterprise');
 
     // "Features I can edit" sl-details exists and has a correct query
     assert.exists(featureICanEdit);
-    assert.include(
-      featureICanEdit.innerHTML, 'query="can_edit:me feature_type>=0"');
+    assert.include(featureICanEdit.innerHTML, 'query="can_edit:me"');
+    assert.include(featureICanEdit.innerHTML, 'showenterprise');
 
     // "Features I starred" sl-details exists and has a correct query
     assert.exists(featureIStarred);
-    assert.include(
-      featureIStarred.innerHTML, 'query="starred-by:me feature_type>=0"');
+    assert.include(featureIStarred.innerHTML, 'query="starred-by:me"');
+    assert.include(featureIStarred.innerHTML, 'showenterprise');
   });
 });

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -294,8 +294,11 @@ class ChromeStatusClient {
     return this.doGet(`/features?releaseNotesMilestone=${milestone}`);
   }
 
-  async searchFeatures(userQuery, sortSpec, start, num) {
+  async searchFeatures(userQuery, showEnterprise, sortSpec, start, num) {
     let url = `/features?q=${userQuery}`;
+    if (showEnterprise) {
+      url += '&showEnterprise';
+    }
     if (sortSpec) {
       url += '&sort=' + sortSpec;
     }

--- a/index.yaml
+++ b/index.yaml
@@ -283,6 +283,11 @@ indexes:
     direction: desc
 - kind: FeatureEntry
   properties:
+  - name: deleted
+  - name: unlisted
+  - name: feature_type
+- kind: FeatureEntry
+  properties:
   - name: category
   - name: updated
     direction: desc

--- a/internals/search.py
+++ b/internals/search.py
@@ -35,6 +35,25 @@ MAX_TERMS = 6
 DEFAULT_RESULTS_PER_PAGE = 100
 
 
+def process_exclude_deleted_unlisted_query() -> Future:
+  """Return a future for all features, minus deleted and unlisted."""
+  query = FeatureEntry.query(
+      FeatureEntry.deleted == False,
+      FeatureEntry.unlisted == False)
+  future_feature_ids = query.fetch_async(keys_only=True)
+  return future_feature_ids
+
+
+def process_exclude_deleted_unlisted_enterprise_query() -> Future:
+  """Return a future for all features, minus deleted, unlisted, enterprise."""
+  query = FeatureEntry.query(
+      FeatureEntry.deleted == False,
+      FeatureEntry.unlisted == False,
+      FeatureEntry.feature_type <= core_enums.FEATURE_TYPE_DEPRECATION_ID)
+  future_feature_ids = query.fetch_async(keys_only=True)
+  return future_feature_ids
+
+
 def process_pending_approval_me_query() -> list[int]:
   """Return a list of features needing approval by current user."""
   user = users.get_current_user()
@@ -115,8 +134,10 @@ TERM_RE = re.compile(
         VALUE_PATTERN, TEXT_PATTERN),
     re.I)
 
-SIMPLE_QUERY_TERMS = ['pending-approval-by:me', 'starred-by:me',
-                      'is:recently-reviewed', 'owner:me', 'editor:me', 'can_edit:me', 'cc:me']
+SIMPLE_QUERY_TERMS = [
+    'deleted_unlisted=false', 'deleted_unlisted_enterprise=false',
+    'pending-approval-by:me', 'starred-by:me',
+    'is:recently-reviewed', 'owner:me', 'editor:me', 'can_edit:me', 'cc:me']
 
 
 def process_query_term(
@@ -140,6 +161,12 @@ def process_predefined_query_term(
     field_name: str, op_str: str, val_str: str) -> Future:
   """Parse and run a simple query term."""
   query_term = field_name + op_str + val_str
+
+  if query_term == 'deleted_unlisted_enterprise=false':
+    return process_exclude_deleted_unlisted_enterprise_query()
+  if query_term == 'deleted_unlisted=false':
+    return process_exclude_deleted_unlisted_query()
+
   if query_term == 'pending-approval-by:me':
     return process_pending_approval_me_query()
   if query_term == 'starred-by:me':
@@ -210,15 +237,22 @@ def process_query(
 
   # 1b. Add permission and search scope terms.
   permission_terms = []
-  if not show_deleted:
-    permission_terms.append(('', 'deleted', '=', 'false', None))
-  # TODO(jrobbins): include unlisted features that the user is allowed to view.
-  if not show_unlisted:
-    permission_terms.append(('', 'unlisted', '=', 'false', None))
-  if not show_enterprise:
+  if not show_deleted and not show_unlisted and not show_enterprise:
     permission_terms.append(
-        ('', 'feature_type', '<=',
-         str(core_enums.FEATURE_TYPE_DEPRECATION_ID), None))
+        ('', 'deleted_unlisted_enterprise', '=', 'false', None))
+  elif not show_deleted and not show_unlisted:
+    permission_terms.append(
+        ('', 'deleted_unlisted', '=', 'false', None))
+  else:
+    if not show_deleted:
+      permission_terms.append(('', 'deleted', '=', 'false', None))
+    # TODO(jrobbins): include unlisted features that the user is allowed to view.
+    if not show_unlisted:
+      permission_terms.append(('', 'unlisted', '=', 'false', None))
+    if not show_enterprise:
+      permission_terms.append(
+          ('', 'feature_type', '<=',
+           str(core_enums.FEATURE_TYPE_DEPRECATION_ID), None))
 
   # 1c. Parse the sort directive.
   sort_spec = sort_spec or '-created.when'


### PR DESCRIPTION
This speeds up the query for features pending review by 50-250ms on staging.

Google Cloud NDB requires an index to be defined for every combination of conditions that are used in each query sent from the app.  That makes it impossible for apps that have user-defined queries to translate the user query into a single complex NDB query because the needed index would not exist.  So, our approach to running user queries is to translate each term of the user query into a single-term NDB query, run those multiple NDB queries in parallel, and then do set union and intersection in python.

Each of these parallel queries is done with `fetch_async()` so that one does not need to wait for the others.  However, once the results are returned from NDB to python, they must be decoded into python objects.  This step is CPU intensive and does not run in parallel because python is not truly multi-threaded.  Decoding each result `feature_id` takes something like 0.1ms, which adds up if we do 5 NDB queries in parallel with each one having 3000 results.

In this PR:
* We still exclude enterprise queries by default, but now we turn off that default by using an explicit query-string parameter `showEnterprise` rather than adding a tautological term to the user query (thus avoiding one parallel NDB query).
* For the two most common permission terms, we define a built-in query for each.  These built-in queries use 2 or 3 combined conditions in a single NDB query (thus avoiding one or two parallel NDB queries).