### PR TITLE
Validate Chromium inputs for OT creation (UI)

### DIFF
--- a/client-src/elements/chromedash-ot-creation-page.js
+++ b/client-src/elements/chromedash-ot-creation-page.js
@@ -274,13 +274,13 @@ export class ChromedashOTCreationPage extends LitElement {
       field.checkMessage = nothing;
       return false;
     }
-    const webfeatureUseCounterName = this.fieldValues.find(
-      field => field.name === 'ot_webfeature_use_counter').value;
+    const chromiumTrialName = this.fieldValues.find(
+      field => field.name === 'ot_chromium_trial_name').value;
     if (!this.gracePeriodFile) {
       this.gracePeriodFile = await this.getChromiumFile(GRACE_PERIOD_FILE);
     }
     const includedInGracePeriodArray = this.gracePeriodFile.includes(
-      `blink::mojom::OriginTrialFeature::${webfeatureUseCounterName}`);
+      `blink::mojom::OriginTrialFeature::k${chromiumTrialName}`);
     if (!includedInGracePeriodArray) {
       field.checkMessage = html`
         <br>

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -1242,7 +1242,10 @@ export const ALL_FIELDS = {
     help_text: html`
       Whether this trial supports third party origins. See
       <a href="https://web.dev/third-party-origin-trials/">this article</a>
-      for more information.`,
+      for more information. The feature should have "origin_trial_allows_third_party"
+      set to "true" in <a target="_blank"
+      href="https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/renderer/platform/runtime_enabled_features.json5"
+      >runtime_enabled_features.json5</a>`,
   },
 
   'ot_is_critical_trial': {
@@ -1252,7 +1255,10 @@ export const ALL_FIELDS = {
     help_text: html`
       See <a href="https://goto.google.com/running-an-origin-trial"
       >go/running-an-origin-trial</a>
-      for criteria and additional process requirements.`,
+      for criteria and additional process requirements.
+      The feature name must be added to the "kHasExpiryGracePeriod" array in <a target="_blank"
+      href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/common/origin_trials/manual_completion_origin_trial_features.cc"
+      >manual_completion_origin_trial_features.cc</a>`,
   },
 
   'ot_is_deprecation_trial': {
@@ -1283,8 +1289,9 @@ export const ALL_FIELDS = {
     label: 'WebFeature UseCounter name',
     help_text: html`
     For measuring usage, this must be a single named value from the
-    WebFeature enum, e.g. kWorkerStart. See
-    <a href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/use_counter/metrics/web_feature.mojom"
+    WebFeature enum, e.g. kWorkerStart. The use counter must be landed in
+    <a target="_blank"
+      href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/use_counter/metrics/web_feature.mojom"
     >web_feature.mojom</a>.`,
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@polymer/iron-collapse": "^3.0.1",
         "@polymer/iron-icon": "^3.0.1",
         "@polymer/iron-iconset-svg": "^3.0.1",
+        "json5": "^2.2.3",
         "lit": "^3",
         "node-fetch": ">=3.3.2",
         "page": "^1.11.6",
@@ -9127,7 +9128,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -19943,8 +19943,7 @@
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonfile": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@polymer/iron-collapse": "^3.0.1",
     "@polymer/iron-icon": "^3.0.1",
     "@polymer/iron-iconset-svg": "^3.0.1",
+    "json5": "^2.2.3",
     "lit": "^3",
     "node-fetch": ">=3.3.2",
     "page": "^1.11.6",


### PR DESCRIPTION
This PR adds a number of checks when the user attempts to submit an OT Creation request that validates the input is in the correct format in accordance with the Chromium code. This PR does not include these checks server-side, which will come in a later PR.

Checks each of these params are set up in Chromium:
- Webfeature UseCounter
- Chromium trial name
- Third-party support setting
- Critical trial grace period setting

This is checked by obtaining the Chromium file contents and ensuring the files contain the given information as expected.

Some of the definitions of the form fields have been updated to include links to the files that require the data be added.

Note: These checks are handled on a submission attempt, so they are not handled through the semantic checks process, which is processed after each input change.

![Screenshot 2024-04-10 at 11 59 16 AM](https://github.com/GoogleChrome/chromium-dashboard/assets/56164590/4a6694fd-6e4b-4e9d-bab1-5b9845b50774)


https://github.com/GoogleChrome/chromium-dashboard/assets/56164590/0a7ee267-79e3-4ae4-bfed-540030fa1182

