### PR TITLE
Make OT creation cron job routes available

### DIFF
--- a/main.py
+++ b/main.py
@@ -283,10 +283,9 @@ internals_routes: list[Route] = [
   Route('/cron/associate_origin_trials', maintenance_scripts.AssociateOTs),
   Route('/cron/send-ot-process-reminders',
         reminders.SendOTReminderEmailsHandler),
-  # TODO(DanielRyanSmith): Add this route when OT creation is fully implemented.
-  # Route('/cron/create_origin_trials', maintenance_scripts.CreateOriginTrials),
-  # Route('/cron/activate_origin_trials',
-  #       maintenance_scripts.ActivateOriginTrials),
+  Route('/cron/create_origin_trials', maintenance_scripts.CreateOriginTrials),
+  Route('/cron/activate_origin_trials',
+        maintenance_scripts.ActivateOriginTrials),
 
   Route('/admin/find_stop_words', search_fulltext.FindStopWords),
 


### PR DESCRIPTION
This change makes the cron job routes for automated OT creation available. The cron jobs are already scheduled and running, but the route is not yet available. However, making these routes will make any discernible change until the [automated OT creation flag](https://github.com/GoogleChrome/chromium-dashboard/blob/23998966cec24ed070de53d19850b3a246561dce/settings.py#L41-L42) has been set to "True". The cron jobs are [written to check if this flag is set](https://github.com/GoogleChrome/chromium-dashboard/blob/23998966cec24ed070de53d19850b3a246561dce/internals/maintenance_scripts.py#L575-L576), and only run if it is.