### PR TITLE
Note to prefer google emails as OT contacts

### DIFF
--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -1313,11 +1313,13 @@ export const ALL_FIELDS = {
     required: false,
     label: 'Origin trial contacts',
     help_text: html` List any other individuals or groups to include on the
-    contact list (e.g. for reminders on trial milestones).
-    <p><strong>
-      Please prefer using "@google.com" domain email addresses for any contacts
-      that have one.
-    </strong></p>`,
+      contact list (e.g. for reminders on trial milestones).
+      <p>
+        <strong>
+          Please prefer using "@google.com" domain email addresses for any
+          contacts that have one.
+        </strong>
+      </p>`,
   },
 
   ot_has_third_party_support: {

--- a/client-src/elements/form-field-specs.js
+++ b/client-src/elements/form-field-specs.js
@@ -1313,7 +1313,11 @@ export const ALL_FIELDS = {
     required: false,
     label: 'Origin trial contacts',
     help_text: html` List any other individuals or groups to include on the
-    contact list (e.g. for reminders on trial milestones).`,
+    contact list (e.g. for reminders on trial milestones).
+    <p><strong>
+      Please prefer using "@google.com" domain email addresses for any contacts
+      that have one.
+    </strong></p>`,
   },
 
   ot_has_third_party_support: {


### PR DESCRIPTION
This adds a note in the OT creation form to prefer Google email addresses over others (e.g. Chromium emails). This is because all Google contact emails are added to internal groups that allow the viewing of OT feedback.

![Screenshot 2024-05-20 at 3 01 30 PM](https://github.com/GoogleChrome/chromium-dashboard/assets/56164590/a964599a-2df1-44bf-8f47-ee172ed61731)
