### PR TITLE
roadmap bug fix

### DIFF
--- a/client-src/elements/chromedash-roadmap-milestone-card.ts
+++ b/client-src/elements/chromedash-roadmap-milestone-card.ts
@@ -32,7 +32,7 @@ class ChromedashRoadmapMilestoneCard extends LitElement {
   @property({attribute: false})
   templateContent!: TemplateContent;
   @property({attribute: false})
-  channel!: ReleaseInfo;
+  channel?: ReleaseInfo;
   @property({type: Boolean})
   showDates = false;
   @property({type: Boolean})
@@ -70,8 +70,8 @@ class ChromedashRoadmapMilestoneCard extends LitElement {
   }
 
   _isAnyFeatureReleased() {
-    for (const shippingType of this._objKeys(this.channel.features)) {
-      if (this.channel.features[shippingType].length != 0) {
+    for (const shippingType of this._objKeys(this.channel?.features)) {
+      if (this.channel?.features[shippingType].length != 0) {
         return true;
       }
     }
@@ -178,10 +178,13 @@ class ChromedashRoadmapMilestoneCard extends LitElement {
 
   renderCardHeader() {
     // Starting with M110, display Early Stable Release dates.
+    if (!this.channel) {
+      return nothing;
+    }
     const stableStart =
       this.channel.version >= 110
-        ? this.channel.final_beta
-        : this.channel.stable_date;
+        ? this.channel?.final_beta
+        : this.channel?.stable_date;
     const logo = html`
       <span class="chrome-logo">
         ${this.templateContent.channelTag
@@ -201,18 +204,18 @@ class ChromedashRoadmapMilestoneCard extends LitElement {
           class="chrome_version layout horizontal center ${this.templateContent
             .h1Class}"
         >
-          ${logo} Chrome ${this.channel.version}
+          ${logo} Chrome ${this.channel?.version}
         </h1>
       </div>
-      ${this.showDates && this.channel.earliest_beta
+      ${this.showDates && this.channel?.earliest_beta
         ? html`
             <div class="milestone_info layout horizontal center-center">
               <h3>
                 <span class="channel_label">Beta</span> ${this.templateContent
                   .dateText}
                 <span class="milestone_info-beta">
-                  ${this._computeDate(this.channel.earliest_beta)} -
-                  ${this._computeDate(this.channel.latest_beta)}
+                  ${this._computeDate(this.channel?.earliest_beta)} -
+                  ${this._computeDate(this.channel?.latest_beta)}
                 </span>
               </h3>
             </div>
@@ -319,12 +322,12 @@ class ChromedashRoadmapMilestoneCard extends LitElement {
         ${this._isAnyFeatureReleased()
           ? html`
         <div class="features_header">${this.templateContent.featureHeader}:</div>
-          ${this._objKeys(this.channel.features).map(shippingType =>
-            this.channel.features[shippingType] != 0
+          ${this._objKeys(this.channel?.features).map(shippingType =>
+            this.channel?.features[shippingType] != 0
               ? html`
                   <h3 class="feature_shipping_type">${shippingType}</h3>
                   <ul>
-                    ${this.channel.features[shippingType].map(
+                    ${this.channel?.features[shippingType].map(
                       f => html`
                         ${this._cardFeatureItemTemplate(f, shippingType)}
                       `

--- a/client-src/elements/chromedash-roadmap.ts
+++ b/client-src/elements/chromedash-roadmap.ts
@@ -313,7 +313,7 @@ export class ChromedashRoadmap extends LitElement {
         milestone => html`
           <chromedash-roadmap-milestone-card
             style="width:${this.cardWidth}px;"
-            .channel=${this.milestoneInfo[milestone]}
+            .channel=${this.milestoneInfo?.[milestone]}
             .templateContent=${TEMPLATE_CONTENT['stable_minus_one']}
             ?showdates=${SHOW_DATES}
             .starredFeatures=${this.starredFeatures}
@@ -329,7 +329,7 @@ export class ChromedashRoadmap extends LitElement {
         type => html`
           <chromedash-roadmap-milestone-card
             style="width:${this.cardWidth}px;"
-            .channel=${this.channels[type]}
+            .channel=${this.channels?.[type]}
             .templateContent=${TEMPLATE_CONTENT[type]}
             ?showdates=${SHOW_DATES}
             .starredFeatures=${this.starredFeatures}
@@ -345,7 +345,7 @@ export class ChromedashRoadmap extends LitElement {
         milestone => html`
           <chromedash-roadmap-milestone-card
             style="width:${this.cardWidth}px;"
-            .channel=${this.milestoneInfo[milestone]}
+            .channel=${this.milestoneInfo?.[milestone]}
             .templateContent=${TEMPLATE_CONTENT['dev_plus_one']}
             ?showdates=${SHOW_DATES}
             .starredFeatures=${this.starredFeatures}


### PR DESCRIPTION
This change addresses a bug in the staging environment around the roadmap page.

```
TypeError: Cannot read properties of undefined (reading '127')
    at chromedash-roadmap.js:214:42
    at Array.map (<anonymous>)
    at ChromedashRoadmap.render (chromedash-roadmap.js:211:33)
    at ChromedashRoadmap.update (lit-element.js:6:235)
    at ChromedashRoadmap.performUpdate (reactive-element.js:6:4891)
    at ChromedashRoadmap.scheduleUpdate (reactive-element.js:6:4427)
    at ChromedashRoadmap._$ET (reactive-element.js:6:4335)
```

This is because the "milestoneInfo" property is fetched asynchronously and is not guaranteed to have a value when accessing it. This also means that the channel prop on chromedash-roadmap-milestone-card will sometimes be null. This change ensures we take steps to reference the channel variable only when it is set.

Additionally, I did not add logic to check "if (!this.milestoneInfo) {...}" in the render method for chromedash-roadmap, because that would stop the milestone cards from displaying the loading skeletons.