### PR TITLE
Generalize /newfeatures page via QS params.

### DIFF
--- a/client-src/elements/chromedash-all-features-page.js
+++ b/client-src/elements/chromedash-all-features-page.js
@@ -15,7 +15,12 @@ export class ChromedashAllFeaturesPage extends LitElement {
   static get properties() {
     return {
       rawQuery: {type: Object},
+      title: {type: String},
+      showQuery: {type: Boolean},
       query: {type: String},
+      columns: {type: String},
+      showEnterprise: {type: Boolean},
+      sortSpec: {type: String},
       user: {type: Object},
       start: {type: Number},
       num: {type: Number},
@@ -25,7 +30,12 @@ export class ChromedashAllFeaturesPage extends LitElement {
 
   constructor() {
     super();
+    this.title = 'Features';
+    this.showQuery = true;
     this.query = '';
+    this.columns = 'normal';
+    this.sortSpec = '';
+    this.showEnterprise = false;
     this.user = {};
     this.start = 0;
     this.num = 100;
@@ -43,15 +53,26 @@ export class ChromedashAllFeaturesPage extends LitElement {
       return;
     }
 
+    if (this.rawQuery.hasOwnProperty('title')) {
+      this.title = this.rawQuery['title'];
+      this.showQuery = false;
+    }
     if (this.rawQuery.hasOwnProperty('q')) {
       this.query = this.rawQuery['q'];
     }
-
+    if (this.rawQuery.hasOwnProperty('columns')) {
+      this.columns = this.rawQuery['columns'];
+    }
+    if (this.rawQuery.hasOwnProperty('showEnterprise')) {
+      this.showEnterprise = true;
+    }
+    if (this.rawQuery.hasOwnProperty('sort')) {
+      this.sortSpec = this.rawQuery['sort'];
+    }
     if (this.rawQuery.hasOwnProperty('start') &&
       !Number.isNaN(parseInt(this.rawQuery['start']))) {
       this.start = parseInt(this.rawQuery['start']);
     }
-
     if (this.rawQuery.hasOwnProperty('num') &&
       !Number.isNaN(parseInt(this.rawQuery['num']))) {
       this.num = parseInt(this.rawQuery['num']);
@@ -64,6 +85,13 @@ export class ChromedashAllFeaturesPage extends LitElement {
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });
+  }
+
+  refetch() {
+    const tables = this.shadowRoot.querySelectorAll('chromedash-feature-table');
+    for (const table of tables) {
+      table.refetch();
+    }
   }
 
   // Handles the Star-Toggle event fired by any one of the child components
@@ -83,30 +111,29 @@ export class ChromedashAllFeaturesPage extends LitElement {
       });
   }
 
-  renderBox(query) {
+  renderFeatureList() {
     return html`
       <chromedash-feature-table
-        .query=${query}
+        .query=${this.query}
+        ?showEnterprise=${this.showEnterprise}
+        .sortSpec=${this.sortSpec}
         .start=${this.start}
         .num=${this.num}
-        showQuery
+        ?showQuery=${this.showQuery}
         ?signedIn=${Boolean(this.user)}
         ?canEdit=${this.user && this.user.can_edit_all}
         .starredFeatures=${this.starredFeatures}
         @star-toggle-event=${this.handleStarToggle}
-        alwaysOfferPagination columns="normal">
+        alwaysOfferPagination
+        columns=${this.columns}>
       </chromedash-feature-table>
     `;
   }
 
-  renderFeatureList() {
-    return this.renderBox(this.query);
-  }
-
   render() {
     return html`
-      <div id="feature-count">
-        <h2>Features</h2>
+      <div id="content-title">
+        <h2>${this.title}</h2>
       </div>
       ${this.renderFeatureList()}
     `;

--- a/client-src/elements/chromedash-all-features-page.js
+++ b/client-src/elements/chromedash-all-features-page.js
@@ -1,4 +1,4 @@
-import {LitElement, css, html} from 'lit';
+import {LitElement, css, html, nothing} from 'lit';
 import {showToastMessage} from './utils.js';
 import './chromedash-feature-table';
 import {SHARED_STYLES} from '../css/shared-css.js';
@@ -25,6 +25,7 @@ export class ChromedashAllFeaturesPage extends LitElement {
       start: {type: Number},
       num: {type: Number},
       starredFeatures: {type: Object},
+      selectedGateId: {type: Number},
     };
   }
 
@@ -40,6 +41,7 @@ export class ChromedashAllFeaturesPage extends LitElement {
     this.start = 0;
     this.num = 100;
     this.starredFeatures = new Set();
+    this.selectedGateId = 0;
   }
 
   connectedCallback() {
@@ -124,6 +126,7 @@ export class ChromedashAllFeaturesPage extends LitElement {
         ?canEdit=${this.user && this.user.can_edit_all}
         .starredFeatures=${this.starredFeatures}
         @star-toggle-event=${this.handleStarToggle}
+        selectedGateId=${this.selectedGateId}
         alwaysOfferPagination
         columns=${this.columns}>
       </chromedash-feature-table>
@@ -131,10 +134,15 @@ export class ChromedashAllFeaturesPage extends LitElement {
   }
 
   render() {
+    const adminNotice = (this.user?.is_admin && this.columns === 'approvals') ?
+      html`<p>You see all pending approvals because you're a site admin.</p>` :
+      nothing;
+
     return html`
       <div id="content-title">
         <h2>${this.title}</h2>
       </div>
+      ${adminNotice}
       ${this.renderFeatureList()}
     `;
   }

--- a/client-src/elements/chromedash-all-features-page_test.js
+++ b/client-src/elements/chromedash-all-features-page_test.js
@@ -86,7 +86,8 @@ describe('chromedash-all-features-page', () => {
     assert.exists(featureTableEl);
 
     // title exists
-    const titleEl = component.shadowRoot.querySelector('div#feature-count');
-    assert.include(titleEl.innerHTML, '<h2>Features</h2>');
+    const titleEl = component.shadowRoot.querySelector('div#content-title');
+    assert.include(titleEl.innerHTML, '<h2>');
+    assert.include(titleEl.innerHTML, 'Features</h2>');
   });
 });


### PR DESCRIPTION
This is a step toward being ready to split the /myfeatures page into separate pages that are basically just /newfeatures with a lot of query-string parameters.  

The reason for doing this is because with only a single table on the page, it can load faster than the /myfeatures page.  The feature owners never used any of the other boxes anyway.  With this change, this new functionality will be available at a specific URL that has no navigation link to it yet.  After I am sure that all four boxes can be replaced, I will replace the main menu navigation link to /myfeatures with four links to /newfeatures.

In this PR:
* Allow title, showQuery, columns, showEnterprise, and sort to be passed into the /newfeatures page via qs-params.
* Add a `refetch()` method so that if any editing it done via a gate column, the table content will reload (same as /myfeatures)
* Simplify the rendering functions since `renderBox()` was only called once.
* Add a property for the selected gate so that it can be highlighted after the user clicks on it, and display a message to explain why some users see more pending reviews than other users.

