### PR TITLE
Warn people not to use Google Docs for explainers and specifications.

### DIFF
--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -733,6 +733,11 @@ export const ALL_FIELDS: Record<string, Field> = {
           >specification mentor</a
         >.
       </p>`,
+    check: value =>
+      checkNotGoogleDocs(
+        value,
+        'Explainers should not be hosted on Google Docs.'
+      ),
   },
 
   spec_link: {
@@ -743,6 +748,11 @@ export const ALL_FIELDS: Record<string, Field> = {
     help_text: html` Link to the spec, if and when available. When implementing
     a spec update, please link to a heading in a published spec rather than a
     pull request when possible.`,
+    check: value =>
+      checkNotGoogleDocs(
+        value,
+        'Specifications should not be hosted on Google Docs.'
+      ),
   },
 
   comments: {
@@ -2330,5 +2340,15 @@ async function checkExtensionMilestoneIsValid(value) {
   }
   // TODO(DanielRyanSmith): Check that the extension milestone comes after
   // OT end milestone and all previous extension end milestones.
+  return undefined;
+}
+
+function checkNotGoogleDocs(
+  value: string,
+  warning = 'Avoid using Google Docs'
+) {
+  if (/docs.google.com\/document/.test(value)) {
+    return {warning};
+  }
   return undefined;
 }

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -748,6 +748,16 @@ export const ALL_FIELDS: Record<string, Field> = {
     help_text: html` Link to the spec, if and when available. When implementing
     a spec update, please link to a heading in a published spec rather than a
     pull request when possible.`,
+    extra_help: html`<p>
+      Specifications should be written in the format and hosted in the URL space
+      expected by your target standards body. For example, the W3C expects
+      <a href="https://respec.org/" target="_blank">Respec</a> or
+      <a href="https://speced.github.io/bikeshed/" target="_blank">Bikeshed</a>
+      hosted on w3.org or in Github Pages. The IETF expects an
+      <a href="https://authors.ietf.org/" target="_blank">Internet-Draft</a>
+      hosted in the
+      <a href="https://datatracker.ietf.org/" target="_blank">Datatracker</a>.
+    </p>`,
     check: value =>
       checkNotGoogleDocs(
         value,

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -2357,7 +2357,7 @@ function checkNotGoogleDocs(
   value: string,
   warning = 'Avoid using Google Docs'
 ) {
-  if (/docs.google.com\/document/.test(value)) {
+  if (/docs\.google\.com\/document/.test(value)) {
     return {warning};
   }
   return undefined;


### PR DESCRIPTION
![image](https://github.com/GoogleChrome/chromium-dashboard/assets/83420/566222d2-0055-4edd-b015-5f6334d435dc)

![image](https://github.com/GoogleChrome/chromium-dashboard/assets/83420/b1e73910-83da-4406-9735-339b4a3e0895)


@chrishtr, I think this is all the fields where people inappropriately put google docs, but let me know if you've noticed others.