### PR TITLE
Update "Associate OTs" script to handle multiple stages

### DIFF
--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -347,11 +347,6 @@ class AssociateOTs(FlaskHandler):
       trial_stages: list[Stage] = Stage.query(
           Stage.stage_type == trial_stage_type,
           Stage.feature_id == feature_id).fetch()
-      # If there are no OT stages for the feature, we can't associate the
-      # trial with any stages.
-      if len(trial_stages) == 0:
-        logging.info(f'No OT stages found for feature ID: {feature_id}')
-        return None
       # Look for a stage that does not already have an origin trial associated
       # with it.
       unassociated_trial_stages =  [s for s in trial_stages

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -337,7 +337,7 @@ class AssociateOTs(FlaskHandler):
         return None
       return chromestatus_id
 
-  def find_trial_stage(self, feature_id: int) -> Stage|None:
+  def find_unassociated_trial_stage(self, feature_id: int) -> Stage|None:
       fe: FeatureEntry|None = FeatureEntry.get_by_id(feature_id)
       if fe is None:
         logging.info(f'No feature found for ChromeStatus ID: {feature_id}')
@@ -360,6 +360,10 @@ class AssociateOTs(FlaskHandler):
         logging.info('Multiple origin trial stages found for feature '
                      f'{feature_id}. Cannot discern which stage to associate '
                      'trial with.')
+        return None
+      if len(unassociated_trial_stages) == 0:
+        logging.info(f'No unassociated OT stages found for feature ID: '
+                     f'{feature_id}')
         return None
       return unassociated_trial_stages[0]
 
@@ -422,7 +426,7 @@ class AssociateOTs(FlaskHandler):
         trials_with_no_feature.append(trial_data)
         continue
 
-      ot_stage = self.find_trial_stage(feature_id)
+      ot_stage = self.find_unassociated_trial_stage(feature_id)
       if ot_stage is None:
         trials_with_no_feature.append(trial_data)
         continue

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -352,8 +352,8 @@ class AssociateOTs(FlaskHandler):
       if len(trial_stages) == 0:
         logging.info(f'No OT stages found for feature ID: {feature_id}')
         return None
-      # If there is currently more than one origin trial stage for the
-      # feature, we don't know which one represents the given trial.
+      # Look for a stage that does not already have an origin trial associated
+      # with it.
       unassociated_trial_stages =  [s for s in trial_stages
                                     if not s.origin_trial_id]
       if len(unassociated_trial_stages) > 1:

--- a/internals/maintenance_scripts_test.py
+++ b/internals/maintenance_scripts_test.py
@@ -37,8 +37,13 @@ class AssociateOTsTest(testing_config.CustomTestCase):
         owner_emails=['feature_owner@example.com'])
     self.feature_3.put()
 
-    self.ot_stage_1 = Stage(
-        id=321, feature_id=123, stage_type=150)
+    self.feature_4 = FeatureEntry(
+        id=890,
+        name='feature d', summary='sum', category=1,
+        owner_emails=['feature_owner4@example.com'])
+    self.feature_4.put()
+
+    self.ot_stage_1 = Stage(id=321, feature_id=123, stage_type=150)
     self.ot_stage_1.put()
 
     self.ot_stage_2 = Stage(
@@ -49,9 +54,12 @@ class AssociateOTsTest(testing_config.CustomTestCase):
         id=987, feature_id=789, stage_type=150, origin_trial_id='-12395825')
     self.ot_stage_3.put()
 
-    self.ot_stage_4 = Stage(
-        id=1002, feature_id=789, stage_type=150)
+    self.ot_stage_4 = Stage(id=1002, feature_id=789, stage_type=150)
     self.ot_stage_4.put()
+
+    self.ot_stage_5 = Stage(
+      id=1003, feature_id=890, stage_type=150, origin_trial_id='100020301')
+    self.ot_stage_5.put()
 
     self.extension_stage_1 = Stage(
         feature_id=456,
@@ -135,6 +143,31 @@ class AssociateOTsTest(testing_config.CustomTestCase):
         ],
         'type': 'ORIGIN_TRIAL',
         'allow_third_party_origins': True
+      },
+      {
+        'id': '2230401243',
+        'display_name': 'Sample trial 4',
+        'description': 'Another origin trial 4',
+        'origin_trial_feature_name': 'ChromiumTrialName4',
+        'enabled': True,
+        'status': 'ACTIVE',
+        'chromestatus_url': 'https://chromestatus.com/feature/890',
+        'start_milestone': '130',
+        'end_milestone': '136',
+        'original_end_milestone': '123',
+        'end_time': '2023-11-10T23:59:59Z',
+        'documentation_url': 'https://example.com/docs4',
+        'feedback_url': 'https://example.com/feedback4',
+        'intent_to_experiment_url': 'https://example.com/experiment4',
+        'trial_extensions': [
+          {
+            'endMilestone': '136',
+            'endTime': '2030-11-10T23:59:59Z',
+            'extensionIntentUrl': 'https://example.com/extension4'
+          }
+        ],
+        'type': 'ORIGIN_TRIAL',
+        'allow_third_party_origins': False
       }]
 
     testing_config.sign_in('one@example.com', 123567890)
@@ -168,6 +201,9 @@ class AssociateOTsTest(testing_config.CustomTestCase):
 
     # Feature with multiple OT stages should still be recognized.
     self.assertEqual(self.ot_stage_4.origin_trial_id, '121240182987')
+
+    # OT stage with already set ID should not have changed.
+    self.assertEqual(self.ot_stage_5.origin_trial_id, '100020301')
 
     # Check that the extension request was cleared.
     self.assertFalse(self.extension_stage_1.ot_action_requested)

--- a/internals/maintenance_scripts_test.py
+++ b/internals/maintenance_scripts_test.py
@@ -31,6 +31,12 @@ class AssociateOTsTest(testing_config.CustomTestCase):
         owner_emails=['feature_owner@example.com'])
     self.feature_2.put()
 
+    self.feature_3 = FeatureEntry(
+        id=789,
+        name='feature c', summary='sum', category=1,
+        owner_emails=['feature_owner@example.com'])
+    self.feature_3.put()
+
     self.ot_stage_1 = Stage(
         id=321, feature_id=123, stage_type=150)
     self.ot_stage_1.put()
@@ -38,6 +44,14 @@ class AssociateOTsTest(testing_config.CustomTestCase):
     self.ot_stage_2 = Stage(
         id=654, feature_id=456, stage_type=150, origin_trial_id='1')
     self.ot_stage_2.put()
+
+    self.ot_stage_3 = Stage(
+        id=987, feature_id=789, stage_type=150, origin_trial_id='-12395825')
+    self.ot_stage_3.put()
+
+    self.ot_stage_4 = Stage(
+        id=1002, feature_id=789, stage_type=150)
+    self.ot_stage_4.put()
 
     self.extension_stage_1 = Stage(
         feature_id=456,
@@ -96,6 +110,31 @@ class AssociateOTsTest(testing_config.CustomTestCase):
         ],
         'type': 'ORIGIN_TRIAL',
         'allow_third_party_origins': False
+      },
+      {
+        'id': '121240182987',
+        'display_name': 'Sample trial 3',
+        'description': 'Another origin trial 3',
+        'origin_trial_feature_name': 'ChromiumTrialName3',
+        'enabled': True,
+        'status': 'ACTIVE',
+        'chromestatus_url': 'https://chromestatus.com/feature/789',
+        'start_milestone': '130',
+        'end_milestone': '136',
+        'original_end_milestone': '123',
+        'end_time': '2023-11-10T23:59:59Z',
+        'documentation_url': 'https://example.com/docs3',
+        'feedback_url': 'https://example.com/feedback3',
+        'intent_to_experiment_url': 'https://example.com/experiment3',
+        'trial_extensions': [
+          {
+            'endMilestone': '136',
+            'endTime': '2030-11-10T23:59:59Z',
+            'extensionIntentUrl': 'https://example.com/extension3'
+          }
+        ],
+        'type': 'ORIGIN_TRIAL',
+        'allow_third_party_origins': True
       }]
 
     testing_config.sign_in('one@example.com', 123567890)
@@ -113,7 +152,7 @@ class AssociateOTsTest(testing_config.CustomTestCase):
     handler = maintenance_scripts.AssociateOTs()
     msg = handler.get_template_data()
     self.assertEqual(
-        msg, '2 Stages updated with trial data.\n1 extension requests cleared.')
+        msg, '3 Stages updated with trial data.\n1 extension requests cleared.')
 
     # Check that fields were updated.
     ot_1 = self.ot_stage_1
@@ -126,6 +165,9 @@ class AssociateOTsTest(testing_config.CustomTestCase):
     self.assertTrue(ot_1.ot_is_deprecation_trial)
     self.assertEqual(ot_1.milestones.desktop_first, 97)
     self.assertEqual(ot_1.milestones.desktop_last, 100)
+
+    # Feature with multiple OT stages should still be recognized.
+    self.assertEqual(self.ot_stage_4.origin_trial_id, '121240182987')
 
     # Check that the extension request was cleared.
     self.assertFalse(self.extension_stage_1.ot_action_requested)


### PR DESCRIPTION
This change updates the script that associates origin trial IDs with their corresponding Chromestatus stage to assume that if multiple OT stages exist for a feature, associate the origin trial with the stage that does not already have an OT association if exactly 1 stage exists without a matching trial.

Previously, the script would ignore all associations with any stage that had multiple OT stages. This change adds a little more granularity to the script to allow for better data integrity.