### PR TITLE
New email template for automated OT activation failures

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -702,6 +702,7 @@ class OTCreationProcessedHandler(basehandlers.FlaskHandler):
       'html': body,
     }
 
+
 class OTCreationRequestFailedHandler(basehandlers.FlaskHandler):
   """Notify about an origin trial creation request failing automated request."""
 
@@ -723,6 +724,33 @@ class OTCreationRequestFailedHandler(basehandlers.FlaskHandler):
     return {
       'to': OT_SUPPORT_EMAIL,
       'subject': ('Automated trial creation request failed for '
+                  f'{stage["ot_display_name"]}'),
+      'reply_to': None,
+      'html': body,
+    }
+
+
+class OTActivationFailedHandler(basehandlers.FlaskHandler):
+  """Notify about an origin trial activation automated request failing."""
+
+  IS_INTERNAL_HANDLER = True
+  EMAIL_TEMPLATE_PATH = 'origintrials/ot-activation-failed-email.html'
+
+  def process_post_data(self, **kwargs):
+    stage = self.get_param('stage', required=True)
+    send_emails([self.build_email(stage)])
+    return {'message': 'OK'}
+
+  def build_email(self, stage: StageDict) -> dict:
+    body_data = {
+      'stage': stage,
+      'chromestatus_url': ('https://chromestatus.com/feature/'
+                           f'{stage["feature_id"]}')
+    }
+    body = render_template(self.EMAIL_TEMPLATE_PATH, **body_data)
+    return {
+      'to': OT_SUPPORT_EMAIL,
+      'subject': ('Automated trial activation request failed for '
                   f'{stage["ot_display_name"]}'),
       'reply_to': None,
       'html': body,

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -1267,6 +1267,41 @@ class OTCreationRequestFailedHandlerTest(testing_config.CustomTestCase):
         TESTDATA['test_make_creation_request_failed_email.html'])
 
 
+class OTActivationFailedHandlerTest(testing_config.CustomTestCase):
+  def setUp(self):
+    self.feature_1 = FeatureEntry(
+        id=1, name='feature one', summary='sum', category=1, feature_type=0)
+    self.feature_1.put()
+    self.ot_stage = Stage(
+        feature_id=1, stage_type=150, ot_display_name='Example Trial',
+        origin_trial_id='111222333', ot_activation_date=date(2030, 1, 1),
+        ot_owner_email='feature_owner@google.com',
+        ot_chromium_trial_name='ExampleTrial',
+        milestones=MilestoneSet(desktop_first=100, desktop_last=106),
+        ot_documentation_url='https://example.com/docs',
+        ot_feedback_submission_url='https://example.com/feedback',
+        intent_thread_url='https://example.com/experiment',
+        ot_description='OT description', ot_has_third_party_support=True,
+        ot_is_deprecation_trial=True)
+    self.ot_stage.put()
+
+  def tearDown(self):
+    self.feature_1.key.delete()
+    self.ot_stage.key.delete()
+
+  def test_make_activation_failed_email(self):
+    with test_app.app_context():
+      handler = notifier.OTActivationFailedHandler()
+      stage_dict = converters.stage_to_json_dict(self.ot_stage)
+      email_task = handler.build_email(stage_dict)
+      TESTDATA.make_golden(email_task['html'], 'test_make_activation_failed_email.html')
+      self.assertEqual(
+        email_task['subject'],
+        'Automated trial activation request failed for Example Trial')
+      self.assertEqual(email_task['html'],
+        TESTDATA['test_make_activation_failed_email.html'])
+
+
 class OTEndingNextReleaseReminderHandlerTest(testing_config.CustomTestCase):
   def setUp(self):
     self.contacts = ['example_user@example.com', 'another_user@exmaple.com']

--- a/internals/testdata/notifier_test/test_make_activation_failed_email.html
+++ b/internals/testdata/notifier_test/test_make_activation_failed_email.html
@@ -1,0 +1,10 @@
+<h3>An automated origin trial activation has failed to process</h3>
+<p>
+  Trial Name: Example Trial
+  <br>
+  Trial ID: 111222333
+  <br>
+  Chromestatus URL: https://chromestatus.com/feature/1
+  <br>
+  Scheduled activation date: 2030-01-01
+</p>

--- a/main.py
+++ b/main.py
@@ -292,6 +292,8 @@ internals_routes: list[Route] = [
         notifier.OTCreationProcessedHandler),
   Route('/tasks/email-ot-creation-request-failed',
         notifier.OTCreationRequestFailedHandler),
+  Route('/tasks/email-ot-activation-failed',
+        notifier.OTActivationFailedHandler),
   Route('/tasks/email-ot-creation-request', notifier.OTCreationRequestHandler),
   Route('/tasks/email-ot-extended', notifier.OTExtendedHandler),
   Route('/tasks/email-ot-extension-approved',

--- a/templates/origintrials/ot-activation-failed-email.html
+++ b/templates/origintrials/ot-activation-failed-email.html
@@ -1,0 +1,10 @@
+<h3>An automated origin trial activation has failed to process</h3>
+<p>
+  Trial Name: {{stage.ot_display_name}}
+  <br>
+  Trial ID: {{stage.origin_trial_id}}
+  <br>
+  Chromestatus URL: {{chromestatus_url}}
+  <br>
+  Scheduled activation date: {{stage.ot_activation_date}}
+</p>


### PR DESCRIPTION
This email template is not yet used, and will be formally implemented once automated trial creation is ready.

Adds a new email template that will be sent to origin-trials-support when an automated origin trial activation request has failed.