### PR TITLE
Change postToThreadType to type int.

### DIFF
--- a/gen/js/chromestatus-openapi/src/models/CommentsRequest.ts
+++ b/gen/js/chromestatus-openapi/src/models/CommentsRequest.ts
@@ -27,10 +27,10 @@ export interface CommentsRequest {
     comment?: string;
     /**
      * 
-     * @type {string}
+     * @type {number}
      * @memberof CommentsRequest
      */
-    postToThreadType?: string;
+    postToThreadType?: number;
 }
 
 /**

--- a/gen/py/chromestatus_openapi/chromestatus_openapi/models/comments_request.py
+++ b/gen/py/chromestatus_openapi/chromestatus_openapi/models/comments_request.py
@@ -18,11 +18,11 @@ class CommentsRequest(Model):
         :param comment: The comment of this CommentsRequest.  # noqa: E501
         :type comment: str
         :param post_to_thread_type: The post_to_thread_type of this CommentsRequest.  # noqa: E501
-        :type post_to_thread_type: str
+        :type post_to_thread_type: int
         """
         self.openapi_types = {
             'comment': str,
-            'post_to_thread_type': str
+            'post_to_thread_type': int
         }
 
         self.attribute_map = {
@@ -66,22 +66,22 @@ class CommentsRequest(Model):
         self._comment = comment
 
     @property
-    def post_to_thread_type(self) -> str:
+    def post_to_thread_type(self) -> int:
         """Gets the post_to_thread_type of this CommentsRequest.
 
 
         :return: The post_to_thread_type of this CommentsRequest.
-        :rtype: str
+        :rtype: int
         """
         return self._post_to_thread_type
 
     @post_to_thread_type.setter
-    def post_to_thread_type(self, post_to_thread_type: str):
+    def post_to_thread_type(self, post_to_thread_type: int):
         """Sets the post_to_thread_type of this CommentsRequest.
 
 
         :param post_to_thread_type: The post_to_thread_type of this CommentsRequest.
-        :type post_to_thread_type: str
+        :type post_to_thread_type: int
         """
 
         self._post_to_thread_type = post_to_thread_type

--- a/gen/py/chromestatus_openapi/chromestatus_openapi/openapi/openapi.yaml
+++ b/gen/py/chromestatus_openapi/chromestatus_openapi/openapi/openapi.yaml
@@ -1494,7 +1494,7 @@ components:
       type: object
     CommentsRequest:
       example:
-        postToThreadType: postToThreadType
+        postToThreadType: 0
         comment: comment
       properties:
         comment:
@@ -1503,7 +1503,7 @@ components:
         postToThreadType:
           nullable: true
           title: postToThreadType
-          type: string
+          type: integer
       title: CommentsRequest
       type: object
     GetCommentsResponse:

--- a/gen/py/chromestatus_openapi/chromestatus_openapi/test/test_default_controller.py
+++ b/gen/py/chromestatus_openapi/chromestatus_openapi/test/test_default_controller.py
@@ -43,7 +43,7 @@ class TestDefaultController(BaseTestCase):
 
         Add a comment to a feature
         """
-        comments_request = {"postToThreadType":"postToThreadType","comment":"comment"}
+        comments_request = {"postToThreadType":0,"comment":"comment"}
         headers = { 
             'Accept': 'application/json',
             'Content-Type': 'application/json',
@@ -62,7 +62,7 @@ class TestDefaultController(BaseTestCase):
 
         Add a comment to a specific gate
         """
-        comments_request = {"postToThreadType":"postToThreadType","comment":"comment"}
+        comments_request = {"postToThreadType":0,"comment":"comment"}
         headers = { 
             'Accept': 'application/json',
             'Content-Type': 'application/json',

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -996,7 +996,7 @@ components:
         comment:
           type: string
         postToThreadType:
-          type: string
+          type: integer
           nullable: true
     GetCommentsResponse:
       type: object


### PR DESCRIPTION
This avoids an error seen on staging when posting a comment on a gate:
```
File "/usr/local/google/home/jrobbins/testgh/chromium-dashboard/api/comments_api.py", line 123, in do_post
    notifier.post_comment_to_mailing_list(
  File "/usr/local/google/home/jrobbins/testgh/chromium-dashboard/internals/notifier.py", line 1207, in post_comment_to_mailing_list
    approval_field = approval_defs.APPROVAL_FIELDS_BY_ID[approval_field_id]
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
KeyError: '0'
```
The defect was that postToThreadType is an int but it was declared as a string.  The int `0` is false, but the string `'0'` is true, which which lead to the server trying to post to a thread even through the user had not requested it (or even if they had, it would not work).

The fix is to declare it as an integer in api.yaml.

It is worrisome that mypy did not detect this type error. 