### PR TITLE
Make sending emails with CC more robust.

### DIFF
--- a/framework/sendemail.py
+++ b/framework/sendemail.py
@@ -58,6 +58,8 @@ def format_staging_email(addr: str) -> str:
 def handle_outbound_mail_task():
   """Task to send a notification email to one recipient."""
   require_task_header()
+  json_body = flask.request.get_json(force=True)
+  logging.info('params: %r', json_body)
 
   to = get_param(flask.request, 'to')
   cc = get_param(flask.request, 'cc', required=False)
@@ -67,11 +69,13 @@ def handle_outbound_mail_task():
   references = get_param(flask.request, 'references', required=False)
   reply_to = get_param(flask.request, 'reply_to', required=False)
 
+  if isinstance(to, str):
+    to = [to]
+  if isinstance(cc, str):
+    cc = [cc]
+
   if settings.SEND_ALL_EMAIL_TO and to != settings.REVIEW_COMMENT_MAILING_LIST:
-    if isinstance(to, list):
-      to = [format_staging_email(addr) for addr in to]
-    else:
-      to = format_staging_email(to)
+    to = [format_staging_email(addr) for addr in to]
 
     if cc:
       new_cc = []

--- a/framework/sendemail_test.py
+++ b/framework/sendemail_test.py
@@ -82,7 +82,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
       actual_response = sendemail.handle_outbound_mail_task()
 
     mock_emailmessage_constructor.assert_called_once_with(
-        sender=self.sender, to=self.to, subject=self.subject,
+        sender=self.sender, to=[self.to], subject=self.subject,
         html=self.html)
     mock_message = mock_emailmessage_constructor.return_value
     mock_message.check_initialized.assert_called_once_with()
@@ -107,7 +107,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
 
     expected_to = 'cr-status-staging-emails+user+example.com@google.com'
     mock_emailmessage_constructor.assert_called_once_with(
-        sender=self.sender, to=expected_to, subject=self.subject,
+        sender=self.sender, to=[expected_to], subject=self.subject,
         html=self.html)
     mock_message = mock_emailmessage_constructor.return_value
     mock_message.check_initialized.assert_called_once_with()
@@ -131,7 +131,7 @@ class OutboundEmailHandlerTest(testing_config.CustomTestCase):
     expected_cc = [
         'cr-status-staging-cc-emails+another_user+example.com@google.com']
     mock_emailmessage_constructor.assert_called_once_with(
-        sender=self.sender, to=expected_to, subject=self.subject,
+        sender=self.sender, to=[expected_to], subject=self.subject,
         html=self.html)
     mock_message = mock_emailmessage_constructor.return_value
     mock_message.check_initialized.assert_called_once_with()

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -1082,26 +1082,30 @@ def send_emails(email_tasks):
   """Process a list of email tasks (send or log)."""
   logging.info('Processing %d email tasks', len(email_tasks))
   for task in email_tasks:
+    logging.info(
+        'Working on the following email:\n'
+        'To: %s\n'
+        'Cc: %s\n'
+        'From: %s\n'
+        'References: %s\n'
+        'Reply-To: %s\n'
+        'Subject: %s\n'
+        'Body:\n%s',
+        task.get('to', None),
+        task.get('cc', None),
+        task.get('from_user', None),
+        task.get('references', None),
+        task.get('reply_to', None),
+        task.get('subject', None),
+        task.get('html', "")[:settings.MAX_LOG_LINE])
     if settings.SEND_EMAIL:
-      cloud_tasks_helpers.enqueue_task(
-          '/tasks/outbound-email', task)
+      try:
+        cloud_tasks_helpers.enqueue_task(
+            '/tasks/outbound-email', task)
+      except e:
+        logging.exception('could not enqueue.')
     else:
-      logging.info(
-          'Would send the following email:\n'
-          'To: %s\n'
-          'Cc: %s\n'
-          'From: %s\n'
-          'References: %s\n'
-          'Reply-To: %s\n'
-          'Subject: %s\n'
-          'Body:\n%s',
-          task.get('to', None),
-          task.get('cc', None),
-          task.get('from_user', None),
-          task.get('references', None),
-          task.get('reply_to', None),
-          task.get('subject', None),
-          task.get('html', "")[:settings.MAX_LOG_LINE])
+      logging.info('Not enqueued because of settings.SEND_EMAIL')
 
 
 def post_comment_to_mailing_list(


### PR DESCRIPTION
We have some tasks with the CC field being a string and some with it being an array of strings.  This handles either.