### PR TITLE
Add name_only for data fetch in /newfeatures

### DIFF
--- a/client-src/elements/chromedash-all-features-page.ts
+++ b/client-src/elements/chromedash-all-features-page.ts
@@ -44,6 +44,10 @@ export class ChromedashAllFeaturesPage extends LitElement {
   num = 100;
   @state()
   starredFeatures: Set<number> = new Set();
+  @state()
+  isNewfeaturesPage = false;
+  @state()
+  nameOnly = false;
 
   @queryAll('chromedash-feature-table')
   chromedashFeatureTables;
@@ -82,6 +86,9 @@ export class ChromedashAllFeaturesPage extends LitElement {
       !Number.isNaN(parseInt(this.rawQuery['num']))
     ) {
       this.num = parseInt(this.rawQuery['num']);
+    }
+    if (this.rawQuery.name_only != null && this.isNewfeaturesPage) {
+      this.nameOnly = true;
     }
   }
 
@@ -131,6 +138,7 @@ export class ChromedashAllFeaturesPage extends LitElement {
         .sortSpec=${this.sortSpec}
         .start=${this.start}
         .num=${this.num}
+        .nameOnly=${this.nameOnly}
         ?showQuery=${this.showQuery}
         ?signedIn=${Boolean(this.user)}
         ?canEdit=${this.user && this.user.can_edit_all}

--- a/client-src/elements/chromedash-all-features-page.ts
+++ b/client-src/elements/chromedash-all-features-page.ts
@@ -87,7 +87,7 @@ export class ChromedashAllFeaturesPage extends LitElement {
     ) {
       this.num = parseInt(this.rawQuery['num']);
     }
-    if (this.rawQuery.name_only != null && this.isNewfeaturesPage) {
+    if (this.isNewfeaturesPage) {
       this.nameOnly = true;
     }
   }

--- a/client-src/elements/chromedash-app.ts
+++ b/client-src/elements/chromedash-app.ts
@@ -362,6 +362,7 @@ export class ChromedashApp extends LitElement {
       if (!this.setupNewPage(ctx, 'chromedash-all-features-page', true)) return;
       this.pageComponent.user = this.user;
       this.pageComponent.rawQuery = parseRawQuery(ctx.querystring);
+      this.pageComponent.isNewfeaturesPage = true;
       this.pageComponent.addEventListener(
         'search',
         this.handleSearchQuery.bind(this)

--- a/client-src/elements/chromedash-feature-table.ts
+++ b/client-src/elements/chromedash-feature-table.ts
@@ -46,6 +46,8 @@ export class ChromedashFeatureTable extends LitElement {
   columns!: 'normal' | 'approvals';
   @property({type: Boolean})
   signedIn!: boolean;
+  @property({type: Boolean})
+  nameOnly = false;
 
   connectedCallback() {
     super.connectedCallback();
@@ -61,7 +63,8 @@ export class ChromedashFeatureTable extends LitElement {
         this.showEnterprise,
         this.sortSpec,
         this.start,
-        this.num
+        this.num,
+        this.nameOnly
       )
       .then(resp => {
         this.features = resp.features;

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -403,7 +403,6 @@ export interface RawQuery {
   start?: string;
   after?: string;
   num?: string;
-  name_only?: string;
   [key: string]: string | undefined;
 }
 

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -403,6 +403,7 @@ export interface RawQuery {
   start?: string;
   after?: string;
   num?: string;
+  name_only?: string;
   [key: string]: string | undefined;
 }
 

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -576,7 +576,14 @@ export class ChromeStatusClient {
     return this.doGet(`/features?releaseNotesMilestone=${milestone}`);
   }
 
-  async searchFeatures(userQuery, showEnterprise, sortSpec, start, num) {
+  async searchFeatures(
+    userQuery,
+    showEnterprise,
+    sortSpec,
+    start,
+    num,
+    nameOnly
+  ) {
     const query = new URLSearchParams();
     query.set('q', userQuery);
     if (showEnterprise) {
@@ -590,6 +597,9 @@ export class ChromeStatusClient {
     }
     if (num) {
       query.set('num', num);
+    }
+    if (nameOnly) {
+      query.set('name_only', nameOnly);
     }
     return this.doGet(`/features?${query.toString()}`);
   }


### PR DESCRIPTION
Add the name_only param when fetching FeatureEntries in `/newfeatures`.  Speeds up the page load.

A follow-up for https://github.com/GoogleChrome/chromium-dashboard/pull/4337.

See responses in /newfeatures page:
![Screenshot 2024-09-18 1 41 50 PM](https://github.com/user-attachments/assets/dab67946-430e-44e8-9cf9-25888515ee20)

