### PR TITLE
Add webstatus group contacts for escalated feature accuracy emails

### DIFF
--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -57,25 +57,27 @@ def get_current_milestone_info(anchor_channel: str):
 def choose_email_recipients(
     feature: FeatureEntry, is_escalated: bool, is_accuracy_email: bool) -> list[str]:
   """Choose which recipients will receive the email notification."""
+  ws_group_emails = []
+  if is_escalated:
+    if settings.PROD:
+      ws_group_emails = [WEBSTATUS_EMAIL, CBE_ESCLATION_EMAIL]
+    else:
+      ws_group_emails = [STAGING_EMAIL]
 
   # Only feature owners are notified for accuracy or non-escalated notification emails, if not bounced.
   if is_accuracy_email or not is_escalated:
     user_prefs = UserPref.get_prefs_for_emails(feature.owner_emails)
-    receivers = list(set([up.email for up in user_prefs
-                  if not up.bounced]))
+    receivers = list(set([up.email for up in user_prefs if not up.bounced]))
     if receivers:
-      return receivers
+      return receivers + ws_group_emails
 
   # Escalated notification. Add extended recipients.
-  ws_group_emails = [STAGING_EMAIL]
-  if settings.PROD:
-    ws_group_emails = [WEBSTATUS_EMAIL, CBE_ESCLATION_EMAIL]
   all_notified_users = set(ws_group_emails)
   all_notified_users.add(feature.creator_email)
   all_notified_users.update(feature.owner_emails)
   all_notified_users.update(feature.editor_emails)
   all_notified_users.update(feature.spec_mentor_emails or [])
-  return list(all_notified_users)
+  return list(all_notified_users) + ws_group_emails
 
 
 def build_email_tasks(

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -58,11 +58,10 @@ def choose_email_recipients(
     feature: FeatureEntry, is_escalated: bool, is_accuracy_email: bool) -> list[str]:
   """Choose which recipients will receive the email notification."""
   ws_group_emails = []
-  if is_escalated:
-    if settings.PROD:
-      ws_group_emails = [WEBSTATUS_EMAIL, CBE_ESCLATION_EMAIL]
-    else:
-      ws_group_emails = [STAGING_EMAIL]
+  if settings.PROD:
+    ws_group_emails = [WEBSTATUS_EMAIL, CBE_ESCLATION_EMAIL]
+  else:
+    ws_group_emails = [STAGING_EMAIL]
 
   # Only feature owners are notified for accuracy or non-escalated notification emails, if not bounced.
   if is_accuracy_email or not is_escalated:

--- a/internals/reminders_test.py
+++ b/internals/reminders_test.py
@@ -136,8 +136,10 @@ class FunctionTest(testing_config.CustomTestCase):
     """Normal reminders go to feature owners."""
     actual = reminders.choose_email_recipients(
         self.feature_template, False, False)
-    expected = ['feature_owner@example.com',
-                ]
+    expected = [
+      'feature_owner@example.com',
+      'jrobbins-test@googlegroups.com',
+    ]
     self.assertEqual(set(actual), set(expected))
 
   def test_choose_email_recipients__owners_bounced(self):
@@ -148,11 +150,13 @@ class FunctionTest(testing_config.CustomTestCase):
 
     actual = reminders.choose_email_recipients(
         self.feature_template, False, False)
-    expected = ['creator@example.com',
-                'feature_editor@example.com',
-                'feature_owner@example.com',
-                'mentor@example.com',
-                ]
+    expected = [
+      'creator@example.com',
+      'feature_editor@example.com',
+      'feature_owner@example.com',
+      'mentor@example.com',
+      'jrobbins-test@googlegroups.com',
+    ]
     self.assertEqual(set(actual), set(expected))
 
   @mock.patch('settings.PROD', True)
@@ -173,8 +177,7 @@ class FunctionTest(testing_config.CustomTestCase):
     """Normal accuracy emails go to feature owners."""
     actual = reminders.choose_email_recipients(
         self.feature_template, False, True)
-    expected = ['feature_owner@example.com',
-                ]
+    expected = ['feature_owner@example.com', 'jrobbins-test@googlegroups.com']
     self.assertEqual(set(actual), set(expected))
 
   def test_choose_email_recipients__normal_accuracy_email_when_owners_bounced(self):
@@ -189,6 +192,7 @@ class FunctionTest(testing_config.CustomTestCase):
                 'feature_editor@example.com',
                 'feature_owner@example.com',
                 'mentor@example.com',
+                'jrobbins-test@googlegroups.com',
                 ]
     self.assertEqual(set(actual), set(expected))
 
@@ -216,7 +220,7 @@ class FunctionTest(testing_config.CustomTestCase):
         handler.is_accuracy_email,
       )
 
-    self.assertEqual(1, len(actual))
+    self.assertEqual(2, len(actual))
     task = actual[0]
     self.assertEqual('feature_owner@example.com', task['to'])
     self.assertEqual('Action requested - Verify feature one', task['subject'])
@@ -237,7 +241,7 @@ class FunctionTest(testing_config.CustomTestCase):
         handler.is_accuracy_email,
       )
 
-    self.assertEqual(1, len(actual))
+    self.assertEqual(2, len(actual))
     task = actual[0]
     self.assertEqual('feature_owner@example.com', task['to'])
     self.assertEqual('Action requested - Verify feature one', task['subject'])
@@ -282,7 +286,7 @@ class FunctionTest(testing_config.CustomTestCase):
         handler.should_escalate_notification,
         handler.is_accuracy_email,
       )
-    self.assertEqual(1, len(actual))
+    self.assertEqual(2, len(actual))
     task = actual[0]
     self.assertEqual('feature_owner@example.com', task['to'])
     self.assertEqual('Action requested - Verify feature one', task['subject'])
@@ -333,9 +337,10 @@ class FeatureAccuracyHandlerTest(testing_config.CustomTestCase):
     mock_get.return_value = mock_return
     with test_app.app_context():
       result = self.handler.get_template_data()
-    expected_message = ('1 email(s) sent or logged.\n'
+    expected_message = ('2 email(s) sent or logged.\n'
                         'Recipients:\n'
-                        'feature_owner@example.com')
+                        'feature_owner@example.com\n'
+                        'jrobbins-test@googlegroups.com')
     expected = {'message': expected_message}
     self.assertEqual(result, expected)
 
@@ -347,8 +352,9 @@ class FeatureAccuracyHandlerTest(testing_config.CustomTestCase):
     mock_get.return_value = mock_return
     with test_app.app_context():
       result = self.handler.get_template_data()
-    expected_message = ('2 email(s) sent or logged.\n'
+    expected_message = ('3 email(s) sent or logged.\n'
                         'Recipients:\n'
+                        'jrobbins-test@googlegroups.com\n'
                         'owner_1@example.com\n'
                         'owner_2@example.com')
     expected = {'message': expected_message}
@@ -390,8 +396,9 @@ class FeatureAccuracyHandlerTest(testing_config.CustomTestCase):
     mock_get.return_value = mock_return
     with test_app.app_context():
       result = self.handler.get_template_data()
-    expected_message = ('2 email(s) sent or logged.\n'
+    expected_message = ('3 email(s) sent or logged.\n'
                         'Recipients:\n'
+                        'jrobbins-test@googlegroups.com\n'
                         'owner_1@example.com\n'
                         'owner_2@example.com')
     expected = {'message': expected_message}

--- a/internals/reminders_test.py
+++ b/internals/reminders_test.py
@@ -152,7 +152,6 @@ class FunctionTest(testing_config.CustomTestCase):
                 'feature_editor@example.com',
                 'feature_owner@example.com',
                 'mentor@example.com',
-                'jrobbins-test@googlegroups.com',
                 ]
     self.assertEqual(set(actual), set(expected))
 
@@ -190,7 +189,6 @@ class FunctionTest(testing_config.CustomTestCase):
                 'feature_editor@example.com',
                 'feature_owner@example.com',
                 'mentor@example.com',
-                'jrobbins-test@googlegroups.com',
                 ]
     self.assertEqual(set(actual), set(expected))
 
@@ -199,8 +197,11 @@ class FunctionTest(testing_config.CustomTestCase):
     """Escalated accuracy emails go to feature owners."""
     actual = reminders.choose_email_recipients(
         self.feature_template, True, True)
-    expected = ['feature_owner@example.com',
-                ]
+    expected = [
+      'feature_owner@example.com',
+      'cbe-releasenotes@google.com',
+      'webstatus@google.com',
+    ]
     self.assertEqual(set(actual), set(expected))
 
   def test_build_email_tasks_feature_accuracy(self):
@@ -261,7 +262,7 @@ class FunctionTest(testing_config.CustomTestCase):
         handler.is_accuracy_email,
       )
 
-    self.assertEqual(1, len(actual))
+    self.assertEqual(2, len(actual))
     task = actual[0]
     self.assertEqual(
         'Escalation request - Verify feature one', task['subject'])
@@ -365,8 +366,9 @@ class FeatureAccuracyHandlerTest(testing_config.CustomTestCase):
     with test_app.app_context():
       result = self.handler.get_template_data()
     # More email tasks should be created to notify extended contributors.
-    expected_message = ('2 email(s) sent or logged.\n'
+    expected_message = ('3 email(s) sent or logged.\n'
                         'Recipients:\n'
+                        'jrobbins-test@googlegroups.com\n'
                         'owner_1@example.com\n'
                         'owner_2@example.com')
     expected = {'message': expected_message}


### PR DESCRIPTION
Add webstatus group contacts for escalated feature accuracy emails. It was missing in the recent change, https://github.com/GoogleChrome/chromium-dashboard/pull/4528