### PR TITLE
Obtain Chromium source files concurrently

### DIFF
--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -95,8 +95,6 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
       validation_errors['ot_chromium_trial_name'] = (
           'Chromium trial name is already used by another origin trial')
 
-    print(chromium_files['enabled_features_text'])
-    print(type(chromium_files['enabled_features_text']))
     enabled_features_json = json5.loads(chromium_files['enabled_features_text'])
     if (not any(feature.get('origin_trial_feature_name') == chromium_trial_name
                 for feature in enabled_features_json['data'])):

--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -68,10 +68,10 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
     """Check that all provided OT creation arguments are valid."""
     chromium_files = {}  # Chromium source file contents.
     with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
-      future_to_url = {executor.submit(get_chromium_file, f['url']): f['name']
+      future_to_name = {executor.submit(get_chromium_file, f['url']): f['name']
                       for f in CHROMIUM_SRC_FILES}
-      for future in concurrent.futures.as_completed(future_to_url):
-        name = future_to_url[future]
+      for future in concurrent.futures.as_completed(future_to_name):
+        name = future_to_name[future]
         try:
           chromium_files[name] = future.result()
         except Exception as exc:

--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import concurrent.futures
 import flask
 import json5
 import logging
 import requests
+import urllib.request
 import validators
 from base64 import b64decode
 
@@ -31,18 +33,17 @@ from internals.review_models import Gate, Vote
 WEBFEATURE_FILE_URL = 'https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/public/mojom/use_counter/metrics/web_feature.mojom?format=TEXT'
 ENABLED_FEATURES_FILE_URL = 'https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/renderer/platform/runtime_enabled_features.json5?format=TEXT'
 GRACE_PERIOD_FILE = 'https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/common/origin_trials/manual_completion_origin_trial_features.cc?format=TEXT'
+CHROMIUM_SRC_FILES = [
+  {'name': 'webfeature_file', 'url': WEBFEATURE_FILE_URL},
+  {'name': 'enabled_features_text', 'url': ENABLED_FEATURES_FILE_URL},
+  {'name': 'grace_period_file', 'url': GRACE_PERIOD_FILE}
+]
 
 
-# TODO(jrobbins): Fetch these in parallel, but in a way that is easy to test.
 def get_chromium_file(url: str) -> str:
   """Get chromium file contents from a given URL"""
-  try:
-    resp = requests.get(url)
-  except requests.RequestException as e:
-    logging.exception(
-        f'Failed to get response to obtain Chromium file: {url}')
-    raise e
-  return b64decode(resp.text).decode('utf-8')
+  with urllib.request.urlopen(url, timeout=60) as conn:
+    return  b64decode(conn.read()).decode('utf-8')
 
 
 class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
@@ -65,12 +66,18 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
   def _validate_creation_args(
       self, body: dict) -> dict[str, str]:
     """Check that all provided OT creation arguments are valid."""
-    try:
-      enabled_features_text = get_chromium_file(ENABLED_FEATURES_FILE_URL)
-      webfeature_file = get_chromium_file(WEBFEATURE_FILE_URL)
-      grace_period_file = get_chromium_file(GRACE_PERIOD_FILE)
-    except requests.exceptions.RequestException:
-      self.abort(500, 'Error obtaining Chromium file for validation')
+    chromium_files = {}  # Chromium source file contents.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+      future_to_url = {executor.submit(get_chromium_file, f['url']): f['name']
+                      for f in CHROMIUM_SRC_FILES}
+      for future in concurrent.futures.as_completed(future_to_url):
+        name = future_to_url[future]
+        try:
+          chromium_files[name] = future.result()
+        except Exception as exc:
+          self.abort(
+              500, f'Error obtaining Chromium file for validation: {str(exc)}')
+
     validation_errors: dict[str, str] = {}
     chromium_trial_name = body.get(
         'ot_chromium_trial_name', {}).get('value')
@@ -88,7 +95,9 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
       validation_errors['ot_chromium_trial_name'] = (
           'Chromium trial name is already used by another origin trial')
 
-    enabled_features_json = json5.loads(enabled_features_text)
+    print(chromium_files['enabled_features_text'])
+    print(type(chromium_files['enabled_features_text']))
+    enabled_features_json = json5.loads(chromium_files['enabled_features_text'])
     if (not any(feature.get('origin_trial_feature_name') == chromium_trial_name
                 for feature in enabled_features_json['data'])):
       validation_errors['ot_chromium_trial_name'] = (
@@ -99,7 +108,7 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
       if not use_counter:
         validation_errors['ot_webfeature_use_counter'] = (
             'No UseCounter specified for non-deprecation trial.')
-      elif f'{use_counter} =' not in webfeature_file:
+      elif f'{use_counter} =' not in chromium_files['webfeature_file']:
           validation_errors['ot_webfeature_use_counter'] = (
               'UseCounter not landed in web_feature.mojom')
 
@@ -114,7 +123,7 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
 
     if body.get('ot_is_critical_trial', {}).get('value', False):
       if (f'blink::mojom::OriginTrialFeature::k{chromium_trial_name}'
-          not in grace_period_file):
+          not in chromium_files['grace_period_file']):
         validation_errors['ot_is_critical_trial'] = (
             'Use counter has not landed in grace period array '
             'for critical trial')

--- a/api/origin_trials_api_test.py
+++ b/api/origin_trials_api_test.py
@@ -127,6 +127,16 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
       for entity in kind.query():
         entity.key.delete()
 
+  def mock_chromium_file_return_value_generator(self, *args, **kwargs):
+    """Returns mock milestone info based on input."""
+    if args == ('https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/public/mojom/use_counter/metrics/web_feature.mojom?format=TEXT',):
+      return self.mock_usecounters_file
+    if args == ('https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/renderer/platform/runtime_enabled_features.json5?format=TEXT',):
+      return self.mock_features_file
+    if args == ('https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/common/origin_trials/manual_completion_origin_trial_features.cc?format=TEXT',):
+      return self.mock_grace_period_file
+    return ''
+
   def test_check_post_permissions__anon(self):
     """Anon users cannot request origin trials."""
     testing_config.sign_out()
@@ -195,10 +205,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
   @mock.patch('api.origin_trials_api.get_chromium_file')
   def test_validate_creation_args__valid(self, mock_get_chromium_file):
     """No error messages should be returned if all args are valid."""
-    mock_get_chromium_file.side_effect = [
-      self.mock_features_file,
-      self.mock_usecounters_file,
-      self.mock_grace_period_file]
+    mock_get_chromium_file.side_effect = self.mock_chromium_file_return_value_generator
 
     body = {
       'ot_chromium_trial_name': {
@@ -232,10 +239,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
   def test_validate_creation_args__invalid_webfeature_use_counter(
       self, mock_get_chromium_file):
     """Error message returned if UseCounter not found in file."""
-    mock_get_chromium_file.side_effect = [
-      self.mock_features_file,
-      self.mock_usecounters_file,
-      self.mock_grace_period_file]
+    mock_get_chromium_file.side_effect = self.mock_chromium_file_return_value_generator
     body = {
       'ot_chromium_trial_name': {
         'form_field_name': 'ot_chromium_trial_name',
@@ -268,10 +272,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
   def test_validate_creation_args__missing_webfeature_use_counter(
       self, mock_get_chromium_file):
     """Error message returned if UseCounter is missing."""
-    mock_get_chromium_file.side_effect = [
-      self.mock_features_file,
-      self.mock_usecounters_file,
-      self.mock_grace_period_file]
+    mock_get_chromium_file.side_effect = self.mock_chromium_file_return_value_generator
     body = {
       'ot_chromium_trial_name': {
         'form_field_name': 'ot_chromium_trial_name',
@@ -301,10 +302,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
       self, mock_get_chromium_file):
     """No error message returned for missing UseCounter if deprecation trial."""
     """Deprecation trial does not need a webfeature use counter value."""
-    mock_get_chromium_file.side_effect = [
-      self.mock_features_file,
-      self.mock_usecounters_file,
-      self.mock_grace_period_file]
+    mock_get_chromium_file.side_effect = self.mock_chromium_file_return_value_generator
     body = {
       'ot_chromium_trial_name': {
         'form_field_name': 'ot_chromium_trial_name',
@@ -332,10 +330,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
   def test_validate_creation_args__invalid_chromium_trial_name(
       self, mock_get_chromium_file):
     """Error message returned if Chromium trial name not found in file."""
-    mock_get_chromium_file.side_effect = [
-      self.mock_features_file,
-      self.mock_usecounters_file,
-      self.mock_grace_period_file]
+    mock_get_chromium_file.side_effect = self.mock_chromium_file_return_value_generator
     body = {
       'ot_chromium_trial_name': {
         'form_field_name': 'ot_chromium_trial_name',
@@ -368,10 +363,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
   def test_validate_creation_args__missing_chromium_trial_name(
       self, mock_get_chromium_file):
     """Error message returned if Chromium trial is missing from request."""
-    mock_get_chromium_file.side_effect = [
-      self.mock_features_file,
-      self.mock_usecounters_file,
-      self.mock_grace_period_file]
+    mock_get_chromium_file.side_effect = self.mock_chromium_file_return_value_generator
     body = {
       'ot_webfeature_use_counter': {
         'form_field_name': 'ot_webfeature_use_counter',
@@ -398,10 +390,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
   def test_validate_creation_args__invalid_third_party_trial(
       self, mock_get_chromium_file):
     """Error message returned if third party support not found in file."""
-    mock_get_chromium_file.side_effect = [
-      self.mock_features_file,
-      self.mock_usecounters_file,
-      self.mock_grace_period_file]
+    mock_get_chromium_file.side_effect = self.mock_chromium_file_return_value_generator
     body = {
       'ot_chromium_trial_name': {
         'form_field_name': 'ot_chromium_trial_name',
@@ -436,10 +425,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
   def test_validate_creation_args__invalid_critical_trial(
       self, mock_get_chromium_file):
     """Error message returned if critical trial name not found in file."""
-    mock_get_chromium_file.side_effect = [
-      self.mock_features_file,
-      self.mock_usecounters_file,
-      self.mock_grace_period_file]
+    mock_get_chromium_file.side_effect = self.mock_chromium_file_return_value_generator
     body = {
       'ot_chromium_trial_name': {
         'form_field_name': 'ot_chromium_trial_name',


### PR DESCRIPTION
This change updates the logic in which Chromium source file contents are obtained in order to fetch files asynchronously. This approach is based on the [example of using concurrent.futures in the docs](https://docs.python.org/3/library/concurrent.futures.html#threadpoolexecutor-example) and may be handled with less issues than the previous implementation.