### PR TITLE
Fix Cc email attribute

### DIFF
--- a/framework/sendemail_test.py
+++ b/framework/sendemail_test.py
@@ -128,12 +128,15 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
       actual_response = sendemail.handle_outbound_mail_task()
 
     expected_to = 'cr-status-staging-emails+user+example.com@google.com'
+    expected_cc = [
+        'cr-status-staging-cc-emails+another_user+example.com@google.com']
     mock_emailmessage_constructor.assert_called_once_with(
         sender=self.sender, to=expected_to, subject=self.subject,
         html=self.html)
     mock_message = mock_emailmessage_constructor.return_value
     mock_message.check_initialized.assert_called_once_with()
     mock_message.send.assert_not_called()
+    self.assertEqual(expected_cc, mock_message.cc)
     self.assertEqual({'message': 'Done'}, actual_response)
 
 

--- a/framework/sendemail_test.py
+++ b/framework/sendemail_test.py
@@ -60,7 +60,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
 
     self.to = 'user@example.com'
     self.subject = 'test subject'
-    self.cc = 'another_user@example.com'
+    self.cc = ['another_user@example.com']
     self.html = '<b>body</b>'
     self.sender = ('Chromestatus <admin@%s.appspotmail.com>' %
                    settings.APP_ID)
@@ -82,7 +82,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
       actual_response = sendemail.handle_outbound_mail_task()
 
     mock_emailmessage_constructor.assert_called_once_with(
-        sender=self.sender, to=self.to, cc=self.cc, subject=self.subject,
+        sender=self.sender, to=self.to, subject=self.subject,
         html=self.html)
     mock_message = mock_emailmessage_constructor.return_value
     mock_message.check_initialized.assert_called_once_with()
@@ -90,6 +90,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
     self.assertEqual({'message': 'Done'}, actual_response)
     self.assertEqual(self.refs, mock_message.headers['References'])
     self.assertEqual(self.refs, mock_message.headers['In-Reply-To'])
+    self.assertEqual(self.cc, mock_message.cc)
 
   @mock.patch('settings.SEND_EMAIL', True)
   @mock.patch('google.appengine.api.mail.EmailMessage')
@@ -106,7 +107,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
 
     expected_to = 'cr-status-staging-emails+user+example.com@google.com'
     mock_emailmessage_constructor.assert_called_once_with(
-        sender=self.sender, to=expected_to, cc=None, subject=self.subject,
+        sender=self.sender, to=expected_to, subject=self.subject,
         html=self.html)
     mock_message = mock_emailmessage_constructor.return_value
     mock_message.check_initialized.assert_called_once_with()
@@ -128,7 +129,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
 
     expected_to = 'cr-status-staging-emails+user+example.com@google.com'
     mock_emailmessage_constructor.assert_called_once_with(
-        sender=self.sender, to=expected_to, cc=None, subject=self.subject,
+        sender=self.sender, to=expected_to, subject=self.subject,
         html=self.html)
     mock_message = mock_emailmessage_constructor.return_value
     mock_message.check_initialized.assert_called_once_with()

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -727,6 +727,8 @@ class OriginTrialExtensionApprovedHandler(basehandlers.FlaskHandler):
     logging.info('Starting to notify about successful origin trial extension.')
     send_emails([self.build_email(feature, requester_email, gate_id)])
 
+    return {'message': 'OK'}
+
   def build_email(
       self, feature: FeatureEntry, requester_email: str, gate_id: int):
     body_data = {
@@ -738,7 +740,7 @@ class OriginTrialExtensionApprovedHandler(basehandlers.FlaskHandler):
 
     return {
       'to': requester_email,
-      'cc': OT_SUPPORT_EMAIL,
+      'cc': [OT_SUPPORT_EMAIL],
       'subject': ('Origin trial approved and ready to be initiated: '
                   f'{feature["name"]}'),
       'reply_to': None,
@@ -757,6 +759,8 @@ class OriginTrialExtendedHandler(basehandlers.FlaskHandler):
     ot_stage = self.get_param('ot_stage')
     logging.info('Starting to notify about successful origin trial extension.')
     send_emails([self.build_email(extension_stage, ot_stage)])
+
+    return {'message': 'OK'}
 
   def build_email(self, extension_stage, ot_stage):
     body_data = {
@@ -824,12 +828,14 @@ def send_emails(email_tasks):
       logging.info(
           'Would send the following email:\n'
           'To: %s\n'
+          'Cc: %s\n'
           'From: %s\n'
           'References: %s\n'
           'Reply-To: %s\n'
           'Subject: %s\n'
           'Body:\n%s',
           task.get('to', None),
+          task.get('cc', None),
           task.get('from_user', None),
           task.get('references', None),
           task.get('reply_to', None),

--- a/settings.py
+++ b/settings.py
@@ -15,6 +15,10 @@ def get_flask_template_path() -> str:
 # For the live cr-status server, this setting is None.
 SEND_ALL_EMAIL_TO: str|None = (
     'cr-status-staging-emails+%(user)s+%(domain)s@google.com')
+# Any emails with Cc addresses will instead be sent this group
+# for non-prod environments.
+CC_ALL_EMAIL_TO: str|None = (
+    'cr-status-staging-cc-emails+%(user)s+%(domain)s@google.com')
 
 BOUNCE_ESCALATION_ADDR = 'cr-status-bounces@google.com'
 
@@ -92,6 +96,7 @@ elif APP_ID == 'cr-status':
   APP_TITLE = 'Chrome Platform Status'
   SEND_EMAIL = True
   SEND_ALL_EMAIL_TO = None  # Deliver it to the intended users
+  CC_ALL_EMAIL_TO = None
   SITE_URL = 'https://chromestatus.com/'
   OT_API_URL = 'https://chromeorigintrials-pa.googleapis.com'
   GOOGLE_SIGN_IN_CLIENT_ID = (


### PR DESCRIPTION
This is a fix for the new "Cc" attribute for sending emails.

- Attribute is now always passed as a list of email addresses or null.
- In staging environments, Cc addresses are instead sent to a new Google group for debugging, cr-status-staging-cc-emails@google.com.
- `cc` email attribute is now added after `mail.EmailMessage` is instantiated, rather than passing it into the constructor. This is to avoid passing in an invalid null value.
- Two notifier classes now return default success values, `{'message': 'OK'}`.