### PR TITLE
Update OT process reminders weekly run time

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -37,7 +37,7 @@ cron:
   schedule: every day 6:00
 - description: Send origin trial process reminder emails.
   url: /cron/send-ot-process-reminders
-  schedule: every monday 4:00
+  schedule: every monday 11:00
 - description: Check if any origin trials require creation
   url: /cron/create_origin_trials
   schedule: every 5 minutes

--- a/cron.yaml
+++ b/cron.yaml
@@ -37,7 +37,7 @@ cron:
   schedule: every day 6:00
 - description: Send origin trial process reminder emails.
   url: /cron/send-ot-process-reminders
-  schedule: every monday 11:00
+  schedule: every monday 10:00
 - description: Check if any origin trials require creation
   url: /cron/create_origin_trials
   schedule: every 5 minutes


### PR DESCRIPTION
Previously, the process reminders script ran at ~3:00AM PT on Mondays. Currently, it's running at ~9:00PM PT on Sundays. This change adjusts the scheduled run time to better match when the reminders script used to run weekly.