### PR TITLE
Implement phrase search via post processing

### DIFF
--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -45,7 +45,7 @@ def filter_unlisted(feature_list: list[dict]) -> list[dict]:
   return listed_features
 
 
-def _get_entries_by_id_async(ids) -> Future | None:
+def get_entries_by_id_async(ids) -> Future | None:
   if ids:
     q = FeatureEntry.query(FeatureEntry.key.IN(
         [ndb.Key('FeatureEntry', id) for id in ids]))
@@ -54,7 +54,7 @@ def _get_entries_by_id_async(ids) -> Future | None:
   return None
 
 
-def _get_future_results(async_features: Future | None) -> list[FeatureEntry]:
+def get_future_results(async_features: Future | None) -> list[FeatureEntry]:
   if async_features is None:
     return []
   return async_features.result()
@@ -83,7 +83,7 @@ def get_features_in_release_notes(milestone: int):
   feature_ids = list(set({
       *[s.feature_id for s in stages]}))
   features = [dict(converters.feature_entry_to_json_verbose(f))
-            for f in _get_future_results(_get_entries_by_id_async(feature_ids))]
+            for f in get_future_results(get_entries_by_id_async(feature_ids))]
   features = [f for f in filter_unlisted(features)
     if not f['deleted'] and
       (f['enterprise_impact'] > ENTERPRISE_IMPACT_NONE or
@@ -194,31 +194,31 @@ def get_in_milestone(milestone: int,
     # Query for FeatureEntry entities that match the stage feature IDs.
     # Querying with an empty list will raise an error, so check if each
     # list is not empty first.
-    desktop_shipping_future = _get_entries_by_id_async(desktop_shipping_ids)
-    android_only_shipping_future = _get_entries_by_id_async(
+    desktop_shipping_future = get_entries_by_id_async(desktop_shipping_ids)
+    android_only_shipping_future = get_entries_by_id_async(
         android_only_shipping_ids)
-    desktop_origin_trial_future = _get_entries_by_id_async(
+    desktop_origin_trial_future = get_entries_by_id_async(
         desktop_origin_trials_ids)
-    android_origin_trial_future = _get_entries_by_id_async(
+    android_origin_trial_future = get_entries_by_id_async(
         android_origin_trials_ids)
-    webview_origin_trial_future = _get_entries_by_id_async(
+    webview_origin_trial_future = get_entries_by_id_async(
         webview_origin_trials_ids)
-    desktop_dev_trial_future = _get_entries_by_id_async(
+    desktop_dev_trial_future = get_entries_by_id_async(
         desktop_dev_trials_ids)
-    android_dev_trial_future = _get_entries_by_id_async(
+    android_dev_trial_future = get_entries_by_id_async(
         android_dev_trials_ids)
 
-    desktop_shipping_features = _get_future_results(desktop_shipping_future)
-    android_only_shipping_features = _get_future_results(
+    desktop_shipping_features = get_future_results(desktop_shipping_future)
+    android_only_shipping_features = get_future_results(
         android_only_shipping_future)
-    desktop_origin_trial_features = _get_future_results(
+    desktop_origin_trial_features = get_future_results(
         desktop_origin_trial_future)
-    android_origin_trial_features = _get_future_results(
+    android_origin_trial_features = get_future_results(
         android_origin_trial_future)
-    webview_origin_trial_features = _get_future_results(
+    webview_origin_trial_features = get_future_results(
         webview_origin_trial_future)
-    desktop_dev_trial_features = _get_future_results(desktop_dev_trial_future)
-    android_dev_trial_features = _get_future_results(android_dev_trial_future)
+    desktop_dev_trial_features = get_future_results(desktop_dev_trial_future)
+    android_dev_trial_features = get_future_results(android_dev_trial_future)
 
     # Push feature to list corresponding to the implementation status of
     # feature in queried milestone

--- a/internals/search_fulltext.py
+++ b/internals/search_fulltext.py
@@ -161,7 +161,7 @@ def index_feature(fe: FeatureEntry) -> None:
   updated_fw_list[0].put()
 
 
-def _canonicalize_string(s: str) -> str:
+def canonicalize_string(s: str) -> str:
   """Return a string of lowercase words separated by single spaces."""
   lower_s = s.lower().replace("'", "")
   words = WORD_RE.findall(lower_s)
@@ -173,11 +173,11 @@ def _canonicalize_string(s: str) -> str:
 def post_process_phrase(phrase: str, feature_ids: list[int]) -> list[int]:
   """Fetch the given features and check if the really have the phrase."""
   features = get_future_results(get_entries_by_id_async(feature_ids))
-  canon_phrase = _canonicalize_string(phrase)
+  canon_phrase = canonicalize_string(phrase)
   result = []
   for fe in features:
     feature_strings = get_strings(fe)
-    has_phrase = any(canon_phrase in _canonicalize_string(fs)
+    has_phrase = any(canon_phrase in canonicalize_string(fs)
                      for fs in feature_strings)
     if has_phrase:
       result.append(fe.key.integer_id())

--- a/internals/search_fulltext.py
+++ b/internals/search_fulltext.py
@@ -24,8 +24,7 @@ from framework.basehandlers import FlaskHandler
 from internals.core_models import FeatureEntry
 from internals.feature_helpers import (
     get_future_results,
-    get_entries_by_id_async,
-    )
+    get_entries_by_id_async)
 
 
 # We consider all words that have three or more letters.
@@ -165,13 +164,12 @@ def canonicalize_string(s: str) -> str:
   """Return a string of lowercase words separated by single spaces."""
   lower_s = s.lower().replace("'", "")
   words = WORD_RE.findall(lower_s)
-  words = [w for w in words if w not in STOP_WORDS]
-  canonicalized = ' '.join(words)
-  return ' ' + canonicalized + ' '
+  canonicalized = ' '.join(w for w in words if w not in STOP_WORDS)
+  return ' ' + canonicalized + ' '  # Avoids matching partial words.
 
 
 def post_process_phrase(phrase: str, feature_ids: list[int]) -> list[int]:
-  """Fetch the given features and check if the really have the phrase."""
+  """Fetch the given features and check if they really have the phrase."""
   features = get_future_results(get_entries_by_id_async(feature_ids))
   canon_phrase = canonicalize_string(phrase)
   result = []

--- a/internals/search_fulltext.py
+++ b/internals/search_fulltext.py
@@ -167,7 +167,7 @@ def _canonicalize_string(s: str) -> str:
   words = WORD_RE.findall(lower_s)
   words = [w for w in words if w not in STOP_WORDS]
   canonicalized = ' '.join(words)
-  return canonicalized
+  return ' ' + canonicalized + ' '
 
 
 def post_process_phrase(phrase: str, feature_ids: list[int]) -> list[int]:

--- a/internals/search_fulltext.py
+++ b/internals/search_fulltext.py
@@ -22,6 +22,10 @@ from google.cloud import ndb  # type: ignore
 
 from framework.basehandlers import FlaskHandler
 from internals.core_models import FeatureEntry
+from internals.feature_helpers import (
+    get_future_results,
+    get_entries_by_id_async,
+    )
 
 
 # We consider all words that have three or more letters.
@@ -157,6 +161,29 @@ def index_feature(fe: FeatureEntry) -> None:
   updated_fw_list[0].put()
 
 
+def _canonicalize_string(s: str) -> str:
+  """Return a string of lowercase words separated by single spaces."""
+  lower_s = s.lower().replace("'", "")
+  words = WORD_RE.findall(lower_s)
+  words = [w for w in words if w not in STOP_WORDS]
+  canonicalized = ' '.join(words)
+  return canonicalized
+
+
+def post_process_phrase(phrase: str, feature_ids: list[int]) -> list[int]:
+  """Fetch the given features and check if the really have the phrase."""
+  features = get_future_results(get_entries_by_id_async(feature_ids))
+  canon_phrase = _canonicalize_string(phrase)
+  result = []
+  for fe in features:
+    feature_strings = get_strings(fe)
+    has_phrase = any(canon_phrase in _canonicalize_string(fs)
+                     for fs in feature_strings)
+    if has_phrase:
+      result.append(fe.key.integer_id())
+  return result
+
+
 def search_fulltext(textterm: str) -> Optional[list[int]]:
   """Return IDs of features that have some word(s) from phrase."""
   search_words = parse_words([textterm])
@@ -170,15 +197,11 @@ def search_fulltext(textterm: str) -> Optional[list[int]]:
     query = query.filter(FeatureWords.words == sw)
   feature_projections = query.fetch(projection=['feature_id'])
   feature_ids = [proj.feature_id for proj in feature_projections]
-  return feature_ids
+  if len(search_words) > 1:
+    return post_process_phrase(textterm, feature_ids)
+  else:
+    return feature_ids
 
-
-# TODO(jrobbins): Implement phrase search as post-procesing.  I.e.,
-# searching for phrase "build useful stuff" would first be handled as
-# a search for any combination of those words.  Then, after all search
-# conditions have been applied, a post-processing step would load all
-# potentially matching features and keep only the ones that contain
-# the entire phrase in one string.
 
 # TODO(jrobbins): Likewise, searching for a word or phrase in a
 # specific field of a feature entry can be done with post-processing.

--- a/internals/search_fulltext_test.py
+++ b/internals/search_fulltext_test.py
@@ -148,7 +148,7 @@ class SearchFulltextFunctionsTest(testing_config.CustomTestCase):
     fe = core_models.FeatureEntry(
         creator_email='creator@example.com',
         name='Once upon a time',
-        summary='rode all around the land',
+        summary='rode and strode all around',
         motivation='lived happily ever after.',
         category=core_enums.NETWORKING,
         cc_emails=['one@example.com', 'two@example.com'],
@@ -174,8 +174,8 @@ class SearchFulltextFunctionsTest(testing_config.CustomTestCase):
 
     # Phrase can be found in any field or value of multi-valued field
     assert_found('lived happily')
-    assert_found('rode all around the land')
-    assert_found('rode all-around the land')
+    assert_found('strode all around')
+    assert_found('strode all-around')
     assert_found('creator example com')
     assert_found('creator@example.com')
     assert_found('two@example.com')
@@ -188,6 +188,10 @@ class SearchFulltextFunctionsTest(testing_config.CustomTestCase):
     # A single phrase cannot span fields or values of multi-valued fields
     assert_not_found('time rode')
     assert_not_found('one example com two example com')
+
+    # It does not match part of a word, even if that is a different word
+    assert_not_found('round')
+    assert_not_found('rode all around')
 
   # TODO(jrobbins): Unit test for search_fulltext.
 

--- a/internals/search_fulltext_test.py
+++ b/internals/search_fulltext_test.py
@@ -118,6 +118,77 @@ class SearchFulltextFunctionsTest(testing_config.CustomTestCase):
 
   # TODO(jrobbins): Unit test for index_feature.
 
+  def test_canonicalize_string(self):
+    """It converts strings to a canonical form for less finickymatches."""
+    self.assertEqual(
+        search_fulltext.canonicalize_string(''),
+        '  ')
+    self.assertEqual(
+        search_fulltext.canonicalize_string('abc xyz'),
+        ' abc xyz ')
+    self.assertEqual(
+        search_fulltext.canonicalize_string(' Abc    xYz'),
+        ' abc xyz ')
+    self.assertEqual(
+        search_fulltext.canonicalize_string("That's the way I like it."),
+        ' thats way like ')
+
+    self.assertEqual(
+        search_fulltext.canonicalize_string('Four score and 7 years ago'),
+        ' four score years ago ')
+
+  def test_post_process_phrase__no_candidates(self):
+    """If there were no word-bag results then they can be no phrase results."""
+    word_bag_feature_ids = []
+    actual = search_fulltext.post_process_phrase('hello', word_bag_feature_ids)
+    self.assertEqual([], actual)
+
+  def test_post_process_phrase__phrase_detection(self):
+    """It returns feature_ids for only features with the words in the phrase."""
+    fe = core_models.FeatureEntry(
+        creator_email='creator@example.com',
+        name='Once upon a time',
+        summary='rode all around the land',
+        motivation='lived happily ever after.',
+        category=core_enums.NETWORKING,
+        cc_emails=['one@example.com', 'two@example.com'],
+    )
+    fe.put()
+    fe_id = fe.key.integer_id()
+    word_bag_feature_ids = [fe_id]
+
+    def assert_found(s):
+      actual = search_fulltext.post_process_phrase(
+          s, word_bag_feature_ids)
+      self.assertEqual([fe_id], actual)
+
+    def assert_not_found(s):
+      actual = search_fulltext.post_process_phrase(
+          s, word_bag_feature_ids)
+      self.assertEqual([], actual)
+
+    # Not a phrase match
+    assert_not_found('random junk')
+    assert_not_found('upon once')
+    assert_not_found('once time')
+
+    # Phrase can be found in any field or value of multi-valued field
+    assert_found('lived happily')
+    assert_found('rode all around the land')
+    assert_found('rode all-around the land')
+    assert_found('creator example com')
+    assert_found('creator@example.com')
+    assert_found('two@example.com')
+
+    # Stop-words are ignored
+    assert_found('once upon time')
+    assert_found('once upon a time')
+    assert_found('once upon the time')
+
+    # A single phrase cannot span fields or values of multi-valued fields
+    assert_not_found('time rode')
+    assert_not_found('one example com two example com')
+
   # TODO(jrobbins): Unit test for search_fulltext.
 
   # TODO(jrobbins): Unit test for ReindexAllFeatures.


### PR DESCRIPTION
This implements one of the missing details on our list before making the new search page the default.  

Basically, if the user searches for `"one two three"` inside quotes: 
1. first do the search separate words `one`, `two`, and `three` using the datastore indexes to get feature_ids,
2. then we get those feature entires
3. then we iterate through them and look for the phrase `one two three` in the strings of each entry.