### PR TITLE
Fix showEnterprise on enterprise list page.

### DIFF
--- a/client-src/elements/chromedash-feature-table.ts
+++ b/client-src/elements/chromedash-feature-table.ts
@@ -19,9 +19,9 @@ export class ChromedashFeatureTable extends LitElement {
   totalCount = 0;
   @property({type: Number, attribute: false})
   start = 0;
-  @property({type: String, attribute: false})
+  @property({type: String})
   query = '';
-  @property({type: Boolean, attribute: false})
+  @property({type: Boolean})
   showEnterprise = false;
   @property({type: String, attribute: false})
   sortSpec = '';


### PR DESCRIPTION
The enterprise feature list page was just showing regular features rather than enterprise features.

The code path is a little complicated, but basically whenever a query is set for the chromedash-feature-table, and that query mentions `feature_type`, then `showEnterprise` should be set to true, and the query should be set. 

However, those properties had `attribute: false`, so the values passed to them via attributes was not being set.  That cause the enterprise feature list to show all features rather than sending any query string to the server, and it did not ask the server to include enterprise features.