### PR TITLE
fix recent reviews query

### DIFF
--- a/internals/search.py
+++ b/internals/search.py
@@ -33,7 +33,7 @@ from internals import (
   search_queries,
 )
 from internals.core_models import FeatureEntry
-from internals.review_models import Gate
+from internals.review_models import (Gate, Vote)
 
 MAX_TERMS = 6
 DEFAULT_RESULTS_PER_PAGE = 100
@@ -87,8 +87,8 @@ def process_starred_me_query() -> list[int]:
 
 def process_recent_reviews_query() -> list[int] | Future:
   """Return features that were reviewed recently."""
-  query = Gate.query(
-      Gate.state.IN(Gate.FINAL_STATES))
+  query = Vote.query(
+      Vote.state.IN(Gate.FINAL_STATES))
   future_feature_ids = query.fetch_async(projection=['feature_id'], limit=40)
   return future_feature_ids
 

--- a/internals/search.py
+++ b/internals/search.py
@@ -89,7 +89,7 @@ def process_recent_reviews_query() -> list[int] | Future:
   """Return features that were reviewed recently."""
   query = Vote.query(Vote.state.IN(Gate.FINAL_STATES))
   query = query.filter(
-      Vote.set_on > datetime.datetime.now() - datetime.timedelta(days=90))
+      Vote.set_on > (datetime.datetime.now() - datetime.timedelta(days=90)))
   future_feature_ids = query.fetch_async(projection=['feature_id'])
   return future_feature_ids
 

--- a/internals/search.py
+++ b/internals/search.py
@@ -87,9 +87,10 @@ def process_starred_me_query() -> list[int]:
 
 def process_recent_reviews_query() -> list[int] | Future:
   """Return features that were reviewed recently."""
-  query = Vote.query(
-      Vote.state.IN(Gate.FINAL_STATES))
-  future_feature_ids = query.fetch_async(projection=['feature_id'], limit=40)
+  query = Vote.query(Vote.state.IN(Gate.FINAL_STATES))
+  query = query.filter(
+      Vote.set_on > datetime.datetime.now() - datetime.timedelta(days=90))
+  future_feature_ids = query.fetch_async(projection=['feature_id'])
   return future_feature_ids
 
 

--- a/internals/search_queries.py
+++ b/internals/search_queries.py
@@ -25,7 +25,7 @@ from google.cloud.ndb.tasklets import Future  # for type checking only
 from framework import users
 from internals import core_enums
 from internals.core_models import FeatureEntry, Stage
-from internals.review_models import Gate
+from internals.review_models import (Gate, Vote)
 
 T = TypeVar('T')
 QueryValue: TypeAlias = bool | int | str | datetime.datetime
@@ -244,9 +244,9 @@ def sorted_by_pending_request_date(descending: bool) -> Future:
 def sorted_by_review_date(descending: bool) -> Future:
   """Return feature_ids of reviewed approvals sorted by last review."""
   return _sorted_by_joined_model(
-      Gate,
-      Gate.state.IN(Gate.FINAL_STATES),
-      descending, Gate.requested_on)
+      Vote,
+      Vote.state.IN(Gate.FINAL_STATES),
+      descending, Vote.set_on)
 
 
 QUERIABLE_FIELDS: dict[str, Property] = {
@@ -403,10 +403,6 @@ STAGE_TYPES_BY_QUERY_FIELD: dict[str, dict[int, Optional[int]]] = {
 
 SORTABLE_FIELDS: dict[str, Union[Property, Callable]] = QUERIABLE_FIELDS.copy()
 SORTABLE_FIELDS.update({
-    # TODO(jrobbins): remove the 'approvals.*' items after 2023-01-01.
-    'approvals.requested_on': sorted_by_pending_request_date,
-    'approvals.reviewed_on': sorted_by_review_date,
-
     'gate.requested_on': sorted_by_pending_request_date,
     'gate.reviewed_on': sorted_by_review_date,
     })

--- a/internals/search_queries_test.py
+++ b/internals/search_queries_test.py
@@ -344,7 +344,7 @@ class SearchFeaturesTest(testing_config.CustomTestCase):
     future = search_queries.total_order_query_async('gate.reviewed_on')
     actual = search._resolve_promise_to_id_list(future)
     self.assertEqual(
-        [self.feature_1_id],
+        [self.feature_1_id, self.feature_2_id],
         actual)
 
   def test_stage_fields_have_join_conditions(self):

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -386,23 +386,29 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     mock_approvable_by.return_value = set({1, 2, 3})
     time_1 = datetime.datetime.now() - datetime.timedelta(days=4)
     time_2 = datetime.datetime.now()
-    Gate(
-        feature_id=self.featureentry_1.key.integer_id(), stage_id=1,
-        gate_type=1, state=Vote.NA,
-        requested_on=time_2).put()
-    Gate(
-        feature_id=self.featureentry_2.key.integer_id(), stage_id=1,
-        gate_type=1, state=Vote.APPROVED,
-        requested_on=time_1).put()
+    fe_1_id = self.featureentry_1.key.integer_id()
+    fe_2_id = self.featureentry_2.key.integer_id()
+    gate_1 = Gate(
+        feature_id=fe_1_id, stage_id=1, gate_type=1, state=Vote.NA,
+        requested_on=time_2)
+    gate_1.put()
+    vote_1_1 = Vote(
+        feature_id=fe_1_id, gate_id=gate_1.key.integer_id(),
+        state=Vote.NA, set_on=time_2, set_by='reviewer@example.com')
+    vote_1_1.put()
+    gate_2 = Gate(
+        feature_id=fe_2_id, stage_id=1, gate_type=1, state=Vote.APPROVED,
+        requested_on=time_1)
+    gate_2.put()
+    vote_2_1 = Vote(
+        feature_id=fe_2_id, gate_id=gate_2.key.integer_id(),
+        state=Vote.APPROVED, set_on=time_1, set_by='reviewer@example.com')
+    vote_2_1.put()
 
     future = search.process_recent_reviews_query()
     feature_ids = search._resolve_promise_to_id_list(future)
 
-    self.assertEqual(2, len(feature_ids))
-    self.assertEqual(
-        feature_ids[0], self.featureentry_1.key.integer_id())  # Most recent
-    self.assertEqual(
-        feature_ids[1], self.featureentry_2.key.integer_id())
+    self.assertEqual([fe_1_id, fe_2_id], feature_ids)
 
   def test_sort_by_total_order__empty(self):
     """Sorting an empty list works."""

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -386,6 +386,7 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
     mock_approvable_by.return_value = set({1, 2, 3})
     time_1 = datetime.datetime.now() - datetime.timedelta(days=4)
     time_2 = datetime.datetime.now()
+    time_3 = datetime.datetime.now() - datetime.timedelta(days=100)
     fe_1_id = self.featureentry_1.key.integer_id()
     fe_2_id = self.featureentry_2.key.integer_id()
     gate_1 = Gate(
@@ -404,10 +405,15 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
         feature_id=fe_2_id, gate_id=gate_2.key.integer_id(),
         state=Vote.APPROVED, set_on=time_1, set_by='reviewer@example.com')
     vote_2_1.put()
+    vote_2_2 = Vote(
+        feature_id=fe_2_id, gate_id=gate_2.key.integer_id(),
+        state=Vote.APPROVED, set_on=time_3, set_by='old@example.com')
+    vote_2_2.put()
 
     future = search.process_recent_reviews_query()
     feature_ids = search._resolve_promise_to_id_list(future)
 
+    # Note: vote_2_2 does not contribute to the list because it is too old.
     self.assertEqual([fe_1_id, fe_2_id], feature_ids)
 
   def test_sort_by_total_order__empty(self):


### PR DESCRIPTION
This should resolve #4240 and improve the accuracy of the recent-reviews query.

The immediate cause of the 500 was that sorting by `-gate.reviewed_on` was comparing values for `gate.requested_on`, but since that was a field that we added in November 2022, there were some Gate entities that had no defined value for that field. A bigger problem was that `gate.reviewed_on' was incorrectly sorting based on the date of the request for review, but it should have been looking at the conclusion of the review. 

In this PR:
* Change sorting for `gate.reviewed_on` to sort based on `Vote.set_on` which measures the date of the reviewers' responses and is always defined.
* Change the query for `is:recently-reviewed` to also look for `Vote.set_on` with in the last 90 days so that it is measuring the right thing.  This also avoids randomness due to taking a limited number of results from an unsorted query.