### PR TITLE
Avoid errors accessing `this.feature` when request not finished.

### DIFF
--- a/client-src/elements/chromedash-guide-metadata-page.ts
+++ b/client-src/elements/chromedash-guide-metadata-page.ts
@@ -153,15 +153,18 @@ export class ChromedashGuideMetadataPage extends LitElement {
   }
 
   renderSubheader() {
-    return html`
-      <div id="subheader">
-        <h2 id="breadcrumbs">
+    const link = this.loading ? nothing : html`
           <a href=${this.getNextPage()}>
-            <iron-icon icon="chromestatus:arrow-back"></iron-icon>
-            Edit feature: ${this.feature.name}
-          </a>
-        </h2>
-      </div>
+              <iron-icon icon="chromestatus:arrow-back"></iron-icon>
+              Edit feature: ${this.feature.name}
+           </a>
+         `;
+     return html`
+        <div id="subheader">
+          <h2 id="breadcrumbs">
+            ${link}
+          </h2>
+        </div>
     `;
   }
 

--- a/client-src/elements/chromedash-guide-metadata-page.ts
+++ b/client-src/elements/chromedash-guide-metadata-page.ts
@@ -1,4 +1,4 @@
-import {LitElement, css, html} from 'lit';
+import {LitElement, css, html, nothing} from 'lit';
 import {ref} from 'lit/directives/ref.js';
 import {
   formatFeatureChanges,
@@ -230,7 +230,7 @@ export class ChromedashGuideMetadataPage extends LitElement {
 
   render() {
     return html`
-      ${this.renderSubheader()}
+      ${this.loading ? nothing : this.renderSubheader()}
       ${this.loading ? this.renderSkeletons() : this.renderForm()}
     `;
   }

--- a/client-src/elements/chromedash-guide-metadata-page.ts
+++ b/client-src/elements/chromedash-guide-metadata-page.ts
@@ -233,7 +233,7 @@ export class ChromedashGuideMetadataPage extends LitElement {
 
   render() {
     return html`
-      ${this.loading ? nothing : this.renderSubheader()}
+      ${this.renderSubheader()}
       ${this.loading ? this.renderSkeletons() : this.renderForm()}
     `;
   }

--- a/client-src/elements/chromedash-guide-metadata-page.ts
+++ b/client-src/elements/chromedash-guide-metadata-page.ts
@@ -153,18 +153,18 @@ export class ChromedashGuideMetadataPage extends LitElement {
   }
 
   renderSubheader() {
-    const link = this.loading ? nothing : html`
+    const link = this.loading
+      ? nothing
+      : html`
           <a href=${this.getNextPage()}>
-              <iron-icon icon="chromestatus:arrow-back"></iron-icon>
-              Edit feature: ${this.feature.name}
-           </a>
-         `;
-     return html`
-        <div id="subheader">
-          <h2 id="breadcrumbs">
-            ${link}
-          </h2>
-        </div>
+            <iron-icon icon="chromestatus:arrow-back"></iron-icon>
+            Edit feature: ${this.feature.name}
+          </a>
+        `;
+    return html`
+      <div id="subheader">
+        <h2 id="breadcrumbs">${link}</h2>
+      </div>
     `;
   }
 

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -442,7 +442,7 @@ export class ChromedashOTCreationPage extends LitElement {
 
   render() {
     return html`
-      ${this.renderSubheader()}
+      ${this.loading ? nothing : this.renderSubheader()}
       ${this.loading ? this.renderSkeletons() : this.renderForm()}
     `;
   }

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -445,7 +445,7 @@ export class ChromedashOTCreationPage extends LitElement {
 
   render() {
     return html`
-      ${this.loading ? nothing : this.renderSubheader()}
+      ${this.renderSubheader()}
       ${this.loading ? this.renderSkeletons() : this.renderForm()}
     `;
   }

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -363,18 +363,18 @@ export class ChromedashOTCreationPage extends LitElement {
   }
 
   renderSubheader() {
-    const link = this.loading ? nothing : html`
+    const link = this.loading
+      ? nothing
+      : html`
           <a href=${this.getNextPage()}>
-              <iron-icon icon="chromestatus:arrow-back"></iron-icon>
-              Request origin trial creation: ${this.feature.name}
-           </a>
-         `;
-     return html`
-        <div id="subheader">
-          <h2 id="breadcrumbs">
-            ${link}
-          </h2>
-        </div>
+            <iron-icon icon="chromestatus:arrow-back"></iron-icon>
+            Request origin trial creation: ${this.feature.name}
+          </a>
+        `;
+    return html`
+      <div id="subheader">
+        <h2 id="breadcrumbs">${link}</h2>
+      </div>
     `;
   }
 

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -363,15 +363,18 @@ export class ChromedashOTCreationPage extends LitElement {
   }
 
   renderSubheader() {
-    return html`
-      <div id="subheader">
-        <h2 id="breadcrumbs">
+    const link = this.loading ? nothing : html`
           <a href=${this.getNextPage()}>
-            <iron-icon icon="chromestatus:arrow-back"></iron-icon>
-            Request origin trial creation: ${this.feature.name}
-          </a>
-        </h2>
-      </div>
+              <iron-icon icon="chromestatus:arrow-back"></iron-icon>
+              Request origin trial creation: ${this.feature.name}
+           </a>
+         `;
+     return html`
+        <div id="subheader">
+          <h2 id="breadcrumbs">
+            ${link}
+          </h2>
+        </div>
     `;
   }
 

--- a/client-src/elements/chromedash-ot-extension-page.ts
+++ b/client-src/elements/chromedash-ot-extension-page.ts
@@ -244,15 +244,18 @@ export class ChromedashOTExtensionPage extends LitElement {
   }
 
   renderSubheader() {
-    return html`
-      <div id="subheader">
-        <h2 id="breadcrumbs">
+    const link = this.loading ? nothing : html`
           <a href=${this.getNextPage()}>
-            <iron-icon icon="chromestatus:arrow-back"></iron-icon>
-            Request origin trial extension: ${this.feature.name}
-          </a>
-        </h2>
-      </div>
+              <iron-icon icon="chromestatus:arrow-back"></iron-icon>
+              Request origin trial extension: ${this.feature.name}
+           </a>
+         `;
+     return html`
+        <div id="subheader">
+          <h2 id="breadcrumbs">
+            ${link}
+          </h2>
+        </div>
     `;
   }
 

--- a/client-src/elements/chromedash-ot-extension-page.ts
+++ b/client-src/elements/chromedash-ot-extension-page.ts
@@ -244,18 +244,18 @@ export class ChromedashOTExtensionPage extends LitElement {
   }
 
   renderSubheader() {
-    const link = this.loading ? nothing : html`
+    const link = this.loading
+      ? nothing
+      : html`
           <a href=${this.getNextPage()}>
-              <iron-icon icon="chromestatus:arrow-back"></iron-icon>
-              Request origin trial extension: ${this.feature.name}
-           </a>
-         `;
-     return html`
-        <div id="subheader">
-          <h2 id="breadcrumbs">
-            ${link}
-          </h2>
-        </div>
+            <iron-icon icon="chromestatus:arrow-back"></iron-icon>
+            Request origin trial extension: ${this.feature.name}
+          </a>
+        `;
+    return html`
+      <div id="subheader">
+        <h2 id="breadcrumbs">${link}</h2>
+      </div>
     `;
   }
 

--- a/client-src/elements/chromedash-ot-extension-page.ts
+++ b/client-src/elements/chromedash-ot-extension-page.ts
@@ -1,4 +1,4 @@
-import {LitElement, css, html} from 'lit';
+import {LitElement, css, html, nothing} from 'lit';
 import {property, state} from 'lit/decorators.js';
 import {ref} from 'lit/directives/ref.js';
 import {FORM_STYLES} from '../css/forms-css.js';
@@ -369,7 +369,7 @@ export class ChromedashOTExtensionPage extends LitElement {
 
   render() {
     return html`
-      ${this.renderSubheader()}
+      ${this.loading ? nothing : this.renderSubheader()}
       ${this.loading ? this.renderSkeletons() : this.renderForm()}
     `;
   }

--- a/client-src/elements/chromedash-ot-extension-page.ts
+++ b/client-src/elements/chromedash-ot-extension-page.ts
@@ -372,7 +372,7 @@ export class ChromedashOTExtensionPage extends LitElement {
 
   render() {
     return html`
-      ${this.loading ? nothing : this.renderSubheader()}
+      ${this.renderSubheader()}
       ${this.loading ? this.renderSkeletons() : this.renderForm()}
     `;
   }


### PR DESCRIPTION
Not sure if this is from recent changes, but some locations with the `renderSubheader` method did not wait for relevant properties to be populated (namely, the feature to be displayed), which caused some log errors. The page would render correctly after the data was fetched, however. Regardless, waiting until the data has finished loading will fix this problem.