### PR TITLE
Give more RAM to notifier to avoid OOMs.

### DIFF
--- a/notifier.yaml
+++ b/notifier.yaml
@@ -1,5 +1,6 @@
 runtime: python311
 service: notifier
+instance_class: F4_1G
 
 handlers:
 - url: /tasks/detect-intent


### PR DESCRIPTION
This should resolve issue #3883.

After fixing some other adjacent defects, the repeated email continued.  The email-subscribers task was running part way, then running out of RAM, then failing and starting over.  Users who were the first ones to star a feature got emails for every run while more recent starrers got no emails.

I could not find anything in that part of the code that used an excessive amount of RAM.  Instead, I found that our notifier service did not specify a GAE instance class, which caused it to default to the smallest size instance with only 128MB of RAM.  Increasing it to 1G allowed the existing email-subscribers tasks to run to completion successfully.