### PR TITLE
Don't sent "extension approved" email without an OT contact

### DIFF
--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -202,8 +202,13 @@ def send_ot_creation_notification(stage: Stage):
 
 
 def send_trial_extension_approved_notification(
-    fe: 'FeatureEntry', stage: Stage, gate_id: int):
+    fe: 'FeatureEntry', stage: Stage, gate_id: int) -> None:
   """Notify that a trial extension is ready to be finalized."""
+  # If we don't have an OT owner email, don't send the email out.
+  # This should always be set, and is collected during the extension request.
+  if not stage.ot_owner_email:
+    return
+
   params = {
     'feature': converters.feature_entry_to_json_verbose(fe),
     'requester_email': stage.ot_owner_email,


### PR DESCRIPTION
This change fixes a bug where "OT extension approved" email tasks are created without any valid recipients, which adds tasks to the AppEngine queue that cannot be resolved.

During the automated extension process, `ot_owner_email` is always set with the email address of the user who requested the extension. However, this value is not set for older extension stages that were created before the automated process. Additionally, we don't want to send emails out when changing the approval status of these old extension stages, since there is no extension to actually be initiated.

In summary, this change allows us to set approval status of old extension stages in the UI without creating failing task queues or notifying users who shouldn't be notified.