### PR TITLE
Update stage edit path to not require intent stage

### DIFF
--- a/client-src/elements/chromedash-app.js
+++ b/client-src/elements/chromedash-app.js
@@ -429,10 +429,10 @@ class ChromedashApp extends LitElement {
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
       this.pageComponent.appTitle = this.appTitle;
     });
-    page('/guide/stage/:featureId(\\d+)/:intentStage(\\d+)', ctx => {
+    page('/guide/stage/:featureId(\\d+)/:stageId(\\d+)', ctx => {
       if (!this.setupNewPage(ctx, 'chromedash-guide-stage-page')) return;
       this.pageComponent.featureId = parseInt(ctx.params.featureId);
-      this.pageComponent.intentStage = parseInt(ctx.params.intentStage);
+      this.pageComponent.stageId = parseInt(ctx.params.stageId);
       this.pageComponent.appTitle = this.appTitle;
     });
     page(
@@ -441,7 +441,6 @@ class ChromedashApp extends LitElement {
         if (!this.setupNewPage(ctx, 'chromedash-guide-stage-page')) return;
         this.pageComponent.featureId = parseInt(ctx.params.featureId);
         this.pageComponent.stageId = parseInt(ctx.params.stageId);
-        this.pageComponent.intentStage = parseInt(ctx.params.intentStage);
         this.pageComponent.appTitle = this.appTitle;
       }
     );

--- a/client-src/elements/chromedash-guide-stage-page.js
+++ b/client-src/elements/chromedash-guide-stage-page.js
@@ -31,7 +31,6 @@ export class ChromedashGuideStagePage extends LitElement {
   static get properties() {
     return {
       stageId: {type: Number},
-      intentStage: {type: Number},
       stageName: {type: String},
       featureId: {type: Number},
       feature: {type: Object},
@@ -48,7 +47,6 @@ export class ChromedashGuideStagePage extends LitElement {
   constructor() {
     super();
     this.stageId = 0;
-    this.intentStage = 0;
     this.stageName = '';
     this.featureId = 0;
     this.feature = {};


### PR DESCRIPTION
This change fixes an apparent oversight in which a possible path for the stage edit page was using the "intentStage" argument instead of the "stageId" argument. The current path `/guide/stage/{featureId}/{intentStage}` is not used anywhere on the site, and navigating to this URL will show a mostly blank page with an error toast message. The error is caused because no stage ID is available to obtain relevant stage data to populate the fields.

This change should have no effect on current site behavior.

The original plan for this path is what is being fixed. The path is now `/guide/stage/{featureId}/{stageId}`. The stage edit page does not use the intentStage arg for anything relevant to the page. This will now allow some of our redirect URLs to no longer pass in a (mostly irrelevant) intent stage variable. 

For reference, the reason there is even a URL that adds the intent stage argument for the stage edit page is a relic of the schema migration. Previously, the fields that were shown on the page were specific to this intent stage arg, but this is no longer the case.