### PR TITLE
Make sorting use the earliest matches rather than the last.

### DIFF
--- a/internals/search.py
+++ b/internals/search.py
@@ -220,7 +220,15 @@ def _sort_by_total_order(
   value itself as the sorting value, which will effectively put those
   features at the end of the list in order of creation.
   """
-  total_order_dict = {f_id: idx for idx, f_id in enumerate(total_order_ids)}
+  total_order_dict = {}
+  # For each feature entry ID in the total-order list, record the index of
+  # the first time that it occurs.  A feature could be in the list multiple
+  # times if it was produced via a join.  E.g., sorting by gate.requested_on
+  # would have total_order_ids items for every gate, not just one per feature.
+  for idx, f_id in enumerate(total_order_ids):
+    if f_id not in total_order_dict:
+      total_order_dict[f_id] = idx
+
   sorted_id_list = sorted(
       result_id_list,
       key=lambda f_id: total_order_dict.get(f_id, f_id))

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -302,6 +302,14 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     actual = search._sort_by_total_order(feature_ids, total_order_ids)
     self.assertEqual([10, 9, 4, 1, 997, 998, 999], actual)
 
+  def test_sort_by_total_order__multiple_items(self):
+    """If the sort order is done via join, the total_order could have
+    multiple copies of the same feature IDs.  We use the earliest."""
+    feature_ids = [10, 1, 9, 4]
+    total_order_ids = [10, 9, 8, 7, 9, 6, 10, 5, 8, 4, 7, 3, 9, 6, 2, 1, 1, 4]
+    actual = search._sort_by_total_order(feature_ids, total_order_ids)
+    self.assertEqual([10, 9, 4, 1], actual)
+
   @mock.patch('internals.search.process_pending_approval_me_query')
   @mock.patch('internals.search.process_starred_me_query')
   @mock.patch('internals.search_queries.handle_me_query_async')


### PR DESCRIPTION
This fixes a minor bug in the way that we sort features that are pending review and that have multiple reviews pending.  

Specifically, if feature One had a review requested, then feature Two had a review requested, and then much later feature One had a review requested on a different gate, then the sorted order should be [One, Two] because One's first review request came before Two's first request.  We want feature One to stay at the top of the reviewers' dashboard because it has had a gate pending the longest.  We don't want it to drop to the end of the dashboard where it might not be addressed for longer.

The way sorting works is to do a DB query to get a total order of all features in the DB according to some sort order criteria.  If that sort order is based on a field in the FeatureEntry entity kind, then the total order list will naturally have each feature ID exactly once.  However, if the total order is produced by getting the feature_id field of a different entity kind, like Gate, then there would be one copy of the feature ID for each gate on that feature.  In such cases, it makes sense to use the earliest one to sort the overall list features.

In this PR:
* Build the sorting index table using a for-loop that implicitly uses the first occurrence of each feature ID rather than the old code which implicitly used the last.
