### PR TITLE
2024-05-09 deployment bug fixes

### DIFF
--- a/framework/sendemail.py
+++ b/framework/sendemail.py
@@ -49,6 +49,8 @@ def get_param(request, name, required=True):
 
 def format_staging_email(addr: str) -> str:
   """Format emails addresses to be redirected for staging logging."""
+  if not settings.SEND_ALL_EMAIL_TO:
+    return ''
   to_user, to_domain = addr.split('@')
   return settings.SEND_ALL_EMAIL_TO % {'user': to_user, 'domain': to_domain}
 

--- a/internals/ot_process_reminders.py
+++ b/internals/ot_process_reminders.py
@@ -313,14 +313,14 @@ def diff_days(t1: date, t2: date) -> int:
 
 def format_date(time_stamp):
   """Format a datetime object into a date string."""
-  if not isinstance(time_stamp, datetime):
+  if not isinstance(time_stamp, date):
     return ''
   return time_stamp.strftime("%Y-%m-%d")
 
 
 def format_date_for_email(time_stamp):
   """Format a datetime object into a readable date for emails."""
-  if not isinstance(time_stamp, datetime):
+  if not isinstance(time_stamp, date):
     return ''
   return time_stamp.strftime("%A, %B %d, %Y")
 

--- a/internals/testdata/notifier_test/test_make_ot_process_email.html
+++ b/internals/testdata/notifier_test/test_make_ot_process_email.html
@@ -7,7 +7,7 @@ identified the following facts:
   </li>
   <li>
     The current stable release is <strong>M201</strong>
-    as of 2030-02-01
+    as of 2030-02-01.
   </li>
   <li>There are <strong>100</strong> emails sent.</li>
 </ul>

--- a/templates/origintrials/ot-automated-process-email.html
+++ b/templates/origintrials/ot-automated-process-email.html
@@ -7,7 +7,7 @@ identified the following facts:
   </li>
   <li>
     The current stable release is <strong>M{{stable_milestone}}</strong>
-    as of {{stable_date}}
+    as of {{stable_date}}.
   </li>
   <li>There are <strong>{{send_count}}</strong> emails sent.</li>
 </ul>


### PR DESCRIPTION
This PR fixes 2 issues that were detected during the weekly deployment.

- The "to" attribute for sending emails will be processed if it is a list of email addresses or a single email address string.
- When sending OT process reminder emails, python date objects are being used to represent dates. A check was erroneously confirming that the objects were datetime objects rather than date objects, which caused unexpected missing dates in email templates.