### PR TITLE
Escape the /api/v0/features query string.

### DIFF
--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -300,20 +300,21 @@ class ChromeStatusClient {
   }
 
   async searchFeatures(userQuery, showEnterprise, sortSpec, start, num) {
-    let url = `/features?q=${userQuery}`;
+    let query = new URLSearchParams();
+    query.set('q', userQuery);
     if (showEnterprise) {
-      url += '&showEnterprise';
+      query.set('showEnterprise', '');
     }
     if (sortSpec) {
-      url += '&sort=' + sortSpec;
+      query.set('sort', sortSpec);
     }
     if (start) {
-      url += '&start=' + start;
+      query.set('start', start);
     }
     if (num) {
-      url += '&num=' + num;
+      query.set('num', num);
     }
-    return this.doGet(url);
+    return this.doGet(`/features?${query.toString()}`);
   }
 
   async updateFeature(featureChanges) {

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -300,7 +300,7 @@ class ChromeStatusClient {
   }
 
   async searchFeatures(userQuery, showEnterprise, sortSpec, start, num) {
-    let query = new URLSearchParams();
+    const query = new URLSearchParams();
     query.set('q', userQuery);
     if (showEnterprise) {
       query.set('showEnterprise', '');


### PR DESCRIPTION
This changes the `&showEnterprise` parameter to `&showEnterprise=`, but the other end (`get_bool_arg`) treats an empty string as true, so it should be fine.