### PR TITLE
Make clearing extension requests more robust.

### DIFF
--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -377,7 +377,8 @@ class AssociateOTs(FlaskHandler):
     extension_stages_to_update = []
     for extension_stage in extension_stages:
       # skip the stage if it doesn't have an end milestone explicitly defined.
-      if extension_stage.milestones is None:
+      if (extension_stage.milestones is None or
+          not extension_stage.milestones.desktop_last):
         continue
       extension_end = extension_stage.milestones.desktop_last
       # If the end milestone of the trial is equal or greater than the


### PR DESCRIPTION
This should prevent the new error that happened in prod early this morning.  Basically, the `>=` comparison in `clear_extension_requests` failed because `extension_end` was None.

It looks like the feature owner accidentally created two extension requests and then cleared out the fields of the unwanted duplicate extension request.  That made `extension_end` be None, which then caused the error when the cron job ran.

There was already code there to `continue` in the case where there was no end milestone, but it did not check enough cases.  The Stage entity should pretty much always have a `Milestones` sub-entity, but the needed field of `Milestones` happened to be None.

The remaining question is how the user created two extension requests.  The UI shows a disabled button when one extension request is pending, so this mistake should no be common.  My guess is that the user had two browser tabs open.  Or, maybe they submitted the form, then navigated back to it with the browser's Back button, then submitted it again.