### PR TITLE
Implement attachments widget with thumbnails

### DIFF
--- a/client-src/components.js
+++ b/client-src/components.js
@@ -87,6 +87,7 @@ import './elements/chromedash-preflight-dialog';
 import './elements/chromedash-settings-page';
 import './elements/chromedash-stack-rank';
 import './elements/chromedash-stack-rank-page';
+import './elements/chromedash-attachments';
 import './elements/chromedash-textarea';
 import './elements/chromedash-timeline';
 import './elements/chromedash-timeline-page';

--- a/client-src/elements/chromedash-attachments.ts
+++ b/client-src/elements/chromedash-attachments.ts
@@ -1,0 +1,104 @@
+import {LitElement, css, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {createRef, ref, Ref} from 'lit/directives/ref.js';
+import {styleMap} from 'lit-html/directives/style-map.js';
+import {ChromedashTextarea} from './chromedash-textarea.js';
+import {URL_REGEX} from './form-field-specs.js';
+
+const DEFAULT_PLACEHOLDER = 'https://...\nhttps://...';
+const DEFAULT_SPLIT_PATTERN = String.raw`\s+`;
+
+@customElement('chromedash-attachments')
+export class ChromedashAttachments extends LitElement {
+  textareaRef: Ref<ChromedashTextarea> = createRef();
+
+  @property({type: String})
+  name;
+  @property({type: String})
+  value;
+  @property({type: String})
+  pattern;
+  @property({type: String})
+  chromedash_single_pattern = URL_REGEX;
+  @property({type: String})
+  chromedash_split_pattern = DEFAULT_SPLIT_PATTERN;
+
+  // Note: Form element components cannot have their own styles.
+
+  // Must render to light DOM, so sl-form-fields work as intended.
+  createRenderRoot() {
+    return this;
+  }
+
+  validate() {
+    if (this.textareaRef?.value?.validate) {
+      this.textareaRef.value.validate();
+    }
+  }
+
+  handleFieldUpdated(e) {
+    let fieldValue: string = e.target.value;
+    this.value = fieldValue;
+  }
+
+  renderOneThumbnail(url) {
+    if (url == '') {
+      return nothing;
+    }
+
+    const linkStyles = {
+      display: 'inline-block',
+      padding: 'var(--content-padding-quarter)',
+      margin: 'var(--content-padding-half)',
+      border: `2px solid var(--link-color)`,
+      cursor: `zoom-in`,
+    }
+    const imgStyles = {
+      maxHeight: '150px',
+      maxWidth: '200px',
+    };
+
+    return html`
+    <a href=${url} target="_blank" style=${styleMap(linkStyles)}>
+      <img style=${styleMap(imgStyles)} src=${url}></img>
+    </a>
+    `;
+  }
+
+  renderThumbnails() {
+    if (!this.value?.length) {
+      return nothing;
+    }
+    const items = this.value.split(new RegExp(this.chromedash_split_pattern));
+    return items.map(url => this.renderOneThumbnail(url));
+  }
+
+  render() {
+    return html`
+    <chromedash-textarea ${ref(this.textareaRef)}
+      size="small"
+      name=${this.name}
+      .value=${this.value}
+      multiple
+      placeholder=${DEFAULT_PLACEHOLDER}
+      pattern=${this.pattern}
+      chromedash_single_pattern=${this.chromedash_single_pattern}
+      chromedash_split_pattern=${this.chromedash_split_pattern}
+      @sl-change=${this.handleFieldUpdated}
+      @keyup=${this.handleFieldUpdated}
+      ></chromedash-textarea>
+      <div id=thumbnails>
+        ${this.renderThumbnails()}
+      </div>
+    `;
+  }
+
+  firstUpdated() {
+    this.validate();
+  }
+
+  updated() {
+    this.validate();
+  }
+
+}

--- a/client-src/elements/chromedash-attachments.ts
+++ b/client-src/elements/chromedash-attachments.ts
@@ -59,9 +59,9 @@ export class ChromedashAttachments extends LitElement {
     };
 
     return html`
-    <a href=${url} target="_blank" style=${styleMap(linkStyles)}>
-      <img style=${styleMap(imgStyles)} src=${url}></img>
-    </a>
+      <a href=${url} target="_blank" style=${styleMap(linkStyles)}>
+        <img style=${styleMap(imgStyles)} src=${url}></img>
+      </a>
     `;
   }
 
@@ -79,7 +79,7 @@ export class ChromedashAttachments extends LitElement {
         ${ref(this.textareaRef)}
         size="small"
         name=${this.name}
-        .value=${this.value}
+        value=${this.value}
         multiple
         placeholder=${DEFAULT_PLACEHOLDER}
         pattern=${this.pattern}

--- a/client-src/elements/chromedash-attachments.ts
+++ b/client-src/elements/chromedash-attachments.ts
@@ -52,7 +52,7 @@ export class ChromedashAttachments extends LitElement {
       margin: 'var(--content-padding-half)',
       border: `2px solid var(--link-color)`,
       cursor: `zoom-in`,
-    }
+    };
     const imgStyles = {
       maxHeight: '150px',
       maxWidth: '200px',
@@ -75,21 +75,20 @@ export class ChromedashAttachments extends LitElement {
 
   render() {
     return html`
-    <chromedash-textarea ${ref(this.textareaRef)}
-      size="small"
-      name=${this.name}
-      .value=${this.value}
-      multiple
-      placeholder=${DEFAULT_PLACEHOLDER}
-      pattern=${this.pattern}
-      chromedash_single_pattern=${this.chromedash_single_pattern}
-      chromedash_split_pattern=${this.chromedash_split_pattern}
-      @sl-change=${this.handleFieldUpdated}
-      @keyup=${this.handleFieldUpdated}
+      <chromedash-textarea
+        ${ref(this.textareaRef)}
+        size="small"
+        name=${this.name}
+        .value=${this.value}
+        multiple
+        placeholder=${DEFAULT_PLACEHOLDER}
+        pattern=${this.pattern}
+        chromedash_single_pattern=${this.chromedash_single_pattern}
+        chromedash_split_pattern=${this.chromedash_split_pattern}
+        @sl-change=${this.handleFieldUpdated}
+        @keyup=${this.handleFieldUpdated}
       ></chromedash-textarea>
-      <div id=thumbnails>
-        ${this.renderThumbnails()}
-      </div>
+      <div id="thumbnails">${this.renderThumbnails()}</div>
     `;
   }
 
@@ -100,5 +99,4 @@ export class ChromedashAttachments extends LitElement {
   updated() {
     this.validate();
   }
-
 }

--- a/client-src/elements/chromedash-attachments_test.ts
+++ b/client-src/elements/chromedash-attachments_test.ts
@@ -11,7 +11,8 @@ describe('chromedash-attachments', () => {
     assert.exists(component);
     assert.instanceOf(component, ChromedashAttachments);
     const textareaElement = component.renderRoot.querySelector(
-      'chromedash-textarea');
+      'chromedash-textarea'
+    );
     assert.exists(textareaElement);
     assert.instanceOf(textareaElement, ChromedashTextarea);
   });
@@ -19,9 +20,7 @@ describe('chromedash-attachments', () => {
   it('renders with a URL', async () => {
     const url = 'https://chromestatus.com/static/img/chrome_logo.svg';
     const component: ChromedashAttachments = await fixture(
-      html`<chromedash-attachments
-      value=${url}
-      ></chromedash-attachments>`
+      html`<chromedash-attachments value=${url}></chromedash-attachments>`
     );
     assert.exists(component);
     await component.updateComplete;
@@ -35,5 +34,4 @@ describe('chromedash-attachments', () => {
     assert.exists(imgElement);
     assert.equal(imgElement.getAttribute('src'), url);
   });
-
 });

--- a/client-src/elements/chromedash-attachments_test.ts
+++ b/client-src/elements/chromedash-attachments_test.ts
@@ -1,0 +1,39 @@
+import {html} from 'lit';
+import {assert, fixture} from '@open-wc/testing';
+import {ChromedashAttachments} from './chromedash-attachments';
+import {ChromedashTextarea} from './chromedash-textarea.js';
+
+describe('chromedash-attachments', () => {
+  it('renders with no data', async () => {
+    const component = await fixture(
+      html`<chromedash-attachments></chromedash-attachments>`
+    );
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashAttachments);
+    const textareaElement = component.renderRoot.querySelector(
+      'chromedash-textarea');
+    assert.exists(textareaElement);
+    assert.instanceOf(textareaElement, ChromedashTextarea);
+  });
+
+  it('renders with a URL', async () => {
+    const url = 'https://chromestatus.com/static/img/chrome_logo.svg';
+    const component: ChromedashAttachments = await fixture(
+      html`<chromedash-attachments
+      value=${url}
+      ></chromedash-attachments>`
+    );
+    assert.exists(component);
+    await component.updateComplete;
+    const textareaElement: ChromedashTextarea | null =
+      component.renderRoot.querySelector('chromedash-textarea');
+    assert.exists(textareaElement);
+    assert.equal(textareaElement.checkValidity(), true);
+    assert.equal(textareaElement.value, url);
+    const imgElement: HTMLElement | null =
+      component.renderRoot.querySelector('img');
+    assert.exists(imgElement);
+    assert.equal(imgElement.getAttribute('src'), url);
+  });
+
+});

--- a/client-src/elements/chromedash-form-field.ts
+++ b/client-src/elements/chromedash-form-field.ts
@@ -340,7 +340,7 @@ export class ChromedashFormField extends LitElement {
           name="${fieldName}"
           id="id_${this.name}"
           size="small"
-          .value=${fieldValue}
+          value=${fieldValue}
           ?required=${this.fieldProps.required}
           @sl-change="${this.handleFieldUpdated}"
         >
@@ -353,7 +353,7 @@ export class ChromedashFormField extends LitElement {
           name="${fieldName}"
           id="id_${this.name}"
           size="small"
-          .value=${fieldValue}
+          value=${fieldValue}
           ?required=${this.fieldProps.required}
           @sl-change="${this.handleFieldUpdated}"
         >

--- a/client-src/elements/chromedash-form-field.ts
+++ b/client-src/elements/chromedash-form-field.ts
@@ -4,6 +4,7 @@ import {customElement, property, state} from 'lit/decorators.js';
 import {ref} from 'lit/directives/ref.js';
 
 import {ChromedashApp} from './chromedash-app';
+import './chromedash-attachments';
 import './chromedash-textarea';
 import {ALL_FIELDS, resolveFieldForFeature} from './form-field-specs';
 import {
@@ -344,6 +345,19 @@ export class ChromedashFormField extends LitElement {
           @sl-change="${this.handleFieldUpdated}"
         >
         </chromedash-textarea>
+      `;
+    } else if (type === 'attachments') {
+      fieldHTML = html`
+        <chromedash-attachments
+          ${ref(this.updateAttributes)}
+          name="${fieldName}"
+          id="id_${this.name}"
+          size="small"
+          .value=${fieldValue}
+          ?required=${this.fieldProps.required}
+          @sl-change="${this.handleFieldUpdated}"
+        >
+        </chromedash-attachments>
       `;
     } else if (type === 'radios') {
       fieldHTML = html`

--- a/client-src/elements/chromedash-textarea.ts
+++ b/client-src/elements/chromedash-textarea.ts
@@ -57,6 +57,9 @@ export class ChromedashTextarea extends SlTextarea {
   }
 
   validate() {
+    if (this.input === null) {
+      return;
+    }
     const invalidMsg = this.customCheckValidity(this.input.value)
       ? ''
       : 'invalid';

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -118,7 +118,7 @@ const EMAIL_ADDRESSES_REGEX: string =
 
 // Simple http URLs
 const PORTNUM_REGEX: string = '(:[0-9]+)?';
-const URL_REGEX: string =
+export const URL_REGEX: string =
   '(https?)://' + DOMAIN_REGEX + PORTNUM_REGEX + String.raw`(/\S*)?`;
 const URL_PADDED_REGEX: string = String.raw`\s*` + URL_REGEX + String.raw`\s*`;
 
@@ -596,34 +596,12 @@ export const ALL_FIELDS: Record<string, Field> = {
       >.`,
   },
   screenshot_links: {
-    type: 'textarea',
+    type: 'attachments',
     attrs: MULTI_URL_FIELD_ATTRS,
     required: false,
     label: 'Screenshots link(s)',
     help_text: html` Optional: Link to screenshots showcasing this feature (one
     URL per line). These will be shared publicly.`,
-    check: async value => {
-      const urls = value.split('\n').filter(x => !!x);
-      if (!urls.length) {
-        return undefined;
-      }
-      const urlTypes = await Promise.all(
-        urls.map(url =>
-          fetch(url, {method: 'HEAD'})
-            .then(response => response.blob())
-            .then(blob => blob.type)
-            .catch(() => 'error')
-        )
-      );
-      // All urls must link to an image.
-      if (urlTypes.some(type => !type.startsWith('image'))) {
-        return {
-          error:
-            'One or more urls are not actual images. Use a valid link to an actual image.',
-        };
-      }
-      return undefined;
-    },
   },
 
   first_enterprise_notification_milestone: {


### PR DESCRIPTION
This is a step toward hosting screenshots on the site.  It enhances the current approach where the user enters URLs for screenshots by dynamically adding `<img>` elements to display a thumbnail-sized version of the linked image.

In this PR:
* Define a new form element chromedash-attachments, which contains a chrome dash-textarea and a set of thumbnails.
* Add dispatch logic to our form field container class to create a chromedash-attachments element when specified.
* Change the form spec for the screenshots field to use a widget of type `attachments`.
* Remove the existing logic that loaded images and displayed an error message in case of an unexpected content type.  Now the image either shows up or a broken-image icon shows up.

In an upcoming PR, I will add an "upload" button that immediately uploads and image and appends its URL in the text box.  So, users will be able to use a mix of screenshots hosted on our server and screenshots hosted elsewhere.