### PR TITLE
Remove unnecessary OT creation prereqs bullets

### DIFF
--- a/client-src/elements/chromedash-ot-prereqs-dialog.js
+++ b/client-src/elements/chromedash-ot-prereqs-dialog.js
@@ -220,8 +220,6 @@ class ChromedashOTPrereqsDialog extends LitElement {
       </div>
       <br />
       <ul id="prereqs-list">
-        <li>Your Intent to Experiment has been drafted.</li>
-        <li>The required LGTMs have been received.</li>
         <li>
           The trial's UseCounter has landed on
           <a


### PR DESCRIPTION
Access to the OT creation form is now gated by receiving all approvals necessary, so the removed prerequisites were redundant, as they are implicitly completed by this step.