### PR TITLE
Handle OpenAPI models correctly for GET requests

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -197,7 +197,9 @@ class APIHandler(BaseHandler):
     """Handle an incoming HTTP GET request."""
     headers = self.get_headers()
     handler_data = self.do_get(*args, **kwargs)
-    if isinstance(handler_data, Model):
+    # OpenAPI models have a to_dict attribute that should be used for
+    # converting to JSON.
+    if hasattr(handler_data, 'to_dict'):
         handler_data = handler_data.to_dict()
     return self.defensive_jsonify(handler_data), headers
 

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from gen.py.chromestatus_openapi.chromestatus_openapi.models.feature_links_response import FeatureLinksResponse
 import testing_config  # Must be imported before the module under test.
 
 import json
@@ -440,6 +441,29 @@ class APIHandlerTests(testing_config.CustomTestCase):
     """If a subclass has do_get(), get() should return a JSON response."""
     self.handler = TestableAPIHandler()
     self.check_http_method_handler(self.handler.get, 'done get')
+
+  @mock.patch('framework.basehandlers.APIHandler.do_get')
+  def test_get__dict(self, mock_do_get):
+    """get() should return a JSON response if the do_get() return value is a
+    dict."""
+    mock_do_get.return_value = {'key': 'value'}
+    with test_app.test_request_context('/path'):
+      response, _ = self.handler.get()
+    self.assertEqual(basehandlers.XSSI_PREFIX + '{"key": "value"}',
+                     response.get_data().decode('utf-8'))
+
+  @mock.patch('framework.basehandlers.APIHandler.do_get')
+  def test_get__openapi_model(self, mock_do_get):
+    """get() should return a JSON response if the do_get() return value is a
+    OpenAPI model."""
+    mock_do_get.return_value = FeatureLinksResponse(data='data',
+                                                    has_stale_links=True)
+    with test_app.test_request_context('/path'):
+      response, _ = self.handler.get()
+    self.assertEqual(basehandlers.XSSI_PREFIX +
+                     '{"data": "data", "has_stale_links": true}',
+                     response.get_data().decode('utf-8'))
+
 
   def test_post(self):
     """If a subclass has do_post(), post() should return a JSON response."""

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -454,7 +454,7 @@ class APIHandlerTests(testing_config.CustomTestCase):
 
   @mock.patch('framework.basehandlers.APIHandler.do_get')
   def test_get__openapi_model(self, mock_do_get):
-    """get() should return a JSON response if the do_get() return value is a
+    """get() should return a JSON response if the do_get() return value is an
     OpenAPI model."""
     mock_do_get.return_value = FeatureLinksResponse(data='data',
                                                     has_stale_links=True)


### PR DESCRIPTION
This change fixes a bug where OpenAPI models were not handled properly for GET requests. The conditional logic to handle OpenAPI models has been changed to properly detect them by checking if the handler_data has a `to_dict` attribute, and to use it accordingly.