### PR TITLE
Fix the "Request N/A" dialog on safari

### DIFF
--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -400,9 +400,9 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   handleNARequested() {
-    openNaRationaleDialog(this.gate).then(
-        rationale => {this.handleNARequestSubmitted(rationale);}
-    );
+    openNaRationaleDialog(this.gate).then(rationale => {
+      this.handleNARequestSubmitted(rationale);
+    });
   }
 
   async handleNARequestSubmitted(rationale) {
@@ -413,9 +413,7 @@ export class ChromedashGateColumn extends LitElement {
     );
     // Post the comment after the review request so that it will go
     // to the assigned reviewer rather than all reviewers.
-    const commentText =
-      'An "N/A" response is requested because: ' +
-      rationale;
+    const commentText = 'An "N/A" response is requested because: ' + rationale;
     await this.postComment(commentText);
     this._fireEvent('refetch-needed', {});
   }

--- a/client-src/elements/chromedash-gate-column.js
+++ b/client-src/elements/chromedash-gate-column.js
@@ -7,6 +7,7 @@ import {
   somePendingGates,
 } from './chromedash-preflight-dialog';
 import {maybeOpenPrevoteDialog} from './chromedash-prevote-dialog';
+import {openNaRationaleDialog} from './chromedash-na-rationale-dialog';
 import {
   autolink,
   showToastMessage,
@@ -28,8 +29,6 @@ export class ChromedashGateColumn extends LitElement {
   voteSelectRef = createRef();
   commentAreaRef = createRef();
   postToThreadRef = createRef();
-  rationaleDialogRef = createRef();
-  rationaleRef = createRef();
   assigneeSelectRef = createRef();
 
   static get styles() {
@@ -401,10 +400,12 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   handleNARequested() {
-    this.rationaleDialogRef.value.show();
+    openNaRationaleDialog(this.gate).then(
+        rationale => {this.handleNARequestSubmitted(rationale);}
+    );
   }
 
-  async handleNARequestSubmitted() {
+  async handleNARequestSubmitted(rationale) {
     await window.csClient.setVote(
       this.feature.id,
       this.gate.id,
@@ -414,9 +415,8 @@ export class ChromedashGateColumn extends LitElement {
     // to the assigned reviewer rather than all reviewers.
     const commentText =
       'An "N/A" response is requested because: ' +
-      this.rationaleRef.value.value;
+      rationale;
     await this.postComment(commentText);
-    this.rationaleDialogRef.value.hide();
     this._fireEvent('refetch-needed', {});
   }
 
@@ -507,26 +507,6 @@ export class ChromedashGateColumn extends LitElement {
       );
     }
 
-    const dialog = html`
-      <sl-dialog ${ref(this.rationaleDialogRef)} label="Request an N/A">
-        <p style="padding: var(--content-padding)">
-          Please briefly explain why your feature does not require a review.
-          Your response will be posted as a comment on this review gate and it
-          will generate a notification to the reviewers. The
-          ${this.gate.team_name} reviewers will still evaluate whether to give
-          an "N/A" response or do a review.
-        </p>
-        <sl-textarea ${ref(this.rationaleRef)}></sl-textarea>
-        <sl-button
-          slot="footer"
-          variant="primary"
-          size="small"
-          @click=${this.handleNARequestSubmitted}
-          >Post</sl-button
-        >
-      </sl-dialog>
-    `;
-
     return html`
       <sl-button
         size="small"
@@ -537,7 +517,6 @@ export class ChromedashGateColumn extends LitElement {
       <sl-button size="small" @click=${this.handleNARequested}
         >Request N/A</sl-button
       >
-      ${dialog}
     `;
   }
 

--- a/client-src/elements/chromedash-na-rationale-dialog.js
+++ b/client-src/elements/chromedash-na-rationale-dialog.js
@@ -1,4 +1,4 @@
-import {LitElement, css, html, nothing} from 'lit';
+import {LitElement, css, html} from 'lit';
 import {ref, createRef} from 'lit/directives/ref.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 
@@ -6,7 +6,9 @@ let naRationalDialogEl;
 
 export async function openNaRationaleDialog(gate) {
   if (!naRationalDialogEl) {
-    naRationalDialogEl = document.createElement('chromedash-na-rationale-dialog');
+    naRationalDialogEl = document.createElement(
+      'chromedash-na-rationale-dialog'
+    );
     document.body.appendChild(naRationalDialogEl);
     await naRationalDialogEl.updateComplete;
   }
@@ -27,11 +29,7 @@ export class ChromedashNaRationaleDialog extends LitElement {
   }
 
   static get styles() {
-    return [
-      ...SHARED_STYLES,
-      css`
-      `,
-    ];
+    return [...SHARED_STYLES, css``];
   }
 
   constructor() {
@@ -56,11 +54,11 @@ export class ChromedashNaRationaleDialog extends LitElement {
   renderDialogContent() {
     return html`
       <p style="padding: var(--content-padding)">
-        Please briefly explain why your feature does not require a review.
-        Your response will be posted as a comment on this review gate and it
-        will generate a notification to the reviewers. The
-        ${this.gate.team_name} reviewers will still evaluate whether to give
-        an "N/A" response or do a review.
+        Please briefly explain why your feature does not require a review. Your
+        response will be posted as a comment on this review gate and it will
+        generate a notification to the reviewers. The ${this.gate.team_name}
+        reviewers will still evaluate whether to give an "N/A" response or do a
+        review.
       </p>
       <sl-textarea ${ref(this.rationaleRef)}></sl-textarea>
       <sl-button
@@ -68,7 +66,8 @@ export class ChromedashNaRationaleDialog extends LitElement {
         variant="primary"
         size="small"
         @click=${this.handlePost}
-        >Post</sl-button>
+        >Post</sl-button
+      >
     `;
   }
 
@@ -82,5 +81,6 @@ export class ChromedashNaRationaleDialog extends LitElement {
 }
 
 customElements.define(
-    'chromedash-na-rationale-dialog',
-    ChromedashNaRationaleDialog);
+  'chromedash-na-rationale-dialog',
+  ChromedashNaRationaleDialog
+);

--- a/client-src/elements/chromedash-na-rationale-dialog.js
+++ b/client-src/elements/chromedash-na-rationale-dialog.js
@@ -1,0 +1,86 @@
+import {LitElement, css, html, nothing} from 'lit';
+import {ref, createRef} from 'lit/directives/ref.js';
+import {SHARED_STYLES} from '../css/shared-css.js';
+
+let naRationalDialogEl;
+
+export async function openNaRationaleDialog(gate) {
+  if (!naRationalDialogEl) {
+    naRationalDialogEl = document.createElement('chromedash-na-rationale-dialog');
+    document.body.appendChild(naRationalDialogEl);
+    await naRationalDialogEl.updateComplete;
+  }
+  return new Promise(resolve => {
+    naRationalDialogEl.openOn(gate, resolve);
+  });
+}
+
+export class ChromedashNaRationaleDialog extends LitElement {
+  rationaleDialogRef = createRef();
+  rationaleRef = createRef();
+
+  static get properties() {
+    return {
+      gate: {attribute: false},
+      resolve: {attribute: false},
+    };
+  }
+
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      css`
+      `,
+    ];
+  }
+
+  constructor() {
+    super();
+    this.gate = {};
+    this.resolve = function () {
+      console.log('Missing resolve action');
+    };
+  }
+
+  openOn(gate, resolve) {
+    this.gate = gate;
+    this.resolve = resolve;
+    this.rationaleDialogRef.value.show();
+  }
+
+  handlePost() {
+    this.resolve(this.rationaleRef.value.value);
+    this.rationaleDialogRef.value.hide();
+  }
+
+  renderDialogContent() {
+    return html`
+      <p style="padding: var(--content-padding)">
+        Please briefly explain why your feature does not require a review.
+        Your response will be posted as a comment on this review gate and it
+        will generate a notification to the reviewers. The
+        ${this.gate.team_name} reviewers will still evaluate whether to give
+        an "N/A" response or do a review.
+      </p>
+      <sl-textarea ${ref(this.rationaleRef)}></sl-textarea>
+      <sl-button
+        slot="footer"
+        variant="primary"
+        size="small"
+        @click=${this.handlePost}
+        >Post</sl-button>
+    `;
+  }
+
+  render() {
+    return html`
+      <sl-dialog ${ref(this.rationaleDialogRef)} label="Request an N/A">
+        ${this.renderDialogContent()}
+      </sl-dialog>
+    `;
+  }
+}
+
+customElements.define(
+    'chromedash-na-rationale-dialog',
+    ChromedashNaRationaleDialog);


### PR DESCRIPTION
This should resolve #3837.

I believe that the problem was that the `<sl-dialog>` element was contained within a `<div>` that had `overflow:scroll`.  The dialog was actually appearing inside that context, but outside its bounds, so it was not visible. 

The solution is to use the same pattern that we use for other dialog boxes: Create a separate file that has a custom component for the dialog and a function that opens it by appending it to the end of `document`, where it is not inside any `<div>`.

The result looks the same on Safari as it does on Chrome.