### PR TITLE
OT Extension: display warning dialog if intent thread URL not found

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -255,6 +255,7 @@ class ChromedashFeatureDetail extends LitElement {
     }
     openFinalizeExtensionDialog(
       this.feature.id,
+      extensionStage,
       extensionStage.id,
       extensionStage.desktop_last,
       dialogTypes.FINALIZE_EXTENSION
@@ -701,7 +702,7 @@ class ChromedashFeatureDetail extends LitElement {
       @click=${() =>
         openFinalizeExtensionDialog(
           this.feature.id,
-          extensionStage.id,
+          extensionStage,
           extensionStage.desktop_last,
           dialogTypes.FINALIZE_EXTENSION
         )}
@@ -809,12 +810,11 @@ class ChromedashFeatureDetail extends LitElement {
       </sl-tooltip>`;
       // Display the creation request button if user has edit access.
     } else if (canSeeOTControls) {
-      const stageId = feStage.id;
       return html` <sl-button
         size="small"
         variant="primary"
         @click="${() =>
-          openPrereqsDialog(this.feature.id, stageId, dialogTypes.CREATION)}"
+          openPrereqsDialog(this.feature.id, feStage, dialogTypes.CREATION)}"
         >Request Trial Creation</sl-button
       >`;
     }

--- a/client-src/elements/chromedash-ot-prereqs-dialog.js
+++ b/client-src/elements/chromedash-ot-prereqs-dialog.js
@@ -146,7 +146,7 @@ class ChromedashOTPrereqsDialog extends LitElement {
         LGTMS have been detected for this trial extension, but
         <strong>no intent thread link has been detected or provided</strong>.
         All extension proposals must be discussed publicly on blink-dev.
-        Please add the link to the "Intent to Extend Experiment link"
+        Please add the value to the "Intent to Extend Experiment link"
         field by selecting "Edit fields" button on your feature's "Origin Trial"
         section.
       </p>


### PR DESCRIPTION
This change adds a new dialog that is displayed when the "Finalize Extension" button is pressed, but no intent thread value is found. It instructs the user on how to provide an intent thread link before initiating the extension.

![Screenshot 2024-05-21 at 1 26 57 PM](https://github.com/GoogleChrome/chromium-dashboard/assets/56164590/643c7379-f347-45ae-a8d9-31604abd8e06)
