### PR TITLE
When error fetching OWNERS, fall back to stale ndb entity.

### DIFF
--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -36,7 +36,7 @@ class OwnersFile(ndb.Model):
     return self.put()
 
   @classmethod
-  def get_raw_owner_file(cls, url):
+  def get_raw_owner_file(cls, url) -> OwnersFile | None:
     """Retrieve raw the owner file's content, if it is created with an hour."""
     q = cls.query()
     q = q.filter(cls.url == url)
@@ -45,13 +45,12 @@ class OwnersFile(ndb.Model):
       logging.info('API_OWNERS content does not exist for URL %s.' % (url))
       return None
 
-    owners_file = owners_file_list[0]
-    # Check if it is created within an hour.
-    an_hour_before = datetime.datetime.now() - datetime.timedelta(hours=1)
-    if owners_file.created_on < an_hour_before:
-      return None
+    return owners_file_list[0]
 
-    return owners_file.raw_content
+  def is_fresh(self) -> bool:
+    """Check if it was created within the past hour."""
+    an_hour_before = datetime.datetime.now() - datetime.timedelta(hours=1)
+    return self.created_on > an_hour_before
 
 
 class GateDef(ndb.Model):

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -113,8 +113,9 @@ class OwnersFileTest(testing_config.CustomTestCase):
     self.owner_file_2.key.delete()
 
   def test_get_raw_owner_file(self):
-    raw_content = OwnersFile.get_raw_owner_file('abc')
-    self.assertEqual('foo', raw_content)
+    owners_file = OwnersFile.get_raw_owner_file('abc')
+    self.assertEqual('foo', owners_file.raw_content)
+    self.assertTrue(owners_file.is_fresh())
 
-    expired_content = OwnersFile.get_raw_owner_file('def')
-    self.assertEqual(None, expired_content)
+    expired_owners_file = OwnersFile.get_raw_owner_file('def')
+    self.assertFalse(expired_owners_file.is_fresh())


### PR DESCRIPTION
We had a site outage due to Gerrit being unresponsive, so this PR makes our dependency on Gerrit more robust.

The existing code had two levels of caching: redis for 1 hour, and a copy of the Gerrit response in ndb that is marked with its creation time and only used for 1 hour.  Both are useful even while Gerrit is working because we sometimes clear redis.

In this PR:
* Break out a separate `is_fresh()` method to check whether the ndb value should be used, rather than returning None.
* Use the ndb value if it is fresh.
* In the case of an error fetching from Gerrit, use the ndb value even if it was stale.  Also, treat it like a new response, so it is stored to ndb again and considered fresh for the next hour.  This prevents a huge number of requests to Gerrit during an outage.
* If Gerrit is down, and we have no OwnersFile in ndb, return an empty list of approvers rather than raising an exception.  This will lock out non-admin API owners, but our site will still be usable.