### PR TITLE
Show a link for shipping next year after Sept 1.

### DIFF
--- a/client-src/elements/chromedash-drawer.ts
+++ b/client-src/elements/chromedash-drawer.ts
@@ -261,11 +261,21 @@ export class ChromedashDrawer extends LitElement {
     const myFeaturesMenu = this.renderMyFeaturesMenu();
     const adminMenu = this.renderAdminMenu();
 
-    const year = new Date().getFullYear();
+    const now = new Date();
+    const year = now.getFullYear();
     const shippingThisYear = this.renderNavItem(
       '/features?q=shipping_year=' + year,
       'Shipping ' + year
     );
+    const nextYear = year + 1;
+    let shippingNextYear = this.renderNavItem(
+      '/features?q=shipping_year=' + nextYear,
+      'Shipping ' + nextYear
+    );
+    // Only show next year starting on September 1.
+    if (now.getMonth() < 8) {
+      shippingNextYear = html``;
+    }
 
     return html`
       <sl-drawer
@@ -279,7 +289,7 @@ export class ChromedashDrawer extends LitElement {
       >
         ${accountMenu} ${this.renderNavItem('/roadmap', 'Roadmap')}
         ${this.renderNavItem('/features', 'All features')} ${shippingThisYear}
-        ${myFeaturesMenu}
+        ${shippingNextYear} ${myFeaturesMenu}
         <hr />
         <div class="section-header">Stats</div>
         ${this.renderNavItem('/metrics/css/popularity', 'CSS')}


### PR DESCRIPTION
A chat with Panos, Chris H, and Nandu led to the conclusion that we should show the next year starting each September.  In other words, January through August, it will only show one link for the current year, but in September through the end of December, it will show two links.