### PR TITLE
Handle ID key when updating OT milestones

### DIFF
--- a/api/stages_api_test.py
+++ b/api/stages_api_test.py
@@ -572,6 +572,7 @@ class StagesAPITest(testing_config.CustomTestCase):
     """
     testing_config.sign_in('feature_owner@example.com', 123)
     json = {
+      'id': 10,
       'desktop_first': {
         'form_field_name': 'ot_milestone_desktop_start',
         'value': 200,
@@ -595,6 +596,7 @@ class StagesAPITest(testing_config.CustomTestCase):
     """Raises 400 if OT end milestone is updated during OT creation process."""
     testing_config.sign_in('feature_owner@example.com', 123)
     json = {
+      'id': 10,
       'desktop_last': {
         'form_field_name': 'ot_milestone_desktop_end',
         'value': 206,

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -360,8 +360,9 @@ class EntitiesAPIHandler(APIHandler):
     ot_action_requested = False
 
     mutating_ot_milestones = any(
+        isinstance(v, dict) and (
         v['form_field_name'] == 'ot_milestone_desktop_start' or
-        v['form_field_name'] == 'ot_milestone_desktop_end'
+        v['form_field_name'] == 'ot_milestone_desktop_end')
         for v in change_info.values())
     ot_creation_in_progress =  (
         stage.ot_setup_status == OT_READY_FOR_CREATION or


### PR DESCRIPTION
This is a small bug fix that that occurs on certain forms when updating stages (specifically, the OT creation request form) with the new change that disallows OT milestones from being edited while a creation request is in progress. The `id` key is part of the dictionary that describes the group of changes that will be made to the stage, which is not referenced in the same way that other dictionary values are (as a nested dictionary with a `form_field_name` key).

This change checks that the value in the dictionary is actually a nested dictionary before trying to access values in it. The bug that was introduced has not landed in production, so it is not an urgent change (but should be landed before next deployment).