### PR TITLE
Record an Activity when assigning a reviewer.

### DIFF
--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -173,6 +173,13 @@ def notify_assignees(
   }
 
   cloud_tasks_helpers.enqueue_task('/tasks/email-assigned', params)
+  amendment = Amendment(
+      field_name='review_assignee',
+      old_value=', '.join(old_assignees), new_value=', '.join(new_assignees))
+  gate_id = gate.key.integer_id()
+  activity = Activity(feature_id=fe.key.integer_id(), gate_id=gate_id,
+                      author=triggering_user_email, amendments=[amendment])
+  activity.put()
 
 
 def notify_subscribers_of_new_comments(fe: 'FeatureEntry', gate: Gate,

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -200,7 +200,7 @@ class Amendment(ndb.Model):
   new_value = ndb.TextProperty()
 
 
-class Activity(ndb.Model):  # copy from Comment
+class Activity(ndb.Model):
   """An activity log entry (comment + amendments) on a gate or feature."""
   feature_id = ndb.IntegerProperty(required=True)
   gate_id = ndb.IntegerProperty()  # The gate commented on, or general comment.


### PR DESCRIPTION
This resolves #4273.

There are two ways to assign a reviewer: via a UI menu, or by requesting a review which triggers auto-assignment.  In each case we now create an Activity records that shows up as a comment on the gate.