### PR TITLE
Fix checking for usecounter

### DIFF
--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -98,7 +98,7 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
           'Origin trial feature name not found in file')
 
     if not body.get('ot_is_deprecation_trial', {}).get('value', False):
-      use_counter = body.get('ot_webfeature_use_counter', {}).get('')
+      use_counter = body.get('ot_webfeature_use_counter', {}).get('value')
       if not use_counter:
         validation_errors['ot_webfeature_use_counter'] = (
             'No UseCounter specified for non-deprecation trial.')

--- a/api/origin_trials_api_test.py
+++ b/api/origin_trials_api_test.py
@@ -123,7 +123,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
         entity.key.delete()
 
   @mock.patch('api.origin_trials_api.get_chromium_file')
-  async def test_validate_creation_args__valid(self, mock_get_chromium_file):
+  def test_validate_creation_args__valid(self, mock_get_chromium_file):
     """No error messages should be returned if all args are valid."""
     mock_get_chromium_file.side_effect = [
       self.mock_features_file,
@@ -154,12 +154,12 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
     }
     # No exception should be raised.
     with test_app.test_request_context(self.request_path):
-       result = await self.handler._validate_creation_args(body)
+       result = self.handler._validate_creation_args(body)
     expected = {}
     self.assertEqual(expected, result)
 
   @mock.patch('api.origin_trials_api.get_chromium_file')
-  async def test_validate_creation_args__invalid_webfeature_use_counter(
+  def test_validate_creation_args__invalid_webfeature_use_counter(
       self, mock_get_chromium_file):
     """Error message returned if UseCounter not found in file."""
     mock_get_chromium_file.side_effect = [
@@ -195,7 +195,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
     self.assertEqual(expected, result)
 
   @mock.patch('api.origin_trials_api.get_chromium_file')
-  async def test_validate_creation_args__missing_webfeature_use_counter(
+  def test_validate_creation_args__missing_webfeature_use_counter(
       self, mock_get_chromium_file):
     """Error message returned if UseCounter is missing."""
     mock_get_chromium_file.side_effect = [
@@ -221,13 +221,13 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
       },
     }
     with test_app.test_request_context(self.request_path):
-      result = await self.handler._validate_creation_args(body)
+      result = self.handler._validate_creation_args(body)
     expected = {'ot_webfeature_use_counter': (
         'No UseCounter specified for non-deprecation trial.')}
     self.assertEqual(expected, result)
 
   @mock.patch('api.origin_trials_api.get_chromium_file')
-  async def test_validate_creation_args__missing_webfeature_use_counter_deprecation(
+  def test_validate_creation_args__missing_webfeature_use_counter_deprecation(
       self, mock_get_chromium_file):
     """No error message returned for missing UseCounter if deprecation trial."""
     """Deprecation trial does not need a webfeature use counter value."""
@@ -254,12 +254,12 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
       },
     }
     with test_app.test_request_context(self.request_path):
-      result = await self.handler._validate_creation_args(body)
+      result = self.handler._validate_creation_args(body)
     expected = {}
     self.assertEqual(expected, result)
 
   @mock.patch('api.origin_trials_api.get_chromium_file')
-  async def test_validate_creation_args__invalid_chromium_trial_name(
+  def test_validate_creation_args__invalid_chromium_trial_name(
       self, mock_get_chromium_file):
     """Error message returned if Chromium trial name not found in file."""
     mock_get_chromium_file.side_effect = [
@@ -289,13 +289,13 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
       },
     }
     with test_app.test_request_context(self.request_path):
-      result = await self.handler._validate_creation_args(body)
+      result = self.handler._validate_creation_args(body)
     expected = {'ot_chromium_trial_name': (
         'Origin trial feature name not found in file')}
     self.assertEqual(expected, result)
 
   @mock.patch('api.origin_trials_api.get_chromium_file')
-  async def test_validate_creation_args__missing_chromium_trial_name(
+  def test_validate_creation_args__missing_chromium_trial_name(
       self, mock_get_chromium_file):
     """Error message returned if Chromium trial is missing from request."""
     mock_get_chromium_file.side_effect = [
@@ -322,10 +322,10 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
     }
     with test_app.test_request_context(self.request_path):
       with self.assertRaises(werkzeug.exceptions.BadRequest):
-        await self.handler._validate_creation_args(body)
+        self.handler._validate_creation_args(body)
 
   @mock.patch('api.origin_trials_api.get_chromium_file')
-  async def test_validate_creation_args__invalid_third_party_trial(
+  def test_validate_creation_args__invalid_third_party_trial(
       self, mock_get_chromium_file):
     """Error message returned if third party support not found in file."""
     mock_get_chromium_file.side_effect = [
@@ -355,7 +355,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
       },
     }
     with test_app.test_request_context(self.request_path):
-      result = await self.handler._validate_creation_args(body)
+      result = self.handler._validate_creation_args(body)
     expected = {'ot_has_third_party_support': (
         'One or more features do not have third party '
         'support set in runtime_enabled_features.json5. '
@@ -363,7 +363,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
     self.assertEqual(expected, result)
 
   @mock.patch('api.origin_trials_api.get_chromium_file')
-  async def test_validate_creation_args__invalid_critical_trial(
+  def test_validate_creation_args__invalid_critical_trial(
       self, mock_get_chromium_file):
     """Error message returned if critical trial name not found in file."""
     mock_get_chromium_file.side_effect = [
@@ -393,7 +393,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
       },
     }
     with test_app.test_request_context(self.request_path):
-      result = await self.handler._validate_creation_args(body)
+      result = self.handler._validate_creation_args(body)
     expected = {'ot_is_critical_trial': (
         'Use counter has not landed in grace period array for critical trial')}
     self.assertEqual(expected, result)


### PR DESCRIPTION
This fixes a simple coding error that blocked a user from creating an OT request.

The other problem is that the unit tests for this file were not running because they are async.  Apparently it is possible to test async functions, but it gets complicated because we also need the NDB context.   Instead, I rewrote the file fetching function to be synchronous.  This will make the user wait an extra few seconds, but it should not add up to too much of a delay.