### PR TITLE
Save a screenshot when a test fails.

### DIFF
--- a/packages/playwright/playwright.config.cjs
+++ b/packages/playwright/playwright.config.cjs
@@ -34,6 +34,9 @@ module.exports = defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+
+    // See https://playwright.dev/docs/test-use-options#recording-options.
+    screenshot: 'only-on-failure',
   },
   preserveOutput: 'always',
 


### PR DESCRIPTION
We can get to the screenshots in Github by clicking the "test-results" artifact on screens like https://github.com/GoogleChrome/chromium-dashboard/actions/runs/9277100741.