### PR TITLE
Move measurement field to devtrials stage.

### DIFF
--- a/client-src/elements/form-definition.ts
+++ b/client-src/elements/form-definition.ts
@@ -308,6 +308,7 @@ const FLAT_DEV_TRIAL_FIELDS: MetadataFields = {
         'activation_risks',
         'security_risks',
         'debuggability',
+        'measurement',
         'all_platforms',
         'all_platforms_descr',
         'wpt',
@@ -413,7 +414,6 @@ const FLAT_PREPARE_TO_SHIP_FIELDS: MetadataFields = {
         'adoption_expectation',
         'adoption_plan',
         // Implementation
-        'measurement',
         'non_oss_deps',
 
         // Stage-specific fields
@@ -527,6 +527,7 @@ const DEPRECATION_DEV_TRIAL_FIELDS: MetadataFields = {
         'security_risks',
         'webview_risks',
         'debuggability',
+        'measurement',
         'all_platforms',
         'all_platforms_descr',
         'wpt',


### PR DESCRIPTION
This should resolve #4606.   This PR moves the `measurement` field from the OT stage form definition to the DevTrial stage.  It also adds it the the DevTrial stage of deprecations, because it was previously missing from that type of feature.