### PR TITLE
Avoid a 404 because there is no ot_requests.css.

### DIFF
--- a/templates/admin/features/ot_requests.html
+++ b/templates/admin/features/ot_requests.html
@@ -4,7 +4,6 @@
 
 {% block css %}
 <link rel="stylesheet" href="/static/css/forms.css?v={{app_version}}">
-<link rel="stylesheet" href="/static/css/features/ot_requests.css?v={{app_version}}">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This reference was added in https://github.com/GoogleChrome/chromium-dashboard/pull/3352/files
but there was no file added for ot_requests.css.