### PR TITLE
Utilize "OT Extended" email template

### DIFF
--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -20,8 +20,9 @@ import validators
 from base64 import b64decode
 
 from framework import basehandlers
-from framework import permissions
 from framework import origin_trials_client
+from internals import notifier_helpers
+from framework import permissions
 from internals.core_models import FeatureEntry, Stage
 from internals.review_models import Gate, Vote
 
@@ -227,4 +228,6 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
     # This extension has been processed and action is no longer needed.
     extension_stage.ot_action_requested = False
     extension_stage.put()
+
+    notifier_helpers.send_trial_extended_notification(ot_stage, extension_stage)
     return {'message': 'Origin trial extended successfully.'}

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -211,10 +211,10 @@ def send_ot_notification(stage: Stage):
         '/tasks/email-ot-creation-request',params)
 
 
-def send_trial_extended_notification(stage: Stage):
+def send_trial_extended_notification(ot_stage: Stage, extension_stage: Stage):
   """Notify about a successful automatic trial extension."""
-  stage_dict = converters.stage_to_json_dict(stage)
-  params = {'stage': stage_dict}
-  ot_stage = Stage.get_by_id(stage.ot_stage_id)
-  params['ot_stage'] = converters.stage_to_json_dict(ot_stage)
+  params = {
+    'stage': converters.stage_to_json_dict(extension_stage),
+    'ot_stage': converters.stage_to_json_dict(ot_stage),
+  }
   cloud_tasks_helpers.enqueue_task('/tasks/email-ot-extended', params)


### PR DESCRIPTION
This change updates the origin trials API endpoint to now utilize the new email template that notifies the origin trials team when an automated origin trial extension has been processed.