### PR TITLE
New pagination UI for new search page

### DIFF
--- a/client-src/components.js
+++ b/client-src/components.js
@@ -60,6 +60,7 @@ import './elements/chromedash-feature';
 import './elements/chromedash-feature-detail';
 import './elements/chromedash-feature-filter';
 import './elements/chromedash-feature-page';
+import './elements/chromedash-feature-pagination';
 import './elements/chromedash-feature-table';
 import './elements/chromedash-feature-row';
 import './elements/chromedash-featurelist';

--- a/client-src/elements/chromedash-app.ts
+++ b/client-src/elements/chromedash-app.ts
@@ -339,10 +339,6 @@ export class ChromedashApp extends LitElement {
       this.pageComponent.showEnterprise = true;
       this.pageComponent.showQuery = false;
       this.pageComponent.rawQuery = parseRawQuery(ctx.querystring);
-      this.pageComponent.addEventListener(
-        'pagination',
-        this.handlePagination.bind(this)
-      );
     });
     page('/myfeatures/starred', ctx => {
       if (!this.setupNewPage(ctx, 'chromedash-all-features-page', true)) return;
@@ -352,10 +348,6 @@ export class ChromedashApp extends LitElement {
       this.pageComponent.showEnterprise = true;
       this.pageComponent.showQuery = false;
       this.pageComponent.rawQuery = parseRawQuery(ctx.querystring);
-      this.pageComponent.addEventListener(
-        'pagination',
-        this.handlePagination.bind(this)
-      );
     });
     page('/myfeatures/editable', ctx => {
       if (!this.setupNewPage(ctx, 'chromedash-all-features-page', true)) return;
@@ -365,19 +357,11 @@ export class ChromedashApp extends LitElement {
       this.pageComponent.showEnterprise = true;
       this.pageComponent.showQuery = false;
       this.pageComponent.rawQuery = parseRawQuery(ctx.querystring);
-      this.pageComponent.addEventListener(
-        'pagination',
-        this.handlePagination.bind(this)
-      );
     });
     page('/newfeatures', ctx => {
       if (!this.setupNewPage(ctx, 'chromedash-all-features-page', true)) return;
       this.pageComponent.user = this.user;
       this.pageComponent.rawQuery = parseRawQuery(ctx.querystring);
-      this.pageComponent.addEventListener(
-        'pagination',
-        this.handlePagination.bind(this)
-      );
       this.pageComponent.addEventListener(
         'search',
         this.handleSearchQuery.bind(this)
@@ -560,10 +544,6 @@ export class ChromedashApp extends LitElement {
       this.pageComponent.user = this.user;
     });
     page.start();
-  }
-
-  handlePagination(e) {
-    updateURLParams('start', e.detail.index);
   }
 
   handleSearchQuery(e) {

--- a/client-src/elements/chromedash-feature-pagination.ts
+++ b/client-src/elements/chromedash-feature-pagination.ts
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement, type TemplateResult, CSSResultGroup, css, html} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {formatURLParams} from './utils.js';
+import {ifDefined} from 'lit/directives/if-defined.js';
+import {range} from 'lit/directives/range.js';
+import {map} from 'lit/directives/map.js';
+import {SHARED_STYLES} from '../css/shared-css.js';
+
+@customElement('chromedash-feature-pagination')
+export class ChromedashFeaturePagination extends LitElement {
+  @property({type: Number})
+  totalCount = 0; // The total number of items
+
+  @property({type: Number})
+  start = 0; // Index of first result among total results.
+
+  @property({type: Number})
+  pageSize = 100; // Number of items to display per page
+
+  static get styles(): CSSResultGroup {
+    return [
+      SHARED_STYLES,
+      css`
+        .active {
+          background: var(--light-grey);
+        }
+        .stepper {
+          width: 7em;
+        }
+        .pagination {
+          padding: var(--content-padding-half) 0;
+          min-height: 50px;
+        }
+        .pagination span {
+          color: var(--unimportant-text-color);
+          margin-right: var(--content-padding);
+        }
+        sl-button::part(base):hover {
+          background: var(--sl-color-blue-100);
+        }
+        .pagination sl-icon-button {
+          font-size: 1.6rem;
+        }
+        .pagination sl-icon-button::part(base) {
+          padding: 0;
+        }
+      `,
+    ];
+  }
+
+  formatUrlForRelativeOffset(delta: number): string | undefined {
+    const offset = this.start + delta;
+    if (
+      this.totalCount === undefined ||
+      offset <= -this.pageSize ||
+      offset >= this.totalCount
+    ) {
+      return undefined;
+    }
+    return this.formatUrlForOffset(Math.max(0, offset));
+  }
+
+  formatUrlForOffset(offset: number): string {
+    return formatURLParams('start', offset).toString();
+  }
+
+  renderPageButtons(): TemplateResult {
+    if (this.totalCount === undefined || this.totalCount === 0) {
+      return html``;
+    }
+    const currentPage = Math.floor(this.start / this.pageSize);
+    const numPages = Math.ceil(this.totalCount / this.pageSize);
+
+    return html`
+      ${map(
+        range(numPages),
+        i => html`
+          <sl-button
+            variant="text"
+            id="jump_${i + 1}"
+            class="page-button ${i === currentPage ? 'active' : ''}"
+            href=${this.formatUrlForOffset(i * this.pageSize)}
+          >
+            ${i + 1}
+          </sl-button>
+        `
+      )}
+    `;
+  }
+
+  render(): TemplateResult {
+    if (this.totalCount === undefined || this.totalCount === 0) {
+      return html``;
+    }
+
+    const prevUrl = this.formatUrlForRelativeOffset(-this.pageSize);
+    const nextUrl = this.formatUrlForRelativeOffset(this.pageSize);
+
+    return html`
+      <div id="main" class="pagination hbox halign-items-space-between">
+        <div class="spacer"></div>
+        <sl-button
+          variant="text"
+          id="previous"
+          class="stepper"
+          href=${ifDefined(prevUrl)}
+          ?disabled=${prevUrl === undefined}
+          >Previous</sl-button
+        >
+
+        ${this.renderPageButtons()}
+
+        <sl-button
+          variant="text"
+          id="next"
+          class="stepper"
+          href=${ifDefined(nextUrl)}
+          ?disabled=${nextUrl === undefined}
+          >Next</sl-button
+        >
+
+        <div class="spacer"></div>
+      </div>
+    `;
+  }
+}

--- a/client-src/elements/chromedash-feature-pagination_test.ts
+++ b/client-src/elements/chromedash-feature-pagination_test.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assert, fixture} from '@open-wc/testing';
+
+import {ChromedashFeaturePagination} from './chromedash-feature-pagination';
+
+describe('chromedash-feature-pagination', () => {
+  let el: ChromedashFeaturePagination;
+
+  beforeEach(async () => {
+    el = await fixture<ChromedashFeaturePagination>(
+      '<chromedash-feature-pagination></chromedash-feature-pagination>'
+    );
+    el.totalCount = 12;
+    el.start = 0;
+    el.pageSize = 2;
+
+    await el.updateComplete;
+  });
+
+  it('can be added to the page', async () => {
+    assert.exists(el);
+    assert.instanceOf(el, ChromedashFeaturePagination);
+  });
+
+  it('renders navigation buttons', async () => {
+    const previous = el.shadowRoot!.querySelector('#previous');
+    assert.exists(previous);
+
+    const jump_1 = el.shadowRoot!.querySelector('#jump_1');
+    assert.exists(jump_1);
+    const jump_2 = el.shadowRoot!.querySelector('#jump_2');
+    assert.exists(jump_2);
+    const jump_3 = el.shadowRoot!.querySelector('#jump_3');
+    assert.exists(jump_3);
+    const jump_4 = el.shadowRoot!.querySelector('#jump_4');
+    assert.exists(jump_4);
+
+    const next = el.shadowRoot!.querySelector('#next');
+    assert.exists(next);
+  });
+});

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -451,13 +451,7 @@ export function getNewLocation(params, location) {
  * @param {string} val is the unencoded value of the query param.
  */
 export function updateURLParams(key, val) {
-  // Update the query param object.
-  const rawQuery = parseRawQuery(window.location.search);
-  rawQuery[key] = encodeURIComponent(val);
-
-  // Assemble the new URL.
-  const newURL = getNewLocation(rawQuery, window.location);
-  newURL.hash = '';
+  const newURL = formatURLParams(key, val);
   if (newURL.toString() === window.location.toString()) {
     return;
   }
@@ -465,6 +459,22 @@ export function updateURLParams(key, val) {
   // an issue in page.js:
   // https://github.com/visionmedia/page.js/issues/293#issuecomment-456906679
   window.history.pushState({path: newURL.toString()}, '', newURL);
+}
+
+/**
+ * Format the existing URL with new query params.
+ * @param {string} key is the key of the query param.
+ * @param {string} val is the unencoded value of the query param.
+ */
+export function formatURLParams(key, val) {
+  // Update the query param object.
+  const rawQuery = parseRawQuery(window.location.search);
+  rawQuery[key] = encodeURIComponent(val);
+
+  // Assemble the new URL.
+  const newURL = getNewLocation(rawQuery, window.location);
+  newURL.hash = '';
+  return newURL;
 }
 
 /**


### PR DESCRIPTION
Re-implement pagination in all feature page to be consistent with webstatus. The new implementation navigates the pages through `href`, instead of `pagination` event.

All features displayed in a single page:
![Screenshot 2024-08-28 4 15 36 PM](https://github.com/user-attachments/assets/ab12851b-ba77-436a-a7fe-72c0279da121)

Multi-pager:
![Screenshot 2024-08-28 4 23 56 PM](https://github.com/user-attachments/assets/81448352-cf80-4816-9368-1e62f237833f)
