### PR TITLE
OT creation form deprecation trial bug fix

### DIFF
--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -356,15 +356,17 @@ export class ChromedashOTCreationPage extends LitElement {
       this.featureId
     );
     // We only need the single stage changes.
-    const stageSubmitBody = featureSubmitBody.stages[0] as Object;
+    const stageSubmitBody = featureSubmitBody.stages[0];
 
     // Add on the appropriate use counter prefix.
     const useCounterPrefix =
       this.webfeatureUseCounterType === USE_COUNTER_TYPE_WEBFEATURE
         ? ''
         : 'WebDXFeature::';
-    stageSubmitBody['ot_webfeature_use_counter'].value =
-      `${useCounterPrefix}${stageSubmitBody['ot_webfeature_use_counter'].value}`;
+    if ('ot_webfeature_use_counter' in stageSubmitBody) {
+      stageSubmitBody['ot_webfeature_use_counter'].value =
+        `${useCounterPrefix}${stageSubmitBody['ot_webfeature_use_counter'].value}`;
+    }
 
     this.submitting = true;
     window.csClient

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -364,8 +364,7 @@ export class ChromedashOTCreationPage extends LitElement {
         this.webfeatureUseCounterType === USE_COUNTER_TYPE_WEBFEATURE
           ? ''
           : 'WebDXFeature::';
-      stageSubmitBody.ot_webfeature_use_counter.value =
-        `${useCounterPrefix}${stageSubmitBody.ot_webfeature_use_counter.value}`;
+      stageSubmitBody.ot_webfeature_use_counter.value = `${useCounterPrefix}${stageSubmitBody.ot_webfeature_use_counter.value}`;
     }
 
     this.submitting = true;

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -358,14 +358,14 @@ export class ChromedashOTCreationPage extends LitElement {
     // We only need the single stage changes.
     const stageSubmitBody = featureSubmitBody.stages[0];
 
-    // Add on the appropriate use counter prefix.
-    const useCounterPrefix =
-      this.webfeatureUseCounterType === USE_COUNTER_TYPE_WEBFEATURE
-        ? ''
-        : 'WebDXFeature::';
     if ('ot_webfeature_use_counter' in stageSubmitBody) {
-      stageSubmitBody['ot_webfeature_use_counter'].value =
-        `${useCounterPrefix}${stageSubmitBody['ot_webfeature_use_counter'].value}`;
+      // Add on the appropriate use counter prefix.
+      const useCounterPrefix =
+        this.webfeatureUseCounterType === USE_COUNTER_TYPE_WEBFEATURE
+          ? ''
+          : 'WebDXFeature::';
+      stageSubmitBody.ot_webfeature_use_counter.value =
+        `${useCounterPrefix}${stageSubmitBody.ot_webfeature_use_counter.value}`;
     }
 
     this.submitting = true;

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -541,21 +541,22 @@ export interface FieldInfo {
   checkMessage?: string;
 }
 
-/**
- * @typedef {Object} UpdateSubmitBody
- * @property {Object.<string, *>} feature_changes An object with feature changes.
- *   key=field name, value=new field value.
- * @property {Array.<Object>} stages The list of changes to specific stages.
- * @property {boolean} has_changes Whether any valid changes are present for submission.
- */
+interface UpdateSubmitBody {
+  feature_changes: FeatureUpdateInfo;
+  stages: StageUpdateInfo[];
+  has_changes: boolean;
+}
 
-/**
- * Prepare feature/stage changes to be submitted.
- * @param {Array.<FieldInfo>} fieldValues List of fields in the form.
- * @param {number} featureId The ID of the feature being updated.
- * @return {UpdateSubmitBody} Formatted body of new PATCH request.
- */
-export function formatFeatureChanges(fieldValues, featureId) {
+interface StageUpdateInfo {
+  [stageField: string]: any;
+}
+
+interface FeatureUpdateInfo {
+  [featureField: string]: any;
+}
+
+// Prepare feature/stage changes to be submitted.
+export function formatFeatureChanges(fieldValues, featureId): UpdateSubmitBody {
   let hasChanges = false;
   const featureChanges = {id: featureId};
   // Multiple stages can be mutated, so this object is a stage of stages.


### PR DESCRIPTION
A bug was introduced in staging that involved accessing an undefined value when submitting the OT creation form for a deprecation trial. This change updates the implementation to only access and update the `ot_webfeature_use_counter` property on the submission body if it already exists.

Additionally, some JSDoc definitions were converted to TypeScript definitions for better reference to these values.