### PR TITLE
Remove the obsolete `version` field from docker-compose files, to avoid a warning.

### DIFF
--- a/.devcontainer/db-docker-compose.yml
+++ b/.devcontainer/db-docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     image: google/cloud-sdk:402.0.0-emulators

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   ide:
     build:

--- a/packages/playwright/docker-compose.yml
+++ b/packages/playwright/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # In GitHub Actions, the volumes will still mount as root.
   # This service will fix the ownership.


### PR DESCRIPTION
Documented at https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete.

I also checked that I can still recreate the devcontainer after this change.