### PR TITLE
Allow searching relative to the current stable milestone.

### DIFF
--- a/client-src/elements/chromedash-search-help-dialog.js
+++ b/client-src/elements/chromedash-search-help-dialog.js
@@ -67,11 +67,17 @@ export class ChromedashSearchHelpDialog extends LitElement {
             'Features that include or exclude words in any field.'
           )}
           ${this.renderExampleRow(
-            ['browsers.chrome.desktop=123'],
+            [
+              'browsers.chrome.desktop=123',
+              'browsers.chrome.desktop=current_stable+1',
+            ],
             'Features shipping in the specified milestone.'
           )}
           ${this.renderExampleRow(
-            ['browsers.chrome.desktop>=120 browsers.chrome.desktop<=122'],
+            [
+              'browsers.chrome.desktop=120..122',
+              'browsers.chrome.desktop=current_stable-1..current_stable+1',
+            ],
             'Features shipping in a milestone range.'
           )}
           ${this.renderExampleRow(
@@ -152,6 +158,12 @@ export class ChromedashSearchHelpDialog extends LitElement {
                 For dates, you can compute a date a certain number of days or
                 weeks before or after now. "<code>now-3d</code>" is 3 days ago,
                 and "<code>now+2w</code>" is 2 weeks from now.
+              </li>
+              <li>
+                For milestones, you can compute a milestone relative to the
+                current stable version of Chrome.
+                "<code>current_stable+1</code>" is 1 version after the current
+                stable version.
               </li>
             </ul>
           </li>

--- a/internals/search.py
+++ b/internals/search.py
@@ -17,7 +17,7 @@ import dataclasses
 import datetime
 import logging
 import re
-from typing import Any, Optional, Union, Self
+from typing import Any, Optional, Self, Union
 
 from google.cloud.ndb import Key
 from google.cloud.ndb.tasklets import Future  # for type checking only

--- a/internals/search.py
+++ b/internals/search.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import datetime
 import logging
 import re
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, Self
 
 from google.cloud.ndb import Key
 from google.cloud.ndb.tasklets import Future  # for type checking only
@@ -26,6 +27,7 @@ from internals import (
   approval_defs,
   core_enums,
   feature_helpers,
+  fetchchannels,
   notifier,
   search_fulltext,
   search_queries,
@@ -91,12 +93,28 @@ def process_recent_reviews_query() -> list[int] | Future:
   return future_feature_ids
 
 
+@dataclasses.dataclass
+class QueryContext:
+  now: datetime.datetime
+  current_stable_milestone: int
+
+  @classmethod
+  def current(cls) -> Self:
+    """Computes the "current" QueryContext based on ambient information."""
+    current_stable = None
+    for version in fetchchannels.get_omaha_data()[0]['versions']:
+      if version['channel'] == 'stable':
+        current_stable = int(version['version'].split('.')[0])
+        break
+    assert current_stable is not None
+    return cls(now=datetime.datetime.now(), current_stable_milestone=current_stable)
+
+
 NOW_RELATIVE_DATE = re.compile(r'now(?:(?P<offset>[+-]\d+)(?P<unit>[dw]))?')
+MILESTONE_RELATIVE_TO_STABLE = re.compile(r'current_stable(?P<offset>[+-]\d+)?')
 
 
-def parse_query_value(
-  val_str: str, now: datetime.datetime
-) -> search_queries.QueryValue:
+def parse_query_value(val_str: str, context: QueryContext) -> search_queries.QueryValue:
   """Return a python object that can be used as a value in an NDB query."""
 
   if val_str.startswith('"') and val_str.endswith('"'):
@@ -113,12 +131,12 @@ def parse_query_value(
       unit = now_relative_date.group('unit')
       if unit is None:
         # Value was just a literal "now".
-        return now
+        return context.now
       offset = int(now_relative_date.group('offset'))
       if unit == 'd':
-        return now + datetime.timedelta(days=offset)
+        return context.now + datetime.timedelta(days=offset)
       if unit == 'w':
-        return now + datetime.timedelta(weeks=offset)
+        return context.now + datetime.timedelta(weeks=offset)
     except OverflowError:
       pass
     # Otherwise, treat the value as a literal string.
@@ -129,6 +147,14 @@ def parse_query_value(
     logging.info('%r is not a date' % val_str)
     pass
 
+  milestone_relative_to_stable = MILESTONE_RELATIVE_TO_STABLE.fullmatch(val_str)
+  if milestone_relative_to_stable:
+    result = context.current_stable_milestone
+    offset_str = milestone_relative_to_stable.group('offset')
+    if offset_str:
+      result += int(offset_str)
+    return result
+
   try:
     return int(val_str)
   except ValueError:
@@ -138,24 +164,25 @@ def parse_query_value(
 
 
 def parse_query_value_interval(
-  val_str: str, now: datetime.datetime
+  val_str: str, context: QueryContext
 ) -> search_queries.QueryValue | search_queries.Interval[search_queries.QueryValue]:
   """Return a value or interval of values that can be used in an NDB query."""
   try_interval = val_str.split('..')
   if len(try_interval) == 2:
     return search_queries.Interval(
-      parse_query_value(try_interval[0], now), parse_query_value(try_interval[1], now)
+      parse_query_value(try_interval[0], context),
+      parse_query_value(try_interval[1], context),
     )
-  return parse_query_value(val_str, now)
+  return parse_query_value(val_str, context)
 
 
 def parse_query_value_list(
-  vals_str: str, now: datetime.datetime
+  vals_str: str, context: QueryContext
 ) -> list[
   search_queries.QueryValue | search_queries.Interval[search_queries.QueryValue]
 ]:
   """Return a list of values that can be used in an NDB query."""
-  return [parse_query_value_interval(part, now) for part in vals_str.split(',')]
+  return [parse_query_value_interval(part, context) for part in vals_str.split(',')]
 
 
 # A full-text query term consisting of a single word or quoted string.
@@ -191,13 +218,13 @@ SIMPLE_QUERY_TERMS = [
 
 
 def process_query_term(
-  is_negation: bool, field_name: str, op_str: str, vals_str: str, now: datetime.datetime
+  is_negation: bool, field_name: str, op_str: str, vals_str: str, context: QueryContext
 ) -> Future:
   """Parse and run a user-supplied query, if we can handle it."""
   if is_negation:
     op_str = search_queries.negate_operator(op_str)
 
-  val_list = parse_query_value_list(vals_str, now)
+  val_list = parse_query_value_list(vals_str, context)
   logging.info('trying %r %r %r', field_name, op_str, val_list)
 
   future = search_queries.single_field_query_async(
@@ -291,10 +318,10 @@ def process_query(
   show_enterprise=False,
   start=0,
   num=DEFAULT_RESULTS_PER_PAGE,
-  now: Optional[datetime.datetime] = None,
+  context: Optional[QueryContext] = None,
 ) -> tuple[list[dict[str, Any]], int]:
-  if now is None:
-    now = datetime.datetime.now()
+  if context is None:
+    context = QueryContext.current()
 
   """Parse the user's query, run it, and return a list of features."""
   # 1a. Parse the user query into terms.
@@ -324,11 +351,13 @@ def process_query(
 
   # 2a. Create parallel queries for each term.  Each yields a future.
   logging.info('creating parallel queries for %r', terms)
-  feature_id_future_ops = create_future_operations_from_queries(terms, now)
+  feature_id_future_ops = create_future_operations_from_queries(terms, context)
 
   # 2b. Create parallel queries for each permission queries.
   logging.info('creating parallel queries for %r', permission_terms)
-  permissions_future_ops = create_future_operations_from_queries(permission_terms, now)
+  permissions_future_ops = create_future_operations_from_queries(
+    permission_terms, context
+  )
 
   # 2c. Create a parallel query for total sort order.
   logging.info('creating total sort order for %r', sort_spec)
@@ -371,7 +400,7 @@ def process_query(
   return features_on_page, total_count
 
 
-def create_future_operations_from_queries(terms, now: datetime.datetime):
+def create_future_operations_from_queries(terms, context: QueryContext):
   """Create parallel queries for each term. Each yields a future operation"""
   feature_id_future_ops = []
   for logical_op, field_name, op_str, vals_str, textterm in terms:
@@ -384,7 +413,7 @@ def create_future_operations_from_queries(terms, now: datetime.datetime):
                    field_name, op_str, vals_str)
       future = process_predefined_query_term(field_name, op_str, vals_str)
     else:
-      future = process_query_term(is_negation, field_name, op_str, vals_str, now)
+      future = process_query_term(is_negation, field_name, op_str, vals_str, context)
       is_normal_query = True
 
     if future is None:

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import testing_config  # Must be imported before the module under test.
+import testing_config  # isort: split
 
 import datetime
 from unittest import mock
 
-from internals import core_enums
-from internals.core_models import FeatureEntry
+from internals import core_enums, notifier, search
+from internals.core_models import FeatureEntry, MilestoneSet, Stage
 from internals.review_models import Gate, Vote
-from internals import notifier
-from internals import search
 from internals.search_queries import Interval
 
 
@@ -138,41 +136,61 @@ class SearchRETest(testing_config.CustomTestCase):
 class SearchParsingTest(testing_config.CustomTestCase):
   def test_parse_query_value__dates(self):
     d = datetime.datetime
-    now = d(2024, 5, 15)
-    self.assertEqual(d(2024, 5, 15), search.parse_query_value('now', now))
-    self.assertEqual(d(2024, 5, 13), search.parse_query_value('now-2d', now))
-    self.assertEqual(d(2024, 5, 18), search.parse_query_value('now+3d', now))
-    self.assertEqual(d(2024, 4, 10), search.parse_query_value('now-5w', now))
-    self.assertEqual(d(2024, 6, 5), search.parse_query_value('now+3w', now))
+    context = search.QueryContext(now=d(2024, 5, 15), current_stable_milestone=0)
+    self.assertEqual(d(2024, 5, 15), search.parse_query_value('now', context))
+    self.assertEqual(d(2024, 5, 13), search.parse_query_value('now-2d', context))
+    self.assertEqual(d(2024, 5, 18), search.parse_query_value('now+3d', context))
+    self.assertEqual(d(2024, 4, 10), search.parse_query_value('now-5w', context))
+    self.assertEqual(d(2024, 6, 5), search.parse_query_value('now+3w', context))
     self.assertEqual(
       'now+1000000000d',
-      search.parse_query_value('now+1000000000d', now),
+      search.parse_query_value('now+1000000000d', context),
       'Overflow should fall back to a string.',
     )
-    self.assertEqual(d(2023, 7, 8), search.parse_query_value('2023-07-08', now))
-    self.assertEqual(d(2023, 7, 8), search.parse_query_value('2023-7-8', now))
+    self.assertEqual(d(2023, 7, 8), search.parse_query_value('2023-07-08', context))
+    self.assertEqual(d(2023, 7, 8), search.parse_query_value('2023-7-8', context))
 
     # And some cases that shouldn't parse:
-    self.assertEqual('nows', search.parse_query_value('nows', now))
-    self.assertEqual('now-2days', search.parse_query_value('now-2days', now))
-    self.assertEqual('now + 2d', search.parse_query_value('now + 2d', now))
-    self.assertEqual('now-5weeks', search.parse_query_value('now-5weeks', now))
-    self.assertEqual('2023-13-8', search.parse_query_value('2023-13-8', now))
-    self.assertEqual('2023/07/08', search.parse_query_value('2023/07/08', now))
+    self.assertEqual('nows', search.parse_query_value('nows', context))
+    self.assertEqual('now-2days', search.parse_query_value('now-2days', context))
+    self.assertEqual('now + 2d', search.parse_query_value('now + 2d', context))
+    self.assertEqual('now-5weeks', search.parse_query_value('now-5weeks', context))
+    self.assertEqual('2023-13-8', search.parse_query_value('2023-13-8', context))
+    self.assertEqual('2023/07/08', search.parse_query_value('2023/07/08', context))
+
+  def test_parse_query_value__milestones(self):
+    context = search.QueryContext(
+      now=datetime.datetime(1, 1, 1), current_stable_milestone=123
+    )
+    self.assertEqual(123, search.parse_query_value('current_stable', context))
+    self.assertEqual(122, search.parse_query_value('current_stable-1', context))
+    self.assertEqual(128, search.parse_query_value('current_stable+5', context))
+
+    # And some cases that shouldn't parse:
+    self.assertEqual(
+      'current_stable_m', search.parse_query_value('current_stable_m', context)
+    )
+    self.assertEqual(
+      'current_stable+2m', search.parse_query_value('current_stable+2m', context)
+    )
 
   def test_parse_query_value__intervals(self):
-    now = datetime.datetime(2024, 5, 15)
-    self.assertEqual([Interval(1, 5)], search.parse_query_value_list('1..5', now))
+    context = search.QueryContext(
+      now=datetime.datetime(2024, 5, 15), current_stable_milestone=0
+    )
+    self.assertEqual([Interval(1, 5)], search.parse_query_value_list('1..5', context))
     self.assertEqual(
       [Interval(datetime.datetime(2023, 1, 1), datetime.datetime(2024, 1, 1))],
-      search.parse_query_value_list('2023-01-01..2024-01-01', now),
+      search.parse_query_value_list('2023-01-01..2024-01-01', context),
     )
     # This parses, but it's excluded by the regex and isn't converted into an efficient query.
-    self.assertEqual([1, Interval(2, 3)], search.parse_query_value_list('1,2..3', now))
+    self.assertEqual(
+      [1, Interval(2, 3)], search.parse_query_value_list('1,2..3', context)
+    )
 
     self.assertEqual(
       ['1..2..3'],
-      search.parse_query_value_list('1..2..3', now),
+      search.parse_query_value_list('1..2..3', context),
       "Don't get confused by funny syntax",
     )
 
@@ -192,6 +210,16 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     self.featureentry_1.editor_emails = ['editor@example.com']
     self.featureentry_1.cc_emailss = ['cc@example.com']
     self.featureentry_1.put()
+
+    self.featureentry_1_shipping_stage = Stage(
+      feature_id=self.featureentry_1.key.id(),
+      stage_type=core_enums.STAGE_BLINK_SHIPPING,
+      milestones=MilestoneSet(desktop_first=123),
+    )
+    self.featureentry_1_shipping_stage.put()
+    self.featureentry_1.active_stage_id = self.featureentry_1_shipping_stage.key.id()
+    self.featureentry_1.put()
+
     self.featureentry_2 = FeatureEntry(
       created=datetime.datetime(2024, 3, 4),
       name='feature 2',
@@ -488,11 +516,26 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
         [f['name'] for f in actual],
         ['feature 1', 'feature 2'])
 
-    actual, tc = search.process_query('accurate_as_of=now-3d', now=datetime.datetime(2024,5,26))
+    actual, tc = search.process_query(
+      'accurate_as_of=now-3d',
+      context=search.QueryContext(
+        now=datetime.datetime(2024, 5, 26), current_stable_milestone=0
+      ),
+    )
     self.assertEqual(1, len(actual))
     self.assertCountEqual(
         [f['name'] for f in actual],
         ['feature 2'])
+
+  def test_process_query__milestones(self):
+    """We can find milestones."""
+    actual, tc = search.process_query(
+      'browsers.chrome.desktop=current_stable+2',
+      context=search.QueryContext(
+        now=datetime.datetime(1, 1, 1), current_stable_milestone=121
+      ),
+    )
+    self.assertCountEqual([f['name'] for f in actual], ['feature 1'])
 
   def test_process_query__interval(self):
     """We can run interval queries."""


### PR DESCRIPTION
Using a 'current_stable' keyword, to leave room for the possibility that
we'll want to be able to also search relative to the current beta or dev
versions.

This uses a different notion of "current" from [`reminders.py`](https://github.com/GoogleChrome/chromium-dashboard/blob/58b02bf7f31d663651516f76e0d4d78a73f5557a/internals/reminders.py#L47), but I couldn't think of a way to explain that "current" in a search term is the version _after_ the one currently being used by users. I think we can just use `current_stable+1` for the verification report.

This also depends on #3959 for the `x+y` syntax to work. (So did #3941, but `now+y` is much less common, so I didn't notice.) Testing that interaction would be tricky, so I didn't add a test.