### PR TITLE
Check that Chromium trial name not used by other OTs

### DIFF
--- a/client-src/elements/chromedash-ot-creation-page.js
+++ b/client-src/elements/chromedash-ot-creation-page.js
@@ -222,11 +222,20 @@ export class ChromedashOTCreationPage extends LitElement {
       const enabledFeaturesFileText = await this.getChromiumFile(ENABLED_FEATURES_FILE_URL);
       this.enabledFeaturesJson = json5.parse(enabledFeaturesFileText);
     }
+    const existingTrials = await window.csClient.getOriginTrials();
+
     if (!this.enabledFeaturesJson.data.some(
       feature => feature.origin_trial_feature_name === field.value)) {
       field.checkMessage = html`
         <span class="check-error">
           <b>Error</b>: Name not found in file.
+        </span>`;
+      return true;
+    } else if (existingTrials.some(
+      trial => trial.origin_trial_feature_name === field.value)) {
+      field.checkMessage = html`
+        <span class="check-error">
+          <b>Error</b>: This name is used by an existing origin trial.
         </span>`;
       return true;
     } else {

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -367,6 +367,10 @@ class ChromeStatusClient {
   }
 
   // Origin trials API
+  async getOriginTrials() {
+    return this.doGet('/origintrials');
+  }
+
   async extendOriginTrial(featureId, stageId, body) {
     return this.doPost(`/origintrials/${featureId}/${stageId}/extend`, body);
   }


### PR DESCRIPTION
This adds an additional check for OT creation to make sure that the Chromium trial name that is provided by the user is not already designated and in use by an existing origin trial.