### PR TITLE
Make the new feature search page the default

### DIFF
--- a/client-src/elements/chromedash-app.ts
+++ b/client-src/elements/chromedash-app.ts
@@ -358,7 +358,8 @@ export class ChromedashApp extends LitElement {
       this.pageComponent.showQuery = false;
       this.pageComponent.rawQuery = parseRawQuery(ctx.querystring);
     });
-    page('/newfeatures', ctx => {
+    page('/newfeatures', () => page.redirect('/features'));
+    page('/features', ctx => {
       if (!this.setupNewPage(ctx, 'chromedash-all-features-page', true)) return;
       this.pageComponent.user = this.user;
       this.pageComponent.rawQuery = parseRawQuery(ctx.querystring);
@@ -623,11 +624,11 @@ export class ChromedashApp extends LitElement {
   }
 
   renderRolloutBanner(currentPage) {
-    if (currentPage.startsWith('/newfeatures')) {
+    if (currentPage.startsWith('/features')) {
       return html`
-        <div id="rollout">
-          <a href="/features">Back to the old features page</a>
-        </div>
+        <p style="padding: 2em 6em">
+          <a href="/oldfeatures">Use the old features page</a>
+        </p>
       `;
     }
 
@@ -679,10 +680,10 @@ export class ChromedashApp extends LitElement {
                   .timestamp=${this.bannerTime}
                 >
                 </chromedash-banner>
-                ${this.renderRolloutBanner(this.currentPage)}
                 <div id="content-flex-wrapper">
                   ${this.renderContentAndSidebar()}
                 </div>
+                ${this.renderRolloutBanner(this.currentPage)}
               </div>
             </div>
             <chromedash-footer></chromedash-footer>

--- a/main.py
+++ b/main.py
@@ -186,6 +186,7 @@ spa_page_routes = [
   Route('/myfeatures/review', defaults={'require_signin': True}),
   Route('/myfeatures/starred', defaults={'require_signin': True}),
   Route('/myfeatures/editable', defaults={'require_signin': True}),
+  Route('/features'),
   Route('/newfeatures'),
   Route('/feature/<int:feature_id>'),
   Route('/feature/<int:feature_id>/activity'),
@@ -255,7 +256,7 @@ mpa_page_routes: list[Route] = [
     Route(r'/features.json', featurelist.FeaturesJsonHandler),
     Route(r'/features_v2.json', featurelist.FeaturesJsonHandler),
 
-    Route('/features', featurelist.FeatureListHandler),
+    Route('/oldfeatures', featurelist.FeatureListHandler),
     Route('/features/<int:feature_id>', featurelist.FeatureListHandler),
     Route('/features.xml', basehandlers.ConstHandler,
         defaults={'template_path': 'farewell-rss.xml'}),

--- a/packages/playwright/tests/chromedash-old-features-page_pwtest.js
+++ b/packages/playwright/tests/chromedash-old-features-page_pwtest.js
@@ -15,7 +15,7 @@ test('new features page link is clickable while features are loading', async ({
       body: `)]}'\n${JSON.stringify(await featuresMayResolve)}`,
     });
   });
-  await page.goto('/features');
+  await page.goto('/oldfeatures');
   const newFeaturesLocator = page.getByRole('link', {
     name: 'Try out our new features page',
   });
@@ -37,7 +37,7 @@ test('new features page link is clickable while features are loading', async ({
       throw e;
     }
   }
-  await expect(page).toHaveURL('/newfeatures');
+  await expect(page).toHaveURL('/features');
 
   // Don't leave the network request hanging forever.
   resolveFeatures({});

--- a/pages/testdata/featurelist_test/test_html_rendering.html
+++ b/pages/testdata/featurelist_test/test_html_rendering.html
@@ -108,7 +108,7 @@ limitations under the License.
           timestamp="None">
         </chromedash-banner>
         <div id="rollout">
-          <a href="/newfeatures">Try out our new features page</a>
+          <a href="/features">Try out our new features page</a>
         </div>
         <div id="spinner">
           <img src="/static/img/ring.svg">

--- a/pages/testdata/intentpreview_test/test_html_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_rendering.html
@@ -107,7 +107,7 @@ limitations under the License.
           timestamp="None">
         </chromedash-banner>
         <div id="rollout">
-          <a href="/newfeatures">Try out our new features page</a>
+          <a href="/features">Try out our new features page</a>
         </div>
         <div id="spinner">
           <img src="/static/img/ring.svg">

--- a/pages/testdata/users_test/test_html_rendering.html
+++ b/pages/testdata/users_test/test_html_rendering.html
@@ -106,7 +106,7 @@ limitations under the License.
           timestamp="None">
         </chromedash-banner>
         <div id="rollout">
-          <a href="/newfeatures">Try out our new features page</a>
+          <a href="/features">Try out our new features page</a>
         </div>
         <div id="spinner">
           <img src="/static/img/ring.svg">

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -104,7 +104,7 @@ limitations under the License.
           timestamp="{{banner_time}}">
         </chromedash-banner>
         <div id="rollout">
-          <a href="/newfeatures">Try out our new features page</a>
+          <a href="/features">Try out our new features page</a>
         </div>
         <div id="spinner">
           <img src="/static/img/ring.svg">


### PR DESCRIPTION
I believe that we have checked off everything that we had in mind for this feature, so it is time to finally make it the default this week.

In this PR:
* Route traffic to the new feature list page at /features
* Redirect from /newfeatures to /features
* Move old feature list to /oldfeatures
* Update banner links, but keep them, and de-emphasize the link back to the old page.