### PR TITLE
Remove OT request note field from form

### DIFF
--- a/client-src/elements/form-definition.ts
+++ b/client-src/elements/form-definition.ts
@@ -628,7 +628,6 @@ export const ORIGIN_TRIAL_CREATION_FIELDS: MetadataFields = {
         'ot_has_third_party_support',
         'ot_is_critical_trial',
         'ot_require_approvals',
-        'ot_request_note',
       ],
     },
   ],

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -333,7 +333,7 @@ class Stage(ndb.Model):
   ot_is_critical_trial = ndb.BooleanProperty(default=False)
   ot_is_deprecation_trial = ndb.BooleanProperty(default=False)
   ot_owner_email = ndb.StringProperty()
-  ot_request_note = ndb.TextProperty()
+  ot_request_note = ndb.TextProperty()  # Deprecated.
   ot_require_approvals = ndb.BooleanProperty(default=False)
   ot_setup_status = ndb.IntegerProperty()
   ot_webfeature_use_counter = ndb.StringProperty()


### PR DESCRIPTION
The "Anything else?" request note field for OT creation is being deprecated with the automation of the process, so this field will be removed entirely from the form.