### PR TITLE
Make OT milestone fields required on creation form

### DIFF
--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -1590,7 +1590,6 @@ export const ALL_FIELDS: Record<string, Field> = {
   },
 
   ot_creation__milestone_desktop_first: {
-    name: 'ot_milestone_desktop_start',
     type: 'input',
     attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: true,
@@ -1605,7 +1604,6 @@ export const ALL_FIELDS: Record<string, Field> = {
   },
 
   ot_creation__milestone_desktop_last: {
-    name: 'ot_milestone_desktop_end',
     type: 'input',
     attrs: MILESTONE_NUMBER_FIELD_ATTRS,
     required: true,


### PR DESCRIPTION
Part of #4133
This change removes an unnecessary attribute to form-field-specs.ts, which caused the OT milestone fields to use the wrong description and attributes when being listed on the OT creation request form. The difference was minor, but the most important change is that these fields were not required to submit the form, which should be the way the form functions. This update now causes the fields to be required.

https://github.com/user-attachments/assets/18580fa6-e7ac-4c45-9f05-ff52c7ce7e4c

