### PR TITLE
OT association script uses new enum

### DIFF
--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -321,6 +321,13 @@ class AssociateOTs(FlaskHandler):
       trial_stage.ot_action_requested = False
       stage_changed = True
 
+    # Set the setup status to complete if the trial is created or activated.
+    trial_activated = (trial_data['status'] == 'ACTIVE' or
+                       trial_data['status'] == 'COMPLETE')
+    if trial_stage.ot_setup_status != OT_ACTIVATED and trial_activated:
+      trial_stage.ot_setup_status = OT_ACTIVATED
+      stage_changed = True
+
     return stage_changed
 
   def parse_feature_id(self, chromestatus_url: str|None) -> int|None:

--- a/internals/maintenance_scripts_test.py
+++ b/internals/maintenance_scripts_test.py
@@ -204,6 +204,8 @@ class AssociateOTsTest(testing_config.CustomTestCase):
     self.assertTrue(ot_1.ot_is_deprecation_trial)
     self.assertEqual(ot_1.milestones.desktop_first, 97)
     self.assertEqual(ot_1.milestones.desktop_last, 100)
+    # OT setup status should be marked as activated.
+    self.assertEqual(ot_1.ot_setup_status, core_enums.OT_ACTIVATED)
 
     # Feature with multiple OT stages should still be recognized.
     self.assertEqual(self.ot_stage_4.origin_trial_id, '121240182987')

--- a/pages/ot_requests.py
+++ b/pages/ot_requests.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from google.cloud import ndb
+
 from api.converters import stage_to_json_dict
-from internals.core_enums import OT_EXTENSION_STAGE_TYPES
+from internals.core_enums import OT_EXTENSION_STAGE_TYPES, OT_READY_FOR_CREATION
 from internals.core_models import Stage
 
 from framework import basehandlers
@@ -28,7 +30,8 @@ class OriginTrialsRequests(basehandlers.FlaskHandler):
   @permissions.require_admin_site
   def get_template_data(self, **kwargs):
     stages_with_requests = Stage.query(
-        Stage.ot_action_requested == True).fetch()
+        ndb.OR(Stage.ot_action_requested == True,
+               Stage.ot_setup_status == OT_READY_FOR_CREATION)).fetch()
     creation_stages = []
     extension_stages = []
     for stage in stages_with_requests:


### PR DESCRIPTION
This changes the OT association script to set the new `ot_setup_status` enum for origin trial stages that have an associated origin trial that is active or completed.

Additionally, this changes the `/admin/ot_requests` page to query for stages based on `ot_setup_status`. This page is still planned to be temporary, but may still be useful when tracking the OT automation process.