### PR TITLE
Set shipping_year initial value only on feature creation.

### DIFF
--- a/client-src/elements/chromedash-guide-new-page.ts
+++ b/client-src/elements/chromedash-guide-new-page.ts
@@ -157,7 +157,10 @@ export class ChromedashGuideNewPage extends LitElement {
   }
 
   renderForm() {
-    const newFeatureInitialValues = {owner: this.userEmail};
+    const newFeatureInitialValues = {
+      owner: this.userEmail,
+      shipping_year: new Date().getFullYear(),
+    };
     this.fieldValues.feature = this.feature;
 
     const formFields = this.isEnterpriseFeature

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -2027,7 +2027,6 @@ export const ALL_FIELDS: Record<string, Field> = {
   shipping_year: {
     type: 'input',
     attrs: {type: 'number', min: 2000, max: 2050},
-    initial: new Date().getFullYear(),
     required: true,
     label: 'Estimated shipping year',
     help_text: html` Estimate of the calendar year in which this will first ship


### PR DESCRIPTION
During testing on staging I found that setting the initial value leads to a bad user experience when editing existing features.  When viewing the feature detail page, it says that no value has been filled in for shipping year, but then when the user goes to edit, they see this initial value in the form field.  Submitting the form accomplished nothing because the field was not touched by the user.  So, the user would be puzzled when the detail page still shows no value.

The solution is to set the initial value with code on the feature creation page rather than specify an initial value.  With this PR users will see a reasonable initial value when creating a new feature.  And, when editing an existing feature's metadata they will be required to fill in shipping_year, but at least that UX will work as expected with no surprises.