### PR TITLE
Only highlight main nav items on exact match.

### DIFF
--- a/client-src/elements/chromedash-drawer.ts
+++ b/client-src/elements/chromedash-drawer.ts
@@ -231,7 +231,7 @@ export class ChromedashDrawer extends LitElement {
   }
 
   isCurrentPage(href) {
-    return this.currentPage.startsWith(href);
+    return this.currentPage === href;
   }
 
   toggleDrawerActions() {


### PR DESCRIPTION
This avoids the possibility of both "All features" and "Shipping 2024" main menu items both being highlighted at the same time.  It also means that the "All features" item will not be highlighted if the user specifies a search term, but that is arguably correct since they are no longer looking at *all* features.