### PR TITLE
Fix population of search box from QS.

### DIFF
--- a/client-src/elements/chromedash-typeahead.ts
+++ b/client-src/elements/chromedash-typeahead.ts
@@ -31,7 +31,7 @@ export class ChromedashTypeahead extends LitElement {
   slDropdownRef: Ref<SlDropdown> = createRef();
   slInputRef: Ref<SlInput> = createRef();
 
-  @state()
+  @property()
   value = '';
   @state()
   candidates: Candidate[] = [];


### PR DESCRIPTION
This fixes the case where the user visits a URL that has a `?q=something` query-string parameter by making that `something` appear in the search box.  It was being passed in from the parent element, but that was not having any effect because the query property was defined using `@state` instead of `@property`.