### PR TITLE
Rename field_id to gate_type.

### DIFF
--- a/client-src/elements/chromedash-gate-column.ts
+++ b/client-src/elements/chromedash-gate-column.ts
@@ -52,7 +52,7 @@ export interface Action {
 interface ApprovalFieldDef {
   name: string;
   description: string;
-  field_id: number;
+  gate_type: number;
   rule: string;
   approvers: string | string[];
   team_name: string;

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -497,8 +497,8 @@ class FlaskHandler(BaseHandler):
 
     user = self.get_current_user()
     if user:
-      field_id = approval_defs.ShipApproval.field_id
-      approvers = approval_defs.get_approvers(field_id)
+      gate_type = approval_defs.ShipApproval.gate_type
+      approvers = approval_defs.get_approvers(gate_type)
       user_pref = user_models.UserPref.get_signed_in_user_pref()
       common_data['user'] = {
         'can_create_feature': permissions.can_create_feature(user),

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -55,10 +55,10 @@ TESTING_APPROVERS = [
 DEFAULT_SLO_LIMIT = 5  # Five weekdays in the Pacific timezone.
 
 @dataclass(eq=True, frozen=True)
-class ApprovalFieldDef:
+class GateInfo:
   name: str
   description: str
-  field_id: int
+  gate_type: int
   rule: str
   approvers: str | list[str]
   team_name: str
@@ -69,37 +69,37 @@ class ApprovalFieldDef:
 # Note: This can be requested manually through the UI, but it is not
 # triggered by a blink-dev thread because i2p intents are only FYIs to
 # bilnk-dev and don't actually need approval by the API Owners.
-PrototypeApproval = ApprovalFieldDef(
+PrototypeApproval = GateInfo(
     'Intent to Prototype',
     'Not normally used.  If a review is requested, API Owners can approve.',
     core_enums.GATE_API_PROTOTYPE, ONE_LGTM,
     approvers=API_OWNERS_URL, team_name='API Owners')
 
-ExperimentApproval = ApprovalFieldDef(
+ExperimentApproval = GateInfo(
     'Intent to Experiment',
     'One API Owner must approve your intent',
     core_enums.GATE_API_ORIGIN_TRIAL, ONE_LGTM,
     approvers=API_OWNERS_URL, team_name='API Owners')
 
-ExtendExperimentApproval = ApprovalFieldDef(
+ExtendExperimentApproval = GateInfo(
     'Intent to Extend Experiment',
     'One API Owner must approve your intent',
     core_enums.GATE_API_EXTEND_ORIGIN_TRIAL, ONE_LGTM,
     approvers=API_OWNERS_URL, team_name='API Owners')
 
-ShipApproval = ApprovalFieldDef(
+ShipApproval = GateInfo(
     'Intent to Ship',
     'Three API Owners must approve your intent',
     core_enums.GATE_API_SHIP, THREE_LGTM,
     approvers=API_OWNERS_URL, team_name='API Owners')
 
-PlanApproval = ApprovalFieldDef(
+PlanApproval = GateInfo(
     'Intent to Deprecate and Remove',
     'Three API Owners must approve your intent',
     core_enums.GATE_API_PLAN, THREE_LGTM,
     approvers=API_OWNERS_URL, team_name='API Owners')
 
-PrivacyOriginTrialApproval = ApprovalFieldDef(
+PrivacyOriginTrialApproval = GateInfo(
     'Privacy OT Review',
     'Privacy OT Review',
     core_enums.GATE_PRIVACY_ORIGIN_TRIAL, ONE_LGTM,
@@ -107,7 +107,7 @@ PrivacyOriginTrialApproval = ApprovalFieldDef(
     escalation_email='chrome-privacy-owp-rotation@google.com',
     slo_initial_response=6)
 
-PrivacyShipApproval = ApprovalFieldDef(
+PrivacyShipApproval = GateInfo(
     'Privacy Ship Review',
     'Privacy Ship Review',
     core_enums.GATE_PRIVACY_SHIP, ONE_LGTM,
@@ -117,14 +117,14 @@ PrivacyShipApproval = ApprovalFieldDef(
 
 # Note: There is no PrivacyPlanApproval
 
-SecurityOriginTrialApproval = ApprovalFieldDef(
+SecurityOriginTrialApproval = GateInfo(
     'Security OT Review',
     'Security OT Review',
     core_enums.GATE_SECURITY_ORIGIN_TRIAL, ONE_LGTM,
     approvers=SECURITY_APPROVERS, team_name='Security',
     slo_initial_response=6)
 
-SecurityShipApproval = ApprovalFieldDef(
+SecurityShipApproval = GateInfo(
     'Security Ship Review',
     'Security Ship Review',
     core_enums.GATE_SECURITY_SHIP, ONE_LGTM,
@@ -133,53 +133,53 @@ SecurityShipApproval = ApprovalFieldDef(
 
 # Note: There is no SecurityPlanApproval
 
-EnterpriseShipApproval = ApprovalFieldDef(
+EnterpriseShipApproval = GateInfo(
     'Enterprise Ship Review',
     'Enterprise Ship Review',
     core_enums.GATE_ENTERPRISE_SHIP, ONE_LGTM,
     approvers=ENTERPRISE_APPROVERS, team_name='Enterprise')
 
-EnterprisePlanApproval = ApprovalFieldDef(
+EnterprisePlanApproval = GateInfo(
     'Enterprise Deprecation Plan Review',
     'Enterprise Deprecation Plan Review',
     core_enums.GATE_ENTERPRISE_PLAN, ONE_LGTM,
     approvers=ENTERPRISE_APPROVERS, team_name='Enterprise')
 
-DebuggabilityOriginTrialApproval = ApprovalFieldDef(
+DebuggabilityOriginTrialApproval = GateInfo(
     'Debuggability OT Review',
     'Debuggability OT Review',
     core_enums.GATE_DEBUGGABILITY_ORIGIN_TRIAL, ONE_LGTM,
     approvers=DEBUGGABILITY_APPROVERS, team_name='Debuggability',
     escalation_email='devtools-dev@chromium.org')
 
-DebuggabilityShipApproval = ApprovalFieldDef(
+DebuggabilityShipApproval = GateInfo(
     'Debuggability Ship Review',
     'Debuggability Ship Review',
     core_enums.GATE_DEBUGGABILITY_SHIP, ONE_LGTM,
     approvers=DEBUGGABILITY_APPROVERS, team_name='Debuggability',
     escalation_email='devtools-dev@chromium.org')
 
-DebuggabilityPlanApproval = ApprovalFieldDef(
+DebuggabilityPlanApproval = GateInfo(
     'Debuggability Deprecation Plan Review',
     'Debuggability Deprecation Plan Review',
     core_enums.GATE_DEBUGGABILITY_PLAN, ONE_LGTM,
     approvers=DEBUGGABILITY_APPROVERS, team_name='Debuggability',
     escalation_email='devtools-dev@chromium.org')
 
-TestingShipApproval = ApprovalFieldDef(
+TestingShipApproval = GateInfo(
     'Testing Ship Review',
     'Testing Ship Review',
     core_enums.GATE_TESTING_SHIP, ONE_LGTM,
     approvers=TESTING_APPROVERS, team_name='Testing')
 
-TestingPlanApproval = ApprovalFieldDef(
+TestingPlanApproval = GateInfo(
     'Testing Deprecation Plan Review',
     'Testing Deprecation Plan Review',
     core_enums.GATE_TESTING_PLAN, ONE_LGTM,
     approvers=TESTING_APPROVERS, team_name='Testing')
 
 APPROVAL_FIELDS_BY_ID = {
-    afd.field_id: afd
+    afd.gate_type: afd
     for afd in [
         PrototypeApproval, ExperimentApproval, ExtendExperimentApproval,
         ShipApproval, PlanApproval,
@@ -271,20 +271,20 @@ def auto_assign_reviewer(gate):
     gate.put()
 
 
-def get_approvers(field_id) -> list[str]:
+def get_approvers(gate_type) -> list[str]:
   """Return a list of email addresses of users allowed to approve."""
-  if field_id not in APPROVAL_FIELDS_BY_ID:
+  if gate_type not in APPROVAL_FIELDS_BY_ID:
     return []
 
-  cache_key = '%s|%s' % (APPROVERS_CACHE_KEY, field_id)
+  cache_key = '%s|%s' % (APPROVERS_CACHE_KEY, gate_type)
   cached_approvers = rediscache.get(cache_key)
   if cached_approvers:
     return cached_approvers
 
-  afd = APPROVAL_FIELDS_BY_ID[field_id]
+  afd = APPROVAL_FIELDS_BY_ID[gate_type]
 
   if afd.approvers == IN_NDB:
-    gate_def = GateDef.get_gate_def(field_id)
+    gate_def = GateDef.get_gate_def(gate_type)
     owners = gate_def.approvers
   elif isinstance(afd.approvers, str):
     # afd.approvers can be either a hard-coded list of approver emails
@@ -305,17 +305,17 @@ def fields_approvable_by(user):
 
   email = user.email()
   approvable_ids = {
-      field_id for field_id in APPROVAL_FIELDS_BY_ID
-      if email in get_approvers(field_id)}
+      gate_type for gate_type in APPROVAL_FIELDS_BY_ID
+      if email in get_approvers(gate_type)}
   return approvable_ids
 
 
-def is_valid_field_id(field_id):
-  """Return true if field_id is a known field."""
-  return field_id in APPROVAL_FIELDS_BY_ID
+def is_valid_gate_type(gate_type):
+  """Return true if gate_type is a known field."""
+  return gate_type in APPROVAL_FIELDS_BY_ID
 
 
-def is_approved(approval_values, field_id):
+def is_approved(approval_values, gate_type):
   """Return true if we have all needed APPROVED values and no DENIED."""
   count = 0
   for av in approval_values:
@@ -323,7 +323,7 @@ def is_approved(approval_values, field_id):
       count += 1
     elif av.state == Vote.DENIED:
       return False
-  afd = APPROVAL_FIELDS_BY_ID[field_id]
+  afd = APPROVAL_FIELDS_BY_ID[gate_type]
 
   if afd.rule == ONE_LGTM:
     return count >= 1
@@ -334,9 +334,9 @@ def is_approved(approval_values, field_id):
     return False
 
 
-def is_resolved(approval_values, field_id):
+def is_resolved(approval_values, gate_type):
   """Return true if the review is done (approved or not approved)."""
-  if is_approved(approval_values, field_id):
+  if is_approved(approval_values, gate_type):
     return True
 
   # Any DENIED value means that the review is no longer pending.

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -133,15 +133,15 @@ class AutoAssignmentTest(testing_config.CustomTestCase):
 
 
 MOCK_APPROVALS_BY_ID = {
-    1: approval_defs.ApprovalFieldDef(
+    1: approval_defs.GateInfo(
         'Intent to test',
         'You need permission to test',
         1, approval_defs.ONE_LGTM, ['approver@example.com'], 'API Owners'),
-    2: approval_defs.ApprovalFieldDef(
+    2: approval_defs.GateInfo(
         'Intent to optimize',
         'You need permission to optimize',
         2, approval_defs.THREE_LGTM, 'https://example.com', 'API Owners'),
-    3: approval_defs.ApprovalFieldDef(
+    3: approval_defs.GateInfo(
         'Intent to memorize',
         'You need permission to memorize',
         3, approval_defs.THREE_LGTM, approval_defs.IN_NDB, 'API Owners'),
@@ -211,15 +211,15 @@ class GetApproversTest(testing_config.CustomTestCase):
     self.assertEqual(['a', 'b'], existing_gate_defs[0].approvers)
 
 
-class IsValidFieldIdTest(testing_config.CustomTestCase):
+class IsValidGateTypeTest(testing_config.CustomTestCase):
 
   @mock.patch('internals.approval_defs.APPROVAL_FIELDS_BY_ID',
               MOCK_APPROVALS_BY_ID)
   def test(self):
-    """We know if a field_id is defined or not."""
-    self.assertTrue(approval_defs.is_valid_field_id(1))
-    self.assertTrue(approval_defs.is_valid_field_id(2))
-    self.assertFalse(approval_defs.is_valid_field_id(99))
+    """We know if a gate_type is defined or not."""
+    self.assertTrue(approval_defs.is_valid_gate_type(1))
+    self.assertTrue(approval_defs.is_valid_gate_type(2))
+    self.assertFalse(approval_defs.is_valid_gate_type(99))
 
 
 class IsApprovedTest(testing_config.CustomTestCase):

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -29,11 +29,11 @@ from internals.core_models import FeatureEntry, Stage
 from internals.review_models import Vote, Gate
 
 
-FIELDS_REQUIRING_LGTMS = [
-    approval_defs.PlanApproval,
-    approval_defs.ShipApproval,
-    approval_defs.ExperimentApproval,
-    approval_defs.ExtendExperimentApproval,
+GATE_TYPES_REQUIRING_LGTMS = [
+    approval_defs.PlanApproval.gate_type,
+    approval_defs.ShipApproval.gate_type,
+    approval_defs.ExperimentApproval.gate_type,
+    approval_defs.ExtendExperimentApproval.gate_type,
     ]
 
 
@@ -55,7 +55,7 @@ EXPERIMENT_RE = re.compile('%s %s' % (INTEND_PATTERN, EXPERIMENT_PATTERN))
 EXTEND_RE = re.compile('%s %s' % (INTEND_PATTERN, EXTEND_PATTERN))
 
 
-def detect_field(subject):
+def detect_gate_info(subject: str) -> approval_defs.GateInfo | None:
   """Look for key words in the subject line that indicate intent type.
 
   These should detect recent actual intent threads as seen in the blink-dev
@@ -158,10 +158,10 @@ def detect_lgtm(body):
   return match
 
 
-def is_lgtm_allowed(from_addr, feature, approval_field):
+def is_lgtm_allowed(from_addr, feature, gate_info):
   """Return true if the user is allowed to approve this feature."""
   user = users.User(email=from_addr)
-  approvers = approval_defs.get_approvers(approval_field.field_id)
+  approvers = approval_defs.get_approvers(gate_info.gate_type)
   gate = None  # TODO(jrobbins): Detect assignee who is not an approver.
   allowed = permissions.can_review_gate(user, feature, gate, approvers)
   return allowed
@@ -199,8 +199,8 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
                  'Body:        %r\n',
                  from_addr, subject, in_reply_to, body[:settings.MAX_LOG_LINE])
 
-    approval_field = detect_field(subject)
-    if not approval_field:
+    gate_info = detect_gate_info(subject)
+    if not gate_info:
       logging.info('This does not appear to be an intent')
       return {'message': 'Not an intent'}
 
@@ -217,21 +217,21 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
       return {'message': 'Feature not found'}
 
     gate, stage = self.get_gate_and_stage(
-        feature, approval_field, gate_id, thread_url)
+        feature, gate_info, gate_id, thread_url)
     if stage is None:
-      message = (f'Stage not found for intent type {approval_field.field_id} '
+      message = (f'Stage not found for intent type {gate_info.gate_type} '
                  f'of feature {feature_id}')
       logging.info(message)
       return {'message': message}
     if gate is None:
-      message = (f'Gate not found for intent type {approval_field.field_id} '
+      message = (f'Gate not found for intent type {gate_info.gate_type} '
                  f'of feature {feature_id}')
       logging.info(message)
       return {'message': message}
-    if gate.gate_type != approval_field.field_id:
+    if gate.gate_type != gate_info.gate_type:
       message = (f'Gate {gate.key.integer_id()} has gate type {gate.gate_type} '
-                 'and does not match approval field gate type '
-                 f'{approval_field.field_id}')
+                 'and does not match gate info gate type '
+                 f'{gate_info.gate_type}')
       logging.info(message)
       return {'message': message}
 
@@ -239,8 +239,8 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     gate_id = gate.key.integer_id()  # In case it was found by gate_type.
     is_new_thread = detect_new_thread(gate_id)
     self.create_approvals(
-        feature, stage, gate, approval_field, from_addr, body, is_new_thread)
-    self.record_slo(feature, approval_field, from_addr, is_new_thread)
+        feature, stage, gate, gate_info, from_addr, body, is_new_thread)
+    self.record_slo(feature, gate_info, from_addr, is_new_thread)
     return {'message': 'Done'}
 
   def load_detected_feature(self, feature_id: Optional[int],
@@ -272,7 +272,7 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
   def get_gate_and_stage(
       self,
       feature: FeatureEntry,
-      approval_field: approval_defs.ApprovalFieldDef,
+      gate_info: approval_defs.GateInfo,
       gate_id: int | None,
       thread_url: str) -> tuple[Gate | None, Stage | None]:
     # If a gate ID is detected, query for the gate.
@@ -287,15 +287,15 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     # Otherwise, try to find the matching gate based on other feature info.
     else:
       logging.info('Attempting to find stage/gate without detected gate ID')
-      stage = self.find_matching_stage(feature, approval_field, thread_url)
+      stage = self.find_matching_stage(feature, gate_info, thread_url)
       if stage is None:
         return None, None
       gate = Gate.query(Gate.stage_id == stage.key.integer_id(),
-                        Gate.gate_type == approval_field.field_id).get()
+                        Gate.gate_type == gate_info.gate_type).get()
     return gate, stage
 
   def find_matching_stage(self, feature: FeatureEntry,
-      approval_field: approval_defs.ApprovalFieldDef,
+      gate_info: approval_defs.GateInfo,
       thread_url: str | None) -> Stage | None:
     """Find the stage in which the thread is associated with."""
     if not thread_url:
@@ -303,10 +303,10 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
       return None
 
     stage_type = core_enums.STAGE_TYPES_BY_GATE_TYPE_MAPPING[
-        approval_field.field_id][feature.feature_type]
+        gate_info.gate_type][feature.feature_type]
     if stage_type is None:
       logging.info('stage_type not found for %r %r',
-                   approval_field.field_id, feature.feature_type)
+                   gate_info.gate_type, feature.feature_type)
       return None
 
     # Get all stages of the detected stage type that belong to the feature.
@@ -351,7 +351,7 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
                  f'and intent_subject_line to {subject}')
 
   def create_approvals(self, feature: FeatureEntry, stage: Stage, gate: Gate,
-      approval_field: approval_defs.ApprovalFieldDef,
+      gate_info: approval_defs.GateInfo,
       from_addr: str, body: str, is_new_thread: bool) -> None:
     """Store either a REVIEW_REQUESTED or an APPROVED approval value."""
     feature_id = feature.key.integer_id()
@@ -360,11 +360,11 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     # set an approval value, and update the gate state if
     # the approval rule (1 or 3 LTGMs) is satisfied.
     if (detect_lgtm(body) and
-        is_lgtm_allowed(from_addr, feature, approval_field)):
+        is_lgtm_allowed(from_addr, feature, gate_info)):
       logging.info('found LGTM')
       old_gate_state = gate.state
       new_gate_state = approval_defs.set_vote(
-          feature_id, approval_field.field_id, Vote.APPROVED, from_addr,
+          feature_id, gate_info.gate_type, Vote.APPROVED, from_addr,
           gate.key.integer_id())
       recently_approved = (old_gate_state not in (Vote.APPROVED, Vote.NA) and
                            new_gate_state in (Vote.APPROVED, Vote.NA))
@@ -378,19 +378,19 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     # stored.
     elif is_new_thread:
       logging.info('found new thread')
-      if approval_field in FIELDS_REQUIRING_LGTMS:
+      if gate_info.gate_type in GATE_TYPES_REQUIRING_LGTMS:
         logging.info('requesting a review')
-        approval_defs.set_vote(feature_id, approval_field.field_id,
+        approval_defs.set_vote(feature_id, gate_info.gate_type,
             Vote.REVIEW_REQUESTED, from_addr, gate.key.integer_id())
 
-  def record_slo(self, feature, approval_field, from_addr, is_new_thread) -> None:
+  def record_slo(self, feature, gate_info, from_addr, is_new_thread) -> None:
     """Update SLO timestamps."""
     if is_new_thread:
       return  # The initial request can never count as a response.
     feature_id = feature.key.integer_id()
     matching_gates = Gate.query(
         Gate.feature_id == feature_id,
-        Gate.gate_type == approval_field.field_id).fetch(None)
+        Gate.gate_type == gate_info.gate_type).fetch(None)
     if len(matching_gates) == 0:
       logging.info('Did not find a gate')
       return

--- a/internals/processes.py
+++ b/internals/processes.py
@@ -40,7 +40,7 @@ class ProcessStage:
   description: str
   progress_items: list[ProgressItem]
   actions: list[Action]
-  approvals: list[approval_defs.ApprovalFieldDef]
+  approvals: list[approval_defs.GateInfo]
   incoming_stage: int
   outgoing_stage: int
   stage_type: int | None

--- a/internals/processes_test.py
+++ b/internals/processes_test.py
@@ -24,7 +24,7 @@ from internals import processes
 from internals import stage_helpers
 
 
-BakeApproval = approval_defs.ApprovalFieldDef(
+BakeGateInfo = approval_defs.GateInfo(
     'Approval for baking',
     'The head chef must approve of you using the oven',
     9, approval_defs.ONE_LGTM, ['chef@example.com'], 'Chef')
@@ -34,7 +34,7 @@ BAKE_APPROVAL_DEF_DICT = collections.OrderedDict([
     ('team_name', 'Chef'),
     ('escalation_email', None),
     ('description', 'The head chef must approve of you using the oven'),
-    ('field_id', 9),
+    ('gate_type', 9),
     ('rule', approval_defs.ONE_LGTM),
     ('approvers', ['chef@example.com']),
     ('slo_initial_response', 5),
@@ -67,7 +67,7 @@ class HelperFunctionsTest(testing_config.CustomTestCase):
              'Heat at 375 for 40 minutes',
              [PI_LOAF, PI_DIRTY_PAN],
              [],
-             [BakeApproval],
+             [BakeGateInfo],
              1, 2, STAGE_BAKE_BAKE),
          ])
     expected = {


### PR DESCRIPTION
This should reduce potential confusion when reading the code.  It eliminates some of the older terminology of "approval field IDs" and uses the newer term "gate type".  Also, ApprovalFieldDef is now GateInfo.