### PR TITLE
Dialog for initiating extension opens directly from email link

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -234,12 +234,9 @@ class ChromedashFeatureDetail extends LitElement {
       return;
     }
     const gateId = parseInt(rawQuery.gate);
-    console.log(gateId);
     const extensionGate = this.gates.find(g => g.id === gateId);
-    console.log(extensionGate);
     // Don't try to display dialog if we can't find the associated gate or the gate isn't approved.
     if (!extensionGate || extensionGate.state !== VOTE_OPTIONS.APPROVED[0]) {
-      console.log('gate not found or approved.');
       return;
     }
     let extensionStage;

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -241,7 +241,9 @@ class ChromedashFeatureDetail extends LitElement {
     }
     let extensionStage;
     for (const stage of this.feature.stages) {
-      const foundStage = stage.extensions.find(s => s.id === extensionGate.stage_id);
+      const foundStage = stage.extensions.find(
+        s => s.id === extensionGate.stage_id
+      );
       if (foundStage) {
         extensionStage = foundStage;
         break;

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -229,6 +229,39 @@ class ChromedashFeatureDetail extends LitElement {
     this.intializeGateColumn();
   }
 
+  initializeExtensionDialog(rawQuery) {
+    if (!('initiateExtension' in rawQuery)) {
+      return;
+    }
+    const gateId = parseInt(rawQuery.gate);
+    console.log(gateId);
+    const extensionGate = this.gates.find(g => g.id === gateId);
+    console.log(extensionGate);
+    // Don't try to display dialog if we can't find the associated gate or the gate isn't approved.
+    if (!extensionGate || extensionGate.state !== VOTE_OPTIONS.APPROVED[0]) {
+      console.log('gate not found or approved.');
+      return;
+    }
+    let extensionStage;
+    for (const stage of this.feature.stages) {
+      const foundStage = stage.extensions.find(s => s.id === extensionGate.stage_id);
+      if (foundStage) {
+        extensionStage = foundStage;
+        break;
+      }
+    }
+    // Don't try to display dialog if we can't find the associated stage.
+    if (!extensionStage) {
+      return;
+    }
+    openFinalizeExtensionDialog(
+      this.feature.id,
+      extensionStage.id,
+      extensionStage.desktop_last,
+      dialogTypes.FINALIZE_EXTENSION
+    );
+  }
+
   intializeGateColumn() {
     const rawQuery = parseRawQuery(window.location.search);
     if (!rawQuery.hasOwnProperty('gate')) {
@@ -263,6 +296,7 @@ class ChromedashFeatureDetail extends LitElement {
       stage: stage,
       gate: gate,
     });
+    this.initializeExtensionDialog(rawQuery);
   }
 
   _fireEvent(eventName, detail) {

--- a/internals/testdata/notifier_test/test_make_extension_approved_email.html
+++ b/internals/testdata/notifier_test/test_make_extension_approved_email.html
@@ -36,7 +36,8 @@
   <div><b>Your next steps:</b></div>
 
   <div style="margin: 16px;">
-    <a href="http://127.0.0.1:8888/feature/1?gate=3" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; "
+    <a href="http://127.0.0.1:8888/feature/1?gate=3&initiateExtension"
+       style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; "
      >Finalize trial extension</a></div>
 </section>
 

--- a/templates/origintrials/ot-extension-approved-email.html
+++ b/templates/origintrials/ot-extension-approved-email.html
@@ -31,7 +31,8 @@
   <div><b>Your next steps:</b></div>
 
   <div style="{{styles.button_div}}">
-    <a href="{{SITE_URL}}feature/{{id}}?gate={{gate_id}}" style="{{styles.button_a}}"
+    <a href="{{SITE_URL}}feature/{{id}}?gate={{gate_id}}&initiateExtension"
+       style="{{styles.button_a}}"
      >Finalize trial extension</a></div>
 </section>
 


### PR DESCRIPTION
This change adds an additional query parameter `initiateExtension`, which opens the extension initiation dialog directly from the link in the email that feature owners receive when a trial extension has been approved. This saves the user a couple of clicks to find the location to initiate the trial extension.