### PR TITLE
Treat intent threads as new based on gate.status.

### DIFF
--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -169,10 +169,9 @@ def is_lgtm_allowed(from_addr, feature, gate_info):
   return allowed
 
 
-def detect_new_thread(gate_id: int) -> bool:
-  """Return True if there are no previous approval values for this gate."""
-  existing_votes = Vote.get_votes(gate_id=gate_id)
-  return not existing_votes
+def detect_new_thread(gate: Gate) -> bool:
+  """Treat the thread as new if the associated Gate is still PREPARING."""
+  return gate.state == Gate.PREPARING
 
 
 def remove_markdown(body):
@@ -239,7 +238,7 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
 
     self.set_intent_thread_url(stage, thread_url, subject)
     gate_id = gate.key.integer_id()  # In case it was found by gate_type.
-    is_new_thread = detect_new_thread(gate_id)
+    is_new_thread = detect_new_thread(gate)
     self.create_approvals(
         feature, stage, gate, gate_info, from_addr, body, is_new_thread)
     self.record_slo(feature, gate_info, from_addr, is_new_thread)


### PR DESCRIPTION
This should resolve a problem that Panos brought up in chat today.  

When the review functionality was first designed, there was no `gate.state` variable, instead the state of the gate was always derived from the set of votes on that gate.  So, in detect_intent, an incoming email message is considered to be the start of an intent thread if there were no votes on its gate.  The problem with that is that a reviewer can manually vote REVIEW_STARTED or a vote of NO_RESPONSE can be entered for an assigned reviewer.  So, the list of votes might not be empty even before the intent thread starts.

Now that we have `gate.state` and it has been backfilled for all existing gates, we can use that to make a better decision about when an incoming email message is actually the start of an intent thread.  If the gate is in the initial PREPARING state, regardless of Votes, then we treat the thread as new, and so the gate becomes REVIEW_REQUESTED.  If the gate was anything else, we treat the message as an ongoing discussion, which basically means that we leave the gate state as-is.