### PR TITLE
Add an `accurate_as_of` search field.

### DIFF
--- a/client-src/elements/queriable-fields.js
+++ b/client-src/elements/queriable-fields.js
@@ -236,4 +236,9 @@ export const QUERIABLE_FIELDS = [
     doc: 'Web / Framework developer views',
     choices: WEB_DEV_VIEWS,
   },
+  {
+    name: 'accurate_as_of',
+    kind: DATE_KIND,
+    doc: "When the feature's fields were last verified",
+  },
 ];

--- a/internals/search_queries.py
+++ b/internals/search_queries.py
@@ -211,7 +211,7 @@ def sorted_by_review_date(descending: bool) -> Future:
 QUERIABLE_FIELDS: dict[str, Property] = {
     'created.when': FeatureEntry.created,
     'updated.when': FeatureEntry.updated,
-    # accurate_as_of
+    'accurate_as_of': FeatureEntry.accurate_as_of,
     'creator': FeatureEntry.creator_email,
     'updater': FeatureEntry.updater_email,
     'owner': FeatureEntry.owner_emails,


### PR DESCRIPTION
This is suspiciously little code, but it seems to work. Is there anything else you'd like me to add a test for? Ordering nulls first when querying with `<` seems to be the default Datastore behavior, although I can't find it documented anywhere. 

![image](https://github.com/GoogleChrome/chromium-dashboard/assets/83420/361cdddc-43aa-48d1-a6eb-b172942a651b)