### PR TITLE
Implementation UI warnings for outdated shipped feature

### DIFF
--- a/client-src/elements/chromedash-feature-page.ts
+++ b/client-src/elements/chromedash-feature-page.ts
@@ -238,8 +238,10 @@ export class ChromedashFeaturePage extends LitElement {
       return false;
     }
 
+    // If accurate_as_of is missing from a shipped feature, it is likely
+    // an old feature. Treat it as not oudated.
     if (!this.feature.accurate_as_of) {
-      return true;
+      return false;
     }
 
     return (

--- a/client-src/elements/chromedash-feature-page.ts
+++ b/client-src/elements/chromedash-feature-page.ts
@@ -618,7 +618,7 @@ export class ChromedashFeaturePage extends LitElement {
           <div class="warning layout horizontal center">
             <span
               class="tooltip"
-              id="shipped-outdated-icon"
+              id="shipped-outdated-author"
               title="Feature outdated "
             >
               <iron-icon icon="chromestatus:error" data-tooltip></iron-icon>
@@ -644,7 +644,7 @@ export class ChromedashFeaturePage extends LitElement {
           <div class="warning layout horizontal center">
             <span
               class="tooltip"
-              id="shipped-outdated-icon"
+              id="shipped-outdated-all"
               title="Feature outdated "
             >
               <iron-icon icon="chromestatus:error" data-tooltip></iron-icon>

--- a/client-src/elements/chromedash-roadmap-milestone-card.ts
+++ b/client-src/elements/chromedash-roadmap-milestone-card.ts
@@ -4,6 +4,7 @@ import {customElement, property, state} from 'lit/decorators.js';
 import {createRef, ref} from 'lit/directives/ref.js';
 import {ROADMAP_MILESTONE_CARD_CSS} from '../css/elements/chromedash-roadmap-milestone-card-css.js';
 import {Channels, ReleaseInfo} from '../js-src/cs-client.js';
+import {isVerifiedWithinGracePeriod} from './utils.js';
 
 const REMOVED_STATUS = ['Removed'];
 const DEPRECATED_STATUS = ['Deprecated', 'No longer pursuing'];
@@ -261,17 +262,12 @@ export class ChromedashRoadmapMilestoneCard extends LitElement {
     ) {
       return false;
     }
-    if (!accurateAsOf) {
-      return true;
-    }
-    const accurateDate = Date.parse(accurateAsOf);
-    // 4-week period.
-    const gracePeriod = 4 * 7 * 24 * 60 * 60 * 1000;
-    if (accurateDate + gracePeriod < this.currentDate) {
-      return true;
-    }
 
-    return false;
+    const isVerified = isVerifiedWithinGracePeriod(
+      accurateAsOf,
+      this.currentDate
+    );
+    return !isVerified;
   }
 
   _cardFeatureItemTemplate(f, shippingType) {

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -663,7 +663,7 @@ export function extensionMilestoneIsValid(value, currentMilestone) {
  *
  *  @param accurateAsOf The accurate_as_of date as an ISO string.
  *  @param currentDate The current date in milliseconds.
- *  @param gracePeriod The grace period in milliseconds. Defatuls
+ *  @param gracePeriod The grace period in milliseconds. Defaults
  *                      to ACCURACY_GRACE_PERIOD.
  */
 export function isVerifiedWithinGracePeriod(

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -663,17 +663,20 @@ export function extensionMilestoneIsValid(value, currentMilestone) {
  *
  *  @param accurateAsOf The accurate_as_of date as an ISO string.
  *  @param currentDate The current date in milliseconds.
+ *  @param gracePeriod The grace period in milliseconds. Defatuls
+ *                      to ACCURACY_GRACE_PERIOD.
  */
 export function isVerifiedWithinGracePeriod(
   accurateAsOf: string | undefined,
-  currentDate: number
+  currentDate: number,
+  gracePeriod: number = ACCURACY_GRACE_PERIOD
 ) {
   if (!accurateAsOf) {
     return false;
   }
 
   const accurateDate = Date.parse(accurateAsOf);
-  if (accurateDate + ACCURACY_GRACE_PERIOD < currentDate) {
+  if (accurateDate + gracePeriod < currentDate) {
     return false;
   }
 


### PR DESCRIPTION
A follow-up for #4481. Implement warning banners for outdated shipped features. If a feature is not scheduled to ship in the upcoming two milestones, it will attempt to find the `latest shipping milestone <= latest stable milestone`, as its `closestShippingDate`. If it exists, a feature is considered shipped.

A shipped feature is outdated `if accurate_as_of < closestShippingDate`. If outdated, it will show:
- a warning for feature authors if the viewer is an author, or
- a warning for a regular reader `if accurate_as_of + 9 weeks < current date` ( last updated 2~ months ago)

A feature can only be considered as an upcoming feature or shipped feature, but not both.

For authors:
![Screenshot 2024-10-30 11 54 18 PM](https://github.com/user-attachments/assets/c41ea91d-9c6d-40ee-b54a-6927fb7484e4)

For all readers:
![Screenshot 2024-10-30 11 55 34 PM](https://github.com/user-attachments/assets/6eee074e-baee-4939-9f60-ab8130073f0e)

