### PR TITLE
Fix milestone accessing bug

### DIFF
--- a/internals/stage_helpers.py
+++ b/internals/stage_helpers.py
@@ -243,6 +243,8 @@ def find_earliest_milestone(stages: list[Stage]) -> int|None:
   """Find the earliest milestone in a list of stages."""
   m_list: list[int] = []
   for stage in stages:
+    if stage.milestones is None:
+      continue
     m_list.append(stage.milestones.desktop_first)
     m_list.append(stage.milestones.android_first)
     m_list.append(stage.milestones.ios_first)

--- a/internals/stage_helpers_test.py
+++ b/internals/stage_helpers_test.py
@@ -94,6 +94,7 @@ class StageHelpers_Milestones_Test(testing_config.CustomTestCase):
     self.stage_2_2 = Stage(
         feature_id=22222,
         milestones=MilestoneSet(desktop_first=121, android_first=120))
+    self.stage_2_3 = Stage(feature_id=22222)
 
   def tearDown(self):
     for stage in Stage.query().fetch():
@@ -130,5 +131,5 @@ class StageHelpers_Milestones_Test(testing_config.CustomTestCase):
   def test_find_earliest_milestone__multi_stage(self):
     """We find the earliest milestone in a list of stages."""
     actual = stage_helpers.find_earliest_milestone(
-        [self.stage_2_1, self.stage_2_2])
+        [self.stage_2_1, self.stage_2_2, self.stage_2_3])
     self.assertEqual(120, actual)


### PR DESCRIPTION
This change fixes a small bug caused by attempting to access a stage's MilestoneSet object without checking if the `milestones` attribute is null.