### PR TITLE
Fix typeahead menu item initial highlighting.

### DIFF
--- a/client-src/elements/chromedash-typeahead.ts
+++ b/client-src/elements/chromedash-typeahead.ts
@@ -333,8 +333,12 @@ export class ChromedashTypeaheadItem extends LitElement {
   doc = '';
   @property({type: String})
   prefix = '';
+  // tabindex is initially -1 for menu items so that the tab key does not
+  // navigate among menu items.  Instead, sl-menu handles arrow keys and
+  // mouseover.  Shoelace uses tabindex==0 only for the current menu item.
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
   @property({type: Number})
-  tabindex = 0;
+  tabindex = -1;
   @property({type: String, reflect: true})
   role = 'menuitem';
 


### PR DESCRIPTION
This resolves a bug where the menu items in the typeahead menu were all initially highlighted.

It's not intuitive, but Shoelace sets tabindex == -1 for all menu items, and then sets it to 0 only for the one current menu item that the user is hovering over or has selected using the arrow keys.  So, the initial value for this property should be -1.