### PR TITLE
Fix origin trials GET request

### DIFF
--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -56,13 +56,15 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
       A list of data on all public origin trials.
     """
     try:
-      trials_list = GetOriginTrialsResponse.from_dict(origin_trials_client.get_trials_list())
+      trials_list = origin_trials_client.get_trials_list()
     except requests.exceptions.RequestException:
       self.abort(500, 'Error obtaining origin trial data from API')
     except KeyError:
       self.abort(500, 'Malformed response from origin trials API')
 
-    return trials_list
+    return GetOriginTrialsResponse.from_dict({
+      'origin_trials': trials_list
+    })
 
   def _validate_creation_args(
       self, body: dict) -> dict[str, str]:


### PR DESCRIPTION
Chromestatus has an API endpoint to list all public origin trials. This endpoint is not currently used by anything in the client (it was previously used to associate origin trials with their respective Chromestatus entries before the automated origin trial creation process).

This endpoint was broken during the OpenAPI migration, but the issue wasn't found until recently because it was not being used. This change fixes the endpoint and adds some needed tests to avoid this breakage in the future.