### PR TITLE
OTs with multiple extensions will request API Owner reviews

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -160,9 +160,9 @@ def is_lgtm_allowed(from_addr, feature, approval_field):
   return allowed
 
 
-def detect_new_thread(feature_id: int, gate_id: int) -> bool:
+def detect_new_thread(gate_id: int) -> bool:
   """Return True if there are no previous approval values for this gate."""
-  existing_votes = Vote.get_votes(feature_id=feature_id, gate_id=gate_id)
+  existing_votes = Vote.get_votes(gate_id=gate_id)
   return not existing_votes
 
 
@@ -229,7 +229,7 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
       return {'message': message}
 
     self.set_intent_thread_url(stage, thread_url, subject)
-    is_new_thread = detect_new_thread(feature_id, gate_id)
+    is_new_thread = detect_new_thread(gate_id)
     self.create_approvals(
         feature, stage, gate, approval_field, from_addr, body, is_new_thread)
     self.record_slo(feature, approval_field, from_addr, is_new_thread)

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -160,10 +160,7 @@ def is_lgtm_allowed(from_addr, feature, approval_field):
   return allowed
 
 
-def detect_new_thread(
-    feature_id: int,
-    gate_id: int,
-  ) -> bool:
+def detect_new_thread(feature_id: int, gate_id: int) -> bool:
   """Return True if there are no previous approval values for this gate."""
   existing_votes = Vote.get_votes(feature_id=feature_id, gate_id=gate_id)
   return not existing_votes

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -34,12 +34,30 @@ class FunctionTest(testing_config.CustomTestCase):
 
   def setUp(self):
     self.feature_1 = FeatureEntry(
-        name='feature one', summary='detailed sum', category=1,
+        id=1, name='feature one', summary='detailed sum', category=1,
         intent_stage=core_enums.INTENT_IMPLEMENT)
     self.feature_1.put()
+    # OT extension stage and gate.
+    self.stage_1 = Stage(id=20, feature_id=1, stage_type=151)
+    self.stage_1.put()
+    self.gate_1 = Gate(
+        id=300, feature_id=1, stage_id=20, gate_type=3, state=Vote.NA)
+    self.gate_1.put()
+    # OT extension stage and gate with an existing vote.
+    self.stage_2 = Stage(id=40, feature_id=1, stage_type=151)
+    self.stage_2.put()
+    self.gate_2 = Gate(
+        id=500, feature_id=1, stage_id=2, gate_type=3, state=Vote.NA)
+    self.gate_2.put()
+    self.vote_1 = Vote(
+        id=6000, feature_id=1, gate_id=500, state=Vote.REVIEW_REQUESTED,
+        set_on=datetime.datetime.now(), set_by="some_user@example.com")
+    self.vote_1.put()
 
   def tearDown(self):
-    self.feature_1.key.delete()
+    for kind in [FeatureEntry, Stage, Gate, Vote]:
+      for entity in kind.query():
+        entity.key.delete()
 
   def test_detect_field(self):
     """We can detect intent thread type by subject line."""
@@ -381,16 +399,15 @@ class FunctionTest(testing_config.CustomTestCase):
     self.assertFalse(detect_intent.is_lgtm_allowed(
         'other@example.com', self.feature_1, approval_defs.ShipApproval))
 
-  @mock.patch('internals.review_models.Vote.get_votes')
-  def test_detect_new_thread(self, mock_get_approvals):
-    """A thread is new if there are no previous approval values."""
-    mock_get_approvals.return_value = []
+  def test_detect_new_thread__no_votes(self):
+    """New thread is detected when if no votes exist for a given gate."""
     self.assertTrue(detect_intent.detect_new_thread(
-        self.feature_1.key.integer_id(), approval_defs.ShipApproval))
+        self.feature_1.key.integer_id(), self.gate_1.key.integer_id()))
 
-    mock_get_approvals.return_value = ['fake approval value']
+  def test_detect_new_thread__existing_votes(self):
+    """Existing thread is detected when if votes exist for a given gate."""
     self.assertFalse(detect_intent.detect_new_thread(
-        self.feature_1.key.integer_id(), approval_defs.ShipApproval))
+        self.feature_1.key.integer_id(), self.gate_2.key.integer_id()))
 
 
 class IntentEmailHandlerTest(testing_config.CustomTestCase):

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -402,12 +402,12 @@ class FunctionTest(testing_config.CustomTestCase):
   def test_detect_new_thread__no_votes(self):
     """New thread is detected when if no votes exist for a given gate."""
     self.assertTrue(detect_intent.detect_new_thread(
-        self.feature_1.key.integer_id(), self.gate_1.key.integer_id()))
+        self.gate_1.key.integer_id()))
 
   def test_detect_new_thread__existing_votes(self):
     """Existing thread is detected when if votes exist for a given gate."""
     self.assertFalse(detect_intent.detect_new_thread(
-        self.feature_1.key.integer_id(), self.gate_2.key.integer_id()))
+        self.gate_2.key.integer_id()))
 
 
 class IntentEmailHandlerTest(testing_config.CustomTestCase):


### PR DESCRIPTION
Recently, an OT extension was requested, but API Owners were not notified. This was because the logic that detects a new thread and triggers review requests checks if votes exist for a given gate TYPE, rather than a given gate ID. That meant that the extension was not considered a "new thread" because the feature previously had OT extension votes attributed to it from a previous extension.

This change updates the logic so that votes are detected based on the gate ID, and features with multiple trial extensions will still function correctly when detecting new threads.