### PR TITLE
Limit pagination length

### DIFF
--- a/client-src/elements/chromedash-feature-pagination.ts
+++ b/client-src/elements/chromedash-feature-pagination.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import {LitElement, type TemplateResult, CSSResultGroup, css, html, nothing} from 'lit';
+import {
+  LitElement,
+  type TemplateResult,
+  CSSResultGroup,
+  css,
+  html,
+  nothing,
+} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {formatURLParams} from './utils.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
@@ -98,19 +105,44 @@ export class ChromedashFeaturePagination extends LitElement {
     const currentPage = Math.floor(this.start / this.pageSize);
     const numPages = Math.ceil(this.totalCount / this.pageSize);
 
+    let missingFront = false;
+    let missingBack = false;
+    let hasLastPage = numPages > 1;
+
     let displayPages: Array<number> = [];
+    const displaySet = new Set<number>();
     for (const digit of range(numPages)) {
-      if (digit >= currentPage - 3 && digit <= currentPage + 3) {
-        displayPages.push(digit);
+      if (digit === 0 || digit === numPages - 1) {
+        continue;
       }
+      if (numPages <= 10) {
+        displaySet.add(digit);
+        continue;
+      }
+      if (digit < currentPage - 5) {
+        missingFront = true;
+        continue;
+      }
+      if (digit > currentPage + 5) {
+        missingBack = true;
+        continue;
+      }
+      displaySet.add(digit);
     }
-    const coverFront = (currentPage - 3 <= 0);
-    const coverBack = (currentPage + 3 >= numPages - 1);
+    displayPages = Array.from(displaySet);
 
     return html`
-      ${!coverFront ? html`<div>...</div>` : nothing}
+      <sl-button
+        variant="text"
+        id="jump_1"
+        class="page-button ${0 === currentPage ? 'active' : ''}"
+        href=${this.formatUrlForOffset(0)}
+      >
+        ${1}
+      </sl-button>
+      ${missingFront ? html`<div>...</div>` : nothing}
       ${map(
-        range(numPages),
+        displayPages,
         i => html`
           <sl-button
             variant="text"
@@ -122,7 +154,17 @@ export class ChromedashFeaturePagination extends LitElement {
           </sl-button>
         `
       )}
-      ${!coverBack ? html`<div>...</div>` : nothing}
+      ${missingBack ? html`<div>...</div>` : nothing}
+      ${hasLastPage
+        ? html`<sl-button
+            variant="text"
+            id="jump_${numPages}"
+            class="page-button ${numPages - 1 === currentPage ? 'active' : ''}"
+            href=${this.formatUrlForOffset((numPages - 1) * this.pageSize)}
+          >
+            ${numPages}
+          </sl-button>`
+        : nothing}
     `;
   }
 

--- a/client-src/elements/chromedash-feature-pagination.ts
+++ b/client-src/elements/chromedash-feature-pagination.ts
@@ -119,11 +119,11 @@ export class ChromedashFeaturePagination extends LitElement {
         displaySet.add(digit);
         continue;
       }
-      if (digit < currentPage - 5) {
+      if (digit < currentPage - 4) {
         missingFront = true;
         continue;
       }
-      if (digit > currentPage + 5) {
+      if (digit > currentPage + 4) {
         missingBack = true;
         continue;
       }

--- a/client-src/elements/chromedash-feature-pagination.ts
+++ b/client-src/elements/chromedash-feature-pagination.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {LitElement, type TemplateResult, CSSResultGroup, css, html} from 'lit';
+import {LitElement, type TemplateResult, CSSResultGroup, css, html, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {formatURLParams} from './utils.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
@@ -98,7 +98,17 @@ export class ChromedashFeaturePagination extends LitElement {
     const currentPage = Math.floor(this.start / this.pageSize);
     const numPages = Math.ceil(this.totalCount / this.pageSize);
 
+    let displayPages: Array<number> = [];
+    for (const digit of range(numPages)) {
+      if (digit >= currentPage - 3 && digit <= currentPage + 3) {
+        displayPages.push(digit);
+      }
+    }
+    const coverFront = (currentPage - 3 <= 0);
+    const coverBack = (currentPage + 3 >= numPages - 1);
+
     return html`
+      ${!coverFront ? html`<div>...</div>` : nothing}
       ${map(
         range(numPages),
         i => html`
@@ -112,6 +122,7 @@ export class ChromedashFeaturePagination extends LitElement {
           </sl-button>
         `
       )}
+      ${!coverBack ? html`<div>...</div>` : nothing}
     `;
   }
 

--- a/client-src/elements/chromedash-feature-pagination_test.ts
+++ b/client-src/elements/chromedash-feature-pagination_test.ts
@@ -51,12 +51,12 @@ describe('chromedash-feature-pagination', () => {
     assert.notExists(jump_4);
     const jump_5 = el.shadowRoot!.querySelector('#jump_5');
     assert.notExists(jump_5);
-    const jump_6 = el.shadowRoot!.querySelector('#jump_6');
-    assert.exists(jump_6);
+    const jump_7 = el.shadowRoot!.querySelector('#jump_7');
+    assert.exists(jump_7);
     const jump_11 = el.shadowRoot!.querySelector('#jump_11');
     assert.exists(jump_11);
-    const jump_16 = el.shadowRoot!.querySelector('#jump_16');
-    assert.exists(jump_16);
+    const jump_15 = el.shadowRoot!.querySelector('#jump_15');
+    assert.exists(jump_15);
     const jump_19 = el.shadowRoot!.querySelector('#jump_19');
     assert.notExists(jump_19);
     const jump_20 = el.shadowRoot!.querySelector('#jump_20');

--- a/client-src/elements/chromedash-feature-pagination_test.ts
+++ b/client-src/elements/chromedash-feature-pagination_test.ts
@@ -25,8 +25,8 @@ describe('chromedash-feature-pagination', () => {
     el = await fixture<ChromedashFeaturePagination>(
       '<chromedash-feature-pagination></chromedash-feature-pagination>'
     );
-    el.totalCount = 12;
-    el.start = 0;
+    el.totalCount = 20;
+    el.start = 10;
     el.pageSize = 2;
 
     await el.updateComplete;
@@ -42,13 +42,25 @@ describe('chromedash-feature-pagination', () => {
     assert.exists(previous);
 
     const jump_1 = el.shadowRoot!.querySelector('#jump_1');
-    assert.exists(jump_1);
+    assert.notExists(jump_1);
     const jump_2 = el.shadowRoot!.querySelector('#jump_2');
-    assert.exists(jump_2);
+    assert.notExists(jump_2);
     const jump_3 = el.shadowRoot!.querySelector('#jump_3');
     assert.exists(jump_3);
     const jump_4 = el.shadowRoot!.querySelector('#jump_4');
     assert.exists(jump_4);
+    const jump_5 = el.shadowRoot!.querySelector('#jump_5');
+    assert.exists(jump_5);
+    const jump_6 = el.shadowRoot!.querySelector('#jump_6');
+    assert.exists(jump_6);
+    const jump_7 = el.shadowRoot!.querySelector('#jump_7');
+    assert.exists(jump_7);
+    const jump_8 = el.shadowRoot!.querySelector('#jump_8');
+    assert.exists(jump_8);
+    const jump_9 = el.shadowRoot!.querySelector('#jump_9');
+    assert.exists(jump_9);
+    const jump_10 = el.shadowRoot!.querySelector('#jump_10');
+    assert.notExists(jump_10);
 
     const next = el.shadowRoot!.querySelector('#next');
     assert.exists(next);

--- a/client-src/elements/chromedash-feature-pagination_test.ts
+++ b/client-src/elements/chromedash-feature-pagination_test.ts
@@ -25,8 +25,8 @@ describe('chromedash-feature-pagination', () => {
     el = await fixture<ChromedashFeaturePagination>(
       '<chromedash-feature-pagination></chromedash-feature-pagination>'
     );
-    el.totalCount = 20;
-    el.start = 10;
+    el.totalCount = 40;
+    el.start = 20;
     el.pageSize = 2;
 
     await el.updateComplete;
@@ -42,25 +42,25 @@ describe('chromedash-feature-pagination', () => {
     assert.exists(previous);
 
     const jump_1 = el.shadowRoot!.querySelector('#jump_1');
-    assert.notExists(jump_1);
+    assert.exists(jump_1);
     const jump_2 = el.shadowRoot!.querySelector('#jump_2');
     assert.notExists(jump_2);
     const jump_3 = el.shadowRoot!.querySelector('#jump_3');
-    assert.exists(jump_3);
+    assert.notExists(jump_3);
     const jump_4 = el.shadowRoot!.querySelector('#jump_4');
-    assert.exists(jump_4);
+    assert.notExists(jump_4);
     const jump_5 = el.shadowRoot!.querySelector('#jump_5');
-    assert.exists(jump_5);
+    assert.notExists(jump_5);
     const jump_6 = el.shadowRoot!.querySelector('#jump_6');
     assert.exists(jump_6);
-    const jump_7 = el.shadowRoot!.querySelector('#jump_7');
-    assert.exists(jump_7);
-    const jump_8 = el.shadowRoot!.querySelector('#jump_8');
-    assert.exists(jump_8);
-    const jump_9 = el.shadowRoot!.querySelector('#jump_9');
-    assert.exists(jump_9);
-    const jump_10 = el.shadowRoot!.querySelector('#jump_10');
-    assert.notExists(jump_10);
+    const jump_11 = el.shadowRoot!.querySelector('#jump_11');
+    assert.exists(jump_11);
+    const jump_16 = el.shadowRoot!.querySelector('#jump_16');
+    assert.exists(jump_16);
+    const jump_19 = el.shadowRoot!.querySelector('#jump_19');
+    assert.notExists(jump_19);
+    const jump_20 = el.shadowRoot!.querySelector('#jump_20');
+    assert.exists(jump_20);
 
     const next = el.shadowRoot!.querySelector('#next');
     assert.exists(next);


### PR DESCRIPTION
Limit the pagination length to avoid overflow. 

It shows 4 pages + and - from the current page on the pagination and the first/last page, if exist. For pages not displayed, it shows ... instead. E.g.

Pages at the back missing:
![Screenshot 2024-09-03 2 49 42 PM](https://github.com/user-attachments/assets/1bc481bb-f469-42fc-8fe4-a0732c4a2d2e)


Pages at the front missing:
![Screenshot 2024-09-03 2 49 53 PM](https://github.com/user-attachments/assets/e1ff78cb-9e4e-41a4-ad7b-af903b6d0b45)


4 to the right exactly + last page, without ...:
![Screenshot 2024-09-03 2 50 16 PM](https://github.com/user-attachments/assets/5721ee8c-e113-4682-9987-cb42ede8a2ff)


4 to the left exactly + first page without ...:
![Screenshot 2024-09-03 2 50 26 PM](https://github.com/user-attachments/assets/1341c4a0-98e2-49bf-902c-85b755d1e9c8)

Missing front and back:
![Screenshot 2024-09-03 2 50 32 PM](https://github.com/user-attachments/assets/671a34ff-4b65-4ca8-bace-38331a30717b)


Less than 10 pa
![Screenshot 2024-09-03 2 00 10 PM](https://github.com/user-attachments/assets/f1ed32e7-eab8-4256-8f01-4d55953ee851)
ges, and showed fully:


