### PR TITLE
Extract a <chromedash-feature-highlights> element for the overview part of <chromedash-feature-page>.

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -81,7 +81,6 @@ class ChromedashFeatureDetail extends LitElement {
       gates: {type: Array},
       process: {type: Object},
       progress: {type: Object},
-      dismissedCues: {type: Array},
       anyCollapsed: {type: Boolean},
       selectedGateId: {type: Number},
       openStage: {type: Number},
@@ -97,7 +96,6 @@ class ChromedashFeatureDetail extends LitElement {
     this.gates = [];
     this.process = {};
     this.progress = {};
-    this.dismissedCues = [];
     this.anyCollapsed = true;
     this.previousStageTypeRendered = 0;
     this.sameTypeRendered = 0;

--- a/client-src/elements/chromedash-feature-highlights.ts
+++ b/client-src/elements/chromedash-feature-highlights.ts
@@ -1,0 +1,376 @@
+import {LitElement, css, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {SHARED_STYLES} from '../css/shared-css.js';
+import type {FeatureLink} from '../js-src/cs-client.js';
+import {DETAILS_STYLES} from './chromedash-feature-detail.js';
+import './chromedash-gantt.js';
+import {enhanceUrl} from './chromedash-link.js';
+import './chromedash-vendor-views.js';
+import {autolink, renderAbsoluteDate, renderRelativeDate} from './utils.js';
+
+@customElement('chromedash-feature-highlights')
+export class ChromedashFeatureHighlights extends LitElement {
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      ...DETAILS_STYLES,
+      css`
+        section {
+          margin-bottom: 1em;
+        }
+        section h3 {
+          margin: 24px 0 12px;
+        }
+        section label {
+          font-weight: 500;
+          margin-right: 5px;
+        }
+
+        li {
+          list-style: none;
+        }
+
+        #consensus li {
+          display: flex;
+        }
+        #consensus li label {
+          width: 125px;
+        }
+
+        #history p {
+          margin-top: var(--content-padding-half);
+        }
+
+        sl-dropdown {
+          float: right;
+          margin-right: -16px;
+          margin-top: -20px;
+        }
+      `,
+    ];
+  }
+
+  @property({attribute: false})
+  feature: any = {};
+
+  @property({attribute: false})
+  featureLinks: FeatureLink[] = [];
+
+  @property({type: Boolean})
+  canDeleteFeature = false;
+
+  handleDeleteFeature() {
+    this.dispatchEvent(new Event('delete', {bubbles: true, composed: true}));
+  }
+
+  renderEnterpriseFeatureContent() {
+    return html`
+      ${this.feature.summary
+        ? html`
+            <section id="summary">
+              <!-- prettier-ignore -->
+              <p class="preformatted">${autolink(
+                this.feature.summary,
+                this.featureLinks
+              )}</p>
+            </section>
+          `
+        : nothing}
+    `;
+  }
+
+  renderFeatureContent() {
+    return html`
+      ${this.feature.summary
+        ? html`
+            <section id="summary">
+              <!-- prettier-ignore -->
+              <p class="preformatted">${autolink(
+                this.feature.summary,
+                this.featureLinks
+              )}</p>
+            </section>
+          `
+        : nothing}
+      ${this.feature.motivation
+        ? html`
+            <section id="motivation">
+              <h3>Motivation</h3>
+              <!-- prettier-ignore -->
+              <p class="preformatted">${autolink(
+                this.feature.motivation,
+                this.featureLinks
+              )}</p>
+            </section>
+          `
+        : nothing}
+      ${this.feature.resources?.samples?.length
+        ? html`
+            <section id="demo">
+              <h3>Demos and samples</h3>
+              <ul>
+                ${this.feature.resources.samples.map(
+                  sampleLink => html`
+                    <li>${enhanceUrl(sampleLink, this.featureLinks)}</li>
+                  `
+                )}
+              </ul>
+            </section>
+          `
+        : nothing}
+      ${this.feature.resources?.docs?.length
+        ? html`
+            <section id="documentation">
+              <h3>Documentation</h3>
+              <ul>
+                ${this.feature.resources.docs.map(
+                  docLink => html`
+                    <li>${enhanceUrl(docLink, this.featureLinks)}</li>
+                  `
+                )}
+              </ul>
+            </section>
+          `
+        : nothing}
+      ${this.feature.standards.spec
+        ? html`
+            <section id="specification">
+              <h3>Specification</h3>
+              <p>
+                ${enhanceUrl(this.feature.standards.spec, this.featureLinks)}
+              </p>
+              <p>Spec status: ${this.feature.standards.maturity.text}</p>
+            </section>
+          `
+        : this.feature.explainer_links?.length
+          ? html`
+              <section id="specification">
+                <h3>Explainer(s)</h3>
+                ${this.feature.explainer_links?.map(
+                  link => html`<p>${enhanceUrl(link, this.featureLinks)}</p>`
+                )}
+              </section>
+            `
+          : nothing}
+    `;
+  }
+
+  renderEnterpriseFeatureStatus() {
+    return html`
+      ${this.feature.browsers.chrome.owners
+        ? html`
+            <section id="owner">
+              <h3>
+                ${this.feature.browsers.chrome.owners.length == 1
+                  ? 'Owner'
+                  : 'Owners'}
+              </h3>
+              <ul>
+                ${this.feature.browsers.chrome.owners.map(
+                  owner => html`
+                    <li><a href="mailto:${owner}">${owner}</a></li>
+                  `
+                )}
+              </ul>
+            </section>
+          `
+        : nothing}
+    `;
+  }
+
+  renderFeatureStatus() {
+    return html`
+      <section id="status">
+        <h3>Status in Chromium</h3>
+        ${this.feature.browsers.chrome.blink_components
+          ? html`
+              <p>
+                <label>Blink components:</label>
+                ${this.feature.browsers.chrome.blink_components.map(
+                  c => html`
+                    <a
+                      href="https://bugs.chromium.org/p/chromium/issues/list?q=component:${c}"
+                      target="_blank"
+                      rel="noopener"
+                      >${c}</a
+                    >
+                  `
+                )}
+              </p>
+            `
+          : nothing}
+        <br />
+        <p>
+          <label>Implementation status:</label>
+          <b>${this.feature.browsers.chrome.status.text}</b>
+          ${this.feature.browsers.chrome.bug
+            ? html`<chromedash-link
+                href=${this.feature.browsers.chrome.bug}
+                .featureLinks=${this.featureLinks}
+                alwaysInTag
+                >tracking bug</chromedash-link
+              >`
+            : nothing}
+          <chromedash-gantt .feature=${this.feature}></chromedash-gantt>
+        </p>
+      </section>
+
+      <section id="consensus">
+        <h3>Consensus &amp; Standardization</h3>
+        <div style="font-size:smaller;">
+          After a feature ships in Chrome, the values listed here are not
+          guaranteed to be up to date.
+        </div>
+        <br />
+        <ul>
+          ${this.feature.browsers.ff.view.val
+            ? html`
+                <li>
+                  <label>Firefox:</label>
+                  <chromedash-vendor-views
+                    href=${this.feature.browsers.ff.view.url || nothing}
+                    .featureLinks=${this.featureLinks}
+                    >${this.feature.browsers.ff.view
+                      .text}</chromedash-vendor-views
+                  >
+                </li>
+              `
+            : nothing}
+          ${this.feature.browsers.safari.view.val
+            ? html`
+                <li>
+                  <label>Safari:</label>
+                  <chromedash-vendor-views
+                    href=${this.feature.browsers.safari.view.url || nothing}
+                    .featureLinks=${this.featureLinks}
+                    >${this.feature.browsers.safari.view
+                      .text}</chromedash-vendor-views
+                  >
+                </li>
+              `
+            : nothing}
+          <li>
+            <label>Web Developers:</label> ${this.feature.browsers.webdev.view
+              .text}
+          </li>
+        </ul>
+      </section>
+
+      ${this.feature.browsers.chrome.owners
+        ? html`
+            <section id="owner">
+              <h3>
+                ${this.feature.browsers.chrome.owners.length == 1
+                  ? 'Owner'
+                  : 'Owners'}
+              </h3>
+              <ul>
+                ${this.feature.browsers.chrome.owners.map(
+                  owner => html`
+                    <li><a href="mailto:${owner}">${owner}</a></li>
+                  `
+                )}
+              </ul>
+            </section>
+          `
+        : nothing}
+      ${this.feature.intent_to_implement_url
+        ? html`
+            <section id="intent_to_implement_url">
+              <h3>Intent to Prototype url</h3>
+              <a href=${this.feature.intent_to_implement_url}
+                >Intent to Prototype thread</a
+              >
+            </section>
+          `
+        : nothing}
+      ${this.feature.comments
+        ? html`
+            <section id="comments">
+              <h3>Comments</h3>
+              <!-- prettier-ignore -->
+              <p class="preformatted">${autolink(
+                this.feature.comments,
+                this.featureLinks
+              )}</p>
+            </section>
+          `
+        : nothing}
+      ${this.feature.tags
+        ? html`
+            <section id="tags">
+              <h3>Search tags</h3>
+              ${this.feature.tags.map(
+                tag => html`
+                  <a href="/features#tags:${tag}">${tag}</a
+                  ><span class="conditional-comma">, </span>
+                `
+              )}
+            </section>
+          `
+        : nothing}
+    `;
+  }
+
+  renderHistory() {
+    return html`
+      <section id="history">
+        <h3>History</h3>
+        <p>
+          Entry created on
+          ${renderAbsoluteDate(this.feature.created?.when, true)}
+          ${renderRelativeDate(this.feature.created?.when)}
+        </p>
+        <p>
+          Last updated on
+          ${renderAbsoluteDate(this.feature.updated?.when, true)}
+          ${renderRelativeDate(this.feature.updated?.when)}
+        </p>
+
+        <p>
+          <a href="/feature/${this.feature.id}/activity">
+            All comments &amp; activity
+          </a>
+        </p>
+      </section>
+    `;
+  }
+
+  render() {
+    return html`
+      <sl-details summary="Overview" ?open=${true}>
+        <section class="card">
+          ${this.canDeleteFeature
+            ? html`
+                <sl-dropdown placement="left-start">
+                  <sl-icon-button
+                    library="material"
+                    name="more_vert_24px"
+                    label="Feature menu"
+                    style="font-size: 1.3rem;"
+                    slot="trigger"
+                  ></sl-icon-button>
+                  <sl-menu-item value="undo">
+                    <a
+                      id="delete-feature"
+                      class="delete-button"
+                      @click=${this.handleDeleteFeature}
+                    >
+                      Delete
+                    </a>
+                  </sl-menu-item>
+                </sl-dropdown>
+              `
+            : nothing}
+          ${this.feature.is_enterprise_featqcure
+            ? this.renderEnterpriseFeatureContent()
+            : this.renderFeatureContent()}
+          ${this.feature.is_enterprise_feature
+            ? this.renderEnterpriseFeatureStatus()
+            : this.renderFeatureStatus()}
+          ${this.renderHistory()}
+        </section>
+      </sl-details>
+    `;
+  }
+}

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -3,10 +3,7 @@ import {SHARED_STYLES} from '../css/shared-css.js';
 import './chromedash-feature-detail';
 import {DETAILS_STYLES} from './chromedash-feature-detail';
 import './chromedash-feature-highlights.js';
-import {
-  renderHTMLIf,
-  showToastMessage
-} from './utils.js';
+import {renderHTMLIf, showToastMessage} from './utils.js';
 
 const INACTIVE_STATES = ['No longer pursuing', 'Deprecated', 'Removed'];
 

--- a/client-src/elements/chromedash-feature-page.js
+++ b/client-src/elements/chromedash-feature-page.js
@@ -2,15 +2,10 @@ import {LitElement, css, html, nothing} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import './chromedash-feature-detail';
 import {DETAILS_STYLES} from './chromedash-feature-detail';
-import './chromedash-gantt';
-import {enhanceUrl} from './chromedash-link';
-import './chromedash-vendor-views';
+import './chromedash-feature-highlights.js';
 import {
-  autolink,
-  renderAbsoluteDate,
   renderHTMLIf,
-  renderRelativeDate,
-  showToastMessage,
+  showToastMessage
 } from './utils.js';
 
 const INACTIVE_STATES = ['No longer pursuing', 'Deprecated', 'Removed'];
@@ -51,21 +46,6 @@ export class ChromedashFeaturePage extends LitElement {
           margin-right: 5px;
         }
 
-        li {
-          list-style: none;
-        }
-
-        #consensus li {
-          display: flex;
-        }
-        #consensus li label {
-          width: 125px;
-        }
-
-        #history p {
-          margin-top: var(--content-padding-half);
-        }
-
         sl-skeleton {
           margin-bottom: 1em;
           width: 60%;
@@ -78,12 +58,6 @@ export class ChromedashFeaturePage extends LitElement {
         h3 sl-skeleton {
           width: 30%;
           height: 1.5em;
-        }
-
-        sl-dropdown {
-          float: right;
-          margin-right: -16px;
-          margin-top: -20px;
         }
 
         @media only screen and (max-width: 700px) {
@@ -113,7 +87,6 @@ export class ChromedashFeaturePage extends LitElement {
       comments: {type: Array},
       process: {type: Object},
       progress: {type: Object},
-      dismissedCues: {type: Array},
       contextLink: {type: String},
       appTitle: {type: String},
       starred: {type: Boolean},
@@ -132,7 +105,6 @@ export class ChromedashFeaturePage extends LitElement {
     this.comments = {};
     this.process = {};
     this.progress = {};
-    this.dismissedCues = [];
     this.contextLink = '';
     this.appTitle = '';
     this.starred = false;
@@ -156,7 +128,6 @@ export class ChromedashFeaturePage extends LitElement {
       window.csClient.getGates(this.featureId),
       window.csClient.getComments(this.featureId, null),
       window.csClient.getFeatureProcess(this.featureId),
-      window.csClient.getDismissedCues(),
       window.csClient.getStars(),
       window.csClient.getFeatureProgress(this.featureId),
     ])
@@ -166,7 +137,6 @@ export class ChromedashFeaturePage extends LitElement {
           gatesRes,
           commentRes,
           process,
-          dismissedCues,
           starredFeatures,
           progress,
         ]) => {
@@ -174,7 +144,6 @@ export class ChromedashFeaturePage extends LitElement {
           this.gates = gatesRes.gates;
           this.comments = commentRes.comments;
           this.process = process;
-          this.dismissedCues = dismissedCues;
           this.progress = progress;
           if (starredFeatures.includes(this.featureId)) {
             this.starred = true;
@@ -476,279 +445,6 @@ export class ChromedashFeaturePage extends LitElement {
     return warnings;
   }
 
-  renderEnterpriseFeatureContent() {
-    return html`
-      ${this.feature.summary
-        ? html`
-            <section id="summary">
-              <!-- prettier-ignore -->
-              <p class="preformatted">${autolink(
-                this.feature.summary,
-                this.featureLinks
-              )}</p>
-            </section>
-          `
-        : nothing}
-    `;
-  }
-
-  renderFeatureContent() {
-    return html`
-      ${this.feature.summary
-        ? html`
-            <section id="summary">
-              <!-- prettier-ignore -->
-              <p class="preformatted">${autolink(
-                this.feature.summary,
-                this.featureLinks
-              )}</p>
-            </section>
-          `
-        : nothing}
-      ${this.feature.motivation
-        ? html`
-            <section id="motivation">
-              <h3>Motivation</h3>
-              <!-- prettier-ignore -->
-              <p class="preformatted">${autolink(
-                this.feature.motivation,
-                this.featureLinks
-              )}</p>
-            </section>
-          `
-        : nothing}
-      ${this.feature.resources?.samples?.length
-        ? html`
-            <section id="demo">
-              <h3>Demos and samples</h3>
-              <ul>
-                ${this.feature.resources.samples.map(
-                  sampleLink => html`
-                    <li>${enhanceUrl(sampleLink, this.featureLinks)}</li>
-                  `
-                )}
-              </ul>
-            </section>
-          `
-        : nothing}
-      ${this.feature.resources?.docs?.length
-        ? html`
-            <section id="documentation">
-              <h3>Documentation</h3>
-              <ul>
-                ${this.feature.resources.docs.map(
-                  docLink => html`
-                    <li>${enhanceUrl(docLink, this.featureLinks)}</li>
-                  `
-                )}
-              </ul>
-            </section>
-          `
-        : nothing}
-      ${this.feature.standards.spec
-        ? html`
-            <section id="specification">
-              <h3>Specification</h3>
-              <p>
-                ${enhanceUrl(this.feature.standards.spec, this.featureLinks)}
-              </p>
-              <p>Spec status: ${this.feature.standards.maturity.text}</p>
-            </section>
-          `
-        : this.feature.explainer_links?.length
-          ? html`
-              <section id="specification">
-                <h3>Explainer(s)</h3>
-                ${this.feature.explainer_links?.map(
-                  link => html`<p>${enhanceUrl(link, this.featureLinks)}</p>`
-                )}
-              </section>
-            `
-          : nothing}
-    `;
-  }
-
-  renderEnterpriseFeatureStatus() {
-    return html`
-      ${this.feature.browsers.chrome.owners
-        ? html`
-            <section id="owner">
-              <h3>
-                ${this.feature.browsers.chrome.owners.length == 1
-                  ? 'Owner'
-                  : 'Owners'}
-              </h3>
-              <ul>
-                ${this.feature.browsers.chrome.owners.map(
-                  owner => html`
-                    <li><a href="mailto:${owner}">${owner}</a></li>
-                  `
-                )}
-              </ul>
-            </section>
-          `
-        : nothing}
-    `;
-  }
-
-  renderFeatureStatus() {
-    return html`
-      <section id="status">
-        <h3>Status in Chromium</h3>
-        ${this.feature.browsers.chrome.blink_components
-          ? html`
-              <p>
-                <label>Blink components:</label>
-                ${this.feature.browsers.chrome.blink_components.map(
-                  c => html`
-                    <a
-                      href="https://bugs.chromium.org/p/chromium/issues/list?q=component:${c}"
-                      target="_blank"
-                      rel="noopener"
-                      >${c}</a
-                    >
-                  `
-                )}
-              </p>
-            `
-          : nothing}
-        <br />
-        <p>
-          <label>Implementation status:</label>
-          <b>${this.feature.browsers.chrome.status.text}</b>
-          ${this.feature.browsers.chrome.bug
-            ? html`<chromedash-link
-                href=${this.feature.browsers.chrome.bug}
-                .featureLinks=${this.featureLinks}
-                alwaysInTag
-                >tracking bug</chromedash-link
-              >`
-            : nothing}
-          <chromedash-gantt .feature=${this.feature}></chromedash-gantt>
-        </p>
-      </section>
-
-      <section id="consensus">
-        <h3>Consensus &amp; Standardization</h3>
-        <div style="font-size:smaller;">
-          After a feature ships in Chrome, the values listed here are not
-          guaranteed to be up to date.
-        </div>
-        <br />
-        <ul>
-          ${this.feature.browsers.ff.view.val
-            ? html`
-                <li>
-                  <label>Firefox:</label>
-                  <chromedash-vendor-views
-                    href=${this.feature.browsers.ff.view.url || nothing}
-                    .featureLinks=${this.featureLinks}
-                    >${this.feature.browsers.ff.view
-                      .text}</chromedash-vendor-views
-                  >
-                </li>
-              `
-            : nothing}
-          ${this.feature.browsers.safari.view.val
-            ? html`
-                <li>
-                  <label>Safari:</label>
-                  <chromedash-vendor-views
-                    href=${this.feature.browsers.safari.view.url || nothing}
-                    .featureLinks=${this.featureLinks}
-                    >${this.feature.browsers.safari.view
-                      .text}</chromedash-vendor-views
-                  >
-                </li>
-              `
-            : nothing}
-          <li>
-            <label>Web Developers:</label> ${this.feature.browsers.webdev.view
-              .text}
-          </li>
-        </ul>
-      </section>
-
-      ${this.feature.browsers.chrome.owners
-        ? html`
-            <section id="owner">
-              <h3>
-                ${this.feature.browsers.chrome.owners.length == 1
-                  ? 'Owner'
-                  : 'Owners'}
-              </h3>
-              <ul>
-                ${this.feature.browsers.chrome.owners.map(
-                  owner => html`
-                    <li><a href="mailto:${owner}">${owner}</a></li>
-                  `
-                )}
-              </ul>
-            </section>
-          `
-        : nothing}
-      ${this.feature.intent_to_implement_url
-        ? html`
-            <section id="intent_to_implement_url">
-              <h3>Intent to Prototype url</h3>
-              <a href=${this.feature.intent_to_implement_url}
-                >Intent to Prototype thread</a
-              >
-            </section>
-          `
-        : nothing}
-      ${this.feature.comments
-        ? html`
-            <section id="comments">
-              <h3>Comments</h3>
-              <!-- prettier-ignore -->
-              <p class="preformatted">${autolink(
-                this.feature.comments,
-                this.featureLinks
-              )}</p>
-            </section>
-          `
-        : nothing}
-      ${this.feature.tags
-        ? html`
-            <section id="tags">
-              <h3>Search tags</h3>
-              ${this.feature.tags.map(
-                tag => html`
-                  <a href="/features#tags:${tag}">${tag}</a
-                  ><span class="conditional-comma">, </span>
-                `
-              )}
-            </section>
-          `
-        : nothing}
-    `;
-  }
-
-  renderHistory() {
-    return html`
-      <section id="history">
-        <h3>History</h3>
-        <p>
-          Entry created on
-          ${renderAbsoluteDate(this.feature.created?.when, true)}
-          ${renderRelativeDate(this.feature.created?.when)}
-        </p>
-        <p>
-          Last updated on
-          ${renderAbsoluteDate(this.feature.updated?.when, true)}
-          ${renderRelativeDate(this.feature.updated?.when)}
-        </p>
-
-        <p>
-          <a href="/feature/${this.feature.id}/activity">
-            All comments &amp; activity
-          </a>
-        </p>
-      </section>
-    `;
-  }
-
   renderFeatureDetails() {
     return html`
       <chromedash-feature-detail
@@ -761,7 +457,6 @@ export class ChromedashFeaturePage extends LitElement {
         .comments=${this.comments}
         .process=${this.process}
         .progress=${this.progress}
-        .dismissedCues=${this.dismissedCues}
         .featureLinks=${this.featureLinks}
         selectedGateId=${this.selectedGateId}
       >
@@ -783,39 +478,12 @@ export class ChromedashFeaturePage extends LitElement {
     // At this point, the feature has loaded successfully, render the components.
     return html`
       ${this.renderSubHeader()} ${this.renderWarnings()}
-      <sl-details summary="Overview" ?open=${true}>
-        <section class="card">
-          ${this.canDeleteFeature()
-            ? html`
-                <sl-dropdown placement="left-start">
-                  <sl-icon-button
-                    library="material"
-                    name="more_vert_24px"
-                    label="Feature menu"
-                    style="font-size: 1.3rem;"
-                    slot="trigger"
-                  ></sl-icon-button>
-                  <sl-menu-item value="undo">
-                    <a
-                      id="delete-feature"
-                      class="delete-button"
-                      @click=${this.handleDeleteFeature}
-                    >
-                      Delete
-                    </a>
-                  </sl-menu-item>
-                </sl-dropdown>
-              `
-            : nothing}
-          ${this.feature.is_enterprise_featqcure
-            ? this.renderEnterpriseFeatureContent()
-            : this.renderFeatureContent()}
-          ${this.feature.is_enterprise_feature
-            ? this.renderEnterpriseFeatureStatus()
-            : this.renderFeatureStatus()}
-          ${this.renderHistory()}
-        </section>
-      </sl-details>
+      <chromedash-feature-highlights
+        .feature=${this.feature}
+        .featureLinks=${this.featureLinks}
+        ?canDeleteFeature=${this.canDeleteFeature()}
+        @delete=${this.handleDeleteFeature}
+      ></chromedash-feature-highlights>
       ${this.renderFeatureDetails()}
     `;
   }


### PR DESCRIPTION
And delete an unused dismissedCues variable in the -details element.


I'm going to try to add active-stage-specific information to the feature highlights and figured I'd do this TODO first.

cc/ @markxiong0122 since the new file is in Typescript.