### PR TITLE
Avoid a race condition when processing LGTMs.

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -15,6 +15,8 @@
 
 import re
 import logging
+import random
+import time
 from typing import Optional
 
 import settings
@@ -366,6 +368,9 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
     if (detect_lgtm(body) and
         is_lgtm_allowed(from_addr, feature, gate_info)):
       logging.info('found LGTM')
+      # Avoid a race condition when blink-dev is in both To: and Cc: lines.
+      time.sleep(random.uniform(0, 5))
+      gate = Gate.get_by_id(gate.key.integer_id())  # Reload after sleep
       old_gate_state = gate.state
       new_gate_state = approval_defs.set_vote(
           feature_id, gate_info.gate_type, Vote.APPROVED, from_addr,


### PR DESCRIPTION
There have been two occasions where an API owner sent a LGTM message with blink-dev@ on both the To: and Cc: lines and that caused our server to process both inbound email messages within milliseconds of each other, resulting in two votes being counted.   When recording a vote, we already check for existing votes using a strongly consistent read, but if both processes are doing that same check before either one of them writes the new vote, they can both find no existing vote and then both write a new vote.

This PR adds two kinds of protection:
* Add a random delay of between 0 and 5 seconds.  The idea is that one of the inbound email handlers will wait longer than the other, and that more delayed handler will detect the vote written by the less delayed handler.
* After writing a vote, check for double votes and undo the new vote if this request handler wrote it's vote last