### PR TITLE
 Simplify feature accuracy notification email

### DIFF
--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -40,6 +40,7 @@ CHROME_RELEASE_SCHEDULE_URL = (
 WEBSTATUS_EMAIL = 'webstatus@google.com'
 CBE_ESCLATION_EMAIL = 'cbe-releasenotes@google.com'
 STAGING_EMAIL = 'jrobbins-test@googlegroups.com'
+EMAIL_SUBJECT_PREFIX = 'Action requested'
 
 
 def get_current_milestone_info(anchor_channel: str):
@@ -101,7 +102,10 @@ def build_email_tasks(
     html = render_template(body_template_path, **body_data)
     subject = subject_format % fe.name
     if is_escalated:
-      subject = f'ESCALATED: {subject}'
+      if EMAIL_SUBJECT_PREFIX in subject:
+        subject = subject.replace(EMAIL_SUBJECT_PREFIX, "Escalation request")
+      else:
+        subject = f'ESCALATED: {subject}'
     recipients = choose_email_recipients(fe, is_escalated)
     for recipient in recipients:
       email_tasks.append({
@@ -223,7 +227,7 @@ class FeatureAccuracyHandler(AbstractReminderHandler):
   # This grace period needs to be consistent with
   # ACCURACY_GRACE_PERIOD in client-src/elements/utils.ts.
   ACCURACY_GRACE_PERIOD = timedelta(weeks=4)
-  SUBJECT_FORMAT = '[Action requested] Update %s'
+  SUBJECT_FORMAT = EMAIL_SUBJECT_PREFIX + ' - Verify %s'
   EMAIL_TEMPLATE_PATH = 'accuracy_notice_email.html'
   FUTURE_MILESTONES_TO_CONSIDER = 2
   MILESTONE_FIELDS = [
@@ -270,7 +274,7 @@ class FeatureAccuracyHandler(AbstractReminderHandler):
 class PrepublicationHandler(AbstractReminderHandler):
   """Give feature owners a final preview just before publication."""
 
-  SUBJECT_FORMAT = '[Action requested] Review %s'
+  SUBJECT_FORMAT = EMAIL_SUBJECT_PREFIX + ' - Review %s'
   EMAIL_TEMPLATE_PATH = 'prepublication-notice-email.html'
   MILESTONE_FIELDS = [
       'shipped_android_milestone',
@@ -396,7 +400,10 @@ class SLOOverdueHandler(basehandlers.FlaskHandler):
       html = render_template(self.BODY_TEMPLATE_PATH, **body_data)
       subject = self.SUBJECT_FORMAT % fe.name
       if is_escalated:
-        subject = f'ESCALATED: {subject}'
+        if EMAIL_SUBJECT_PREFIX in subject:
+          subject = subject.replace(EMAIL_SUBJECT_PREFIX, "Escalation request")
+        else:
+          subject = f'ESCALATED: {subject}'
       recipients = self.choose_reviewers(gate, is_escalated)
       for recipient in recipients:
         email_tasks.append({

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -103,7 +103,7 @@ def build_email_tasks(
     subject = subject_format % fe.name
     if is_escalated:
       if EMAIL_SUBJECT_PREFIX in subject:
-        subject = subject.replace(EMAIL_SUBJECT_PREFIX, "Escalation request")
+        subject = subject.replace(EMAIL_SUBJECT_PREFIX, 'Escalation request')
       else:
         subject = f'ESCALATED: {subject}'
     recipients = choose_email_recipients(fe, is_escalated)
@@ -401,7 +401,7 @@ class SLOOverdueHandler(basehandlers.FlaskHandler):
       subject = self.SUBJECT_FORMAT % fe.name
       if is_escalated:
         if EMAIL_SUBJECT_PREFIX in subject:
-          subject = subject.replace(EMAIL_SUBJECT_PREFIX, "Escalation request")
+          subject = subject.replace(EMAIL_SUBJECT_PREFIX, 'Escalation request')
         else:
           subject = f'ESCALATED: {subject}'
       recipients = self.choose_reviewers(gate, is_escalated)

--- a/internals/reminders_test.py
+++ b/internals/reminders_test.py
@@ -145,7 +145,7 @@ class FunctionTest(testing_config.CustomTestCase):
       handler = reminders.FeatureAccuracyHandler()
       actual = reminders.build_email_tasks(
           [(self.feature_template, 100)],
-          '[Action requested] Update %s',
+          'Action requested - Verify %s',
           handler.EMAIL_TEMPLATE_PATH,
           self.current_milestone_info,
           handler.should_escalate_notification)
@@ -153,7 +153,7 @@ class FunctionTest(testing_config.CustomTestCase):
     self.assertEqual(1, len(actual))
     task = actual[0]
     self.assertEqual('feature_owner@example.com', task['to'])
-    self.assertEqual('[Action requested] Update feature one', task['subject'])
+    self.assertEqual('Action requested - Verify feature one', task['subject'])
     self.assertEqual(None, task['reply_to'])
     # TESTDATA.make_golden(task['html'], 'test_build_email_tasks_feature_accuracy.html')
     self.assertMultiLineEqual(
@@ -164,7 +164,7 @@ class FunctionTest(testing_config.CustomTestCase):
       handler = reminders.FeatureAccuracyHandler()
       actual = reminders.build_email_tasks(
           [(self.feature_template, 110)],
-          '[Action requested] Update %s',
+          'Action requested - Verify %s',
           handler.EMAIL_TEMPLATE_PATH,
           self.current_milestone_info,
           handler.should_escalate_notification)
@@ -172,7 +172,7 @@ class FunctionTest(testing_config.CustomTestCase):
     self.assertEqual(1, len(actual))
     task = actual[0]
     self.assertEqual('feature_owner@example.com', task['to'])
-    self.assertEqual('[Action requested] Update feature one', task['subject'])
+    self.assertEqual('Action requested - Verify feature one', task['subject'])
     self.assertEqual(None, task['reply_to'])
     # TESTDATA.make_golden(task['html'], 'test_build_email_tasks_feature_accuracy_enterprise.html')
     self.assertMultiLineEqual(
@@ -187,7 +187,7 @@ class FunctionTest(testing_config.CustomTestCase):
       handler = reminders.FeatureAccuracyHandler()
       actual = reminders.build_email_tasks(
           [(self.feature_template, 100)],
-          '[Action requested] Update %s',
+          'Action requested - Verify %s',
           handler.EMAIL_TEMPLATE_PATH,
           self.current_milestone_info,
           handler.should_escalate_notification)
@@ -195,7 +195,7 @@ class FunctionTest(testing_config.CustomTestCase):
     self.assertEqual(5, len(actual))
     task = actual[0]
     self.assertEqual(
-        'ESCALATED: [Action requested] Update feature one', task['subject'])
+        'Escalation request - Verify feature one', task['subject'])
     self.assertEqual(None, task['reply_to'])
     # TESTDATA.make_golden(task['html'], 'test_build_email_tasks_escalated_feature_accuracy.html')
     self.assertMultiLineEqual(
@@ -205,13 +205,13 @@ class FunctionTest(testing_config.CustomTestCase):
     with test_app.app_context():
       handler = reminders.PrepublicationHandler()
       actual = reminders.build_email_tasks(
-          [(self.feature_template, 100)], '[Action requested] Update %s',
+          [(self.feature_template, 100)], 'Action requested - Verify %s',
           handler.EMAIL_TEMPLATE_PATH,
           self.current_milestone_info, handler.should_escalate_notification)
     self.assertEqual(1, len(actual))
     task = actual[0]
     self.assertEqual('feature_owner@example.com', task['to'])
-    self.assertEqual('[Action requested] Update feature one', task['subject'])
+    self.assertEqual('Action requested - Verify feature one', task['subject'])
     self.assertEqual(None, task['reply_to'])
     # TESTDATA.make_golden(task['html'], 'test_build_email_tasks_prepublication.html')
     self.assertMultiLineEqual(

--- a/internals/testdata/reminders_test/test_build_email_tasks_escalated_feature_accuracy.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_escalated_feature_accuracy.html
@@ -6,42 +6,20 @@
 <section id="context" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <table>
     <tr>
-      <td rowspan=2>
-  
-<div style="border: 4px solid #d32f2f; border-radius: 50%; width: 32px; height: 32px; margin-right: 8px;">
-  </div>
-
-</td>
-      <td><b>Your update is needed</b> on feature entry:</td>
+      <td>Your feature is slated to launch soon for M100. <b>Please verify the accuracy of </b><a
+          href="http://127.0.0.1:7777/feature/123">feature one</a>:</td>
     </tr>
     <tr>
-      <td><a style="font-size: 140%;"
-             href="http://127.0.0.1:7777/feature/123"
-             >feature one</a>
+      <td>
+        <div style="margin: 16px;">
+          <a href="http://127.0.0.1:7777/guide/verify_accuracy/123" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; ">Verify feature accuracy</a>
+        </div>
       </td>
     </tr>
   </table>
 </section>
 
-
-<section id="why-triggered" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
-  
-  <p>
-    In order to ensure feature data accuracy, this notification has been
-    escalated to extended contributors of this feature and to the WebStatus team.
-  </p>
-  
-
-  <p>
-    You are receiving this notification because you are listed as
-    a contributor
-     of the ChromeStatus feature entry.
-  </p>
-</section>
-
-
 <section id="details" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
-  <p>Your feature is slated to launch soon for m100:</p>
   <p>
     
 
@@ -78,23 +56,24 @@
   <p>
     Your feature entry is an important resource for
     cross functional teams that help drive adoption of new features and
-    enterprise IT admins who might be affected by web platform changes.
-  </p>
-
-  <p>
-    We need to know whether your plans are changing or staying
-    the same. <strong>Please click the link below to update and confirm key
-    fields of your feature entry.</strong>
+    enterprise IT admins who might be affected by web platform changes. We need
+    to know whether your plans are changing or staying the same.
   </p>
 </section>
 
+<section id="why-triggered" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
+  
+  <p>
+    In order to ensure feature data accuracy, this notification has been
+    escalated to extended contributors of this feature and to the WebStatus team.
+  </p>
+  
 
-<section id="next-steps" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
-  <div><b>Your next steps:</b></div>
-
-  <div style="margin: 16px;">
-    <a href="http://127.0.0.1:7777/guide/verify_accuracy/123" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; "
-     >Verify feature accuracy</a></div>
+  <p>
+    You are receiving this notification because you are listed as
+    a contributor
+     of the ChromeStatus feature entry.
+  </p>
 </section>
 
 </div>

--- a/internals/testdata/reminders_test/test_build_email_tasks_escalated_feature_accuracy.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_escalated_feature_accuracy.html
@@ -56,9 +56,8 @@
   <p>
     Your feature entry is an important resource for
     cross functional teams that help drive adoption of new features and
-    enterprise IT admins who might be affected by web platform changes. The Blink
-    launch process needs to have a record of whether your plans are changing
-    or staying the same.
+    enterprise IT admins who might be affected by web platform changes. We
+    need to have a record of whether your plans are changing or staying the same.
   </p>
 </section>
 

--- a/internals/testdata/reminders_test/test_build_email_tasks_escalated_feature_accuracy.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_escalated_feature_accuracy.html
@@ -56,8 +56,9 @@
   <p>
     Your feature entry is an important resource for
     cross functional teams that help drive adoption of new features and
-    enterprise IT admins who might be affected by web platform changes. We need
-    to know whether your plans are changing or staying the same.
+    enterprise IT admins who might be affected by web platform changes. The Blink
+    launch process needs to have a record of whether your plans are changing
+    or staying the same.
   </p>
 </section>
 
@@ -65,7 +66,7 @@
   
   <p>
     In order to ensure feature data accuracy, this notification has been
-    escalated to extended contributors of this feature and to the WebStatus team.
+    escalated to extended contributors of this feature and to the Chromestatus team.
   </p>
   
 

--- a/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy.html
@@ -6,37 +6,20 @@
 <section id="context" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <table>
     <tr>
-      <td rowspan=2>
-  
-<div style="border: 4px solid #d32f2f; border-radius: 50%; width: 32px; height: 32px; margin-right: 8px;">
-  </div>
-
-</td>
-      <td><b>Your update is needed</b> on feature entry:</td>
+      <td>Your feature is slated to launch soon for M100. <b>Please verify the accuracy of </b><a
+          href="http://127.0.0.1:7777/feature/123">feature one</a>:</td>
     </tr>
     <tr>
-      <td><a style="font-size: 140%;"
-             href="http://127.0.0.1:7777/feature/123"
-             >feature one</a>
+      <td>
+        <div style="margin: 16px;">
+          <a href="http://127.0.0.1:7777/guide/verify_accuracy/123" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; ">Verify feature accuracy</a>
+        </div>
       </td>
     </tr>
   </table>
 </section>
 
-
-<section id="why-triggered" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
-  
-
-  <p>
-    You are receiving this notification because you are listed as
-    an owner
-     of the ChromeStatus feature entry.
-  </p>
-</section>
-
-
 <section id="details" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
-  <p>Your feature is slated to launch soon for m100:</p>
   <p>
     
 
@@ -73,23 +56,19 @@
   <p>
     Your feature entry is an important resource for
     cross functional teams that help drive adoption of new features and
-    enterprise IT admins who might be affected by web platform changes.
-  </p>
-
-  <p>
-    We need to know whether your plans are changing or staying
-    the same. <strong>Please click the link below to update and confirm key
-    fields of your feature entry.</strong>
+    enterprise IT admins who might be affected by web platform changes. We need
+    to know whether your plans are changing or staying the same.
   </p>
 </section>
 
+<section id="why-triggered" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
+  
 
-<section id="next-steps" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
-  <div><b>Your next steps:</b></div>
-
-  <div style="margin: 16px;">
-    <a href="http://127.0.0.1:7777/guide/verify_accuracy/123" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; "
-     >Verify feature accuracy</a></div>
+  <p>
+    You are receiving this notification because you are listed as
+    an owner
+     of the ChromeStatus feature entry.
+  </p>
 </section>
 
 </div>

--- a/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy.html
@@ -56,9 +56,8 @@
   <p>
     Your feature entry is an important resource for
     cross functional teams that help drive adoption of new features and
-    enterprise IT admins who might be affected by web platform changes. The Blink
-    launch process needs to have a record of whether your plans are changing
-    or staying the same.
+    enterprise IT admins who might be affected by web platform changes. We
+    need to have a record of whether your plans are changing or staying the same.
   </p>
 </section>
 

--- a/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy.html
@@ -56,8 +56,9 @@
   <p>
     Your feature entry is an important resource for
     cross functional teams that help drive adoption of new features and
-    enterprise IT admins who might be affected by web platform changes. We need
-    to know whether your plans are changing or staying the same.
+    enterprise IT admins who might be affected by web platform changes. The Blink
+    launch process needs to have a record of whether your plans are changing
+    or staying the same.
   </p>
 </section>
 

--- a/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy_enterprise.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy_enterprise.html
@@ -56,9 +56,8 @@
   <p>
     Your feature entry is an important resource for
     cross functional teams that help drive adoption of new features and
-    enterprise IT admins who might be affected by web platform changes. The Blink
-    launch process needs to have a record of whether your plans are changing
-    or staying the same.
+    enterprise IT admins who might be affected by web platform changes. We
+    need to have a record of whether your plans are changing or staying the same.
   </p>
 </section>
 

--- a/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy_enterprise.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy_enterprise.html
@@ -56,8 +56,9 @@
   <p>
     Your feature entry is an important resource for
     cross functional teams that help drive adoption of new features and
-    enterprise IT admins who might be affected by web platform changes. We need
-    to know whether your plans are changing or staying the same.
+    enterprise IT admins who might be affected by web platform changes. The Blink
+    launch process needs to have a record of whether your plans are changing
+    or staying the same.
   </p>
 </section>
 

--- a/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy_enterprise.html
+++ b/internals/testdata/reminders_test/test_build_email_tasks_feature_accuracy_enterprise.html
@@ -6,37 +6,20 @@
 <section id="context" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <table>
     <tr>
-      <td rowspan=2>
-  
-<div style="border: 4px solid #d32f2f; border-radius: 50%; width: 32px; height: 32px; margin-right: 8px;">
-  </div>
-
-</td>
-      <td><b>Your update is needed</b> on feature entry:</td>
+      <td>Your feature is slated to launch soon for M110. <b>Please verify the accuracy of </b><a
+          href="http://127.0.0.1:7777/feature/123">feature one</a>:</td>
     </tr>
     <tr>
-      <td><a style="font-size: 140%;"
-             href="http://127.0.0.1:7777/feature/123"
-             >feature one</a>
+      <td>
+        <div style="margin: 16px;">
+          <a href="http://127.0.0.1:7777/guide/verify_accuracy/123" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; ">Verify feature accuracy</a>
+        </div>
       </td>
     </tr>
   </table>
 </section>
 
-
-<section id="why-triggered" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
-  
-
-  <p>
-    You are receiving this notification because you are listed as
-    an owner
-     of the ChromeStatus feature entry.
-  </p>
-</section>
-
-
 <section id="details" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
-  <p>Your feature is slated to launch soon for m110:</p>
   <p>
     
 
@@ -73,23 +56,19 @@
   <p>
     Your feature entry is an important resource for
     cross functional teams that help drive adoption of new features and
-    enterprise IT admins who might be affected by web platform changes.
-  </p>
-
-  <p>
-    We need to know whether your plans are changing or staying
-    the same. <strong>Please click the link below to update and confirm key
-    fields of your feature entry.</strong>
+    enterprise IT admins who might be affected by web platform changes. We need
+    to know whether your plans are changing or staying the same.
   </p>
 </section>
 
+<section id="why-triggered" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
+  
 
-<section id="next-steps" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
-  <div><b>Your next steps:</b></div>
-
-  <div style="margin: 16px;">
-    <a href="http://127.0.0.1:7777/guide/verify_accuracy/123" style="text-decoration: none; font-weight: bold; color: white; background: #01579b; border-radius: 8px; padding: 8px 16px; "
-     >Verify feature accuracy</a></div>
+  <p>
+    You are receiving this notification because you are listed as
+    an owner
+     of the ChromeStatus feature entry.
+  </p>
 </section>
 
 </div>

--- a/templates/accuracy_notice_email.html
+++ b/templates/accuracy_notice_email.html
@@ -26,9 +26,8 @@
   <p>
     Your feature entry is an important resource for
     cross functional teams that help drive adoption of new features and
-    enterprise IT admins who might be affected by web platform changes. The Blink
-    launch process needs to have a record of whether your plans are changing
-    or staying the same.
+    enterprise IT admins who might be affected by web platform changes. We
+    need to have a record of whether your plans are changing or staying the same.
   </p>
 </section>
 

--- a/templates/accuracy_notice_email.html
+++ b/templates/accuracy_notice_email.html
@@ -6,18 +6,30 @@
 <section id="context" style="{{styles.section}}">
   <table>
     <tr>
-      <td rowspan=2>{{styles.icon_alert()}}</td>
-      <td><b>Your update is needed</b> on feature entry:</td>
+      <td>Your feature is slated to launch soon for M{{milestone}}. <b>Please verify the accuracy of </b><a
+          href="{{SITE_URL}}feature/{{id}}">{{feature.name}}</a>:</td>
     </tr>
     <tr>
-      <td><a style="{{styles.feature_name}}"
-             href="{{SITE_URL}}feature/{{id}}"
-             >{{feature.name}}</a>
+      <td>
+        <div style="{{styles.button_div}}">
+          <a href="{{SITE_URL}}guide/verify_accuracy/{{id}}" style="{{styles.button_a}}">Verify feature accuracy</a>
+        </div>
       </td>
     </tr>
   </table>
 </section>
 
+<section id="details" style="{{styles.section}}">
+  <p>
+    {% include "estimated-milestones-table.html" %}
+  </p>
+  <p>
+    Your feature entry is an important resource for
+    cross functional teams that help drive adoption of new features and
+    enterprise IT admins who might be affected by web platform changes. We need
+    to know whether your plans are changing or staying the same.
+  </p>
+</section>
 
 <section id="why-triggered" style="{{styles.section}}">
   {% if is_escalated %}
@@ -32,34 +44,6 @@
     a{% if not is_escalated %}n owner{% endif %}{% if is_escalated %} contributor{% endif %}
      of the ChromeStatus feature entry.
   </p>
-</section>
-
-
-<section id="details" style="{{styles.section}}">
-  <p>Your feature is slated to launch soon for m{{milestone}}:</p>
-  <p>
-    {% include "estimated-milestones-table.html" %}
-  </p>
-  <p>
-    Your feature entry is an important resource for
-    cross functional teams that help drive adoption of new features and
-    enterprise IT admins who might be affected by web platform changes.
-  </p>
-
-  <p>
-    We need to know whether your plans are changing or staying
-    the same. <strong>Please click the link below to update and confirm key
-    fields of your feature entry.</strong>
-  </p>
-</section>
-
-
-<section id="next-steps" style="{{styles.section}}">
-  <div><b>Your next steps:</b></div>
-
-  <div style="{{styles.button_div}}">
-    <a href="{{SITE_URL}}guide/verify_accuracy/{{id}}" style="{{styles.button_a}}"
-     >Verify feature accuracy</a></div>
 </section>
 
 </div>

--- a/templates/accuracy_notice_email.html
+++ b/templates/accuracy_notice_email.html
@@ -26,8 +26,9 @@
   <p>
     Your feature entry is an important resource for
     cross functional teams that help drive adoption of new features and
-    enterprise IT admins who might be affected by web platform changes. We need
-    to know whether your plans are changing or staying the same.
+    enterprise IT admins who might be affected by web platform changes. The Blink
+    launch process needs to have a record of whether your plans are changing
+    or staying the same.
   </p>
 </section>
 
@@ -35,7 +36,7 @@
   {% if is_escalated %}
   <p>
     In order to ensure feature data accuracy, this notification has been
-    escalated to extended contributors of this feature and to the WebStatus team.
+    escalated to extended contributors of this feature and to the Chromestatus team.
   </p>
   {% endif %}
 


### PR DESCRIPTION
I have a few ideas in https://github.com/GoogleChrome/chromium-dashboard/issues/4355#issuecomment-2450979970. Overall, the idea is to simplify the sentences and reduce the overhead of reading it. Instead highlight the actions on top.

Remove use of extra []s and change wording in email subjects:
- From `[webstatus] [Action requested] Update Saved queries in sharedStorage.selectURL`  to  `[webstatus] Action requested - Verify Saved queries in sharedStorage.selectURL` 
- When escalation, from `[webstatus] ESCALATED: [Action requested] Update Saved queries in sharedStorage.selectURL
`  to  `[webstatus] Escalation request - Verify Saved queries in sharedStorage.selectURL` 

Rearrange the email body:
- Move `Verify feature accuracy`  button to the top
- Merge four sections into three 
- Highlight the feature is launched soon in the first sentence

Regular accuracy notification (Note that the email subject in prod will start with [webstatus]):
![Screenshot 2024-11-01 7 44 06 PM](https://github.com/user-attachments/assets/ed234636-425f-4086-b34c-9d5afe38fb0e)

Escalation email:
![Screenshot 2024-11-01 7 46 01 PM](https://github.com/user-attachments/assets/f12352b6-352c-42e4-8e42-30ad25c86c90)


Before this change:
![Screenshot 2024-11-01 7 48 32 PM](https://github.com/user-attachments/assets/72ed8ac2-5ec3-467d-83a0-5ad4b98c053a)


### Other ideas
On top of it, wdyt if I grey the section under `id=why-triggered`? Normally the explanation for "why I receive this email" is always greyed in the email

![Screenshot 2024-10-31 4 59 48 PM](https://github.com/user-attachments/assets/176123bf-4e3a-4e7a-b914-df29d6cdd77a)

