### PR TITLE
Actually display thumbnails rather than full images.

### DIFF
--- a/client-src/elements/chromedash-attachments.ts
+++ b/client-src/elements/chromedash-attachments.ts
@@ -76,7 +76,7 @@ export class ChromedashAttachments extends LitElement {
     };
     var imgSrc = url;
     if (url.includes('/feature/' + this.featureId + '/attachment/')) {
-      imgSrc += '/thumbnail';  // If it an image we serve, try thumbnail.
+      imgSrc += '/thumbnail'; // If it an image we serve, try thumbnail.
     }
 
     return html`

--- a/client-src/elements/chromedash-attachments.ts
+++ b/client-src/elements/chromedash-attachments.ts
@@ -74,10 +74,14 @@ export class ChromedashAttachments extends LitElement {
       maxHeight: '150px',
       maxWidth: '200px',
     };
+    var imgSrc = url;
+    if (url.includes('/feature/' + this.featureId + '/attachment/')) {
+      imgSrc += '/thumbnail';  // If it an image we serve, try thumbnail.
+    }
 
     return html`
       <a href=${url} target="_blank" style=${styleMap(linkStyles)}>
-        <img style=${styleMap(imgStyles)} src=${url}></img>
+        <img style=${styleMap(imgStyles)} src=${imgSrc}></img>
       </a>
     `;
   }

--- a/client-src/elements/chromedash-attachments_test.ts
+++ b/client-src/elements/chromedash-attachments_test.ts
@@ -45,7 +45,7 @@ describe('chromedash-attachments', () => {
     const url = 'http://127.0.0.1/feature/1234/attachment/5678';
     const component: ChromedashAttachments = await fixture(
       html`<chromedash-attachments
-        featureId=1234
+        featureId="1234"
         value=${url}
       ></chromedash-attachments>`
     );

--- a/client-src/elements/chromedash-attachments_test.ts
+++ b/client-src/elements/chromedash-attachments_test.ts
@@ -40,4 +40,25 @@ describe('chromedash-attachments', () => {
       component.renderRoot.querySelector('#upload-button');
     assert.exists(uploadButtonElement);
   });
+
+  it('displays thumbnails for self-hosted images', async () => {
+    const url = 'http://127.0.0.1/feature/1234/attachment/5678';
+    const component: ChromedashAttachments = await fixture(
+      html`<chromedash-attachments
+        featureId=1234
+        value=${url}
+      ></chromedash-attachments>`
+    );
+    assert.exists(component);
+    await component.updateComplete;
+    const textareaElement: ChromedashTextarea | null =
+      component.renderRoot.querySelector('chromedash-textarea');
+    assert.exists(textareaElement);
+    assert.equal(textareaElement.checkValidity(), true);
+    assert.equal(textareaElement.value, url);
+    const imgElement: HTMLElement | null =
+      component.renderRoot.querySelector('img');
+    assert.exists(imgElement);
+    assert.equal(imgElement.getAttribute('src'), url + '/thumbnail');
+  });
 });


### PR DESCRIPTION
This PR makes the gallery of small images actually request the thumbnail-sized images for self-hosted images.  

In the case where a thumbnail does not exist for whatever reason, the full-sized image is returned, so the client-side can always safely request a thumbnail.