### PR TITLE
Make detection of intent_thread_url more robust

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -124,11 +124,11 @@ def detect_gate_id(body) -> int | None:
 THREAD_LINK_RE = re.compile(
     r'To view this discussion on the web visit\s+'
     r'(> )?(https://groups\.google\.com/a/chromium.org/d/msgid/blink-dev/'
-    r'\S+)[\n> .]', re.MULTILINE)
+    r'\S+)[\r\n> .]', re.MULTILINE)
 STAGING_THREAD_LINK_RE = re.compile(
     r'To view this discussion on the web visit\s+'
     r'(> )?(https://groups\.google\.com/d/msgid/jrobbins-test/'
-    r'\S+)[\n> .]', re.MULTILINE)
+    r'\S+)[\r\n> .]', re.MULTILINE)
 
 
 def detect_thread_url(body):
@@ -344,6 +344,10 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
 
   def set_intent_thread_url(
       self, stage: Stage, thread_url: str | None, subject: str | None) -> None:
+    if stage.intent_thread_url and stage.intent_subject_line:
+      logging.info('Not setting intent_thread_url or intent_subject_line')
+      return
+
     stage.intent_thread_url = thread_url
     stage.intent_subject_line = subject
     stage.put()

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -318,6 +318,31 @@ class FunctionTest(testing_config.CustomTestCase):
          '/a/chromium.org/d/msgid/blink-dev/CAL5BFfULP5d3fNCAqeO2gLP56R3HCytmaNk%2B9kpYsC2dj4%3DqoQ%40mail.gmail.com'),
         detect_intent.detect_thread_url(footer))
 
+  def test_detect_thread_url__quoted_return_and_newline_before_period(self):
+    """We can parse a quoted thread archive link from the body footer."""
+    footer = (
+        'On 7/27/23 12:29 PM, USER NAME wrote:'
+        '>'
+        '>  [SNIP]'
+        '> --\r\n'
+        '> You received this message because you are subscribed to the Google\r\n'
+        '> Groups "blink-dev" group.\r\n'
+        '> To unsubscribe from this group and stop receiving emails from it, send\r\n'
+        '> an email to blink-dev+unsubscribe@chromium.org.\r\n'
+        '> To view this discussion on the web visit\r\n'
+        '> https://groups.google.com/a/chromium.org/d/msgid/blink-dev/CAL5BFfULP5d3fNCAqeO2gLP56R3HCytmaNk%2B9kpYsC2dj4%3DqoQ%40mail.gmail.com\r\n'
+        '> <https://groups.google.com/a/chromium.org/d/msgid/blink-dev/CAL5BFfULP5d3fNCAqeO2gLP56R3HCytmaNk%2B9kpYsC2dj4%3DqoQ%40mail.gmail.com?utm_medium=email&utm_source=foo\\r\n'
+        'ter>.\r\n'
+        '\r\n'
+        '--\r\n'
+        'You received this message because you are subscribed to the Google Groups "blink-dev" group.\r\n'
+        'To unsubscribe from this group and stop receiving emails from it, send an email to blink-dev+unsubscribe@chromium.org.\r\n'
+        'To view this discussion on the web visit https://groups.google.com/a/chromium.org/d/msgid/blink-dev/7c94d7c3-212a-62de-dfa4-76bbd25990c9%40chromium.org\r\n.')
+    self.assertEqual(
+        ('https://groups.google.com'
+         '/a/chromium.org/d/msgid/blink-dev/CAL5BFfULP5d3fNCAqeO2gLP56R3HCytmaNk%2B9kpYsC2dj4%3DqoQ%40mail.gmail.com'),
+        detect_intent.detect_thread_url(footer))
+
   def test_detect_thread_url__staging(self):
     """We can parse the staging thread archive link from the body footer."""
     footer = (


### PR DESCRIPTION
This should resolve a failure that was discovered by Kyle today.  The problem was that an intent thread URL was not clickable because it lacked the final `.org` part of the URL.

Logs showed that the URL was correctly parsed in the first message that we detected on this thread.  However, we also detected a quoted version of it in a reply to the original email.  The quoted version of the URL is a little more complicated.  E.g.,
`https://example.com/a-long-path-ending-with.org.` in the first email gets becomes
`https://example.com/a-long-path-ending-with.org <https://example.com/a-long-path-ending-with.org>.`
in the quoted version of the text.  And, that can be word-wrapped like:
'https://example.com/a-long-path-ending-with.org\r\n <https://example.com/a-long-path-ending-with.org>.'

I had covered the `\n` case for unix users, but not the `\r\n` case for windows users.

The fix is to also detect `\r` to indicate the end of the URL.

Also, there is no point to ever set these URLs again if they already have a value, in fact that could overwrite data that a user entered manually.