### PR TITLE
Fix Gantt chart

### DIFF
--- a/client-src/elements/chromedash-gantt.ts
+++ b/client-src/elements/chromedash-gantt.ts
@@ -12,14 +12,7 @@ import {
 class ChromedashGantt extends LitElement {
   @property({type: Object})
   feature!: Feature;
-  @property({type: Number})
-  stableMilestone: number | null = null;
 
-  connectedCallback() {
-    window.csClient
-      .getChannels()
-      .then(channels => (this.stableMilestone = channels['stable'].version));
-  }
   static get styles() {
     return [
       ...SHARED_STYLES,


### PR DESCRIPTION
This fixes a bug that was caused moving the `getChannels()` request to the connectedCallback function in the chromedash-gantt component. The `super.connectedCallback()` was omitted, which caused the function to silently fail. In the end, the invocation was used to populate a property that was not used (probably from an older implementaiton). Removing the call entirely fixed the issue with the Gantt chart not being displayed.