### PR TITLE
Fix detect-intent failures when gate_id was not set.

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -229,6 +229,7 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
       return {'message': message}
 
     self.set_intent_thread_url(stage, thread_url, subject)
+    gate_id = gate.key.integer_id()  # In case it was found by gate_type.
     is_new_thread = detect_new_thread(gate_id)
     self.create_approvals(
         feature, stage, gate, approval_field, from_addr, body, is_new_thread)

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -134,10 +134,12 @@ class Vote(ndb.Model):
       query = query.filter(Vote.state.IN(states))
     if set_by is not None:
       query = query.filter(Vote.set_by == set_by)
+    logging.info('query is %r', query)
     # Query with STRONG consistency because ndb defaults to
     # EVENTUAL consistency and we run this query immediately after
     # saving the user's change that we want included in the query.
     votes: list[Vote] = query.fetch(limit, read_consistency=ndb.STRONG)
+    logging.info('found %r Votes', len(votes))
     return votes
 
   @classmethod


### PR DESCRIPTION
When the gate type is found by looking at the subject line, but there is no gate_id specified in the chromestatus link, we still find the `gate` but `gate_id` was null.  That caused the query by gate_id to end up retrieving all gates on the site, causes the GAE instance to run out of RAM, and that results in a 500 without raising an exception.

This PR uses the ID of the found gate, so the query works and the task successfully completes.