### PR TITLE
Update shipping_year when milestones are edited.

### DIFF
--- a/api/channels_api.py
+++ b/api/channels_api.py
@@ -23,9 +23,6 @@ from internals import fetchchannels
 import settings
 
 
-SCHEDULE_CACHE_TIME = 60 * 60  # 1 hour
-
-
 def construct_chrome_channels_details():
   omaha_data = fetchchannels.get_omaha_data()
   channels = {}
@@ -34,63 +31,28 @@ def construct_chrome_channels_details():
   for v in win_versions:
     channel = v['channel']
     major_version = int(v['version'].split('.')[0])
-    channels[channel] = fetch_chrome_release_info(major_version)
+    channels[channel] = fetchchannels.fetch_chrome_release_info(major_version)
     channels[channel]['version'] = major_version
 
   # Adjust for the brief period after next miletone gets promted to stable/beta
   # channel and their major versions are the same.
   if channels['stable']['version'] == channels['beta']['version']:
     new_beta_version = channels['stable']['version'] + 1
-    channels['beta'] = fetch_chrome_release_info(new_beta_version)
+    channels['beta'] = fetchchannels.fetch_chrome_release_info(new_beta_version)
     channels['beta']['version'] = new_beta_version
   if channels['beta']['version'] == channels['dev']['version']:
     new_dev_version = channels['beta']['version'] + 1
-    channels['dev'] = fetch_chrome_release_info(new_dev_version)
+    channels['dev'] = fetchchannels.fetch_chrome_release_info(new_dev_version)
     channels['dev']['version'] = new_dev_version
 
   # In the situation where some versions are in a gap between
   # stable and beta, show one as 'stable_soon'.
   if channels['stable']['version'] + 1 < channels['beta']['version']:
     stable_soon_version = channels['stable']['version'] + 1
-    channels['stable_soon'] = fetch_chrome_release_info(stable_soon_version)
+    channels['stable_soon'] = fetchchannels.fetch_chrome_release_info(stable_soon_version)
     channels['stable_soon']['version'] = stable_soon_version
 
   return channels
-
-
-def fetch_chrome_release_info(version):
-  key = 'chromerelease|%s' % version
-
-  data = rediscache.get(key)
-  if data is None:
-    url = ('https://chromiumdash.appspot.com/fetch_milestone_schedule?'
-           'mstone=%s' % version)
-    result = requests.get(url, timeout=60)
-    if result.status_code == 200:
-      try:
-        logging.info(
-            'result.content is:\n%s', result.content[:settings.MAX_LOG_LINE])
-        result_json = json.loads(result.content)
-        if 'mstones' in result_json:
-          data = result_json['mstones'][0]
-          del data['owners']
-          del data['feature_freeze']
-          del data['ldaps']
-          rediscache.set(key, data, time=SCHEDULE_CACHE_TIME)
-      except ValueError:
-        pass  # Handled by next statement
-
-    if not data:
-      data = {
-          'stable_date': None,
-          'earliest_beta': None,
-          'latest_beta': None,
-          'mstone': version,
-          'version': version,
-      }
-      # Note: we don't put placeholder data into redis.
-
-  return data
 
 
 def construct_specified_milestones_details(start, end):
@@ -98,7 +60,7 @@ def construct_specified_milestones_details(start, end):
   win_versions = list(range(start,end+1))
 
   for milestone in win_versions:
-    channels[milestone] = fetch_chrome_release_info(milestone)
+    channels[milestone] = fetchchannels.fetch_chrome_release_info(milestone)
 
   return channels
 

--- a/api/channels_api_test.py
+++ b/api/channels_api_test.py
@@ -28,7 +28,7 @@ class ChannelsAPITest(testing_config.CustomTestCase):
     self.handler = channels_api.ChannelsAPI()
     self.request_path = '/api/v0/channels'
 
-  @mock.patch('api.channels_api.fetch_chrome_release_info')
+  @mock.patch('internals.fetchchannels.fetch_chrome_release_info')
   @mock.patch('internals.fetchchannels.get_omaha_data')
   def test_construct_chrome_channels_details(
       self, mock_get_omaha_data, mock_fetch_chrome_release_info):
@@ -93,7 +93,7 @@ class ChannelsAPITest(testing_config.CustomTestCase):
     self.maxDiff = None
     self.assertEqual(expected, actual)
 
-  @mock.patch('api.channels_api.fetch_chrome_release_info')
+  @mock.patch('internals.fetchchannels.fetch_chrome_release_info')
   @mock.patch('internals.fetchchannels.get_omaha_data')
   def test_construct_chrome_channels_details__beta_promotion(
       self, mock_get_omaha_data, mock_fetch_chrome_release_info):
@@ -142,7 +142,7 @@ class ChannelsAPITest(testing_config.CustomTestCase):
     self.maxDiff = None
     self.assertEqual(expected, actual)
 
-  @mock.patch('api.channels_api.fetch_chrome_release_info')
+  @mock.patch('internals.fetchchannels.fetch_chrome_release_info')
   @mock.patch('internals.fetchchannels.get_omaha_data')
   def test_construct_chrome_channels_details__dev_promotion(
       self, mock_get_omaha_data, mock_fetch_chrome_release_info):
@@ -192,62 +192,7 @@ class ChannelsAPITest(testing_config.CustomTestCase):
     self.maxDiff = None
     self.assertEqual(expected, actual)
 
-  @mock.patch('requests.get')
-  def test_fetch_chrome_release_info__found(self, mock_requests_get):
-    """We can get channel data from the chromiumdash app."""
-    mock_requests_get.return_value = testing_config.Blank(
-        status_code=200,
-        content=json.dumps({
-            'mstones': [{
-                'owners': 'ignored',
-                'feature_freeze': 'ignored',
-                'ldaps': 'ignored',
-                'everything else': 'kept',
-             }],
-        }))
-
-    actual = channels_api.fetch_chrome_release_info(90)
-
-    self.assertEqual(
-        {'everything else': 'kept'},
-        actual)
-
-  @mock.patch('requests.get')
-  def test_fetch_chrome_release_info__not_found(self, mock_requests_get):
-    """If chromiumdash app does not have the data, use a placeholder."""
-    mock_requests_get.return_value = testing_config.Blank(
-        status_code=404, content='')
-
-    actual = channels_api.fetch_chrome_release_info(91)
-
-    self.assertEqual(
-        {'stable_date': None,
-         'earliest_beta': None,
-         'latest_beta': None,
-         'mstone': 91,
-         'version': 91,
-         },
-        actual)
-
-  @mock.patch('requests.get')
-  def test_fetch_chrome_release_info__error(self, mock_requests_get):
-    """We can get channel data from the chromiumdash app."""
-    mock_requests_get.return_value = testing_config.Blank(
-        status_code=200,
-        content='{')
-
-    actual = channels_api.fetch_chrome_release_info(90)
-
-    self.assertEqual(
-        {'stable_date': None,
-         'earliest_beta': None,
-         'latest_beta': None,
-         'mstone': 90,
-         'version': 90,
-         },
-        actual)
-
-  @mock.patch('api.channels_api.fetch_chrome_release_info')
+  @mock.patch('internals.fetchchannels.fetch_chrome_release_info')
   def test_construct_specified_milestones_details(
       self, mock_fetch_chrome_release_info):
     mstone_data = {

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -259,8 +259,11 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
     if should_remove_first_notice_milestone(feature, feature_changes):
       feature.first_enterprise_notification_milestone = None
 
-    # Set shipping_year based on milestones.
-    if updated_stages:
+    # If a shipping stage was edited, set shipping_year based on milestones.
+    updated_shipping_stages = [
+        us for us in updated_stages
+        if us.stage_type in STAGE_TYPES_SHIPPING.values()]
+    if updated_shipping_stages:
       existing_shipping_stages = (
           stage_helpers.get_all_shipping_stages_with_milestones(
               feature_id=feature.key.integer_id()))
@@ -269,9 +272,8 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
           for es in existing_shipping_stages
       }
       shipping_stage_dict.update({
-          us.key.integer_id(): us
-          for us in updated_stages
-          if us.stage_type in STAGE_TYPES_SHIPPING.values()
+          uss.key.integer_id(): uss
+          for uss in updated_shipping_stages
       })
       earliest = stage_helpers.find_earliest_milestone(
           list(shipping_stage_dict.values()))

--- a/internals/fetchchannels_test.py
+++ b/internals/fetchchannels_test.py
@@ -1,0 +1,77 @@
+# Copyright 2024 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config  # Must be imported first
+import json
+from unittest import mock
+
+from internals import fetchchannels
+
+
+class ChannelsAPITest(testing_config.CustomTestCase):
+
+  @mock.patch('requests.get')
+  def test_fetch_chrome_release_info__found(self, mock_requests_get):
+    """We can get channel data from the chromiumdash app."""
+    mock_requests_get.return_value = testing_config.Blank(
+        status_code=200,
+        content=json.dumps({
+            'mstones': [{
+                'owners': 'ignored',
+                'feature_freeze': 'ignored',
+                'ldaps': 'ignored',
+                'everything else': 'kept',
+             }],
+        }))
+
+    actual = fetchchannels.fetch_chrome_release_info(90)
+
+    self.assertEqual(
+        {'everything else': 'kept'},
+        actual)
+
+  @mock.patch('requests.get')
+  def test_fetch_chrome_release_info__not_found(self, mock_requests_get):
+    """If chromiumdash app does not have the data, use a placeholder."""
+    mock_requests_get.return_value = testing_config.Blank(
+        status_code=404, content='')
+
+    actual = fetchchannels.fetch_chrome_release_info(91)
+
+    self.assertEqual(
+        {'stable_date': None,
+         'earliest_beta': None,
+         'latest_beta': None,
+         'mstone': 91,
+         'version': 91,
+         },
+        actual)
+
+  @mock.patch('requests.get')
+  def test_fetch_chrome_release_info__error(self, mock_requests_get):
+    """We can get channel data from the chromiumdash app."""
+    mock_requests_get.return_value = testing_config.Blank(
+        status_code=200,
+        content='{')
+
+    actual = fetchchannels.fetch_chrome_release_info(90)
+
+    self.assertEqual(
+        {'stable_date': None,
+         'earliest_beta': None,
+         'latest_beta': None,
+         'mstone': 90,
+         'version': 90,
+         },
+        actual)

--- a/internals/maintenance_scripts_test.py
+++ b/internals/maintenance_scripts_test.py
@@ -23,6 +23,7 @@ from internals import maintenance_scripts
 from internals import core_enums
 from internals.core_models import FeatureEntry, Stage, MilestoneSet
 from internals.review_models import Gate, Vote
+from internals import stage_helpers
 import settings
 
 class EvaluateGateStatusTest(testing_config.CustomTestCase):
@@ -740,52 +741,14 @@ class BackfillShippingYearTest(testing_config.CustomTestCase):
         milestones=MilestoneSet(desktop_first=200))
     self.handler = maintenance_scripts.BackfillShippingYear()
 
-  def test_look_up_year__historic(self):
-    """We can look up the year in which a milestone shippped."""
-    self.assertEqual(2009, self.handler.look_up_year(0))
-    self.assertEqual(2009, self.handler.look_up_year(1))
-    self.assertEqual(2009, self.handler.look_up_year(3))
-    self.assertEqual(2010, self.handler.look_up_year(4))
-    self.assertEqual(2024, self.handler.look_up_year(131))
-    self.assertEqual(2024, self.handler.look_up_year(132))
-
-  def test_look_up_year__chromiumdash(self):
-    """We can retrieve the year in which a milestone will ship."""
-    self.assertEqual(2025, self.handler.look_up_year(140))
-
-  def test_find_earliest_milestone__no_stages(self):
-    """An empty list of stages has no earliest milestone."""
-    actual = self.handler.find_earliest_milestone([])
-    self.assertEqual(None, actual)
-
-  def test_find_earliest_milestone__no_milestones(self):
-    """A stage with no milestones has no earliest milestone."""
-    actual = self.handler.find_earliest_milestone([self.stage_1_1])
-    self.assertEqual(None, actual)
-
-  def test_find_earliest_milestone__single_stage(self):
-    """We find the earliest milestone in a stage."""
-    actual = self.handler.find_earliest_milestone([self.stage_2_1])
-    self.assertEqual(123, actual)
-
-  def test_find_earliest_milestone__multi_stage(self):
-    """We find the earliest milestone in a list of stages."""
-    actual = self.handler.find_earliest_milestone(
-        [self.stage_2_1, self.stage_2_2])
-    self.assertEqual(120, actual)
-
-  @mock.patch.object(
-      maintenance_scripts.BackfillShippingYear,
-      'get_all_shipping_stages_with_milestones')
+  @mock.patch('internals.stage_helpers.get_all_shipping_stages_with_milestones')
   def test_calc_all_shipping_years__empty(self, mock_gasswm: mock.MagicMock):
     """An empty list of stages has no shipping years."""
     mock_gasswm.return_value = []
     actual = self.handler.calc_all_shipping_years()
     self.assertEqual({}, actual)
 
-  @mock.patch.object(
-      maintenance_scripts.BackfillShippingYear,
-      'get_all_shipping_stages_with_milestones')
+  @mock.patch('internals.stage_helpers.get_all_shipping_stages_with_milestones')
   def test_calc_all_shipping_years__some(self, mock_gasswm: mock.MagicMock):
     """We can calculate a dict of earliest milestones for a set of stages."""
     mock_gasswm.return_value = [


### PR DESCRIPTION
Once a feature owner fills in some shipping milestones, the feature's shipping_year should be calculated based on those milestones.  This PR adds that calculation to the features_api.

In this PR:
* Refactor `fetch_chrome_release_info()` into fetchchannels.py to avoid a circular import.
* Implement the new logic in features_api.py
    *  `_patch_update_stages()` now returns the list of stages that were updated so that we can check their milestones later.
    * Those updated stages and `changed_fields` are now passed into `_patch_update_special_fields()` so that we can check milestones and add a changed field item if `shipping_year` is set.
* Refactor three functions from maintenance_scripts.py to stage_helpers to avoid having APIs depend on maintenance stuff.