### PR TITLE
Improve support for quick-OR.

### DIFF
--- a/client-src/elements/chromedash-search-help-dialog.js
+++ b/client-src/elements/chromedash-search-help-dialog.js
@@ -81,7 +81,10 @@ export class ChromedashSearchHelpDialog extends LitElement {
             '-feature_type="Feature deprecation"'],
           'Features of a specific type or excluding a type.')}
         ${this.renderExampleRow(
-          ['category="CSS" OR category="DOM"'],
+          ['category=CSS,DOM'],
+          'Features that have a value in a comma-separated list.')}
+        ${this.renderExampleRow(
+          ['category=CSS OR category=DOM'],
           'Combine two query clauses with a logical-OR.')}
       </table>
       </section>
@@ -101,14 +104,16 @@ export class ChromedashSearchHelpDialog extends LitElement {
       searching for wildcards, partial words, punctuation, or quoted phrases.</p>
 
       <p>When searching using conditions, each condition consists of three
-      parts: FIELD OPERATOR VALUE</p>
+      parts: FIELD OPERATOR VALUE(S)</p>
 
       <ul>
         <li>FIELD: One of the fields listed below.</li>
         <li>OPERATOR: Usually an equals sign, but it can be an
             inequality for numeric, date, or enum fields.</li>
-        <li>VALUE: A single word, number, date, or one
-            of the quoted enum value listed below.</li>
+        <li>VALUE(S): A single word, number, date, or enum value listed below.
+            If the value contains spaces, it must be inside double quotes.
+            Use the equals operator with a comma-separated list to match
+            any value in that list.</li>
       </ul>
 
       <p>You may negate any seearch term by prefixing it with a minus sign.
@@ -137,7 +142,7 @@ export class ChromedashSearchHelpDialog extends LitElement {
     } else {
       return html`
         <tr>
-          <td><code>${queryField.name}=<i>${queryField.kind}</code></td>
+          <td><code>${queryField.name}=<i>${queryField.kind}</i></code></td>
           <td>${queryField.doc}</td>
         </tr>
       `;

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -65,6 +65,21 @@ class SearchRETest(testing_config.CustomTestCase):
         [('OR ', 'flag_name', '=', 'enable-super-stuff', '')],
         search.TERM_RE.findall('OR flag_name=enable-super-stuff '))
 
+  def test_structured_query_terms__quick_or(self):
+    """We can parse queries that use quick-OR syntax for multiple values."""
+    self.assertEqual(
+        [('', 'field', '=', 'value1,value2,value3', '')],
+        search.TERM_RE.findall('field=value1,value2,value3 '))
+    self.assertEqual(
+        [('', 'field', '=', '1,2,3', '')],
+        search.TERM_RE.findall('field=1,2,3 '))
+    self.assertEqual(
+        [('', 'field', '=', '"one","two","three"', '')],
+        search.TERM_RE.findall('field="one","two","three" '))
+    self.assertEqual(
+        [('', 'field', '=', '"enum one","enum two","enum three"', '')],
+        search.TERM_RE.findall('field="enum one","enum two","enum three" '))
+
   def test_text_terms(self):
     """We can parse text terms."""
     self.assertEqual(


### PR DESCRIPTION
This resolves a long-standing TODO comment in the code by implementing better support for the quick-OR syntax in search queries.

The quick-OR syntax allows users to enter a search term that has multiple values listed with commas.  For example:
`category=CSS,DOM,Miscellaneous`. This is easier to type and combines better with other terms that always using the top-level `OR` keyword.

In this PR:
* Update the search help dialog to explain and give examples of value lists.  Also, fix unclosed `<i>` tag.
* Parse values that contain a comma separated list of individual values.  Specifically, allow a comma-separated list of items that are themselves quoted strings.
* Move the previous partial support for splitting on commas up to a higher level in the call stack so that values are split sooner and enum values are looked up for each item in the list.
* Enforce that quick-OR can only be used with the `=` operator and log a note when it any other operator is used with a list.