### PR TITLE
Use Pillow and the uploaded mime_type.

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -798,6 +798,10 @@ def FlaskApplication(import_name, routes, pattern_base='', debug=False):
   # Flask apps also have a debug setting that can be used to auto-reload
   # template source code. TODO: investigate using the setting.
 
+
+  # Reject any huge POSTs
+  app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024  # 16 MB
+
   # Set the CORS HEADERS.
   CORS(app, resources={r'/data/*': {'origins': '*'}})
 

--- a/internals/attachments_test.py
+++ b/internals/attachments_test.py
@@ -28,25 +28,6 @@ class AttachmentsTests(testing_config.CustomTestCase):
     for attach in attachments.Attachment.query().fetch(None):
       attach.key.delete()
 
-  def test_guess_content_type_from_filename(self):
-    """We can guess mime type based on filename extension."""
-    guess = attachments.guess_content_type_from_filename
-    self.assertEqual(guess('screenshot.gif'), 'image/gif')
-    self.assertEqual(guess('screenshot.jpg'), 'image/jpeg')
-    self.assertEqual(guess('screenshot.jpeg'), 'image/jpeg')
-    self.assertEqual(guess('screenshot.png'), 'image/png')
-    self.assertEqual(guess('screenshot.webp'), 'image/webp')
-
-    self.assertEqual(guess('screen.shot.webp'), 'image/webp')
-    self.assertEqual(guess('.webp'), 'image/webp')
-    self.assertEqual(guess('screen shot.webp'), 'image/webp')
-
-    self.assertEqual(guess('screenshot.pdf'), 'application/octet-stream')
-    self.assertEqual(guess('screenshot gif'), 'application/octet-stream')
-    self.assertEqual(guess('screenshotgif'), 'application/octet-stream')
-    self.assertEqual(guess('gif'), 'application/octet-stream')
-    self.assertEqual(guess(''), 'application/octet-stream')
-
   def test_store_attachment(self):
     """We can store attachment content."""
     actual = attachments.store_attachment(

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ validators==0.20.0
 # Work-around for failure to deploy
 # https://stackoverflow.com/questions/69936420/google-cloud-platform-app-deploy-failure-due-to-pyparsing
 pyparsing==2.4.7
-
+pillow==11.0.0
 # OpenAPI files
 ./gen/py/chromestatus_openapi
 types-python-dateutil==2.9.0.20240821


### PR DESCRIPTION
This is a follow-up to #4473.  In that review, it was suggested to limit the upload size and use the Pillow library.  

In this PR:
* Use Pillow instead of the GAE legacy image library
* Specify a maximum upload size (bigger than the max image size in case we ever combine images with other data)
* Remove the filename-to-mime-type logic and use the mime-type that the browser supplies.  (I think that was not available when the Monorail upload code was first written.)