### PR TITLE
Change chrome://flags to about://flags in help text

### DIFF
--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -1926,7 +1926,7 @@ export const ALL_FIELDS: Record<string, Field> = {
     attrs: TEXT_FIELD_ATTRS,
     required: false,
     label: 'Flag name',
-    help_text: html` Name of the flag on chrome://flags that allows a web
+    help_text: html` Name of the flag on about://flags that allows a web
       developer to enable this feature in their own browser to try it out. E.g.,
       "storage-buckets". These are defined in
       <a


### PR DESCRIPTION
This should resolve #4500.

The URLs for `chrome://flags` and `about://flags` both go to the same place.  According to that issue, we should favor `about://flags` because it is more inclusive of other browsers that use blink. 