### PR TITLE
Keep autocomplete menu closed after selection.

### DIFF
--- a/client-src/elements/chromedash-typeahead.js
+++ b/client-src/elements/chromedash-typeahead.js
@@ -136,8 +136,7 @@ export class ChromedashTypeahead extends LitElement {
     // setting or accessing the text selection.
     await this.updateComplete;
 
-    this.chunkStart =
-      this.chunkStart + candidateValue.length;
+    this.chunkStart = this.chunkStart + candidateValue.length;
     this.chunkEnd = this.chunkStart;
     inputEl.selectionStart = this.chunkStart;
     inputEl.selectionEnd = this.chunkEnd;
@@ -186,8 +185,11 @@ export class ChromedashTypeahead extends LitElement {
       this.shouldShowCandidate(c, this.prefix)
     );
     const slDropdown = this.slDropdownRef.value;
-    if (this.candidates.length > 0 && !this.wasDismissed &&
-        !this.termWasCompleted) {
+    if (
+      this.candidates.length > 0 &&
+      !this.wasDismissed &&
+      !this.termWasCompleted
+    ) {
       slDropdown.show();
     } else {
       slDropdown.hide();

--- a/client-src/elements/chromedash-typeahead.js
+++ b/client-src/elements/chromedash-typeahead.js
@@ -47,6 +47,9 @@ export class ChromedashTypeahead extends LitElement {
     this.chunkEnd = 0;
     // If the user hits Escape, keep the menu closed until they use up or down.
     this.wasDismissed = false;
+    // If the user completes an entire term, don't offer the menu again
+    // until they type something.
+    this.termWasCompleted = false;
   }
 
   static get styles() {
@@ -122,14 +125,10 @@ export class ChromedashTypeahead extends LitElement {
     const candidateValue = e.detail.item.value;
     const inputEl = this.slInputRef.value.input;
     const wholeStr = inputEl.value;
-    const maybeAddSpace =
-      !candidateValue.endsWith('=') && wholeStr[this.chunkEnd] !== ' '
-        ? ' '
-        : '';
+    // Don't add a space after the completed value: let the user type it.
     const newWholeStr =
       wholeStr.substring(0, this.chunkStart) +
       candidateValue +
-      maybeAddSpace +
       wholeStr.substring(this.chunkEnd, wholeStr.length);
     this.slInputRef.value.value = newWholeStr;
     this.reflectValue();
@@ -138,10 +137,12 @@ export class ChromedashTypeahead extends LitElement {
     await this.updateComplete;
 
     this.chunkStart =
-      this.chunkStart + candidateValue.length + maybeAddSpace.length;
+      this.chunkStart + candidateValue.length;
     this.chunkEnd = this.chunkStart;
     inputEl.selectionStart = this.chunkStart;
     inputEl.selectionEnd = this.chunkEnd;
+    // TODO(jrobbins): Don't set termWasCompleted if we offer a value.
+    this.termWasCompleted = true;
     this.calcCandidates();
     // The user may have clicked a menu item, causing the sl-input to lose
     // keyboard focus.  So, focus on the sl-input again.
@@ -172,6 +173,7 @@ export class ChromedashTypeahead extends LitElement {
       this.wasDismissed = false;
       return;
     }
+    this.termWasCompleted = false;
     this.calcCandidates();
   }
 
@@ -184,7 +186,8 @@ export class ChromedashTypeahead extends LitElement {
       this.shouldShowCandidate(c, this.prefix)
     );
     const slDropdown = this.slDropdownRef.value;
-    if (this.candidates.length > 0 && !this.wasDismissed) {
+    if (this.candidates.length > 0 && !this.wasDismissed &&
+        !this.termWasCompleted) {
       slDropdown.show();
     } else {
       slDropdown.hide();


### PR DESCRIPTION
This addresses https://github.com/GoogleChrome/webstatus.dev/issues/260 for webstatus.dev, but I am implementing it here for chromestatus.com first.  Basically, after completing one term, the autocomplete widget was immediately ready to help the user complete another term.  That's a mistake because every query has a final term and after that the user wants to submit what they have rather than add another term. Often only one term is desired, so seeing the menu again is undesired.

The solution is to keep track of whether the user has just completed a search term.  If so, don't show the autocomplete menu.  The user can bring up the autocomplete menu again by doing something that indicates that they want another term, such as typing a space.
