### PR TITLE
Extension initiation email updates

### DIFF
--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -247,14 +247,13 @@ class ChromedashFeatureDetail extends LitElement {
         break;
       }
     }
-    // Don't try to display dialog if we can't find the associated stage.
-    if (!extensionStage) {
+    // Don't try to display dialog if we can't find the associated stage or no action is requested.
+    if (!extensionStage || !extensionStage.ot_action_requested) {
       return;
     }
     openFinalizeExtensionDialog(
       this.feature.id,
       extensionStage,
-      extensionStage.id,
       extensionStage.desktop_last,
       dialogTypes.FINALIZE_EXTENSION
     );


### PR DESCRIPTION
This change updates two parts of the behavior found when directed to the feature detail page to finalize an extension.

- Checks that the stage has a pending OT action request before showing the extension finalization dialog, so that the dialog will not be displayed a 2nd time if the action has already been taken.

- Removes an erroneous extra argument that is provided to the dialog.