### PR TITLE
Close the preflight dialog after proceeding.

### DIFF
--- a/client-src/elements/chromedash-preflight-dialog.js
+++ b/client-src/elements/chromedash-preflight-dialog.js
@@ -133,6 +133,12 @@ export class ChromedashPreflightDialog extends LitElement {
     this.hide();
   }
 
+  handleProceed() {
+    // The button opens a new tab due to the href and target attrs.
+    // Also, close this dialog, so it is gone when the user returns.
+    this.hide();
+  }
+
   renderEditLink(stage, feStage, pi) {
     if (pi.field && stage && feStage) {
       return html`
@@ -193,8 +199,9 @@ export class ChromedashPreflightDialog extends LitElement {
          `)}
       </ol>
 
-      <sl-button href="${this.url}" target="_blank" size="small">
-        Proceed anyway
+      <sl-button href="${this.url}" target="_blank" size="small"
+          @click=${this.handleProceed}
+        >Proceed anyway
       </sl-button>
       <sl-button size="small" variant="warning"
           @click=${this.handleCancel}


### PR DESCRIPTION
This avoids a minor annoyance I have with the preflight dialog.

Right now, when the user tries to generate an intent, they get the preflight dialog.  They click "Proceed anyway" and that opens a new tab where they copy the intent body.  Then the user eventually closes that intent tab and comes back to the original tab.  The dialog box is still there, blocking the content of the page.  The user needs to click outside the dialog box to dismiss it.

In this PR:
* Automatically close the dialog when the user clicks to proceed.