### PR TITLE
Make OT reminder emails more robust.

### DIFF
--- a/internals/ot_process_reminders.py
+++ b/internals/ot_process_reminders.py
@@ -32,6 +32,7 @@ trials = None
 
 def build_trial_data(trial_data: dict[str, Any]) -> dict[str, Any] | None:
   """Find corresponding OT stage and assemble necessary info for reminders."""
+  logging.info(f'Building trial data for {trial_data.get("id")}')
   trial_stage: Stage | None = Stage.query(
       Stage.origin_trial_id == trial_data['id']).get()
   if trial_stage is None:
@@ -39,7 +40,7 @@ def build_trial_data(trial_data: dict[str, Any]) -> dict[str, Any] | None:
     return None
   contact_list = trial_stage.ot_emails.copy()
   contact_list.append(trial_stage.ot_owner_email)
-  contact_list = [s.strip() for s in contact_list]
+  contact_list = [s.strip() for s in contact_list if s]
 
   # Remove duplicates
   contact_list = list(set(contact_list))

--- a/internals/ot_process_reminders_test.py
+++ b/internals/ot_process_reminders_test.py
@@ -106,7 +106,12 @@ class OTProcessRemindersTest(testing_config.CustomTestCase):
       },
     ]
 
-  def test_build_trials(self):
+  def tearDown(self):
+    self.feature_1.key.delete()
+    self.stage_1.key.delete()
+    self.stage_2.key.delete()
+
+  def test_build_trials__normal(self):
     """Test that trial data is formatted correctly."""
     expected_trials = [
       {
@@ -153,6 +158,22 @@ class OTProcessRemindersTest(testing_config.CustomTestCase):
                      set(formatted_1['contacts']))
     self.assertEqual(set(expected_trials[1]['contacts']),
                      set(formatted_2['contacts']))
+
+  def test_build_trials__no_contacts(self):
+    """We cope with stages that have no emails listed."""
+    self.stage_1.ot_emails = []
+    self.stage_1.ot_owner_email = None
+    self.stage_1.put()
+    trial_data = {
+        'id': '1',
+        'display_name': 'some trial',
+        'start_milestone': '123',
+        'end_milestone': '126',
+        }
+
+    actual = ot_process_reminders.build_trial_data(trial_data)
+
+    self.assertEqual([], actual['contacts'])
 
   @mock.patch('framework.origin_trials_client.get_trials_list')
   def test_get_trials(self, mock_get_trials_list):

--- a/internals/ot_process_reminders_test.py
+++ b/internals/ot_process_reminders_test.py
@@ -161,9 +161,9 @@ class OTProcessRemindersTest(testing_config.CustomTestCase):
 
   def test_build_trials__no_contacts(self):
     """We cope with stages that have no emails listed."""
-    self.stage_1.ot_emails = []
-    self.stage_1.ot_owner_email = None
-    self.stage_1.put()
+    self.stage_2.ot_emails = []
+    self.stage_2.ot_owner_email = None
+    self.stage_2.put()
     trial_data = {
         'id': '1',
         'display_name': 'some trial',


### PR DESCRIPTION
This is defensive coding that should resolve the alert that we saw today.