### PR TITLE
Set comments API var to integer type

### DIFF
--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -260,7 +260,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
     """Handler adds a comment only, does not require approval permission."""
     mock_get_approvers.return_value = []
     testing_config.sign_in('user2@chromium.org', 123567890)
-    params = {'comment': 'Congratulations'}
+    params = {'comment': 'Congratulations', 'postToThreadType': 0}
     with test_app.test_request_context(self.request_path, json=params):
       actual = self.handler.do_post(feature_id=self.feature_id,
           gate_id=self.gate_1_id)
@@ -281,7 +281,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
     """Outsiders cannot comment."""
     mock_get_approvers.return_value = []
     testing_config.sign_in('outsider@example.com', 123567890)
-    params = {'comment': 'Could be spam'}
+    params = {'comment': 'Could be spam', 'postToThreadType': 0}
     with test_app.test_request_context(self.request_path, json=params):
       with self.assertRaises(werkzeug.exceptions.Forbidden):
         self.handler.do_post(

--- a/gen/js/chromestatus-openapi/src/models/CommentsRequest.ts
+++ b/gen/js/chromestatus-openapi/src/models/CommentsRequest.ts
@@ -27,10 +27,10 @@ export interface CommentsRequest {
     comment?: string;
     /**
      * 
-     * @type {string}
+     * @type {number}
      * @memberof CommentsRequest
      */
-    postToThreadType?: string;
+    postToThreadType?: number;
 }
 
 /**

--- a/gen/py/chromestatus_openapi/chromestatus_openapi/models/comments_request.py
+++ b/gen/py/chromestatus_openapi/chromestatus_openapi/models/comments_request.py
@@ -18,11 +18,11 @@ class CommentsRequest(Model):
         :param comment: The comment of this CommentsRequest.  # noqa: E501
         :type comment: str
         :param post_to_thread_type: The post_to_thread_type of this CommentsRequest.  # noqa: E501
-        :type post_to_thread_type: str
+        :type post_to_thread_type: int
         """
         self.openapi_types = {
             'comment': str,
-            'post_to_thread_type': str
+            'post_to_thread_type': int
         }
 
         self.attribute_map = {
@@ -66,22 +66,22 @@ class CommentsRequest(Model):
         self._comment = comment
 
     @property
-    def post_to_thread_type(self) -> str:
+    def post_to_thread_type(self) -> int:
         """Gets the post_to_thread_type of this CommentsRequest.
 
 
         :return: The post_to_thread_type of this CommentsRequest.
-        :rtype: str
+        :rtype: int
         """
         return self._post_to_thread_type
 
     @post_to_thread_type.setter
-    def post_to_thread_type(self, post_to_thread_type: str):
+    def post_to_thread_type(self, post_to_thread_type: int):
         """Sets the post_to_thread_type of this CommentsRequest.
 
 
         :param post_to_thread_type: The post_to_thread_type of this CommentsRequest.
-        :type post_to_thread_type: str
+        :type post_to_thread_type: int
         """
 
         self._post_to_thread_type = post_to_thread_type

--- a/gen/py/chromestatus_openapi/chromestatus_openapi/openapi/openapi.yaml
+++ b/gen/py/chromestatus_openapi/chromestatus_openapi/openapi/openapi.yaml
@@ -1494,7 +1494,7 @@ components:
       type: object
     CommentsRequest:
       example:
-        postToThreadType: postToThreadType
+        postToThreadType: 0
         comment: comment
       properties:
         comment:
@@ -1503,7 +1503,7 @@ components:
         postToThreadType:
           nullable: true
           title: postToThreadType
-          type: string
+          type: integer
       title: CommentsRequest
       type: object
     GetCommentsResponse:

--- a/gen/py/chromestatus_openapi/chromestatus_openapi/test/test_default_controller.py
+++ b/gen/py/chromestatus_openapi/chromestatus_openapi/test/test_default_controller.py
@@ -43,7 +43,7 @@ class TestDefaultController(BaseTestCase):
 
         Add a comment to a feature
         """
-        comments_request = {"postToThreadType":"postToThreadType","comment":"comment"}
+        comments_request = {"postToThreadType":0,"comment":"comment"}
         headers = { 
             'Accept': 'application/json',
             'Content-Type': 'application/json',
@@ -62,7 +62,7 @@ class TestDefaultController(BaseTestCase):
 
         Add a comment to a specific gate
         """
-        comments_request = {"postToThreadType":"postToThreadType","comment":"comment"}
+        comments_request = {"postToThreadType":0,"comment":"comment"}
         headers = { 
             'Accept': 'application/json',
             'Content-Type': 'application/json',

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -996,7 +996,7 @@ components:
         comment:
           type: string
         postToThreadType:
-          type: string
+          type: integer
           nullable: true
     GetCommentsResponse:
       type: object


### PR DESCRIPTION
This fixes a bug that arose in deployment testing from a request argument erroneously expecting a string type argument. The variable has been changed to an integer type.