### PR TITLE
Extension stages are correctly ordered

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -168,6 +168,9 @@ def _prep_stage_info(
       (stage_info['all_stages'][ot_stage_indexes[ot_id]]['extensions']
           .append(extension))
   stage_info['all_stages'].sort(key=lambda s: (s['stage_type'], s['created']))
+  # Sort all extensions in order of creation as well.
+  for stage in stage_info['all_stages']:
+    stage['extensions'].sort(key=lambda s: (s['created']))
   return stage_info
 
 

--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -369,7 +369,6 @@ class FeatureConvertersTest(testing_config.CustomTestCase):
       'non_oss_deps': None,
       'ongoing_constraints': None,
       'owner_emails': ['feature_owner@example.com'],
-      'owner_emails': ['feature_owner@example.com'],
       'safari_views': 1,
       'search_tags': [],
       'security_risks': None,

--- a/api/stages_api_test.py
+++ b/api/stages_api_test.py
@@ -25,7 +25,6 @@ from api import stages_api
 from internals.user_models import AppUser
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
 from internals.review_models import Gate
-import settings
 
 test_app = flask.Flask(__name__)
 
@@ -98,13 +97,22 @@ class StagesAPITest(testing_config.CustomTestCase):
         created=self.now)
     self.stage_4.put()
 
-    self.stage_5 = Stage(id=50, feature_id=1, stage_type=150, browser='Chrome',
+    # Two extension stages for the same origin trial stage.
+    self.stage_5 = Stage(id=50, feature_id=1, stage_type=151, browser='Chrome',
         ot_stage_id=40,
-        ux_emails=['ux_person@example.com'],
-        intent_thread_url='https://example.com/intent',
-        milestones=MilestoneSet(desktop_first=100),
-        experiment_goals='To be the very best.',
+        ot_emails=['ot_person2@google.com'],
+        intent_thread_url='https://example.com/intent2',
+        milestones=MilestoneSet(desktop_last=106),
+        experiment_extension_reason='To be the very best again.',
         created=self.now)
+    self.stage_5.put()
+    self.stage_5 = Stage(id=51, feature_id=1, stage_type=151, browser='Chrome',
+        ot_stage_id=40,
+        ot_emails=['ot_person@google.com'],
+        intent_thread_url='https://example.com/intent',
+        milestones=MilestoneSet(desktop_last=103),
+        experiment_extension_reason='To be the very best.',
+        created=datetime(2020, 1, 1))
     self.stage_5.put()
 
     self.expected_stage_1 = {
@@ -199,25 +207,27 @@ class StagesAPITest(testing_config.CustomTestCase):
 
   def test_get__valid_with_extension(self):
     """Returns stage data with extension if requesting a valid stage ID."""
-    extension = {
+    # TODO(DanielRyanSmith): this dict format should be tested in
+    # api/converters_test.py instead.
+    extension_1 = {
         'id': 50,
         'created': str(self.now),
         'feature_id': 1,
-        'stage_type': 150,
-        'intent_stage': 3,
+        'stage_type': 151,
+        'intent_stage': 11,
         'pm_emails': [],
         'tl_emails': [],
-        'ux_emails': ['ux_person@example.com'],
+        'ux_emails': [],
         'te_emails': [],
-        'intent_thread_url': 'https://example.com/intent',
-        'desktop_first': 100,
+        'intent_thread_url': 'https://example.com/intent2',
+        'desktop_first': None,
         'display_name': None,
-        'desktop_last': None,
+        'desktop_last': 106,
         'android_first': None,
         'android_last': None,
         'webview_first': None,
         'webview_last': None,
-        'experiment_goals': 'To be the very best.',
+        'experiment_goals': None,
         'experiment_risks': None,
         'origin_trial_feedback_url': None,
         'ot_action_requested': False,
@@ -229,7 +239,7 @@ class StagesAPITest(testing_config.CustomTestCase):
         'ot_description': None,
         'ot_display_name': None,
         'ot_documentation_url': None,
-        'ot_emails': [],
+        'ot_emails': ['ot_person2@google.com'],
         'ot_feedback_submission_url': None,
         'ot_has_third_party_support': False,
         'ot_is_critical_trial': False,
@@ -239,7 +249,7 @@ class StagesAPITest(testing_config.CustomTestCase):
         'ot_webfeature_use_counter': None,
         'announcement_url': None,
         'enterprise_policies': [],
-        'experiment_extension_reason': None,
+        'experiment_extension_reason': 'To be the very best again.',
         'extensions': [],
         'finch_url': None,
         'ios_first': None,
@@ -250,7 +260,59 @@ class StagesAPITest(testing_config.CustomTestCase):
         'rollout_impact': 2,
         'rollout_milestone': None,
         'rollout_platforms': [],
-}
+        }
+    extension_2 = {
+        'id': 51,
+        'created': '2020-01-01 00:00:00',
+        'feature_id': 1,
+        'stage_type': 151,
+        'intent_stage': 11,
+        'pm_emails': [],
+        'tl_emails': [],
+        'ux_emails': [],
+        'te_emails': [],
+        'intent_thread_url': 'https://example.com/intent',
+        'desktop_first': None,
+        'display_name': None,
+        'desktop_last': 103,
+        'android_first': None,
+        'android_last': None,
+        'webview_first': None,
+        'webview_last': None,
+        'experiment_goals': None,
+        'experiment_risks': None,
+        'origin_trial_feedback_url': None,
+        'ot_action_requested': False,
+        'ot_approval_buganizer_component': None,
+        'ot_approval_buganizer_custom_field_id': None,
+        'ot_approval_criteria_url': None,
+        'ot_approval_group_email': None,
+        'ot_chromium_trial_name': None,
+        'ot_description': None,
+        'ot_display_name': None,
+        'ot_documentation_url': None,
+        'ot_emails': ['ot_person@google.com'],
+        'ot_feedback_submission_url': None,
+        'ot_has_third_party_support': False,
+        'ot_is_critical_trial': False,
+        'ot_is_deprecation_trial': False,
+        'ot_owner_email': None,
+        'ot_require_approvals': False,
+        'ot_webfeature_use_counter': None,
+        'announcement_url': None,
+        'enterprise_policies': [],
+        'experiment_extension_reason': 'To be the very best.',
+        'extensions': [],
+        'finch_url': None,
+        'ios_first': None,
+        'ios_last': None,
+        'origin_trial_id': None,
+        'ot_stage_id': 40,
+        'rollout_details': None,
+        'rollout_impact': 2,
+        'rollout_milestone': None,
+        'rollout_platforms': [],
+    }
 
     expect = {
         'id': 40,
@@ -273,7 +335,8 @@ class StagesAPITest(testing_config.CustomTestCase):
         'experiment_extension_reason': None,
         'experiment_goals': 'To be the very best.',
         'experiment_risks': None,
-        'extensions': [extension],
+        # Extensions should be in the order in which they were created.
+        'extensions': [extension_2, extension_1],
         'announcement_url': None,
         'enterprise_policies': [],
         'origin_trial_id': '-5269211564023480319',
@@ -303,7 +366,7 @@ class StagesAPITest(testing_config.CustomTestCase):
         'ios_first': None,
         'ios_last': None,
         'finch_url': None,
-}
+    }
 
     with test_app.test_request_context(f'{self.request_path}1/stages/10'):
       actual = self.handler.do_get(feature_id=1, stage_id=40)

--- a/internals/stage_helpers.py
+++ b/internals/stage_helpers.py
@@ -57,7 +57,7 @@ def create_feature_stage(feature_id: int, feature_type: int, stage_type: int) ->
     gate.put()
 
   return stage
-  
+
 def get_gate_for_stage(feature_type, s_type) -> int | None:
   # Update type-specific fields.
   if s_type == STAGE_TYPES_DEV_TRIAL[feature_type]: # pragma: no cover
@@ -115,7 +115,8 @@ def get_feature_stage_ids_list(feature_id: int) -> list[dict[str, int]]:
 def get_ot_stage_extensions(ot_stage_id: int):
   """Return a list of extension stages associated with a stage in JSON format"""
   q = Stage.query(Stage.ot_stage_id == ot_stage_id)
-  return [converters.stage_to_json_dict(stage) for stage in q]
+  extension_stages =  [converters.stage_to_json_dict(stage) for stage in q]
+  return sorted(extension_stages, key=lambda s: (s['created']))
 
 
 def get_stage_info_for_templates(
@@ -159,10 +160,10 @@ def get_stage_info_for_templates(
       stage_info['should_render_intents'] = True
 
     # Add stages to their respective lists.
-    if s.stage_type == proto_stage_type: 
+    if s.stage_type == proto_stage_type:
       stage_info['proto_stages'].append(s)
 
-    # Make sure a MilestoneSet entity is referenced to avoid errors. 
+    # Make sure a MilestoneSet entity is referenced to avoid errors.
     if s.milestones is None:
       s.milestones = MilestoneSet()
 
@@ -174,13 +175,13 @@ def get_stage_info_for_templates(
       stage_info['dt_stages'].append(s)
       if m.desktop_first or m.android_first or m.ios_first:
         stage_info['should_render_mstone_table'] = True
-    
+
     if s.stage_type == ot_stage_type:
       stage_info['ot_stages'].append(s)
       if (m.desktop_first or m.android_first or m.webview_first or
           m.desktop_last or m.android_last or m.webview_last):
         stage_info['should_render_mstone_table'] = True
-    
+
     if s.stage_type == extension_stage_type:
      stage_info['extension_stages'].append(s)
       # Extension stages are not rendered
@@ -190,7 +191,7 @@ def get_stage_info_for_templates(
       stage_info['ship_stages'].append(s)
       if m.desktop_first or m.android_first or m.webview_first or m.ios_first:
         stage_info['should_render_mstone_table'] = True
-  
+
   # Returns a dictionary of stages needed for rendering info, as well as
   # a boolean value representing whether or not the estimated milestones
   # table will need to be rendered.


### PR DESCRIPTION
Fixes #4144 

This change adds an additional sorting step for the trial extensions associated with an origin trial stage. Currently, the extension stages are unordered for the most part, and are being displayed as such in the UI. It is relatively unusual for origin trial stages to have multiple trial extensions, so this problem has not been readily apparent until recently.

There are also some changes to tests to make them more accurate to the data they are testing (e.g. giving extension stages their proper stage type).