### PR TITLE
OT process reminders code cleanup

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -12,10 +12,10 @@ const uglify = uglifyEs.default;
 import rename from 'gulp-rename';
 import license from 'gulp-license';
 import autoPrefixer from 'gulp-autoprefixer';
-import { rollup } from 'rollup';
-import rollupResolve from '@rollup/plugin-node-resolve';
-import rollupBabel from '@rollup/plugin-babel';
-import rollupMinify from 'rollup-plugin-babel-minify';
+// import { rollup } from 'rollup';
+// import rollupResolve from '@rollup/plugin-node-resolve';
+// import rollupBabel from '@rollup/plugin-babel';
+// import rollupMinify from 'rollup-plugin-babel-minify';
 
 function uglifyJS() {
   return uglify({
@@ -68,48 +68,48 @@ gulp.task('css', function() {
   .pipe(gulp.dest('static/css'));
 });
 
-gulp.task('rollup', () => {
-  return rollup({
-    input: [
-      'client-src/components.js',
-      'client-src/js-src/openapi-client.js',
-    ],
-    plugins: [
-      rollupResolve(),
-      rollupBabel({babelHelpers: 'bundled'}),
-      rollupMinify({mangle: false, comments: false}),
-    ],
-    onwarn: rollupIgnoreUndefinedWarning,
-  }).then(bundle => {
-    return bundle.write({
-      dir: 'static/dist',
-      format: 'es',
-      sourcemap: true,
-      compact: true,
-    });
-  });
-});
+// gulp.task('rollup', () => {
+//   return rollup({
+//     input: [
+//       'client-src/components.js',
+//       'client-src/js-src/openapi-client.js',
+//     ],
+//     plugins: [
+//       rollupResolve(),
+//       rollupBabel({babelHelpers: 'bundled'}),
+//       rollupMinify({mangle: false, comments: false}),
+//     ],
+//     onwarn: rollupIgnoreUndefinedWarning,
+//   }).then(bundle => {
+//     return bundle.write({
+//       dir: 'static/dist',
+//       format: 'es',
+//       sourcemap: true,
+//       compact: true,
+//     });
+//   });
+// });
 
-gulp.task('rollup-cjs', () => {
-  return rollup({
-    input: [
-      'client-src/js-src/openapi-client.js',
-    ],
-    plugins: [
-      rollupResolve(),
-      rollupBabel({babelHelpers: 'bundled'}),
-      rollupMinify({mangle: false, comments: false}),
-    ],
-    onwarn: rollupIgnoreUndefinedWarning,
-  }).then(bundle => {
-    return bundle.write({
-      dir: 'static/dist',
-      format: 'cjs',
-      sourcemap: true,
-      compact: true,
-    });
-  });
-});
+// gulp.task('rollup-cjs', () => {
+//   return rollup({
+//     input: [
+//       'client-src/js-src/openapi-client.js',
+//     ],
+//     plugins: [
+//       rollupResolve(),
+//       rollupBabel({babelHelpers: 'bundled'}),
+//       rollupMinify({mangle: false, comments: false}),
+//     ],
+//     onwarn: rollupIgnoreUndefinedWarning,
+//   }).then(bundle => {
+//     return bundle.write({
+//       dir: 'static/dist',
+//       format: 'cjs',
+//       sourcemap: true,
+//       compact: true,
+//     });
+//   });
+// });
 
 // Run scripts through babel.
 gulp.task('js', () => {
@@ -147,8 +147,6 @@ gulp.task('default', gulp.series(
   // 'styles',
   'css',
   'js',
-  'rollup',
-  'rollup-cjs',
 ));
 
 // Build production files, the default task
@@ -162,11 +160,5 @@ gulp.task('watch', gulp.series(
       'client-src/elements/css/**/*.js',
       'client-src/contexts/*.js',
     ], gulp.series(['js']));
-    gulp.watch([
-      'client-src/components.js',
-      'client-src/elements/*.js',
-      'client-src/elements/css/**/*.js',
-      'client-src/contexts/*.js',
-    ], gulp.series(['rollup']));
   },
 ));

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -12,10 +12,10 @@ const uglify = uglifyEs.default;
 import rename from 'gulp-rename';
 import license from 'gulp-license';
 import autoPrefixer from 'gulp-autoprefixer';
-// import { rollup } from 'rollup';
-// import rollupResolve from '@rollup/plugin-node-resolve';
-// import rollupBabel from '@rollup/plugin-babel';
-// import rollupMinify from 'rollup-plugin-babel-minify';
+import { rollup } from 'rollup';
+import rollupResolve from '@rollup/plugin-node-resolve';
+import rollupBabel from '@rollup/plugin-babel';
+import rollupMinify from 'rollup-plugin-babel-minify';
 
 function uglifyJS() {
   return uglify({
@@ -68,48 +68,48 @@ gulp.task('css', function() {
   .pipe(gulp.dest('static/css'));
 });
 
-// gulp.task('rollup', () => {
-//   return rollup({
-//     input: [
-//       'client-src/components.js',
-//       'client-src/js-src/openapi-client.js',
-//     ],
-//     plugins: [
-//       rollupResolve(),
-//       rollupBabel({babelHelpers: 'bundled'}),
-//       rollupMinify({mangle: false, comments: false}),
-//     ],
-//     onwarn: rollupIgnoreUndefinedWarning,
-//   }).then(bundle => {
-//     return bundle.write({
-//       dir: 'static/dist',
-//       format: 'es',
-//       sourcemap: true,
-//       compact: true,
-//     });
-//   });
-// });
+gulp.task('rollup', () => {
+  return rollup({
+    input: [
+      'client-src/components.js',
+      'client-src/js-src/openapi-client.js',
+    ],
+    plugins: [
+      rollupResolve(),
+      rollupBabel({babelHelpers: 'bundled'}),
+      rollupMinify({mangle: false, comments: false}),
+    ],
+    onwarn: rollupIgnoreUndefinedWarning,
+  }).then(bundle => {
+    return bundle.write({
+      dir: 'static/dist',
+      format: 'es',
+      sourcemap: true,
+      compact: true,
+    });
+  });
+});
 
-// gulp.task('rollup-cjs', () => {
-//   return rollup({
-//     input: [
-//       'client-src/js-src/openapi-client.js',
-//     ],
-//     plugins: [
-//       rollupResolve(),
-//       rollupBabel({babelHelpers: 'bundled'}),
-//       rollupMinify({mangle: false, comments: false}),
-//     ],
-//     onwarn: rollupIgnoreUndefinedWarning,
-//   }).then(bundle => {
-//     return bundle.write({
-//       dir: 'static/dist',
-//       format: 'cjs',
-//       sourcemap: true,
-//       compact: true,
-//     });
-//   });
-// });
+gulp.task('rollup-cjs', () => {
+  return rollup({
+    input: [
+      'client-src/js-src/openapi-client.js',
+    ],
+    plugins: [
+      rollupResolve(),
+      rollupBabel({babelHelpers: 'bundled'}),
+      rollupMinify({mangle: false, comments: false}),
+    ],
+    onwarn: rollupIgnoreUndefinedWarning,
+  }).then(bundle => {
+    return bundle.write({
+      dir: 'static/dist',
+      format: 'cjs',
+      sourcemap: true,
+      compact: true,
+    });
+  });
+});
 
 // Run scripts through babel.
 gulp.task('js', () => {
@@ -147,6 +147,8 @@ gulp.task('default', gulp.series(
   // 'styles',
   'css',
   'js',
+  'rollup',
+  'rollup-cjs',
 ));
 
 // Build production files, the default task
@@ -160,5 +162,11 @@ gulp.task('watch', gulp.series(
       'client-src/elements/css/**/*.js',
       'client-src/contexts/*.js',
     ], gulp.series(['js']));
+    gulp.watch([
+      'client-src/components.js',
+      'client-src/elements/*.js',
+      'client-src/elements/css/**/*.js',
+      'client-src/contexts/*.js',
+    ], gulp.series(['rollup']));
   },
 ));

--- a/internals/ot_process_reminders.py
+++ b/internals/ot_process_reminders.py
@@ -197,12 +197,13 @@ def send_stable_update_emails(release):
       'release_milestone': release,
       'next_release': next_release,
     }
-    cloud_tasks_helpers.enqueue_task(
-        '/tasks/email-ot-ending-this-release', params)
-  close_to_end_count = len(trials_ending_this_release)
-  logging.info('Ending this release reminders - '
-               f'{close_to_end_count} emails to send')
-  return end_in_next_release_count + close_to_end_count
+  # TODO(DanielRyanSmith): Determine if this notification should be added.
+  #   cloud_tasks_helpers.enqueue_task(
+  #       '/tasks/email-ot-ending-this-release', params)
+  # close_to_end_count = len(trials_ending_this_release)
+  # logging.info('Ending this release reminders - '
+  #              f'{close_to_end_count} emails to send')
+  return end_in_next_release_count
 
 
 def get_release(release: str | int) -> dict[str, str]:
@@ -227,14 +228,15 @@ def get_next_branch_release(today: date):
   start_branch_date = get_branch_date(start)
   start_milestone = get_milestone(start)
 
-  if (start_branch_date - today).days >= 0:
+  if diff_days(start_branch_date, today) >= 0:
+    #  branch date is in the future so this is the next branch
     return start
 
   version_num = get_next_release_number(start_milestone)
   next_version = get_release(version_num)
   version_branch_date = get_branch_date(next_version)
 
-  while (version_branch_date - today).days < 0:
+  while diff_days(version_branch_date, today) < 0:
     version_num = get_next_release_number(version_num)
     next_version = get_release(version_num)
     version_branch_date = get_branch_date(next_version)
@@ -247,15 +249,14 @@ def get_current_stable_release(today: date):
   start = get_release('current')
   start_stable_date = get_stable_date(start)
   start_milestone = get_milestone(start)
-
-  if (start_stable_date - today).days <= 0:
+  if diff_days(start_stable_date, today) <= 0:
     return start
 
   version_num = get_previous_release_number(start_milestone)
   next_version = get_release(version_num)
   version_stable_date = get_stable_date(next_version)
 
-  while (version_stable_date - today).days > 0:
+  while diff_days(version_stable_date, today) > 0:
     version_num = get_previous_release_number(version_num)
     next_version = get_release(version_num)
     version_stable_date = get_stable_date(next_version)


### PR DESCRIPTION
Some date handling fixes for the OT process reminders script. Make sure date comparisons use the same helper functions.

Also removes the sending of stable update notifications, as they have been previous disabled [(see original implementation)](https://source.corp.google.com/piper///depot/google3/chrome/origin_trials/trialadmin/app_scripts/process_reminders.ts;l=392).