### PR TITLE
OT extension form code cleanup - make extension milestone field required

### DIFF
--- a/client-src/elements/chromedash-ot-extension-page.js
+++ b/client-src/elements/chromedash-ot-extension-page.js
@@ -160,22 +160,6 @@ export class ChromedashOTExtensionPage extends LitElement {
     setupScrollToHash(this);
   }
 
-  getFieldValueForRequestBody(fieldName) {
-    return this.fieldValues.find(field => field.name === fieldName).value;
-  }
-
-  formatRequestBody() {
-    return {
-      end_milestone: this.getFieldValueForRequestBody(
-        'ot_extension__milestone_desktop_last'
-      ),
-      intent_thread_url: this.getFieldValueForRequestBody(
-        'ot_extension__intent_to_extend_experiment_url'
-      ),
-      origin_trial_id: this.stage.origin_trial_id,
-    };
-  }
-
   handleFormSubmit(e) {
     e.preventDefault();
     const featureSubmitBody = formatFeatureChanges(
@@ -299,7 +283,7 @@ export class ChromedashOTExtensionPage extends LitElement {
       this.fieldValues.push({
         name: featureJSONKey,
         touched: true,
-        value: this.currentMilestone || null,
+        value: null,
         stageId: this.stage.id,
       });
 

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -1271,7 +1271,7 @@ export const ALL_FIELDS: Record<string, Field> = {
   extension_desktop_last: {
     type: 'input',
     attrs: MILESTONE_NUMBER_FIELD_ATTRS,
-    required: false,
+    required: true,
     label: 'Trial extension end milestone',
     help_text: html` The last desktop milestone in which the trial will be
     available after extension.`,


### PR DESCRIPTION
This change includes some simple code cleanup to remove some functions that are no longer used, as well as setting the "extension end milestone" field to be required.

A value is required for the extension end milestone when requesting a trial extension, but was not required when editing fields later - this change makes it so a value is required for this field in all sections when making edits.