### PR TITLE
Fix search for phrases that are one word repeated.

### DIFF
--- a/internals/search_fulltext_test.py
+++ b/internals/search_fulltext_test.py
@@ -89,11 +89,14 @@ class SearchFulltextFunctionsTest(testing_config.CustomTestCase):
   def test_parse_words__empty(self):
     """We can cope with empty strings and lists."""
     self.assertEqual(
-        set(), search_fulltext.parse_words([]))
+        (set(), 0),
+        search_fulltext.parse_words([]))
     self.assertEqual(
-        set(), search_fulltext.parse_words(['']))
+        (set(), 0),
+        search_fulltext.parse_words(['']))
     self.assertEqual(
-        set(), search_fulltext.parse_words(['', '']))
+        (set(), 0),
+        search_fulltext.parse_words(['', '']))
 
   def test_parse_words__normal(self):
     """We parse strings into sets of words, without stopwords."""
@@ -101,8 +104,9 @@ class SearchFulltextFunctionsTest(testing_config.CustomTestCase):
         'one, two, buckle my shoe',
         'three, four, close the door.'])
     self.assertEqual(
-        set(['one', 'two', 'buckle', 'shoe',
-             'three', 'four', 'close', 'door']),
+        (set(['one', 'two', 'buckle', 'shoe',
+              'three', 'four', 'close', 'door']),
+         9),
         actual)
 
   def test_batch_index_features__empty(self):


### PR DESCRIPTION
Testing phrase search on staging turned up a failure in a not-too-important case: searching for a phrase that consists of just a single word repeated, like `"Tuesday Tuesday Tuesday"`, skipped the phrase search post-filtering and gave results that had the word "Tuesday" regardless of phrase context, which is too many results.

The defect was that the phrase post-filtering was conditioned on `len(words) > 1` at a point where `words` was a `set` of query words rather than a list, so `"Tuesday Tuesday Tuesday"` had a word set of length 1 at that point.    The fix is to keep the count separately before distilling the query phrase down to a set.