### PR TITLE
"N/A" counted as approved for trial extensions

### DIFF
--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -193,7 +193,7 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
                        f'{intent_url}'))
 
     gate = Gate.query(Gate.stage_id == extension_stage.key.integer_id()).get()
-    if not gate or gate.state != Vote.APPROVED:
+    if not gate or (gate.state != Vote.APPROVED and gate.state != Vote.NA):
       self.abort(400, 'Extension has not received the required approvals.')
 
   def do_patch(self, **kwargs):

--- a/api/origin_trials_api_test.py
+++ b/api/origin_trials_api_test.py
@@ -506,8 +506,17 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
         self.handler._validate_extension_args(
             self.feature_1_id, self.ot_stage_1, self.extension_stage_1)
 
-  def test_validate_extension_args__not_approved(self):
+  def test_validate_extension_args__na(self):
+    """N/A state should be counted as approved."""
     self.extension_gate_1.state = Vote.NA
+    self.extension_gate_1.put()
+    with test_app.test_request_context(self.request_path):
+      self.handler._validate_extension_args(
+          self.feature_1_id, self.ot_stage_1, self.extension_stage_1)
+
+  def test_validate_extension_args__not_approved(self):
+    """Non-approved extensions should not be processed."""
+    self.extension_gate_1.state = Vote.DENIED
     self.extension_gate_1.put()
     with test_app.test_request_context(self.request_path):
       with self.assertRaises(werkzeug.exceptions.BadRequest):

--- a/client-src/elements/chromedash-feature-detail.js
+++ b/client-src/elements/chromedash-feature-detail.js
@@ -234,7 +234,11 @@ class ChromedashFeatureDetail extends LitElement {
     const gateId = parseInt(rawQuery.gate);
     const extensionGate = this.gates.find(g => g.id === gateId);
     // Don't try to display dialog if we can't find the associated gate or the gate isn't approved.
-    if (!extensionGate || extensionGate.state !== VOTE_OPTIONS.APPROVED[0]) {
+    if (
+      !extensionGate ||
+      (extensionGate.state !== VOTE_OPTIONS.APPROVED[0] &&
+        extensionGate.state !== VOTE_OPTIONS.NA[0])
+    ) {
       return;
     }
     let extensionStage;
@@ -741,7 +745,8 @@ class ChromedashFeatureDetail extends LitElement {
       const extensionGate = this.gates.find(g => g.stage_id === e.id);
       return (
         e.ot_action_requested &&
-        extensionGate.state === VOTE_OPTIONS.APPROVED[0]
+        (extensionGate.state === VOTE_OPTIONS.APPROVED[0] ||
+          extensionGate.state === VOTE_OPTIONS.NA[0])
       );
     });
     if (extensionReadyForFinalize) {


### PR DESCRIPTION
Previously, only trial extensions with "Approved" gate states could be initiated. This change makes it so that extensions with "N/A" gate states can also be initiated.