### PR TITLE
Change request contents for OT creation

### DIFF
--- a/framework/origin_trials_client_test.py
+++ b/framework/origin_trials_client_test.py
@@ -289,5 +289,5 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
       f'{settings.OT_API_URL}/v1/trials/-1234567890:start',
       headers={'Authorization': 'Bearer access_token'},
       params={'key': 'api_key_value'},
-      json={'id': '-1234567890'}
+      json={'trial_id': '-1234567890'}
     )

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -654,7 +654,7 @@ class OTActivatedHandler(basehandlers.FlaskHandler):
     self.require_task_header()
     stage = self.get_param('stage', required=True)
     contacts = stage['ot_emails'] or []
-    contacts.append('ot_owner_email')
+    contacts.append(stage['ot_owner_email'])
     send_emails([self.build_email(stage, contacts)])
     return {'message': 'OK'}
 
@@ -685,7 +685,7 @@ class OTCreationProcessedHandler(basehandlers.FlaskHandler):
     self.require_task_header()
     stage = self.get_param('stage', required=True)
     contacts = stage['ot_emails'] or []
-    contacts.append('ot_owner_email')
+    contacts.append(stage['ot_owner_email'])
     send_emails([self.build_email(stage, contacts)])
     return {'message': 'OK'}
 


### PR DESCRIPTION
This PR updates some API request contents for automated origin trial creation that were either wrong or have recently changed.

- `trial_contacts` is not longer a request parameter for InitializeTrial.
- `id` has been changed to `trial_id` in the ActivateTrial request.
- SetUpTrial now has an explicit 60 second timeout duration to match the OT API timeout constraints.

Additionally, some small fixes are now in place:
- InitializeTrial will not be called if, for some reason, an origin trial ID already exists for the trial stage.
- A small error is fixed that was sending the string "ot_owner_email" as an email recipient rather than the actual origin trial owner.