### PR TITLE
Activate the automated OT creation process

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -409,8 +409,7 @@ class EntitiesAPIHandler(APIHandler):
     # Notify of OT creation request if one was sent.
     # This notification is for non-automated OT creation only.
     if (ot_action_requested and
-        stage.stage_type in ALL_ORIGIN_TRIAL_STAGE_TYPES and
-        not settings.AUTOMATED_OT_CREATION):
+        stage.stage_type in ALL_ORIGIN_TRIAL_STAGE_TYPES):
       notifier_helpers.send_ot_creation_notification(stage)
 
     return stage_was_updated

--- a/settings.py
+++ b/settings.py
@@ -39,7 +39,7 @@ DEFAULT_COMPONENT = 'Blink'
 DEFAULT_ENTERPRISE_COMPONENT = 'Enterprise'
 
 # Enable to activate the automated OT creation process
-AUTOMATED_OT_CREATION = False
+AUTOMATED_OT_CREATION = True
 
 
 ################################################################################


### PR DESCRIPTION
Activates the automated OT creation process.

Additionally, a conditional has been removed so that an email will still be sent to OT support notifying us about a new OT creation request, so the team knows when new requests are submitted.