### PR TITLE
Hide and ignore use counter field for deprecation trials

### DIFF
--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -313,7 +313,9 @@ export class ChromedashOTCreationPage extends LitElement {
       });
     }
     if (this.isDeprecationTrial) {
-      this.fieldValues.find(fv => fv.name === 'ot_webfeature_use_counter')!.touched = false;
+      this.fieldValues.find(
+        fv => fv.name === 'ot_webfeature_use_counter'
+      )!.touched = false;
     }
 
     const featureSubmitBody = formatFeatureChanges(
@@ -392,14 +394,16 @@ export class ChromedashOTCreationPage extends LitElement {
       if (
         fieldInfo.alwaysHidden ||
         (fieldInfo.isApprovalsField && !this.showApprovalsFields) ||
-        (fieldInfo.name === 'ot_webfeature_use_counter' && this.isDeprecationTrial)
+        (fieldInfo.name === 'ot_webfeature_use_counter' &&
+          this.isDeprecationTrial)
       ) {
         return nothing;
       }
       // Fade in transition for the approvals fields or use counter field
       // if they're being displayed.
-      const shouldFadeIn = (
-          fieldInfo.isApprovalsField || fieldInfo.name === 'ot_webfeature_use_counter');
+      const shouldFadeIn =
+        fieldInfo.isApprovalsField ||
+        fieldInfo.name === 'ot_webfeature_use_counter';
 
       return html`
         <chromedash-form-field

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -66,6 +66,8 @@ export class ChromedashOTCreationPage extends LitElement {
   @state()
   showApprovalsFields = false;
   @state()
+  isDeprecationTrial = false;
+  @state()
   stage!: StageDict;
 
   connectedCallback() {
@@ -88,6 +90,9 @@ export class ChromedashOTCreationPage extends LitElement {
     // Toggle the display of the registration approval fields when the box is checked.
     if (this.fieldValues[index].name === 'ot_require_approvals') {
       this.showApprovalsFields = !this.showApprovalsFields;
+      this.requestUpdate();
+    } else if (this.fieldValues[index].name === 'ot_is_deprecation_trial') {
+      this.isDeprecationTrial = value;
       this.requestUpdate();
     }
   }
@@ -307,6 +312,9 @@ export class ChromedashOTCreationPage extends LitElement {
         }
       });
     }
+    if (this.isDeprecationTrial) {
+      this.fieldValues.find(fv => fv.name === 'ot_webfeature_use_counter')!.touched = false;
+    }
 
     const featureSubmitBody = formatFeatureChanges(
       this.fieldValues,
@@ -383,12 +391,15 @@ export class ChromedashOTCreationPage extends LitElement {
     const fields = this.fieldValues.map((fieldInfo, i) => {
       if (
         fieldInfo.alwaysHidden ||
-        (fieldInfo.isApprovalsField && !this.showApprovalsFields)
+        (fieldInfo.isApprovalsField && !this.showApprovalsFields) ||
+        (fieldInfo.name === 'ot_webfeature_use_counter' && this.isDeprecationTrial)
       ) {
         return nothing;
       }
-      // Fade in transition for the approvals fields if they're being displayed.
-      const shouldFadeIn = fieldInfo.isApprovalsField;
+      // Fade in transition for the approvals fields or use counter field
+      // if they're being displayed.
+      const shouldFadeIn = (
+          fieldInfo.isApprovalsField || fieldInfo.name === 'ot_webfeature_use_counter');
 
       return html`
         <chromedash-form-field


### PR DESCRIPTION
WebFeature use counters are not needed (and shouldn't be supplied) for deprecation trials. The use counter field in the OT creation form is already optional when the deprecation trial checkbox is selected, but this change explicitly removes the use counter field from the form when the deprecation trial checkbox is checked.

Making this field inaccessible for deprecation trials is better because adding a use counter value might cause false positives when usage monitoring origin trials. Deprecation trial are not subject to rate limiting.


https://github.com/user-attachments/assets/58c4ee2d-1f87-4176-8659-05a91b956821

