### PR TITLE
Separate creation and setup requests in OT creation process

### DIFF
--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -59,6 +59,12 @@ class CreateOriginTrialRequest(TypedDict):
   trial_contacts: list[str]
 
 
+class SetUpTrialRequest(TypedDict):
+  trial_id: int
+  announcement_groups_owners: list[str]
+  trial_contacts: list[str]
+
+
 def get_trials_list() -> list[dict[str, Any]]:
   """Get a list of all origin trials.
 
@@ -133,24 +139,14 @@ def _get_ot_access_token() -> str:
   return credentials.token
 
 
-def create_origin_trial(ot_stage: Stage) -> tuple[str|None, str|None]:
+def _send_create_trial_request(
+    ot_stage: Stage, api_key: str, access_token: str
+  ) -> tuple[int|None, str|None]:
   """Send an origin trial creation request to the origin trials API.
-
-  Raises:
-    requests.exceptions.RequestException: If the request fails to connect or
-      the HTTP status code is not successful.
   Returns:
     Newly created origin trial ID if trial was created, any error text if there
     was an issue during the creation process.
   """
-  if settings.DEV_MODE:
-    logging.info('Creation request will not be sent to origin trials API in '
-                 'local environment.')
-    return None, None
-  key = secrets.get_ot_api_key()
-  if key is None:
-    return None, 'No API key found for origin trials API'
-
   json: CreateOriginTrialRequest = {
     'trial': {
       'display_name': ot_stage.ot_display_name,
@@ -171,16 +167,6 @@ def create_origin_trial(ot_stage: Stage) -> tuple[str|None, str|None]:
     'registration_config': {'approval_type': 'NONE'},
     'trial_contacts': []
   }
-
-  # Get a list of all OT @google.com contacts (ot_owner_email must be a google
-  # contact).
-  unique_contacts = [ot_stage.ot_owner_email]
-  unique_contacts.extend(ot_stage.ot_emails)
-  unique_contacts = [email for email in set(unique_contacts)
-                     if email.endswith('@google.com')]
-  json['trial_contacts'] = unique_contacts
-  if ot_stage.ot_chromium_trial_name:
-    json['trial']['origin_trial_feature_name'] = ot_stage.ot_chromium_trial_name
   if ot_stage.ot_require_approvals:
     json['registration_config'] = {
       'approval_type': 'CUSTOM',
@@ -189,56 +175,92 @@ def create_origin_trial(ot_stage: Stage) -> tuple[str|None, str|None]:
       'approval_group_email': ot_stage.ot_approval_group_email,
       'approval_buganizer_custom_field_id': ot_stage.ot_approval_buganizer_custom_field_id,
     }
+  if ot_stage.ot_chromium_trial_name:
+    json['trial']['origin_trial_feature_name'] = ot_stage.ot_chromium_trial_name
   if ot_stage.ot_is_deprecation_trial:
     json['registration_config']['allow_public_suffix_subdomains'] = True
-  access_token = _get_ot_access_token()
+
+  headers = {'Authorization': f'Bearer {access_token}'}
+  url = f'{settings.OT_API_URL}/v1/trials:create'
+
+  # Retry the request a number of times if any issues arise.
+  try:
+    response = requests.post(
+        url, headers=headers, params={'key': api_key}, json=json)
+    logging.info(f'CreateTrial response text: {response.text}')
+    response.raise_for_status()
+  except requests.exceptions.RequestException:
+    logging.exception(
+        f'Failed to get response from origin trials API. {response.text}')
+    return None, response.text
+  response_json = response.json()
+  return response_json['trial']['id'], None
+
+
+def _send_set_up_trial_request(trial_id: int, owners: list[str], contacts: list[str], api_key: str, access_token: str) -> str|None:
+  """Send an origin trial setup request to the origin trials API.
+  Returns:
+    Any error text if there was an issue during the setup process.
+  """
+  json: SetUpTrialRequest = {
+    'trial_id': trial_id,
+    'announcement_groups_owners': owners,
+    'trial_contacts': contacts,
+  }
   headers = {'Authorization': f'Bearer {access_token}'}
   url = f'{settings.OT_API_URL}/v1/trials:setup'
+  try:
+    response = requests.post(
+        url, headers=headers, params={'key': api_key}, json=json)
+    logging.info(f'SetUpTrial response text: {response.text}')
+    response.raise_for_status()
+  except requests.exceptions.RequestException:
+    logging.exception(
+        f'Failed to get response from origin trials API. {response.text}')
+    return response.text
+  return None
 
-  request_tries = 0
-  origin_trial_id = None
-  request_success = False
-  retry_error_status = None
-  response = requests.Response()
-  # Retry the request a number of times if any issues arise.
-  while request_tries < 3 and not request_success:
-    request_tries += 1
-    try:
-      response = requests.post(
-          url, headers=headers, params={'key': key}, json=json)
-      logging.info(response.text)
-      response.raise_for_status()
-    except requests.exceptions.RequestException:
-      logging.exception(
-          f'Failed to get response from origin trials API. {response.text}')
-      continue
-    response_json = response.json()
-    if (response.status_code == 200 and
-        response_json['trial'].get('id') is not None):
-      origin_trial_id = response_json['trial']['id']
-    if response_json.get('should_retry'):
-      # The trial was created, but some post-creation steps were not completed.
-      # The request should be retried (the request is idempotent).
-      retry_error_status = response_json.get('retry_error_status')
-      # Add the origin trial ID to the request body to denote that the
-      # trial should not be recreated during a retry.
-      if origin_trial_id:
-        json['trial']['id'] = origin_trial_id
-    else:
-      request_success = True
 
-  # Assemble error information to help diagnose any problems that occurred.
-  error_text = None
-  if not request_success:
-    if retry_error_status:
-      error_text = (f'{retry_error_status["code"]}, '
-                    f'{retry_error_status["message"]}')
-    else:
-      error_text = f'{response.status_code}, {response.text}'
+def create_origin_trial(ot_stage: Stage) -> tuple[str|None, str|None]:
+  """Send an origin trial creation request to the origin trials API.
 
-  if origin_trial_id:
-    return str(origin_trial_id), error_text
-  return None, error_text
+  Raises:
+    requests.exceptions.RequestException: If the request fails to connect or
+      the HTTP status code is not successful.
+  Returns:
+    Newly created origin trial ID if trial was created, any error text if there
+    was an issue during the creation process.
+  """
+  if settings.DEV_MODE:
+    logging.info('Creation request will not be sent to origin trials API in '
+                 'local environment.')
+    return None, None
+  key = secrets.get_ot_api_key()
+  if key is None:
+    return None, 'No API key found for origin trials API'
+
+  # Get a list of all OT @google.com contacts (ot_owner_email must be a google
+  # contact).
+  unique_contacts = [ot_stage.ot_owner_email]
+  unique_contacts.extend(ot_stage.ot_emails)
+  unique_contacts = [email for email in set(unique_contacts)
+                     if email.endswith('@google.com')]
+  # A trial must have a google.com domain contact.
+  if len(unique_contacts) == 0:
+    return None, 'No trial contacts found in google.com domain'
+
+  access_token = _get_ot_access_token()
+  origin_trial_id, error_text = _send_create_trial_request(
+      ot_stage, key, access_token)
+
+  if origin_trial_id is None:
+    return None, error_text
+
+  error_text = _send_set_up_trial_request(
+      # TODO(DanielRyanSmith): Add owners contacts in subsequent PR.
+      origin_trial_id, [], unique_contacts, key, access_token)
+
+  return str(origin_trial_id), error_text
 
 
 def activate_origin_trial(origin_trial_id: str) -> None:

--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -181,7 +181,7 @@ def _send_create_trial_request(
     json['registration_config']['allow_public_suffix_subdomains'] = True
 
   headers = {'Authorization': f'Bearer {access_token}'}
-  url = f'{settings.OT_API_URL}/v1/trials:create'
+  url = f'{settings.OT_API_URL}/v1/trials:initialize'
 
   # Retry the request a number of times if any issues arise.
   try:
@@ -197,7 +197,13 @@ def _send_create_trial_request(
   return response_json['trial']['id'], None
 
 
-def _send_set_up_trial_request(trial_id: int, owners: list[str], contacts: list[str], api_key: str, access_token: str) -> str|None:
+def _send_set_up_trial_request(
+    trial_id: int,
+    owners: list[str],
+    contacts: list[str],
+    api_key: str,
+    access_token: str
+  ) -> str|None:
   """Send an origin trial setup request to the origin trials API.
   Returns:
     Any error text if there was an issue during the setup process.
@@ -208,7 +214,7 @@ def _send_set_up_trial_request(trial_id: int, owners: list[str], contacts: list[
     'trial_contacts': contacts,
   }
   headers = {'Authorization': f'Bearer {access_token}'}
-  url = f'{settings.OT_API_URL}/v1/trials:setup'
+  url = f'{settings.OT_API_URL}/v1/trials/{trial_id}:setup'
   try:
     response = requests.post(
         url, headers=headers, params={'key': api_key}, json=json)

--- a/framework/origin_trials_client_test.py
+++ b/framework/origin_trials_client_test.py
@@ -218,12 +218,9 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
 
     mock_api_key_get.assert_called_once()
     mock_get_ot_access_token.assert_called_once()
-    mock_requests_post.assert_called_once()
-    # unordered list is in the request, so compare args individually.
-    json_args = mock_requests_post.call_args_list[0][1]['json']
-    # Only unique @google.com emails should be sent as contacts.
-    self.assertCountEqual(['someuser@google.com', 'editor@google.com'],
-                          json_args['trial_contacts'])
+    # Two separate POST requests made.
+    self.assertEqual(2, mock_requests_post.call_count)
+    create_trial_json = mock_requests_post.call_args_list[0][1]['json']
     self.assertEqual({
           'display_name': 'Example Trial',
           'start_milestone': '100',
@@ -238,7 +235,7 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
           'chromestatus_url': f'{settings.SITE_URL}feature/1',
           'allow_third_party_origins': True,
           'type': 'DEPRECATION',
-        }, json_args['trial'])
+        }, create_trial_json['trial'])
     self.assertEqual({
           'allow_public_suffix_subdomains': True,
           'approval_type': 'CUSTOM',
@@ -246,130 +243,13 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
           'approval_criteria_url': 'https://example.com/criteria',
           'approval_group_email': 'somegroup@google.com',
           'approval_buganizer_custom_field_id': 111111,
-        }, json_args['registration_config'])
+        }, create_trial_json['registration_config'])
 
-  @mock.patch('framework.secrets.get_ot_api_key')
-  @mock.patch('framework.origin_trials_client._get_ot_access_token')
-  @mock.patch('framework.origin_trials_client._get_trial_end_time')
-  @mock.patch('requests.post')
-  def test_create_origin_trial__retry_to_succeed(
-      self, mock_requests_post, mock_get_trial_end_time,
-      mock_get_ot_access_token, mock_api_key_get):
-    """If the OT creation request fails, it can retry and succeed."""
-    # First request will be flagged for retry, then the 2nd will succeed.
-    mock_requests_post.side_effect = [
-      mock.MagicMock(status_code=200,
-                     json=lambda : {
-                        'trial': {'id': -1234567890},
-                        'should_retry': True,
-                        'retry_error_status': {
-                          'code': 400,
-                          'message': 'some error occurred',
-                        }}),
-      mock.MagicMock(status_code=200,
-                     json=lambda : {
-                        'trial': {'id': -1234567890},
-                        'should_retry': False})]
-    mock_get_trial_end_time.return_value = 111222333
-    mock_get_ot_access_token.return_value = 'access_token'
-    mock_api_key_get.return_value = 'api_key_value'
-
-    ot_id, error_text = origin_trials_client.create_origin_trial(self.ot_stage)
-    self.assertEqual(ot_id, '-1234567890')
-    self.assertIsNone(error_text)
-
-    mock_api_key_get.assert_called_once()
-    mock_get_ot_access_token.assert_called_once()
-    self.assertEqual(2, mock_requests_post.call_count)
-    # unordered list is in the request, so compare args individually.
-    json_args = mock_requests_post.call_args_list[0][1]['json']
+    set_up_trial_json = mock_requests_post.call_args_list[1][1]['json']
     # Only unique @google.com emails should be sent as contacts.
     self.assertCountEqual(['someuser@google.com', 'editor@google.com'],
-                          json_args['trial_contacts'])
-    self.assertEqual({
-        'id': -1234567890,
-        'display_name': 'Example Trial',
-        'start_milestone': '100',
-        'end_milestone': '106',
-        'end_time': {
-          'seconds': 111222333
-        },
-        'description': 'OT description',
-        'documentation_url': 'https://example.com/docs',
-        'feedback_url': 'https://example.com/feedback',
-        'intent_to_experiment_url': 'https://example.com/experiment',
-        'chromestatus_url': f'{settings.SITE_URL}feature/1',
-        'allow_third_party_origins': True,
-        'type': 'DEPRECATION',
-      }, json_args['trial'])
-    self.assertEqual({
-        'allow_public_suffix_subdomains': True,
-        'approval_type': 'CUSTOM',
-        'approval_buganizer_component_id': 123456,
-        'approval_criteria_url': 'https://example.com/criteria',
-        'approval_group_email': 'somegroup@google.com',
-        'approval_buganizer_custom_field_id': 111111,
-      }, json_args['registration_config'])
-
-  @mock.patch('framework.secrets.get_ot_api_key')
-  @mock.patch('framework.origin_trials_client._get_ot_access_token')
-  @mock.patch('framework.origin_trials_client._get_trial_end_time')
-  @mock.patch('requests.post')
-  def test_create_origin_trial__fail_after_retry(
-      self, mock_requests_post, mock_get_trial_end_time,
-      mock_get_ot_access_token, mock_api_key_get):
-    """An OT creation request will be retried until it fails a number of times.
-    """
-    # First request will be flagged for retry, then the 2nd will succeed.
-    mock_requests_post.return_value = mock.MagicMock(status_code=200,
-                     json=lambda : {
-                        'trial': {'id': -1234567890},
-                        'should_retry': True,
-                        'retry_error_status': {
-                          'code': 400,
-                          'message': 'some error occurred',
-                        }})
-    mock_get_trial_end_time.return_value = 111222333
-    mock_get_ot_access_token.return_value = 'access_token'
-    mock_api_key_get.return_value = 'api_key_value'
-
-    ot_id, error_text = origin_trials_client.create_origin_trial(self.ot_stage)
-    self.assertEqual(ot_id, '-1234567890')
-    self.assertEqual('400, some error occurred', error_text)
-
-    mock_api_key_get.assert_called_once()
-    mock_get_ot_access_token.assert_called_once()
-    # OT creation request should have been attempted 3 times
-    self.assertEqual(3, mock_requests_post.call_count)
-    # unordered list is in the request, so compare args individually.
-    json_args = mock_requests_post.call_args_list[0][1]['json']
-    # Only unique @google.com emails should be sent as contacts.
-    self.assertCountEqual(['someuser@google.com', 'editor@google.com'],
-                          json_args['trial_contacts'])
-    self.assertEqual({
-        'id': -1234567890,
-        'display_name': 'Example Trial',
-        'start_milestone': '100',
-        'end_milestone': '106',
-        'end_time': {
-          'seconds': 111222333
-        },
-        'description': 'OT description',
-        'documentation_url': 'https://example.com/docs',
-        'feedback_url': 'https://example.com/feedback',
-        'intent_to_experiment_url': 'https://example.com/experiment',
-        'chromestatus_url': f'{settings.SITE_URL}feature/1',
-        'allow_third_party_origins': True,
-        'type': 'DEPRECATION',
-      }, json_args['trial'])
-    self.assertEqual({
-        'allow_public_suffix_subdomains': True,
-        'approval_type': 'CUSTOM',
-        'approval_buganizer_component_id': 123456,
-        'approval_criteria_url': 'https://example.com/criteria',
-        'approval_group_email': 'somegroup@google.com',
-        'approval_buganizer_custom_field_id': 111111,
-      }, json_args['registration_config'])
+                          set_up_trial_json['trial_contacts'])
+    self.assertEqual(-1234567890, set_up_trial_json['trial_id'])
 
   @mock.patch('framework.secrets.get_ot_api_key')
   @mock.patch('requests.post')

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -26,7 +26,6 @@ from framework import origin_trials_client
 from framework import utils
 from internals import approval_defs
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
-from internals.data_types import StageDict
 from internals.review_models import Gate, Vote, Activity
 from internals.core_enums import *
 from internals.feature_links import batch_index_feature_entries
@@ -523,44 +522,56 @@ class BackfillFeatureEnterpriseImpact(FlaskHandler):
 
 class CreateOriginTrials(FlaskHandler):
 
-  def handle_creation(self, stage: Stage, stage_dict: StageDict) -> str | None:
+  def _send_creation_result_notification(
+      self, task_path: str, stage: Stage, params: dict|None = None) -> None:
+    if not params:
+      params = {}
+    print('sending email task to', task_path, 'with params', params)
+    stage_dict = converters.stage_to_json_dict(stage)
+    params['stage'] = stage_dict
+    cloud_tasks_helpers.enqueue_task(task_path, params)
+
+  def handle_creation(self, stage: Stage) -> bool:
     """Send a flagged creation request for processing to the Origin Trials
     API.
     """
-    new_id = None
-    # TODO(DanielRyanSmith): This request should have a retry process based on
-    # the error code returned from the OT server.
-    try:
-      new_id = origin_trials_client.create_origin_trial(stage)
-      stage.ot_setup_status = OT_CREATED
-    except requests.RequestException:
+    origin_trial_id, error_text = origin_trials_client.create_origin_trial(
+        stage)
+    if origin_trial_id:
+      stage.origin_trial_id = origin_trial_id
+    if error_text:
       logging.warning('Origin trial could not be created for stage '
-                      f'{stage.key.integer_id()}')
-      cloud_tasks_helpers.enqueue_task(
-          '/tasks/email-ot-creation-request-failed', {'stage': stage_dict})
+                     f'{stage.key.integer_id()}')
       stage.ot_setup_status = OT_CREATION_FAILED
-    stage.put()
-    return new_id
+      self._send_creation_result_notification(
+          '/tasks/email-ot-creation-request-failed',
+          stage,
+          {'error_text': error_text})
+      return False
+    else:
+      stage.ot_setup_status = OT_CREATED
+      logging.info(f'Origin trial created for stage {stage.key.integer_id()}')
+    return True
 
-  def handle_activation(self, stage: Stage, stage_dict: StageDict) -> None:
+  def handle_activation(self, stage: Stage) -> None:
     """Send trial activation request."""
     try:
       origin_trials_client.activate_origin_trial(stage.origin_trial_id)
-      cloud_tasks_helpers.enqueue_task(
-          '/tasks/email-ot-activated', {'stage': stage_dict})
       stage.ot_setup_status = OT_ACTIVATED
+      self._send_creation_result_notification(
+          '/tasks/email-ot-activated', stage)
     except requests.RequestException:
-      cloud_tasks_helpers.enqueue_task(
-          '/tasks/email-ot-activation-failed', {'stage': stage_dict})
-      stage.ot_setup_status = OT_ACTIVATION_FAILED
       # The activation still needs to occur,
       # so the activation date is set for current date.
       stage.ot_activation_date = date.today()
+      stage.ot_setup_status = OT_ACTIVATION_FAILED
+      self._send_creation_result_notification(
+          '/tasks/email-ot-activation-failed', stage)
 
   def _get_today(self) -> date:
     return date.today()
 
-  def prepare_for_activation(self, stage: Stage, stage_dict: StageDict) -> None:
+  def prepare_for_activation(self, stage: Stage) -> None:
     """Set up activation date or activate trial now."""
     mstone_info = utils.get_chromium_milestone_info(
         stage.milestones.desktop_first)
@@ -568,12 +579,13 @@ class CreateOriginTrials(FlaskHandler):
         mstone_info['mstones'][0]['branch_point'],
         utils.CHROMIUM_SCHEDULE_DATE_FORMAT).date()
     if date <= self._get_today():
-      self.handle_activation(stage, stage_dict)
+      print('sending for activation. Today:', self._get_today(), 'branch_date: ', date)
+      self.handle_activation(stage)
     else:
       stage.ot_activation_date = date
       stage.ot_setup_status = OT_CREATED
-      cloud_tasks_helpers.enqueue_task(
-          '/tasks/email-ot-creation-processed', {'stage': stage_dict})
+      self._send_creation_result_notification(
+          '/tasks/email-ot-creation-processed', stage)
 
   def get_template_data(self, **kwargs) -> str:
     """Create any origin trials that are flagged for creation."""
@@ -586,11 +598,9 @@ class CreateOriginTrials(FlaskHandler):
         Stage.ot_setup_status == OT_READY_FOR_CREATION).fetch()
     for stage in ot_stages:
       stage.ot_action_requested = False
-      stage_dict = converters.stage_to_json_dict(stage)
-      origin_trial_id = self.handle_creation(stage, stage_dict)
-      if origin_trial_id:
-        stage.origin_trial_id = origin_trial_id
-        self.prepare_for_activation(stage, stage_dict)
+      creation_success = self.handle_creation(stage)
+      if creation_success:
+        self.prepare_for_activation(stage)
       stage.put()
 
     return f'{len(ot_stages)} trial creation request(s) processed.'


### PR DESCRIPTION
Per discussion, this change updates the OT creation logic to have to separate requests - one to create the origin trial and one to handle post-creation setup steps.