### PR TITLE
Avoid rendering roadmap before channel info loads.

### DIFF
--- a/client-src/elements/chromedash-roadmap.ts
+++ b/client-src/elements/chromedash-roadmap.ts
@@ -1,5 +1,5 @@
 import '@polymer/iron-icon';
-import {LitElement, css, html} from 'lit';
+import {LitElement, css, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {Feature} from '../js-src/cs-client.js';
@@ -309,6 +309,9 @@ export class ChromedashRoadmap extends LitElement {
   }
 
   render() {
+    if (this.channels === undefined || this.milestoneInfo === undefined) {
+      return nothing;
+    }
     return html`
       ${this.pastMilestoneArray.map(
         milestone => html`


### PR DESCRIPTION
The render() method can be called before the channel info loads, so in that case just return nothing.  That data loads pretty fast, so there is no need for skeletons.