### PR TITLE
Add setting for automated OT creation flag

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -37,7 +37,7 @@ cron:
   schedule: every day 6:00
 - description: Send origin trial process reminder emails.
   url: /cron/send-ot-process-reminders
-  schedule: every monday 10:00
+  schedule: every monday 4:00
 - description: Check if any origin trials require creation
   url: /cron/create_origin_trials
   schedule: every 5 minutes

--- a/cron.yaml
+++ b/cron.yaml
@@ -37,12 +37,10 @@ cron:
   schedule: every day 6:00
 - description: Send origin trial process reminder emails.
   url: /cron/send-ot-process-reminders
-  schedule: every monday 4:00
-
-# TODO(DanielRyanSmith): Add this job when OT creation is fully implemented.
-# - description: Check if any origin trials require creation
-#   url: /cron/create_origin_trials
-#   schedule: every 5 minutes
-# - description: Check if any origin trials require activation
-#   url: /cron/activate_origin_trials
-#   schedule: every day 4:00
+  schedule: every monday 10:00
+- description: Check if any origin trials require creation
+  url: /cron/create_origin_trials
+  schedule: every 5 minutes
+- description: Check if any origin trials require activation
+  url: /cron/activate_origin_trials
+  schedule: every day 9:00

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -378,9 +378,11 @@ class EntitiesAPIHandler(APIHandler):
       stage.put()
 
     # Notify of OT creation request if one was sent.
+    # This notification is for non-automated OT creation only.
     if (ot_action_requested and
-        stage.stage_type in ALL_ORIGIN_TRIAL_STAGE_TYPES):
-      notifier_helpers.send_ot_notification(stage)
+        stage.stage_type in ALL_ORIGIN_TRIAL_STAGE_TYPES and
+        not settings.AUTOMATED_OT_CREATION):
+      notifier_helpers.send_ot_creation_notification(stage)
 
     return stage_was_updated
 

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -29,6 +29,7 @@ from internals.data_types import StageDict
 from internals.review_models import Gate, Vote, Activity
 from internals.core_enums import *
 from internals.feature_links import batch_index_feature_entries
+import settings
 
 class EvaluateGateStatus(FlaskHandler):
 
@@ -571,6 +572,8 @@ class CreateOriginTrials(FlaskHandler):
   def get_template_data(self, **kwargs):
     """Create any origin trials that are flagged for creation."""
     self.require_cron_header()
+    if not settings.AUTOMATED_OT_CREATION:
+      return 'Automated OT creation process is not active.'
 
     # OT stages that are flagged to process a trial creation.
     ot_stages: list[Stage] = Stage.query(
@@ -597,6 +600,8 @@ class ActivateOriginTrials(FlaskHandler):
     them.
     """
     self.require_cron_header()
+    if not settings.AUTOMATED_OT_CREATION:
+      return 'Automated OT creation process is not active.'
 
     success_count, fail_count = 0, 0
     today = self._get_today()

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -191,7 +191,7 @@ def notify_subscribers_of_new_comments(fe: 'FeatureEntry', gate: Gate,
   cloud_tasks_helpers.enqueue_task('/tasks/email-comments', params)
 
 
-def send_ot_notification(stage: Stage):
+def send_ot_creation_notification(stage: Stage):
   """Notify about new trial creation request."""
   stage_dict = converters.stage_to_json_dict(stage)
   # Add the OT request note, which is usually not publicly visible.

--- a/settings.py
+++ b/settings.py
@@ -38,6 +38,9 @@ DEFAULT_COMPONENT = 'Blink'
 # The default component for enterprise features.
 DEFAULT_ENTERPRISE_COMPONENT = 'Enterprise'
 
+# Enable to activate the automated OT creation process
+AUTOMATED_OT_CREATION = False
+
 
 ################################################################################
 


### PR DESCRIPTION
Addresses #4100 

This change adds a flag that controls whether the entire automated OT creation process is active. This will give an easy rollback option in case some issues arise with the process on the final deployment.

The cron jobs that handle automated trial creation will now run on their regular schedule, but will not perform any actions until the flag is set to run the automated process.