### PR TITLE
Extension emails contain links with full site URL

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -735,6 +735,7 @@ class OriginTrialExtensionApprovedHandler(basehandlers.FlaskHandler):
       'feature': feature,
       'id': feature['id'],
       'gate_id': gate_id,
+      'SITE_URL': settings.SITE_URL,
     }
     body = render_template(self.EMAIL_TEMPLATE_PATH, **body_data)
 

--- a/internals/testdata/notifier_test/test_make_extension_approved_email.html
+++ b/internals/testdata/notifier_test/test_make_extension_approved_email.html
@@ -16,7 +16,7 @@
     </tr>
     <tr>
       <td><a style="font-size: 140%;"
-             href="feature/1"
+             href="http://127.0.0.1:8888/feature/1"
              >A feature</a>
       </td>
     </tr>
@@ -36,7 +36,7 @@
   <div><b>Your next steps:</b></div>
 
   <div style="margin: 16px;">
-    <a href="feature/1?gate=3" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; "
+    <a href="http://127.0.0.1:8888/feature/1?gate=3" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; "
      >Finalize trial extension</a></div>
 </section>
 

--- a/main.py
+++ b/main.py
@@ -288,7 +288,7 @@ internals_routes: list[Route] = [
   Route('/tasks/email-ot-creation-request',
         notifier.OriginTrialCreationRequestHandler),
   Route('/tasks/email-ot-extended',
-        notifier.OriginTrialCreationRequestHandler),
+        notifier.OriginTrialExtendedHandler),
   Route('/tasks/email-ot-extension-approved',
         notifier.OriginTrialExtensionApprovedHandler),
 


### PR DESCRIPTION
This change fixes an oversight where the extension emails do not use the site's URL to construct a link, and an update of a duplicated handler class reference.