### PR TITLE
Fix typo in OT prereqs dialog (2nd)

### DIFF
--- a/client-src/elements/chromedash-ot-prereqs-dialog.ts
+++ b/client-src/elements/chromedash-ot-prereqs-dialog.ts
@@ -243,7 +243,7 @@ class ChromedashOTPrereqsDialog extends LitElement {
           >
             runtime_enabled_features.json5
           </a>
-          contains the key "origin_trials_allows_third_party: true".
+          contains the key "origin_trial_allows_third_party: true".
         </li>
         <li>
           For a critical trial, the feature name has been added to the


### PR DESCRIPTION
I thought I was losing it, because I remember fixing this typo ([and I did fix it](https://github.com/GoogleChrome/chromium-dashboard/pull/3665)), but somehow [I managed to switch it back in a subsequent PR](https://github.com/GoogleChrome/chromium-dashboard/pull/3691/files#diff-0e421f77204aa9e04b17892432fb2ac37a9175162e2aa329a4a46f044b4564eaR239).

Hopefully this will stay fixed for now. 😅