### PR TITLE
Check permissions before offering non-gate actions.

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -580,6 +580,9 @@ class ChromedashFeatureDetail extends LitElement {
   }
 
   renderStageActions(stage, feStage) {
+    if (!this.canEdit) {
+      return nothing;
+    }
     return html`
       ${stage.actions.map(act => this.renderStageAction(act, stage, feStage))}
     `;


### PR DESCRIPTION
This should resolve #3839.   Basically, we should only offer the non-gate actions to users who could edit the feature entry.