### PR TITLE
Fix undefined var in early call to render() in provote dialog.

### DIFF
--- a/client-src/elements/chromedash-prevote-dialog.ts
+++ b/client-src/elements/chromedash-prevote-dialog.ts
@@ -97,6 +97,10 @@ class ChromedashPrevoteDialog extends LitElement {
   }
 
   render() {
+    if (this.pendingGates === undefined) {
+      return html`Loading gates...`;
+    }
+
     return html` <sl-dialog label="Prerequsites for API Owner approval">
       <div id="prereqs-header">
         The following prerequisite gates are missing approvals:


### PR DESCRIPTION
This should resolve #4172.

An undefined variable was being referenced whenever an API Owner tried to vote Approved on their gate on a stage that also had other pending gates.  This triggers the pre-vote dialog to remind them about the need for those other approvals.

Basically, the dialog render() method is called implicitly before the dialog is shown, so that caused an error before the list of gates was set to a defined value.  The fix is to make the render code more robust in the case where that variable is undefined.