### PR TITLE
Fix errors due to undefined initial values.

### DIFF
--- a/client-src/elements/chromedash-feature-table.ts
+++ b/client-src/elements/chromedash-feature-table.ts
@@ -14,7 +14,7 @@ export class ChromedashFeatureTable extends LitElement {
   @state()
   reloading = false;
   @state()
-  features!: Feature[];
+  features: Feature[] = [];
   @state()
   totalCount = 0;
   @property({type: Number, attribute: false})

--- a/client-src/elements/chromedash-featurelist.ts
+++ b/client-src/elements/chromedash-featurelist.ts
@@ -22,7 +22,7 @@ class ChromedashFeaturelist extends LitElement {
   features!: Feature[];
   /** The search input element. */
   @state()
-  filtered!: Feature[];
+  filtered: Feature[] = [];
   @state()
   openFeatures = new Set<number>();
   @state()

--- a/client-src/elements/chromedash-form-field.ts
+++ b/client-src/elements/chromedash-form-field.ts
@@ -50,7 +50,7 @@ export class ChromedashFormField extends LitElement {
   @state()
   loading = false;
   @state()
-  componentChoices; // just for the blink component select field
+  componentChoices: Record<string, [string, string]> = {}; // just for the blink component select field
   @state()
   checkMessage: TemplateResult | string = '';
   @state()
@@ -140,9 +140,11 @@ export class ChromedashFormField extends LitElement {
   handleFieldUpdated(e) {
     // Determine the value based on the input type.
     const type = this.fieldProps.type;
-    let fieldValue;
+    let fieldValue: string;
     if (type === 'checkbox') {
       fieldValue = e.target.checked;
+    } else if (type === 'multiselect') {
+      fieldValue = e.target.value.join(',');
     } else {
       fieldValue = e.target.value;
     }
@@ -291,8 +293,7 @@ export class ChromedashFormField extends LitElement {
         </sl-select>
       `;
     } else if (type === 'multiselect') {
-      const valueArray = fieldValue.split(',');
-
+      const valueArray: string[] = fieldValue.split(',');
       fieldHTML = html`
         <sl-select
           name="${fieldName}"

--- a/client-src/elements/chromedash-na-rationale-dialog.ts
+++ b/client-src/elements/chromedash-na-rationale-dialog.ts
@@ -1,4 +1,4 @@
-import {LitElement, css, html} from 'lit';
+import {LitElement, css, html, nothing} from 'lit';
 import {ref, createRef} from 'lit/directives/ref.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {customElement, property} from 'lit/decorators.js';
@@ -30,7 +30,7 @@ export class ChromedashNaRationaleDialog extends LitElement {
   }
 
   @property({type: Object, attribute: false})
-  gate!: GateDict;
+  gate?: GateDict = undefined;
   @property({attribute: false})
   resolve: (value?: string) => void = () => {
     console.log('Missing resolve action');
@@ -48,6 +48,9 @@ export class ChromedashNaRationaleDialog extends LitElement {
   }
 
   renderDialogContent() {
+    if (this.gate === undefined) {
+      return nothing;
+    }
     return html`
       <p style="padding: var(--content-padding)">
         Please briefly explain why your feature does not require a review. Your


### PR DESCRIPTION
This fixes a few errors that I saw on the browser console while poking around the site locally:
* The feature list pages could not do `this.features.length` before the features had loaded.
* `npm run webtest` was logging an error about not being able to convert undefined to an object  when componentChoices had not finished loading.
* The 'Request N/A' button failed to open a dialog because the dialog tried to render with an undefined gate before the gate was set.

Also, this fixes a problem with multi-valued `<sl-select>` elements.  The code assumed that the `.value` of such an element was a comma-separated list, but it is actually an array of strings.  This caused it to be impossible to edit the platforms of a rollout step.  This change in `<sl-select>` must have happened some time ago because the failure is currently happening in prod.