### PR TITLE
Avoid parsing the period at end of intent thread links.

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -124,11 +124,11 @@ def detect_gate_id(body) -> int | None:
 THREAD_LINK_RE = re.compile(
     r'To view this discussion on the web visit\s+'
     r'(> )?(https://groups\.google\.com/a/chromium.org/d/msgid/blink-dev/'
-    r'\S+)[\r\n> .]', re.MULTILINE)
+    r'[-_0-9a-zA-Z%.]+[-_0-9a-zA-Z])', re.MULTILINE)
 STAGING_THREAD_LINK_RE = re.compile(
     r'To view this discussion on the web visit\s+'
     r'(> )?(https://groups\.google\.com/d/msgid/jrobbins-test/'
-    r'\S+)[\r\n> .]', re.MULTILINE)
+    r'[-_0-9a-zA-Z%.]+[-_0-9a-zA-Z])', re.MULTILINE)
 
 
 def detect_thread_url(body):

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -286,7 +286,7 @@ class FunctionTest(testing_config.CustomTestCase):
         'send an email to blink-dev+unsubscribe@chromium.org.\n'
         'To view this discussion on the web visit https://groups.google.com'
         '/a/chromium.org/d/msgid/blink-dev/CAMO6jDPGfXfE5z6hJcWO112zX3We'
-        '-oNTb%2BZjiJk%2B6RNb9%2Bv05w%40mail.gmail.com.')
+        '-oNTb%2BZjiJk%2B6RNb9%2Bv05w%40mail.gmail.com. ')
     self.assertEqual(
         ('https://groups.google.com'
          '/a/chromium.org/d/msgid/blink-dev/CAMO6jDPGfXfE5z6hJcWO112zX3We'
@@ -352,7 +352,7 @@ class FunctionTest(testing_config.CustomTestCase):
         'send an email to jrobbins-test+unsubscribe@googlegroups.com.\n'
         'To view this discussion on the web visit https://groups.google.com'
         '/d/msgid/jrobbins-test/CAMO6jDPGfXfE5z6hJcWO112zX3We'
-        '-oNTb%2BZjiJk%2B6RNb9%2Bv05w%40mail.gmail.com.')
+        '-oNTb%2BZjiJk%2B6RNb9%2Bv05w%40mail.gmail.com.\n')
     self.assertEqual(
         ('https://groups.google.com'
          '/d/msgid/jrobbins-test/CAMO6jDPGfXfE5z6hJcWO112zX3We'


### PR DESCRIPTION
This should resolve #4330.

It's been tricky to get this regex correct because of variations in the way that emails and replies are quoted and escaped by mail clients.  So, here I am changing the approach to detect characters that are valid in the Google Groups URL rather than trying to detect the delimiter that comes after the URL.