### PR TITLE
Restore list "Reloading..." indicator and count

### DIFF
--- a/client-src/elements/chromedash-feature-pagination.ts
+++ b/client-src/elements/chromedash-feature-pagination.ts
@@ -23,7 +23,11 @@ import {
   nothing,
 } from 'lit';
 import {customElement, property} from 'lit/decorators.js';
-import {formatURLParams, formatUrlForRelativeOffset, formatUrlForOffset} from './utils.js';
+import {
+  formatURLParams,
+  formatUrlForRelativeOffset,
+  formatUrlForOffset,
+} from './utils.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 import {range} from 'lit/directives/range.js';
 import {map} from 'lit/directives/map.js';
@@ -187,9 +191,17 @@ export class ChromedashFeaturePagination extends LitElement {
     }
 
     const prevUrl = formatUrlForRelativeOffset(
-      this.start, -this.pageSize, this.pageSize, this.totalCount);
+      this.start,
+      -this.pageSize,
+      this.pageSize,
+      this.totalCount
+    );
     const nextUrl = formatUrlForRelativeOffset(
-      this.start, this.pageSize, this.pageSize, this.totalCount);
+      this.start,
+      this.pageSize,
+      this.pageSize,
+      this.totalCount
+    );
 
     return html`
       <div id="main" class="pagination hbox halign-items-space-between">

--- a/client-src/elements/chromedash-feature-pagination.ts
+++ b/client-src/elements/chromedash-feature-pagination.ts
@@ -23,7 +23,7 @@ import {
   nothing,
 } from 'lit';
 import {customElement, property} from 'lit/decorators.js';
-import {formatURLParams} from './utils.js';
+import {formatURLParams, formatUrlForRelativeOffset, formatUrlForOffset} from './utils.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 import {range} from 'lit/directives/range.js';
 import {map} from 'lit/directives/map.js';
@@ -82,22 +82,6 @@ export class ChromedashFeaturePagination extends LitElement {
     ];
   }
 
-  formatUrlForRelativeOffset(delta: number): string | undefined {
-    const offset = this.start + delta;
-    if (
-      this.totalCount === undefined ||
-      offset <= -this.pageSize ||
-      offset >= this.totalCount
-    ) {
-      return undefined;
-    }
-    return this.formatUrlForOffset(Math.max(0, offset));
-  }
-
-  formatUrlForOffset(offset: number): string {
-    return formatURLParams('start', offset).toString();
-  }
-
   renderPageButtons(): TemplateResult {
     if (this.totalCount === undefined || this.totalCount === 0) {
       return html``;
@@ -136,7 +120,7 @@ export class ChromedashFeaturePagination extends LitElement {
         variant="text"
         id="jump_1"
         class="page-button ${0 === currentPage ? 'active' : ''}"
-        href=${this.formatUrlForOffset(0)}
+        href=${formatUrlForOffset(0)}
       >
         ${1}
       </sl-button>
@@ -148,7 +132,7 @@ export class ChromedashFeaturePagination extends LitElement {
             variant="text"
             id="jump_${i + 1}"
             class="page-button ${i === currentPage ? 'active' : ''}"
-            href=${this.formatUrlForOffset(i * this.pageSize)}
+            href=${formatUrlForOffset(i * this.pageSize)}
           >
             ${i + 1}
           </sl-button>
@@ -160,7 +144,7 @@ export class ChromedashFeaturePagination extends LitElement {
             variant="text"
             id="jump_${numPages}"
             class="page-button ${numPages - 1 === currentPage ? 'active' : ''}"
-            href=${this.formatUrlForOffset((numPages - 1) * this.pageSize)}
+            href=${formatUrlForOffset((numPages - 1) * this.pageSize)}
           >
             ${numPages}
           </sl-button>`
@@ -202,8 +186,10 @@ export class ChromedashFeaturePagination extends LitElement {
       return html``;
     }
 
-    const prevUrl = this.formatUrlForRelativeOffset(-this.pageSize);
-    const nextUrl = this.formatUrlForRelativeOffset(this.pageSize);
+    const prevUrl = formatUrlForRelativeOffset(
+      this.start, -this.pageSize, this.pageSize, this.totalCount);
+    const nextUrl = formatUrlForRelativeOffset(
+      this.start, this.pageSize, this.pageSize, this.totalCount);
 
     return html`
       <div id="main" class="pagination hbox halign-items-space-between">

--- a/client-src/elements/chromedash-feature-table.ts
+++ b/client-src/elements/chromedash-feature-table.ts
@@ -129,21 +129,21 @@ export class ChromedashFeatureTable extends LitElement {
     return [
       ...SHARED_STYLES,
       css`
-       .status-and-count {
-           padding: var(--content-padding-half) 0;
-           min-height: 50px;
-         }
-         .status-and-count span {
-           color: var(--unimportant-text-color);
-           margin-right: var(--content-padding);
-         }
-         .status-and-count sl-icon-button {
-           font-size: 1.6rem;
-         }
-         .status-and-count sl-icon-button::part(base) {
-           padding: 0;
-      }
-      table {
+        .status-and-count {
+          padding: var(--content-padding-half) 0;
+          min-height: 50px;
+        }
+        .status-and-count span {
+          color: var(--unimportant-text-color);
+          margin-right: var(--content-padding);
+        }
+        .status-and-count sl-icon-button {
+          font-size: 1.6rem;
+        }
+        .status-and-count sl-icon-button::part(base) {
+          padding: 0;
+        }
+        table {
           width: 100%;
         }
         .skel td {
@@ -211,16 +211,24 @@ export class ChromedashFeatureTable extends LitElement {
     const lastShown = this.start + this.features.length;
 
     const prevUrl = formatUrlForRelativeOffset(
-      this.start, -this.num, this.num, this.totalCount);
+      this.start,
+      -this.num,
+      this.num,
+      this.totalCount
+    );
     const nextUrl = formatUrlForRelativeOffset(
-      this.start, this.num, this.num, this.totalCount);
+      this.start,
+      this.num,
+      this.num,
+      this.totalCount
+    );
 
     if (this.alwaysOfferPagination) {
       if (this.loading) {
         // reserve vertical space to use when loaded.
         return html` <div class="status-and-count">
-        <sl-skeleton effect="sheen" style="float: right; width: 12em">
-        </sl-skeleton>
+          <sl-skeleton effect="sheen" style="float: right; width: 12em">
+          </sl-skeleton>
         </div>`;
       }
     } else {
@@ -228,7 +236,7 @@ export class ChromedashFeatureTable extends LitElement {
       // results fit in each box (the most common case).
       if (this.loading || (firstShown == 1 && lastShown == this.totalCount)) {
         return nothing;
-       }
+      }
     }
 
     if (this.features.length === 0) {
@@ -236,26 +244,26 @@ export class ChromedashFeatureTable extends LitElement {
     }
 
     return html`
-       <div class="status-and-count hbox">
-         <span>${this.reloading ? 'Reloading...' : nothing}</span>
-         <div class="spacer"></div>
-         <span>${firstShown} - ${lastShown} of ${this.totalCount}</span>
-         <sl-icon-button
-           library="material"
-           name="navigate_before"
-           title="Previous page"
-           href=${ifDefined(prevUrl)}
-           ?disabled=${prevUrl === undefined}
-         ></sl-icon-button>
-         <sl-icon-button
-           library="material"
-           name="navigate_next"
-           title="Next page"
-           href=${ifDefined(nextUrl)}
-           ?disabled=${nextUrl === undefined}
-         ></sl-icon-button>
-       </div>
-     `;
+      <div class="status-and-count hbox">
+        <span>${this.reloading ? 'Reloading...' : nothing}</span>
+        <div class="spacer"></div>
+        <span>${firstShown} - ${lastShown} of ${this.totalCount}</span>
+        <sl-icon-button
+          library="material"
+          name="navigate_before"
+          title="Previous page"
+          href=${ifDefined(prevUrl)}
+          ?disabled=${prevUrl === undefined}
+        ></sl-icon-button>
+        <sl-icon-button
+          library="material"
+          name="navigate_next"
+          title="Next page"
+          href=${ifDefined(nextUrl)}
+          ?disabled=${nextUrl === undefined}
+        ></sl-icon-button>
+      </div>
+    `;
   }
 
   renderPagination(features) {
@@ -308,8 +316,7 @@ export class ChromedashFeatureTable extends LitElement {
 
   render() {
     return html`
-      ${this.renderSearch()}
-      ${this.renderLoadingStatusAndCount()}
+      ${this.renderSearch()} ${this.renderLoadingStatusAndCount()}
       <table>
         ${this.renderMessages() ||
         this.features.map(feature => this.renderFeature(feature))}

--- a/client-src/elements/chromedash-feature-table.ts
+++ b/client-src/elements/chromedash-feature-table.ts
@@ -1,11 +1,12 @@
 import {LitElement, css, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
+import {ifDefined} from 'lit/directives/if-defined.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {Feature} from '../js-src/cs-client.js';
 import './chromedash-feature-filter';
 import './chromedash-feature-pagination';
 import './chromedash-feature-row';
-import {clamp, showToastMessage} from './utils.js';
+import {clamp, showToastMessage, formatUrlForRelativeOffset} from './utils.js';
 import {GateDict} from './chromedash-gate-chip.js';
 
 @customElement('chromedash-feature-table')
@@ -128,9 +129,22 @@ export class ChromedashFeatureTable extends LitElement {
     return [
       ...SHARED_STYLES,
       css`
-        table {
+       .status-and-count {
+           padding: var(--content-padding-half) 0;
+           min-height: 50px;
+         }
+         .status-and-count span {
+           color: var(--unimportant-text-color);
+           margin-right: var(--content-padding);
+         }
+         .status-and-count sl-icon-button {
+           font-size: 1.6rem;
+         }
+         .status-and-count sl-icon-button::part(base) {
+           padding: 0;
+      }
+      table {
           width: 100%;
-          margin-top: var(--content-padding);
         }
         .skel td {
           background: white;
@@ -191,6 +205,59 @@ export class ChromedashFeatureTable extends LitElement {
     return nothing;
   }
 
+  renderLoadingStatusAndCount() {
+    // Indexes of first and last items shown in one-based counting.
+    const firstShown = this.start + 1;
+    const lastShown = this.start + this.features.length;
+
+    const prevUrl = formatUrlForRelativeOffset(
+      this.start, -this.num, this.num, this.totalCount);
+    const nextUrl = formatUrlForRelativeOffset(
+      this.start, this.num, this.num, this.totalCount);
+
+    if (this.alwaysOfferPagination) {
+      if (this.loading) {
+        // reserve vertical space to use when loaded.
+        return html` <div class="status-and-count">
+        <sl-skeleton effect="sheen" style="float: right; width: 12em">
+        </sl-skeleton>
+        </div>`;
+      }
+    } else {
+      // On MyFeatures page, don't always show conut.  Omit it if
+      // results fit in each box (the most common case).
+      if (this.loading || (firstShown == 1 && lastShown == this.totalCount)) {
+        return nothing;
+       }
+    }
+
+    if (this.features.length === 0) {
+      return nothing;
+    }
+
+    return html`
+       <div class="status-and-count hbox">
+         <span>${this.reloading ? 'Reloading...' : nothing}</span>
+         <div class="spacer"></div>
+         <span>${firstShown} - ${lastShown} of ${this.totalCount}</span>
+         <sl-icon-button
+           library="material"
+           name="navigate_before"
+           title="Previous page"
+           href=${ifDefined(prevUrl)}
+           ?disabled=${prevUrl === undefined}
+         ></sl-icon-button>
+         <sl-icon-button
+           library="material"
+           name="navigate_next"
+           title="Next page"
+           href=${ifDefined(nextUrl)}
+           ?disabled=${nextUrl === undefined}
+         ></sl-icon-button>
+       </div>
+     `;
+  }
+
   renderPagination(features) {
     const firstShown = this.start + 1;
     const lastShown = this.start + features.length;
@@ -242,6 +309,7 @@ export class ChromedashFeatureTable extends LitElement {
   render() {
     return html`
       ${this.renderSearch()}
+      ${this.renderLoadingStatusAndCount()}
       <table>
         ${this.renderMessages() ||
         this.features.map(feature => this.renderFeature(feature))}

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -498,6 +498,26 @@ export function formatURLParams(key, val) {
   return newURL;
 }
 
+export function formatUrlForRelativeOffset(
+  start: number, delta: number, pageSize: number, totalCount: number
+  ): string | undefined {
+  const offset = start + delta;
+  if (
+    totalCount === undefined ||
+      offset <= -pageSize ||
+      offset >= totalCount
+  ) {
+    return undefined;
+  }
+  return formatUrlForOffset(Math.max(0, offset));
+}
+
+export function formatUrlForOffset(offset: number): string {
+  return formatURLParams('start', offset).toString();
+}
+
+
+
 /**
  * Update window.location with new query params.
  * @param {string} key is the key of the query param to delete.

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -499,14 +499,13 @@ export function formatURLParams(key, val) {
 }
 
 export function formatUrlForRelativeOffset(
-  start: number, delta: number, pageSize: number, totalCount: number
-  ): string | undefined {
+  start: number,
+  delta: number,
+  pageSize: number,
+  totalCount: number
+): string | undefined {
   const offset = start + delta;
-  if (
-    totalCount === undefined ||
-      offset <= -pageSize ||
-      offset >= totalCount
-  ) {
+  if (totalCount === undefined || offset <= -pageSize || offset >= totalCount) {
     return undefined;
   }
   return formatUrlForOffset(Math.max(0, offset));
@@ -515,8 +514,6 @@ export function formatUrlForRelativeOffset(
 export function formatUrlForOffset(offset: number): string {
   return formatURLParams('start', offset).toString();
 }
-
-
 
 /**
  * Update window.location with new query params.


### PR DESCRIPTION
When we switched the new pagination component, we lost the "Reloading..." indicator and the total count of results.  This PR restores those elements to the new feature list page.

It also restores the small `<` and `>` buttons at the top of the table for pagination.  That is redundant with the new, better pagination at the bottom of the table, but the redundant buttons are small.  I think it is useful to have `<` and `>` at the top because when the table is long, the user might know that they need to skip to the next page and want to just click rather than scrolling all the way to the bottom.

In this PR:
* Refactor some helper functions to util.ts since they are needed for both elements.
* Add back the top-of-table `<div>` for reloading status, count, and pagination buttons, but give it a clearer name.
* Change the `<` and `>` buttons to use href rather than events.  
* Remove the extra padding recently added to the top of the table because this element provides that padding.