### PR TITLE
Add Blink>HID

### DIFF
--- a/hack_components.py
+++ b/hack_components.py
@@ -100,6 +100,7 @@ HACK_BLINK_COMPONENTS = [
   "Blink>HTML>Script",
   "Blink>HTML>Table",
   "Blink>Handwriting",
+  "Blink>HID",
   "Blink>History",
   "Blink>HitTesting",
   "Blink>Identity",


### PR DESCRIPTION
This PR adds missing Blink component for WebHID as it's needed for https://chromestatus.com/feature/5077348995825664