### PR TITLE
After editing, always navigate to feature detail page.

### DIFF
--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -102,7 +102,6 @@ class ChromedashApp extends LitElement {
       appTitle: {type: String},
       googleSignInClientId: {type: String},
       devMode: {type: String},
-      priorPage: {type: String},
       currentPage: {type: String},
       bannerMessage: {type: String},
       bannerTime: {type: Number},
@@ -122,7 +121,6 @@ class ChromedashApp extends LitElement {
     this.appTitle = '';
     this.googleSignInClientId = '',
     this.devMode = '';
-    this.priorPage = '';
     this.currentPage = '';
     this.bannerMessage = '';
     this.bannerTime = null;
@@ -287,7 +285,6 @@ class ChromedashApp extends LitElement {
     if (shouldSetContext) {
       this.contextLink = ctx.path;
     }
-    this.priorPage = this.currentPage;
     this.currentPage = ctx.path;
     if (shouldHideSidebar) {
       this.hideSidebar();
@@ -394,7 +391,6 @@ class ChromedashApp extends LitElement {
       if (!this.setupNewPage(ctx, 'chromedash-guide-editall-page')) return;
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.appTitle = this.appTitle;
-      this.pageComponent.nextPage = this.priorPage;
     });
     page('/guide/verify_accuracy/:featureId(\\d+)', (ctx) => {
       if (!this.setupNewPage(
@@ -406,7 +402,6 @@ class ChromedashApp extends LitElement {
       if (!this.setupNewPage(ctx, 'chromedash-guide-stage-page')) return;
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.intentStage = parseInt(ctx.params.intentStage);
-      this.pageComponent.nextPage = this.priorPage;
       this.pageComponent.appTitle = this.appTitle;
     });
     page('/guide/stage/:featureId(\\d+)/:intentStage(\\d+)/:stageId(\\d+)', (ctx) => {
@@ -414,14 +409,12 @@ class ChromedashApp extends LitElement {
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.stageId = parseInt(ctx.params.stageId);
       this.pageComponent.intentStage = parseInt(ctx.params.intentStage);
-      this.pageComponent.nextPage = this.priorPage;
       this.pageComponent.appTitle = this.appTitle;
     });
     page('/ot_creation_request/:featureId(\\d+)/:stageId(\\d+)', (ctx) => {
       if (!this.setupNewPage(ctx, 'chromedash-ot-creation-page')) return;
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.stageId = parseInt(ctx.params.stageId);
-      this.pageComponent.nextPage = this.priorPage;
       this.pageComponent.appTitle = this.appTitle;
       this.pageComponent.userEmail = this.user.email;
     });
@@ -429,14 +422,12 @@ class ChromedashApp extends LitElement {
       if (!this.setupNewPage(ctx, 'chromedash-ot-extension-page')) return;
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.stageId = parseInt(ctx.params.stageId);
-      this.pageComponent.nextPage = this.priorPage;
       this.pageComponent.appTitle = this.appTitle;
       this.pageComponent.userEmail = this.user.email;
     });
     page('/guide/stage/:featureId(\\d+)/metadata', (ctx) => {
       if (!this.setupNewPage(ctx, 'chromedash-guide-metadata-page')) return;
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
-      this.pageComponent.nextPage = this.priorPage;
       this.pageComponent.appTitle = this.appTitle;
     });
     page('/settings', (ctx) => {

--- a/client-src/elements/chromedash-guide-editall-page.js
+++ b/client-src/elements/chromedash-guide-editall-page.js
@@ -45,7 +45,6 @@ export class ChromedashGuideEditallPage extends LitElement {
       feature: {type: Object},
       loading: {type: Boolean},
       appTitle: {type: String},
-      nextPage: {type: String},
       nextStageToCreateId: {type: Number},
       fieldValues: {type: Array},
     };
@@ -57,7 +56,6 @@ export class ChromedashGuideEditallPage extends LitElement {
     this.feature = {};
     this.loading = true;
     this.appTitle = '';
-    this.nextPage = '';
     this.previousStageTypeRendered = 0;
     this.sameTypeRendered = 0;
     this.nextStageToCreateId = 0;
@@ -161,13 +159,7 @@ export class ChromedashGuideEditallPage extends LitElement {
   }
 
   getNextPage() {
-    if (this.nextPage) {
-      return this.nextPage;
-    }
-    if (this.feature.is_enterprise_feature) {
-      return `/feature/${this.featureId}`;
-    }
-    return `/guide/edit/${this.featureId}`;
+    return `/feature/${this.featureId}`;
   }
 
   renderSubheader() {

--- a/client-src/elements/chromedash-guide-editall-page_test.js
+++ b/client-src/elements/chromedash-guide-editall-page_test.js
@@ -118,7 +118,7 @@ describe('chromedash-guide-editall-page', () => {
     const subheaderDiv = component.shadowRoot.querySelector('div#subheader');
     assert.exists(subheaderDiv);
     // subheader title is correct and clickable
-    assert.include(subheaderDiv.innerHTML, 'href="/guide/edit/123456"');
+    assert.include(subheaderDiv.innerHTML, 'href="/feature/123456"');
     assert.include(subheaderDiv.innerHTML, 'Edit feature:');
 
     // feature form, hidden token field, and submit/cancel buttons exist

--- a/client-src/elements/chromedash-guide-metadata-page.js
+++ b/client-src/elements/chromedash-guide-metadata-page.js
@@ -27,7 +27,6 @@ export class ChromedashGuideMetadataPage extends LitElement {
       feature: {type: Object},
       loading: {type: Boolean},
       appTitle: {type: String},
-      nextPage: {type: String},
       fieldValues: {type: Array},
     };
   }
@@ -38,7 +37,6 @@ export class ChromedashGuideMetadataPage extends LitElement {
     this.feature = {};
     this.loading = true;
     this.appTitle = '';
-    this.nextPage = '';
     this.fieldValues = [];
   }
 
@@ -89,7 +87,7 @@ export class ChromedashGuideMetadataPage extends LitElement {
       hiddenTokenField.value = window.csClient.token;
       return csClient.updateFeature(submitBody);
     }).then(() => {
-      window.location.href = this.nextPage || `/guide/edit/${this.featureId}`;
+      window.location.href = `/feature/${this.featureId}`;
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });
@@ -109,7 +107,7 @@ export class ChromedashGuideMetadataPage extends LitElement {
   };
 
   handleCancelClick() {
-    window.location.href = `/guide/edit/${this.featureId}`;
+    window.location.href = `/feature/${this.featureId}`;
   }
 
   // get a comma-spearated list of field names
@@ -142,7 +140,7 @@ export class ChromedashGuideMetadataPage extends LitElement {
   }
 
   getNextPage() {
-    return this.nextPage || `/guide/edit/${this.featureId}`;
+    return `/feature/${this.featureId}`;
   }
 
   renderSubheader() {

--- a/client-src/elements/chromedash-guide-metadata.js
+++ b/client-src/elements/chromedash-guide-metadata.js
@@ -100,7 +100,7 @@ export class ChromedashGuideMetadata extends LitElement {
       hiddenTokenField.value = window.csClient.token;
       return csClient.updateFeature(submitBody);
     }).then(() => {
-      window.location.href = this.nextPage || `/guide/edit/${this.feature.id}`;
+      window.location.href = `/feature/${this.feature.id}`;
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });

--- a/client-src/elements/chromedash-guide-stage-page.js
+++ b/client-src/elements/chromedash-guide-stage-page.js
@@ -40,7 +40,6 @@ export class ChromedashGuideStagePage extends LitElement {
       implStatusOffered: {type: String},
       loading: {type: Boolean},
       appTitle: {type: String},
-      nextPage: {type: String},
       fieldValues: {type: Array},
     };
   }
@@ -58,7 +57,6 @@ export class ChromedashGuideStagePage extends LitElement {
     this.implStatusOffered = '';
     this.loading = true;
     this.appTitle = '';
-    this.nextPage = '';
     this.fieldValues = [];
   }
 
@@ -135,7 +133,7 @@ export class ChromedashGuideStagePage extends LitElement {
       hiddenTokenField.value = window.csClient.token;
       return csClient.updateFeature(submitBody);
     }).then(() => {
-      window.location.href = this.nextPage || `/guide/edit/${this.featureId}`;
+      window.location.href = `/feature/${this.featureId}`;
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });
@@ -181,7 +179,7 @@ export class ChromedashGuideStagePage extends LitElement {
   }
 
   getNextPage() {
-    return this.nextPage || `/guide/edit/${this.featureId}`;
+    return `/feature/${this.featureId}`;
   }
 
   renderSubheader() {
@@ -355,7 +353,7 @@ export class ChromedashGuideStagePage extends LitElement {
         </chromedash-form-table>
         <div class="final_buttons">
           <input id='submit-button' class="button" type="submit" value="Submit">
-          <button id="cancel-button" @click=${this.handleCancelClick}>Cancel</button>
+          <button id="cancel-button" type="reset" @click=${this.handleCancelClick}>Cancel</button>
         </div>
       </form>
     `;

--- a/client-src/elements/chromedash-guide-stage-page_test.js
+++ b/client-src/elements/chromedash-guide-stage-page_test.js
@@ -136,7 +136,7 @@ describe('chromedash-guide-stage-page', () => {
     const subheaderDiv = component.shadowRoot.querySelector('div#subheader');
     assert.exists(subheaderDiv);
     // subheader title is correct and clickable
-    assert.include(subheaderDiv.innerHTML, 'href="/guide/edit/123456"');
+    assert.include(subheaderDiv.innerHTML, 'href="/feature/123456"');
     assert.include(subheaderDiv.innerHTML, 'Edit feature:');
 
     // feature form, hidden token field, and submit/cancel buttons exist

--- a/client-src/elements/chromedash-guide-verify-accuracy-page.js
+++ b/client-src/elements/chromedash-guide-verify-accuracy-page.js
@@ -88,7 +88,7 @@ export class ChromedashGuideVerifyAccuracyPage extends LitElement {
       hiddenTokenField.value = window.csClient.token;
       return csClient.updateFeature(submitBody);
     }).then(() => {
-      window.location.href = this.nextPage || `/guide/edit/${this.featureId}`;
+      window.location.href = `/feature/${this.featureId}`;
     }).catch(() => {
       showToastMessage('Some errors occurred. Please refresh the page or try again later.');
     });

--- a/client-src/elements/chromedash-ot-creation-page.js
+++ b/client-src/elements/chromedash-ot-creation-page.js
@@ -30,7 +30,6 @@ export class ChromedashOTCreationPage extends LitElement {
       feature: {type: Object},
       loading: {type: Boolean},
       appTitle: {type: String},
-      nextPage: {type: String},
       fieldValues: {type: Array},
       showApprovalsFields: {type: Boolean},
     };
@@ -43,7 +42,6 @@ export class ChromedashOTCreationPage extends LitElement {
     this.feature = {};
     this.loading = true;
     this.appTitle = '';
-    this.nextPage = '';
     this.fieldValues = [];
     this.showApprovalsFields = false;
   }
@@ -198,7 +196,7 @@ export class ChromedashOTCreationPage extends LitElement {
     window.csClient.updateStage(this.featureId, this.stageId, stageSubmitBody).then(() => {
       showToastMessage('Creation request submitted!');
       setTimeout(() => {
-        window.location.href = this.nextPage || `/feature/${this.featureId}`;
+        window.location.href = `/feature/${this.featureId}`;
       }, 1000);
     });
   }
@@ -227,7 +225,7 @@ export class ChromedashOTCreationPage extends LitElement {
   }
 
   getNextPage() {
-    return this.nextPage || `/feature/${this.featureId}`;
+    return `/feature/${this.featureId}`;
   }
 
   renderSubheader() {
@@ -283,7 +281,7 @@ export class ChromedashOTCreationPage extends LitElement {
             class="button"
             type="submit"
             value="Submit">
-          <button id="cancel-button" @click=${this.handleCancelClick}>Cancel</button>
+          <button id="cancel-button" type="reset" @click=${this.handleCancelClick}>Cancel</button>
         </div>
       </form>
     `;

--- a/client-src/elements/chromedash-ot-extension-page.js
+++ b/client-src/elements/chromedash-ot-extension-page.js
@@ -31,7 +31,6 @@ export class ChromedashOTExtensionPage extends LitElement {
       feature: {type: Object},
       loading: {type: Boolean},
       appTitle: {type: String},
-      nextPage: {type: String},
       fieldValues: {type: Array},
     };
   }
@@ -43,7 +42,6 @@ export class ChromedashOTExtensionPage extends LitElement {
     this.feature = {};
     this.loading = true;
     this.appTitle = '';
-    this.nextPage = '';
     this.fieldValues = [];
   }
 
@@ -117,11 +115,11 @@ export class ChromedashOTExtensionPage extends LitElement {
       showToastMessage('Extension request started!');
       if (!newStageId || !gate) {
         setTimeout(() => {
-          window.location.href = this.nextPage || `/feature/${this.featureId}`;
+          window.location.href = `/feature/${this.featureId}`;
         }, 1000);
       } else {
         setTimeout(() => {
-          window.location.href = this.nextPage || `/feature/${this.featureId}?gate=${gate.id}`;
+          window.location.href = `/feature/${this.featureId}?gate=${gate.id}`;
         }, 1000);
       }
     }).catch(() => {
@@ -153,7 +151,7 @@ export class ChromedashOTExtensionPage extends LitElement {
   }
 
   getNextPage() {
-    return this.nextPage || `/feature/${this.featureId}`;
+    return `/feature/${this.featureId}`;
   }
 
   renderSubheader() {
@@ -252,7 +250,7 @@ export class ChromedashOTExtensionPage extends LitElement {
             class="button"
             type="submit"
             value="Submit">
-          <button id="cancel-button" @click=${this.handleCancelClick}>Cancel</button>
+          <button id="cancel-button" type="reset" @click=${this.handleCancelClick}>Cancel</button>
         </div>
       </form>
     `;


### PR DESCRIPTION
This is a step toward phasing out the Guide UX.

After using one of the stage editing forms or the metadata editing page, always navigate back to the feature detail page rather than the guide edit page.  This will encourage users to go directly from the feature detail page to the stage editing pages by using the "Edit fields" button rather than the pencil icon that takes them through the Guide UX.

In this PR:
+ Eliminate the concept of `nextPage` and the `priorPage` variable that was needed to se the value of `nextPage`.
+ Simplify the logic for handling navigation after the submit or cancel button is pressed.
+ Clarify that the cancel button is for resetting / abandoning changes rather than submitting them.