### PR TITLE
Reload feature table without blanking.

### DIFF
--- a/client-src/css/_flexbox-css.js
+++ b/client-src/css/_flexbox-css.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {css} from 'lit';
+
+/**
+ * Flexbox layout helper classes.
+ *
+ * This is a simplified version of the flexbox layout helper classes from
+ * https://htmlpreview.github.io/?https://raw.githubusercontent.com/dlaliberte/standards-notes/master/flexbox-classes.html
+ */
+export const FLEX_BOX = css`
+  .hbox,
+  .vbox {
+    display: flex;
+    align-items: center;
+  }
+
+  .hbox {
+    flex-direction: row;
+  }
+  .vbox {
+    flex-direction: column;
+  }
+
+  .hbox > .spacer,
+  .vbox > .spacer {
+    flex-grow: 1;
+    visibility: hidden;
+  }
+`;

--- a/client-src/css/shared-css.js
+++ b/client-src/css/shared-css.js
@@ -1,10 +1,12 @@
 import {css} from 'lit';
 import {VARS} from './_vars-css.js';
 import {RESET} from './_reset-css.js';
+import {FLEX_BOX} from './_flexbox-css.js';
 
 export const SHARED_STYLES = [
   VARS,
   RESET,
+  FLEX_BOX,
   css`
 
   * {

--- a/client-src/elements/chromedash-feature-table.js
+++ b/client-src/elements/chromedash-feature-table.js
@@ -15,6 +15,7 @@ class ChromedashFeatureTable extends LitElement {
       features: {type: Array},
       totalCount: {type: Number},
       loading: {type: Boolean},
+      reloading: {type: Boolean},
       start: {type: Number},
       num: {type: Number},
       alwaysOfferPagination: {type: Boolean},
@@ -35,6 +36,7 @@ class ChromedashFeatureTable extends LitElement {
     this.sortSpec = '';
     this.showQuery = false;
     this.loading = true;
+    this.reloading = false;
     this.starredFeatures = new Set();
     this.features = [];
     this.totalCount = 0;
@@ -54,12 +56,14 @@ class ChromedashFeatureTable extends LitElement {
 
   fetchFeatures(isInitialLoad=false) {
     this.loading = isInitialLoad;
+    this.reloading = !isInitialLoad;
     window.csClient.searchFeatures(
       this.query, this.showEnterprise, this.sortSpec,
       this.start, this.num).then((resp) => {
       this.features = resp.features;
       this.totalCount = resp.total_count;
       this.loading = false;
+      this.reloading = false;
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });
@@ -219,7 +223,9 @@ class ChromedashFeatureTable extends LitElement {
     }
 
     return html`
-      <div class="pagination">
+      <div class="pagination hbox">
+        <span>${this.reloading ? 'Reloading...' : nothing}</span>
+        <div class="spacer"></div>
         <span>${firstShown} - ${lastShown} of ${this.totalCount}</span>
         <sl-icon-button
           library="material" name="navigate_before"

--- a/client-src/elements/chromedash-feature-table.js
+++ b/client-src/elements/chromedash-feature-table.js
@@ -129,9 +129,6 @@ class ChromedashFeatureTable extends LitElement {
       .pagination {
         padding: var(--content-padding-half) 0;
         min-height: 50px;
-        display: flex;
-        align-items: center;
-        justify-content: end;
       }
       .pagination span {
         color: var(--unimportant-text-color);

--- a/client-src/elements/chromedash-feature-table.js
+++ b/client-src/elements/chromedash-feature-table.js
@@ -49,11 +49,11 @@ class ChromedashFeatureTable extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.fetchFeatures();
+    this.fetchFeatures(true);
   }
 
-  fetchFeatures() {
-    this.loading = true;
+  fetchFeatures(isInitialLoad=false) {
+    this.loading = isInitialLoad;
     window.csClient.searchFeatures(
       this.query, this.showEnterprise, this.sortSpec,
       this.start, this.num).then((resp) => {


### PR DESCRIPTION
One of the API owners complained that it the feature review dashboard seemed slow because it reloaded everything after every vote.  I think that it does need to reload the data to reflect the impact of that user's vote and any other recent votes.  However, it does not need to make the user wait while it reloads.

Currently, the table shows shimmering skeleton elements whenever the data is loading or reloading.   We only show a few rows of skeletons, so it does not match the layout of the actual data at all.   This causes a lot of visual disruption on the page.

Instead, we can limit the skeletons to the initial loading process. When reloading, we can simply continue to display the old data until the new data arrives.  Lit renders the data very quickly with no blank state between the old and new data.

In this PR:
* Only set `this.loading` during the initial loading process.
* Track a new property `this.reloading` and make it show a simple text indicator "Reloading..." when reloading.
* Position the reloading indicator on the same row as the pagination, so that there is no visual pop.   Small boxes on the myfeatures page that don't show pagination will also not show the reloading indicator, which is nice because it is not needed in that case.  But, it will always show up on the newfeatures list page because that always shows pagination.
* Add CSS rules for a simple version of `hbox`, `vbox`, and `spacer` based on what we are using for the other dashboard.

