### PR TITLE
Update async Chromium file checks

### DIFF
--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -33,7 +33,7 @@ GRACE_PERIOD_FILE = 'https://chromium.googlesource.com/chromium/src/+/main/third
 
 def get_chromium_file(url: str) -> asyncio.Future[requests.Response]:
   """Get chromium file contents from a given URL"""
-  loop = asyncio.get_event_loop()
+  loop = asyncio.get_running_loop()
   try:
     file_future = loop.run_in_executor(None, requests.get, url)
   except requests.RequestException as e:
@@ -148,8 +148,7 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
       return redirect_resp
 
     body = self.get_json_param_dict()
-    loop = asyncio.get_event_loop()
-    validation_errors = loop.run_until_complete(self._validate_creation_args(body))
+    validation_errors = asyncio.run(self._validate_creation_args(body))
     if validation_errors:
       return {
           'message': 'Errors found when validating arguments',


### PR DESCRIPTION
This change fixes an error that caused a `RuntimeError: There is no current event loop in thread` to arises due to the use of  asyncio.get_event_loop(). This function is [deprecated as of the release of Python 3.12](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop) and it is suggested to use loop.get_running_loop() or asyncio.run() in most circumstances. This update has been tested on staging and is confirmed to now function as expected.