### PR TITLE
Script to delete empty extension stages

### DIFF
--- a/main.py
+++ b/main.py
@@ -330,6 +330,8 @@ internals_routes: list[Route] = [
         maintenance_scripts.BackfillFeatureLinks),
   Route('/scripts/backfill_enterprise_impact',
         maintenance_scripts.BackfillFeatureEnterpriseImpact),
+  Route('/scripts/delete_empty_extension_stages',
+        maintenance_scripts.DeleteEmptyExtensionStages)
 ]
 
 dev_routes: list[Route] = []


### PR DESCRIPTION
This change adds a maintenance script to delete any extension stage that exists with no filled out information. The current extension process requires that at least the end milestone be defined at the time of extension stage creation, which means that this will not affect any extension stages that are actually in use. Gates associated with the empty extension stages are also deleted.

This is cleanup for an older schema migration choice in which all origin trial stages had an extension stage created as well by default.