### PR TITLE
Update issue tracker component link.

### DIFF
--- a/client-src/elements/chromedash-feature-highlights.ts
+++ b/client-src/elements/chromedash-feature-highlights.ts
@@ -189,7 +189,7 @@ export class ChromedashFeatureHighlights extends LitElement {
                 ${this.feature.browsers.chrome.blink_components.map(
                   c => html`
                     <a
-                      href="https://bugs.chromium.org/p/chromium/issues/list?q=component:${c}"
+                      href="https://issues.chromium.org/issues?q=customfield1222907:%22${c}%22"
                       target="_blank"
                       rel="noopener"
                       >${c}</a

--- a/internals/testdata/notifier_test/test_make_intent_email.html
+++ b/internals/testdata/notifier_test/test_make_intent_email.html
@@ -20,7 +20,7 @@
 
   <br><br><h4>Blink component</h4>
   
-    <a href="https://bugs.chromium.org/p/chromium/issues/list?q=component:Blink" target="_blank" rel="noopener">Blink</a>
+    <a href="https://issues.chromium.org/issues?q=customfield1222907:%22Blink%22" target="_blank" rel="noopener">Blink</a>
   
 
   

--- a/pages/testdata/intentpreview_test/test_html_ot_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_ot_rendering.html
@@ -20,7 +20,7 @@
 
   <br><br><h4>Blink component</h4>
   
-    <a href="https://bugs.chromium.org/p/chromium/issues/list?q=component:Blink" target="_blank" rel="noopener">Blink</a>
+    <a href="https://issues.chromium.org/issues?q=customfield1222907:%22Blink%22" target="_blank" rel="noopener">Blink</a>
   
 
   

--- a/pages/testdata/intentpreview_test/test_html_prototype_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_prototype_rendering.html
@@ -20,7 +20,7 @@
 
   <br><br><h4>Blink component</h4>
   
-    <a href="https://bugs.chromium.org/p/chromium/issues/list?q=component:Blink" target="_blank" rel="noopener">Blink</a>
+    <a href="https://issues.chromium.org/issues?q=customfield1222907:%22Blink%22" target="_blank" rel="noopener">Blink</a>
   
 
   

--- a/pages/testdata/intentpreview_test/test_html_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_rendering.html
@@ -186,7 +186,7 @@ limitations under the License.
 
   <br><br><h4>Blink component</h4>
   
-    <a href="https://bugs.chromium.org/p/chromium/issues/list?q=component:Blink" target="_blank" rel="noopener">Blink</a>
+    <a href="https://issues.chromium.org/issues?q=customfield1222907:%22Blink%22" target="_blank" rel="noopener">Blink</a>
   
 
   

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -27,7 +27,7 @@
 
   <br><br><h4>Blink component</h4>
   {% for c in feature.browsers.chrome.blink_components %}
-    <a href="https://bugs.chromium.org/p/chromium/issues/list?q=component:{{c}}" target="_blank" rel="noopener">{{c}}</a>
+    <a href="https://issues.chromium.org/issues?q=customfield1222907:%22{{c}}%22" target="_blank" rel="noopener">{{c}}</a>
   {% endfor %}
 
   {% if 'motivation' in sections_to_show %}


### PR DESCRIPTION
This should resolve #4592.  ChromeStatus had links to bugs.chromium.org that searched for all bugs within a given blink component, and the format of those links needed to be updated to do the corresponding search on issues.chromium.org.

