### PR TITLE
Run mypy on generated openapi code too

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "do-coverage": "coverage3 erase && coverage3 run -m unittest discover -p '*_test.py' -b && coverage3 html",
     "coverage": ". cs-env/bin/activate; (npm run start-emulator > /dev/null 2>&1 &); sleep 3; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-coverage;  npm run stop-emulator",
     "view-coverage": "pushd htmlcov/; python3.11 -m http.server 8080; popd",
-    "mypy": ". cs-env/bin/activate; mypy --ignore-missing-imports --exclude cs-env/ --exclude gen/ --exclude appengine_config.py --disable-error-code \"annotation-unchecked\" .",
+    "mypy": ". cs-env/bin/activate; mypy --ignore-missing-imports --exclude cs-env/ --exclude appengine_config.py --exclude gen/py/chromestatus_openapi/build/ --exclude gen/py/chromestatus_openapi/chromestatus_openapi/test --exclude appengine_config.py --no-namespace-packages --disable-error-code \"annotation-unchecked\" .",
     "lint": "prettier client-src/js-src client-src/elements --check && eslint \"client-src/js-src/**/*.{js,ts}\" \"client-src/elements/**/*.{js,ts}\" && tsc -p tsconfig.json && lit-analyzer \"client-src/elements/chromedash-!(featurelist)*.js\"",
     "lint-fix": "prettier client-src/js-src client-src/elements --write && eslint \"client-src/js-src/**/*.{js,ts}\" \"client-src/elements/**/*.{js,ts}\" --fix",
     "presubmit": "npm test && npm run webtest && npm run lint && npm run mypy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,4 +36,4 @@ pyparsing==2.4.7
 
 # OpenAPI files
 ./gen/py/chromestatus_openapi
-types-python-dateutil=2.9.0
+types-python-dateutil==2.9.0.20240821

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ pyparsing==2.4.7
 
 # OpenAPI files
 ./gen/py/chromestatus_openapi
+types-python-dateutil=2.9.0


### PR DESCRIPTION
The recent defect with postToThreadType uncovered the fact that `mypy` was not doing type checking on our generated openapi code, so it was not enforcing that we were using the openapi models correctly.  With this change, it would have flagged that error during development.

In this PR:
* Instead of excluding all of gen/, allow the generated code to be type-checked, but exclude the duplicated parts under gen/py/build and some type-unsafe generated unit testing code.
* Getting the bulk of the generated openapi py code to pass type checking required adding a depenency.