### PR TITLE
Update extension approved email to use "extension"

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -866,7 +866,7 @@ class OTExtensionApprovedHandler(basehandlers.FlaskHandler):
     return {
       'to': requester_email,
       'cc': [OT_SUPPORT_EMAIL],
-      'subject': ('Origin trial approved and ready to be initiated: '
+      'subject': ('Origin trial extension approved and ready to be initiated: '
                   f'{feature["name"]}'),
       'reply_to': None,
       'html': body,

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -1152,6 +1152,10 @@ class OTExtensionApprovedHandlerTest(testing_config.CustomTestCase):
                                        self.extension_stage.ot_owner_email,
                                        self.extension_gate.key.integer_id())
       # TESTDATA.make_golden(email_task['html'], 'test_make_extension_approved_email.html')
+      self.assertEqual(
+          email_task['subject'],
+          ('Origin trial extension approved and ready to be initiated: '
+           'A feature'))
       self.assertEqual(email_task['html'],
         TESTDATA['test_make_extension_approved_email.html'])
 


### PR DESCRIPTION
I noticed recently that the "extension approved" email does not mention that it is an extension that is being approved. This is a small change to fix that.