### PR TITLE
Allow @google and @chromium users to request OTs.

### DIFF
--- a/api/stages_api_test.py
+++ b/api/stages_api_test.py
@@ -323,7 +323,8 @@ class StagesAPITest(testing_config.CustomTestCase):
     with test_app.test_request_context(request_path, json=json):
       with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.do_post(feature_id=1)
-    mock_abort.assert_called_once_with(403)
+    mock_abort.assert_called_once_with(
+        403, description='User cannot edit feature 1')
 
   @mock.patch('framework.permissions.validate_feature_edit_permission')
   def test_post__Redirect(self, permission_call):
@@ -436,7 +437,8 @@ class StagesAPITest(testing_config.CustomTestCase):
         f'{self.request_path}1/stages/10', json=json):
       with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.do_patch(feature_id=1, stage_id=10)
-    mock_abort.assert_called_once_with(403)
+    mock_abort.assert_called_once_with(
+        403, description='User cannot edit feature 1')
 
   @mock.patch('flask.abort')
   def test_patch__bad_id(self, mock_abort):
@@ -673,7 +675,8 @@ class StagesAPITest(testing_config.CustomTestCase):
     with test_app.test_request_context(f'{self.request_path}1/stages/10'):
       with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.do_delete(stage_id=10)
-    mock_abort.assert_called_once_with(403)
+    mock_abort.assert_called_once_with(
+        403, description='User cannot edit feature 1')
 
   @mock.patch('flask.abort')
   def test_delete__no_id(self, mock_abort):

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -75,6 +75,7 @@ class BaseHandler(flask.views.MethodView):
         logging.info('Abort %r: %s' % (status, msg))
       flask.abort(status, description=msg, **kwargs)
     else:
+      logging.info('Abort %r' % status)
       flask.abort(status, **kwargs)
 
   def redirect(self, url):

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -142,6 +142,7 @@ def can_review_gate(
 
 
 def _maybe_redirect_to_login(handler_obj) -> flask.Response | dict:
+  # TODO(jrobbins): For API calls, we should return 401 rather than a redirect.
   common_data = handler_obj.get_common_data()
   if 'current_path' in common_data and 'loginStatus=False' in common_data['current_path']:
     return {}

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -141,7 +141,7 @@ def can_review_gate(
   return is_approver or is_assigned
 
 
-def _maybe_redirect_to_login(handler_obj):
+def _maybe_redirect_to_login(handler_obj) -> flask.Response | dict:
   common_data = handler_obj.get_common_data()
   if 'current_path' in common_data and 'loginStatus=False' in common_data['current_path']:
     return {}
@@ -207,7 +207,8 @@ def validate_feature_create_permission(handler_obj):
     handler_obj.abort(403)
 
 
-def validate_feature_edit_permission(handler_obj, feature_id: int):
+def validate_feature_edit_permission(
+    handler_obj, feature_id: int) -> flask.Response | dict:
   """Check if user has permission to edit feature and abort if not."""
   user = handler_obj.get_current_user()
   req = handler_obj.request
@@ -223,4 +224,6 @@ def validate_feature_edit_permission(handler_obj, feature_id: int):
 
   # Redirect to 403 if user does not have edit permission for feature.
   if not can_edit_feature(user, feature_id):
-    handler_obj.abort(403)
+    handler_obj.abort(403, msg='User cannot edit feature %r' % feature_id)
+
+  return {}

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -17,7 +17,7 @@ from datetime import datetime
 import logging
 from typing import Any, Optional
 from google.cloud import ndb
-import requests  # type: ignore
+import flask
 
 # Appengine imports.
 from framework import rediscache
@@ -414,7 +414,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
   # TODO(danielrsmith): This method's logic is way too complicated to easily
   # maintain. This needs to be scrapped and submission of edits should be
   # handled using features_api and stages_api.
-  def process_post_data(self, **kwargs) -> requests.Response:
+  def process_post_data(self, **kwargs) -> flask.Response | dict:
     feature_id = kwargs.get('feature_id', None)
     stage_id = kwargs.get('stage_id', None)
     # Validate the user has edit permissions and redirect if needed.
@@ -446,7 +446,7 @@ class FeatureEditHandler(basehandlers.FlaskHandler):
         new_field = self.RENAMED_FIELD_MAPPING.get(field, field)
         self._add_changed_field(fe, new_field, field_val, changed_fields)
         setattr(fe, new_field, field_val)
-    
+
     enterprise_impact = self._get_field_val('enterprise_impact', 'int')
     if self.touched('first_enterprise_notification_milestone', form_fields):
       milestone = self._get_field_val('first_enterprise_notification_milestone', 'int')


### PR DESCRIPTION
We had a user report that they could not create an OT, even though they saw the "Request Trial Creation" button.  Their POST to the server resulted in a 403 and they saw an endless spinner.

The underlying cause was that we offer the "Request Trial Creation" button to any user who can edit the feature or that has a @google.com or @chromium.org account.  However, our server was only accepting requests from feature editors.

The fix is to change the server-side logic to also allow @google.com and @chromium.org accounts to request OTs.  This is needed so that a googler can help with a feature being developed by non-gogglers.  The non-gogglers can request the OT themselves, but they might not have all the needed info.

In this PR:
* Refactor and rewrite the permission checking code in origin_trials_api.py to have the new desired behavior and to be more easily testable.
* Add unit tests, logging, and type annotations.  Specifically, calls to `flask.redirect()` are now type-checked as returning `flask.Response` rather than `requests.Response`.
