### PR TITLE
Align feature_type enum names on client and server.

### DIFF
--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -298,7 +298,7 @@ class FeatureConvertersTest(testing_config.CustomTestCase):
       'is_released': True,
       'category': 'Web Components',
       'category_int': 1,
-      'feature_type': 'New feature incubation',
+      'feature_type': 'New or changed feature',
       'feature_type_int': 0,
       'is_enterprise_feature': False,
       'intent_stage': 'Start prototyping',

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -128,10 +128,10 @@ FEATURE_TYPE_DEPRECATION_ID = 3
 FEATURE_TYPE_ENTERPRISE_ID = 4
 
 FEATURE_TYPES = {
-    FEATURE_TYPE_INCUBATE_ID: 'New feature incubation',
-    FEATURE_TYPE_EXISTING_ID: 'Existing feature implementation',
-    FEATURE_TYPE_CODE_CHANGE_ID: 'Web developer facing change to existing code',
-    FEATURE_TYPE_DEPRECATION_ID: 'Feature deprecation',
+    FEATURE_TYPE_INCUBATE_ID: 'New or changed feature',
+    FEATURE_TYPE_EXISTING_ID: 'Chrome cathes up',
+    FEATURE_TYPE_CODE_CHANGE_ID: 'No developer-visible change',
+    FEATURE_TYPE_DEPRECATION_ID: 'Feature removal',
     FEATURE_TYPE_ENTERPRISE_ID: 'New Feature or removal affecting enterprises',
 }
 

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -129,7 +129,7 @@ FEATURE_TYPE_ENTERPRISE_ID = 4
 
 FEATURE_TYPES = {
     FEATURE_TYPE_INCUBATE_ID: 'New or changed feature',
-    FEATURE_TYPE_EXISTING_ID: 'Chrome cathes up',
+    FEATURE_TYPE_EXISTING_ID: 'Chromium catches up',
     FEATURE_TYPE_CODE_CHANGE_ID: 'No developer-visible change',
     FEATURE_TYPE_DEPRECATION_ID: 'Feature removal',
     FEATURE_TYPE_ENTERPRISE_ID: 'New Feature or removal affecting enterprises',

--- a/internals/testdata/notifier_test/test_format_email_body__new.html
+++ b/internals/testdata/notifier_test/test_format_email_body__new.html
@@ -58,7 +58,7 @@
     </tr>
     <tr>
       <td style="padding-left: 16px;">Feature type:</td>
-      <td style="padding-left: 16px;">New feature incubation</td>
+      <td style="padding-left: 16px;">New or changed feature</td>
     </tr>
   </table>
 </section>


### PR DESCRIPTION
A few months back we changed the feature_type enum display names to be more clear.  But, the change was only made on the client side.  This meant that the autocomplete was offering `feature_type="Chrome catches up"` but the server didn't recognize that because it was looking for `"Existing feature implementation"`.  This PR aligns them so that users can use what the search autocomplete suggests.  It also has the effect of using the new terms in notification emails for newly created features.