### PR TITLE
Add new Stage field `ot_activation_date`

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -196,6 +196,8 @@ def stage_to_json_dict(
     'origin_trial_id': stage.origin_trial_id,
     'origin_trial_feedback_url': stage.origin_trial_feedback_url,
     'ot_action_requested': stage.ot_action_requested,
+    'ot_activation_date': (str(stage.ot_activation_date)
+                           if stage.ot_activation_date else None),
     'ot_approval_buganizer_component': stage.ot_approval_buganizer_component,
     'ot_approval_criteria_url': stage.ot_approval_criteria_url,
     'ot_approval_group_email': stage.ot_approval_group_email,

--- a/api/converters.py
+++ b/api/converters.py
@@ -181,7 +181,6 @@ def stage_to_json_dict(
     'created': str(stage.created),
     'feature_id': stage.feature_id,
     'stage_type': stage.stage_type,
-    'ot_description': stage.ot_description,
     'display_name': stage.display_name,
     'intent_stage': INTENT_STAGES_BY_STAGE_TYPE.get(
         stage.stage_type, INTENT_NONE),

--- a/api/converters.py
+++ b/api/converters.py
@@ -196,8 +196,6 @@ def stage_to_json_dict(
     'origin_trial_id': stage.origin_trial_id,
     'origin_trial_feedback_url': stage.origin_trial_feedback_url,
     'ot_action_requested': stage.ot_action_requested,
-    'ot_activation_date': (str(stage.ot_activation_date)
-                           if stage.ot_activation_date else None),
     'ot_approval_buganizer_component': stage.ot_approval_buganizer_component,
     'ot_approval_criteria_url': stage.ot_approval_criteria_url,
     'ot_approval_group_email': stage.ot_approval_group_email,
@@ -234,6 +232,9 @@ def stage_to_json_dict(
     'ios_last': milestones.ios_last,
     'webview_last': milestones.webview_last,
   }
+
+  if stage.ot_activation_date:
+    d['ot_activation_date'] = str(stage.ot_activation_date)
 
   return d
 

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -320,6 +320,7 @@ class Stage(ndb.Model):
   experiment_risks = ndb.TextProperty()
   ot_chromium_trial_name = ndb.StringProperty()
   ot_action_requested = ndb.BooleanProperty(default=False)
+  ot_activation_date = ndb.DateProperty()
   ot_approval_buganizer_component = ndb.IntegerProperty()
   ot_approval_criteria_url = ndb.StringProperty()
   ot_approval_group_email = ndb.StringProperty()

--- a/internals/data_types.py
+++ b/internals/data_types.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, NotRequired, Optional, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 # List of changed fields to be used to create Activity entities
 # and notify subscribed users of changes to a feature.
@@ -45,7 +45,7 @@ class StageDict(TypedDict):
   extensions: list[StageDict]  # type: ignore
   origin_trial_feedback_url: str | None
   ot_action_requested: bool
-  ot_activation_date: Optional[str | None]
+  ot_activation_date: NotRequired[str | None]
   ot_approval_buganizer_component: int | None
   ot_approval_criteria_url: str | None
   ot_approval_group_email: str | None

--- a/internals/data_types.py
+++ b/internals/data_types.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, NotRequired, TypedDict
+from typing import Any, NotRequired, Optional, TypedDict
 
 # List of changed fields to be used to create Activity entities
 # and notify subscribed users of changes to a feature.
@@ -45,6 +45,7 @@ class StageDict(TypedDict):
   extensions: list[StageDict]  # type: ignore
   origin_trial_feedback_url: str | None
   ot_action_requested: bool
+  ot_activation_date: Optional[str | None]
   ot_approval_buganizer_component: int | None
   ot_approval_criteria_url: str | None
   ot_approval_group_email: str | None


### PR DESCRIPTION
This change adds a new field to the Stage kind that denotes when a created origin trial stage should be sent for activation. The field is a Date property rather than DateTime because the cron job will run once a day to find trials that need activation, so only date granularity is needed.

I thought this would be a larger change at first, but this field is not surfaced anywhere client-side, so the change is very simple. 🙂 

An unrelated change is also here removing a line for `ot_description`, as it is duplicated in the dictionary.