### PR TITLE
Split thumbnails out into separate models.

### DIFF
--- a/api/attachments_api.py
+++ b/api/attachments_api.py
@@ -81,12 +81,11 @@ class AttachmentServing(basehandlers.FlaskHandler):
       return redirect_response
 
     headers = self.get_headers()
-    if is_thumb and attachment.thumbnail:
-      content = attachment.thumbnail
-      headers['Content-Type'] = 'image/png'
-    else:
-      content = attachment.content
-      headers['Content-Type'] = attachment.mime_type
+    if is_thumb:
+      thumbnail = attachments.get_thumbnail(attachment_id)
+      if thumbnail:
+        headers['Content-Type'] = 'image/png'
+        return thumbnail.thumb_content, headers
 
-
-    return content, headers
+    headers['Content-Type'] = attachment.mime_type
+    return attachment.content, headers

--- a/internals/attachments_test.py
+++ b/internals/attachments_test.py
@@ -25,8 +25,9 @@ class AttachmentsTests(testing_config.CustomTestCase):
     self.feature_id = 12345678
 
   def tearDown(self):
-    for attach in attachments.Attachment.query().fetch(None):
-      attach.key.delete()
+    for kind in [attachments.Attachment, attachments.Thumbnail]:
+      for model in kind.query().fetch(None):
+        model.key.delete()
 
   def test_store_attachment(self):
     """We can store attachment content."""


### PR DESCRIPTION
Store thumbnails in separate NDB models so that the `Attachment` model has the full 1MB size available.