### PR TITLE
OT Creation allows for the selection of WebDXFeature use counters (client-side)

### DIFF
--- a/client-src/elements/chromedash-form-field.ts
+++ b/client-src/elements/chromedash-form-field.ts
@@ -353,6 +353,7 @@ export class ChromedashFormField extends LitElement {
               id="id_${this.name}_${value}"
               name="${fieldName}"
               value="${value}"
+              .checked="${value === fieldValue}"
               type="radio"
               required
               @change=${this.handleFieldUpdated}

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -361,7 +361,7 @@ export class ChromedashOTCreationPage extends LitElement {
     // Add on the appropriate use counter prefix.
     const useCounterPrefix =
       this.webfeatureUseCounterType === USE_COUNTER_TYPE_WEBFEATURE
-        ? 'WebFeature::'
+        ? ''
         : 'WebDXFeature::';
     stageSubmitBody['ot_webfeature_use_counter'].value =
       `${useCounterPrefix}${stageSubmitBody['ot_webfeature_use_counter'].value}`;

--- a/client-src/elements/form-field-enums.ts
+++ b/client-src/elements/form-field-enums.ts
@@ -92,6 +92,34 @@ export const ROLLOUT_IMPACT_DISPLAYNAME: Record<number, string> = {
   3: 'High', // IMPACT_HIGH
 };
 
+export const USE_COUNTER_TYPE_WEBFEATURE = 0;
+export const USE_COUNTER_TYPE_WEBDXFEATURE = 1;
+export const WEBFEATURE_USE_COUNTER_TYPES: Record<
+  string,
+  [number, string, string | HTMLTemplateResult]
+> = {
+  WEBFEATURE: [
+    USE_COUNTER_TYPE_WEBFEATURE,
+    'WebFeature',
+    html`The feature's use counter has been added to
+      <a
+        target="_blank"
+        href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/use_counter/metrics/web_feature.mojom"
+        >web_feature.mojom</a
+      >.`,
+  ],
+  WEBDXFEATURE: [
+    USE_COUNTER_TYPE_WEBDXFEATURE,
+    'WebDXFeature',
+    html`The feature's use counter has been added to
+      <a
+        target="_blank"
+        href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/use_counter/metrics/webdx_feature.mojom"
+        >webdx_feature.mojom</a
+      >.`,
+  ],
+};
+
 // FEATURE_TYPES object is organized as [intValue, stringLabel, description],
 // the descriptions are used only for the descriptions of feature_type_radio_group
 export const FEATURE_TYPES_WITHOUT_ENTERPRISE: Record<

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -1539,7 +1539,7 @@ export const ALL_FIELDS: Record<string, Field> = {
     label: 'Use counter type',
     choices: WEBFEATURE_USE_COUNTER_TYPES,
     help_text: html`Which type of use counter the feature is using. This can be
-    easily determined by which file the use counter is defined in.`,
+    determined by which file the use counter is defined in.`,
   },
 
   ot_require_approvals: {

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -21,6 +21,7 @@ import {
   VENDOR_VIEWS_COMMON,
   VENDOR_VIEWS_GECKO,
   WEB_DEV_VIEWS,
+  WEBFEATURE_USE_COUNTER_TYPES,
 } from './form-field-enums';
 import {unambiguousStageName} from './utils';
 
@@ -1519,11 +1520,26 @@ export const ALL_FIELDS: Record<string, Field> = {
     label: 'WebFeature UseCounter name',
     help_text: html` For measuring usage, this must be a single named value from
       the WebFeature enum, e.g. kWorkerStart. The use counter must be landed in
+      either
       <a
         target="_blank"
         href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/use_counter/metrics/web_feature.mojom"
         >web_feature.mojom</a
+      >
+      or
+      <a
+        target="_blank"
+        href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/use_counter/metrics/webdx_feature.mojom"
+        >webdx_feature.mojom</a
       >. Not required for deprecation trials.`,
+  },
+
+  ot_webfeature_use_counter__type: {
+    type: 'radios',
+    label: 'Use counter type',
+    choices: WEBFEATURE_USE_COUNTER_TYPES,
+    help_text: html`Which type of use counter the feature is using. This can be
+    easily determined by which file the use counter is defined in.`,
   },
 
   ot_require_approvals: {


### PR DESCRIPTION
Part of #3943

This change adds an additional field on the OT creation form to allow users to specify that they are providing either a WebFeature use counter or a WebDXFeature use counter. The server-side checks will use this to determine which file to use to confirm the use counter has landed.

The logic will add a "WebDXFeature::" prefix to the use counter if a WebDXFeature use counter type is selected. A prefix is not added to the WebFeature use counter type to allow those values to be handled with the default logic.

https://github.com/user-attachments/assets/c40b5c2d-1049-462c-93eb-4970a7c89f1c



