### PR TITLE
Users cannot resubmit OT creation form after submission

### DIFF
--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -17,7 +17,7 @@ import {
   FORMS_BY_STAGE_TYPE,
 } from './form-definition';
 import {
-  OT_EXTENSION_STAGE_MAPPING,
+  OT_SETUP_STATUS_OPTIONS,
   STAGE_SHORT_NAMES,
   STAGE_TYPES_ORIGIN_TRIAL,
   VOTE_OPTIONS,
@@ -782,7 +782,10 @@ class ChromedashFeatureDetail extends LitElement {
         g.state === VOTE_OPTIONS.NA[0]
       );
     });
-    if (feStage.ot_action_requested) {
+    if (
+      feStage.ot_setup_status &&
+      feStage.ot_setup_status !== OT_SETUP_STATUS_OPTIONS.OT_NOT_CREATED
+    ) {
       // Display the button as disabled with tooltip text if a request
       // has already been submitted.
       return html` <sl-tooltip

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -102,7 +102,10 @@ export class ChromedashOTCreationPage extends LitElement {
       this.stage = stage;
 
       // Redirect is stage creation form has already been submitted.
-      if (this.stage.ot_setup_status && this.stage.ot_setup_status !== OT_SETUP_STATUS_OPTIONS.OT_NOT_CREATED) {
+      if (
+        this.stage.ot_setup_status &&
+        this.stage.ot_setup_status !== OT_SETUP_STATUS_OPTIONS.OT_NOT_CREATED
+      ) {
         window.location.href = `/feature/${this.featureId}`;
       }
       // Check that necessary approvals have been obtained.

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -101,7 +101,7 @@ export class ChromedashOTCreationPage extends LitElement {
       this.feature = feature;
       this.stage = stage;
 
-      // Redirect is stage creation form has already been submitted.
+      // Redirect if stage creation form has already been submitted.
       if (
         this.stage.ot_setup_status &&
         this.stage.ot_setup_status !== OT_SETUP_STATUS_OPTIONS.OT_NOT_CREATED

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -5,9 +5,8 @@ import {FORM_STYLES} from '../css/forms-css.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {Feature, StageDict} from '../js-src/cs-client.js';
 import './chromedash-form-field.js';
-import './chromedash-form-table.js';
 import {ORIGIN_TRIAL_CREATION_FIELDS} from './form-definition.js';
-import {VOTE_OPTIONS} from './form-field-enums.js';
+import {OT_SETUP_STATUS_OPTIONS, VOTE_OPTIONS} from './form-field-enums.js';
 import {ALL_FIELDS} from './form-field-specs.js';
 import {
   FieldInfo,
@@ -102,6 +101,10 @@ export class ChromedashOTCreationPage extends LitElement {
       this.feature = feature;
       this.stage = stage;
 
+      // Redirect is stage creation form has already been submitted.
+      if (this.stage.ot_setup_status && this.stage.ot_setup_status !== OT_SETUP_STATUS_OPTIONS.OT_NOT_CREATED) {
+        window.location.href = `/feature/${this.featureId}`;
+      }
       // Check that necessary approvals have been obtained.
       const relevantGates = gatesRes.gates.filter(
         g => g.stage_id === this.stage.id

--- a/client-src/elements/form-field-enums.ts
+++ b/client-src/elements/form-field-enums.ts
@@ -475,6 +475,16 @@ export const OT_MILESTONE_END_FIELDS: Record<string, string> = {
   ot_milestone_webview_end: 'webview_last',
 };
 
+// ot_setup_status values for denoting OT creation progress.
+export const OT_SETUP_STATUS_OPTIONS = {
+  OT_NOT_CREATED: 1,
+  OT_READY_FOR_CREATION: 2,
+  OT_CREATION_FAILED: 3,
+  OT_ACTIVATION_FAILED: 4,
+  OT_CREATED: 5,
+  OT_ACTIVATED: 6,
+};
+
 export const IMPLEMENTATION_STATUS: Record<string, [number, string]> = {
   NO_ACTIVE_DEV: [1, 'No active development'],
   PROPOSED: [2, 'Proposed'],


### PR DESCRIPTION
Addresses #4100 

This change disables the button to navigate to the OT creation form when the form has already been submitted, and navigating directly to the creation form after submission will result in a redirect. This is to avoid users from changing data  and the submissions status of the trial while creation is in progress, and will be required for automated OT creation process.