### PR TITLE
(OT Extension) pass end milestone as string data type

### DIFF
--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -62,7 +62,7 @@ def get_trials_list() -> list[dict[str, Any]]:
   return trials_list
 
 
-def _get_trial_end_time(end_milestone: str) -> int:
+def _get_trial_end_time(end_milestone: int) -> int:
   """Get the end time of the origin trial based on end milestone.
 
   Returns:
@@ -111,7 +111,7 @@ def _get_ot_access_token() -> str:
   return credentials.token
 
 
-def extend_origin_trial(trial_id: str, end_milestone: str, intent_url: str):
+def extend_origin_trial(trial_id: str, end_milestone: int, intent_url: str):
   """Extend an existing origin trial.
 
   Raises:
@@ -136,13 +136,14 @@ def extend_origin_trial(trial_id: str, end_milestone: str, intent_url: str):
     'end_date': {
       'seconds': end_seconds
     },
-    'milestone_end': end_milestone,
+    'milestone_end': str(end_milestone),
     'extension_intent_url': intent_url,
   }
 
   try:
     response = requests.post(
         url, headers=headers, params={'key': key}, json=json)
+    logging.info(response.text)
     response.raise_for_status()
   except requests.exceptions.RequestException as e:
     logging.exception('Failed to get response from origin trials API.')

--- a/framework/origin_trials_client_test.py
+++ b/framework/origin_trials_client_test.py
@@ -156,6 +156,6 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
           ]
         })
 
-    return_result = origin_trials_client._get_trial_end_time('123')
+    return_result = origin_trials_client._get_trial_end_time(123)
     self.assertEqual(return_result, 1682812800)
     mock_requests_get.assert_called_once()

--- a/main.py
+++ b/main.py
@@ -169,7 +169,7 @@ api_routes: list[Route] = [
     Route(f'{API_BASE}/origintrials', origin_trials_api.OriginTrialsAPI),
     Route(f'{API_BASE}/origintrials/<int:feature_id>/<int:stage_id>/create',
           origin_trials_api.OriginTrialsAPI),
-    Route(f'{API_BASE}/origintrials/<int:feature_id>/<int:stage_id>/extend',
+    Route(f'{API_BASE}/origintrials/<int:feature_id>/<int:extension_stage_id>/extend',
           origin_trials_api.OriginTrialsAPI),
 ]
 


### PR DESCRIPTION
This change fixes an error in which the end milestone value was passed to the Origin Trials API as an integer. This value is expected to be a string. Also, an additional logging statement has been added for clarity.