### PR TITLE
Add simple warning header text to OT creation form

### DIFF
--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -43,6 +43,18 @@ export class ChromedashOTCreationPage extends LitElement {
           transform: translate(-50%, -50%);
           height: 300px;
         }
+        .warning-div {
+          background-color: #fbfba7;
+          border: 2px solid #ffe735;
+          border-radius: 10px;
+          padding: 4px;
+          margin-bottom: 32px;
+        }
+        .warning-text {
+          text-align: center;
+          color: #555555;
+          font-weight: 200;
+        }
       `,
     ];
   }
@@ -439,7 +451,16 @@ export class ChromedashOTCreationPage extends LitElement {
             </div>`
           : nothing}
         <chromedash-form-table ${ref(this.registerHandlers)}>
-          <section class="stage_form">${this.renderFields()}</section>
+          <section class="stage_form">
+            <div class="warning-div">
+              <h3 class="warning-text">
+                Please make sure this data is correct before submission! If you
+                are not sure about any information on this form, contact
+                <strong>origin-trials-support@google.com</strong>
+              </h3>
+            </div>
+            ${this.renderFields()}
+          </section>
         </chromedash-form-table>
         <div class="final_buttons">
           <input

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -43,17 +43,17 @@ export class ChromedashOTCreationPage extends LitElement {
           transform: translate(-50%, -50%);
           height: 300px;
         }
-        .warning-div {
-          background-color: #fbfba7;
-          border: 2px solid #ffe735;
+
+        .warning {
+          border: 2px solid #555555;
           border-radius: 10px;
           padding: 4px;
           margin-bottom: 32px;
         }
-        .warning-text {
+        .warning h3 {
           text-align: center;
           color: #555555;
-          font-weight: 200;
+          font-weight: 300;
         }
       `,
     ];
@@ -452,8 +452,8 @@ export class ChromedashOTCreationPage extends LitElement {
           : nothing}
         <chromedash-form-table ${ref(this.registerHandlers)}>
           <section class="stage_form">
-            <div class="warning-div">
-              <h3 class="warning-text">
+            <div class="warning warning-div">
+              <h3>
                 Please make sure this data is correct before submission! If you
                 are not sure about any information on this form, contact
                 <strong>origin-trials-support@google.com</strong>


### PR DESCRIPTION
This is a small change to update the OT creation form to add some text that warns users to be sure that the data in the form is correct, and to contact the OT support team if they have any questions. The reason for adding this is to prevent users from attempting to give bad data (e.g. a fake use counter) to submit the form. We've had some instances of users adding these fake data or filler inputs, and this should discourage that behavior in the future.

The wording can be changed as suggested.
![Screenshot 2024-08-22 at 3 16 27 PM](https://github.com/user-attachments/assets/3853a8b6-c62a-4b6d-9954-f4aeb98f3e5f)
