### PR TITLE
Add `data_access_admin_group_name` to OT SetUpTrial request

### DIFF
--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -61,6 +61,7 @@ class CreateOriginTrialRequest(TypedDict):
 
 class SetUpTrialRequest(TypedDict):
   trial_id: int
+  data_access_admin_group_name: str
   announcement_groups_owners: list[str]
   trial_contacts: list[str]
 
@@ -208,8 +209,14 @@ def _send_set_up_trial_request(
   Returns:
     Any error text if there was an issue during the setup process.
   """
+  data_access_admin_group = secrets.get_ot_data_access_admin_group()
+  # Return some error text about the data access group if not found.
+  if data_access_admin_group is None:
+    return 'No data access admin group found'
+
   json: SetUpTrialRequest = {
     'trial_id': trial_id,
+    'data_access_admin_group_name': data_access_admin_group,
     'announcement_groups_owners': owners,
     'trial_contacts': contacts,
   }

--- a/framework/origin_trials_client_test.py
+++ b/framework/origin_trials_client_test.py
@@ -197,13 +197,14 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
     # POST request should not be executed with no API key.
     mock_requests_post.assert_not_called()
 
+  @mock.patch('framework.secrets.get_ot_data_access_admin_group')
   @mock.patch('framework.secrets.get_ot_api_key')
   @mock.patch('framework.origin_trials_client._get_ot_access_token')
   @mock.patch('framework.origin_trials_client._get_trial_end_time')
   @mock.patch('requests.post')
   def test_create_origin_trial__with_api_key(
       self, mock_requests_post, mock_get_trial_end_time,
-      mock_get_ot_access_token, mock_api_key_get):
+      mock_get_ot_access_token, mock_api_key_get, mock_get_admin_group):
     """If an API key is available, POST should create trial and return true."""
     mock_requests_post.return_value = mock.MagicMock(
         status_code=200, json=lambda : (
@@ -211,6 +212,7 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
     mock_get_trial_end_time.return_value = 111222333
     mock_get_ot_access_token.return_value = 'access_token'
     mock_api_key_get.return_value = 'api_key_value'
+    mock_get_admin_group.return_value = 'test-group-123'
 
     ot_id, error_text = origin_trials_client.create_origin_trial(self.ot_stage)
     self.assertEqual(ot_id, '-1234567890')
@@ -249,6 +251,8 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
     # Only unique @google.com emails should be sent as contacts.
     self.assertCountEqual(['someuser@google.com', 'editor@google.com'],
                           set_up_trial_json['trial_contacts'])
+    self.assertEqual('test-group-123',
+                     set_up_trial_json['data_access_admin_group_name'])
     self.assertEqual(-1234567890, set_up_trial_json['trial_id'])
 
   @mock.patch('framework.secrets.get_ot_api_key')

--- a/framework/secrets.py
+++ b/framework/secrets.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
-import hmac
 import logging
 import random
 import settings
@@ -168,4 +166,24 @@ def get_ot_support_emails() -> str|None:
   response = client.access_secret_version(request={'name': name})
   if response:
     return response.payload.data.decode("UTF-8")
+  return None
+
+
+def get_ot_data_access_admin_group() -> str|None:
+  """Obtain the name of the data access admn group for OT."""
+  # Reuse the value if we've already obtained it.
+  if settings.OT_DATA_ACCESS_ADMIN_GROUP_NAME is not None:
+    return settings.OT_DATA_ACCESS_ADMIN_GROUP_NAME
+
+  # If in staging or prod, pull the value from the project secrets.
+  from google.cloud.secretmanager import SecretManagerServiceClient
+  client = SecretManagerServiceClient()
+  secret_path = client.secret_path(settings.APP_ID,
+                                    "OT_DATA_ACCESS_ADMIN_GROUP_NAME")
+  name = f'{secret_path}/versions/latest'
+  response = client.access_secret_version(request={'name': name})
+  if response:
+    settings.OT_DATA_ACCESS_ADMIN_GROUP_NAME = (
+        response.payload.data.decode("UTF-8"))
+    return settings.OT_DATA_ACCESS_ADMIN_GROUP_NAME
   return None

--- a/settings.py
+++ b/settings.py
@@ -85,7 +85,11 @@ MAX_LOG_LINE = 200 * 1000
 # Origin trials API URL
 OT_URL = 'https://origintrials-staging.corp.google.com/origintrials/'
 OT_API_URL = 'https://staging-chromeorigintrials-pa.sandbox.googleapis.com'
-OT_API_KEY: str|None = None  # Value is set later when request is needed.
+
+# Values are set later when request is needed.
+OT_API_KEY: str|None = None
+OT_DATA_ACCESS_ADMIN_GROUP_NAME: str|None = None
+
 # Dummy data for local OT support emails.
 DEV_MODE_OT_SUPPORT_EMAILS = 'user1@gmail.com,user2@gmail.com'
 


### PR DESCRIPTION
This change updates the OT SetUpTrial request sent during automated origin trial creation to include a new parameter, `data_access_admin_group_name`. This new parameter is required to set up ganpati groups that are created to allow feature owner access to origin trial information.