### PR TITLE
Keep dependencies, including playwright package deps, up to date on each devcontainer startup.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,28 +15,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && sudo apt-get install -y \
        # openapi-generator-cli dependencies
        openjdk-17-jre \
-       # Playwright dependencies - needed for "npm run webtest"
-       libgtk-3-0 \
-       libasound2 \
-       libdrm2 \
-       libgbm1 \
-       libxcomposite1 \
-       libxdamage1 \
-       libxfixes3 \
-       libxrandr2 \
-       libxtst6 \
-       libpangocairo-1.0-0 \
-       libpango-1.0-0 \
-       libatk1.0-0 \
-       libcairo-gobject2 \
-       libcairo2 \
-       libgdk-pixbuf-2.0-0 \
-       libdbus-glib-1-2 \
-       libdbus-1-3 \
-       libxcb-shm0 \
-       libx11-xcb1 \
-       libxcursor1 \
-       libxi6 \
        # Convenience tools
        bash-completion
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -74,6 +74,8 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "npm run clean-setup",
+	// 'postStartCommand' runs each time the devcontainer is started.
+	"postStartCommand": "npm run setup && npx playwright install --with-deps",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",


### PR DESCRIPTION
This opens a terminal-like window on each devcontainer startup to run the installations, but you can start editing files before that finishes. I was inspired to change this because `npm run webtests` complained that I didn't have the right packages installed for the current version of Playwright.