### PR TITLE
Fix space issue in outdated feature warnings

### DIFF
--- a/client-src/elements/chromedash-feature-page.ts
+++ b/client-src/elements/chromedash-feature-page.ts
@@ -494,11 +494,11 @@ export class ChromedashFeaturePage extends LitElement {
               <iron-icon icon="chromestatus:error" data-tooltip></iron-icon>
             </span>
             <span>
-              Your feature hasn't been verified as accurate since${' '}
+              Your feature hasn't been verified as accurate since&nbsp;
               <sl-relative-time
                 date=${this.feature.accurate_as_of}
               ></sl-relative-time
-              >, but it is scheduled to ship${' '}
+              >, but it is scheduled to ship&nbsp;
               <sl-relative-time
                 date=${this.closestShippingDate}
               ></sl-relative-time
@@ -516,11 +516,11 @@ export class ChromedashFeaturePage extends LitElement {
               <iron-icon icon="chromestatus:error" data-tooltip></iron-icon>
             </span>
             <span>
-              This feature hasn't been verified as accurate since${' '}
+              This feature hasn't been verified as accurate since&nbsp;
               <sl-relative-time
                 date=${this.feature.accurate_as_of}
               ></sl-relative-time
-              >, but it is scheduled to ship${' '}
+              >, but it is scheduled to ship&nbsp;
               <sl-relative-time
                 date=${this.closestShippingDate}
               ></sl-relative-time


### PR DESCRIPTION
Small fixes on the space. ${' '} didn't render correctly.

![Screenshot 2024-10-30 6 14 00 PM](https://github.com/user-attachments/assets/e4606a97-adbd-4765-a0ba-14ee54217a00)
