### PR TITLE
Disable submit button while processing.

### DIFF
--- a/client-src/css/shared-css.js
+++ b/client-src/css/shared-css.js
@@ -107,6 +107,12 @@ export const SHARED_STYLES = [
     font-weight: bold;
   }
 
+  button.primary:disabled,
+  input[type="submit"]:disabled,
+  .button.primary:disabled {
+    background: var(--gray-4);
+  }
+
   .button.secondary {
     margin: var(--content-padding);
     border: var(--default-border);

--- a/client-src/elements/chromedash-guide-new-page.ts
+++ b/client-src/elements/chromedash-guide-new-page.ts
@@ -197,8 +197,11 @@ export class ChromedashGuideNewPage extends LitElement {
           `;
     };
 
-    const submitLabel = this.submitting ? 'Submitting...' :
-      (this.isEnterpriseFeature ? 'Continue' : 'Submit');
+    const submitLabel = this.submitting
+      ? 'Submitting...'
+      : this.isEnterpriseFeature
+        ? 'Continue'
+        : 'Submit';
     return html`
       <section id="stage_form">
         <form name="overview_form" method="post" action=${postAction}>

--- a/client-src/elements/chromedash-guide-new-page.ts
+++ b/client-src/elements/chromedash-guide-new-page.ts
@@ -66,6 +66,8 @@ export class ChromedashGuideNewPage extends LitElement {
   feature!: Feature;
   @state()
   fieldValues: FieldInfo[] & {feature?: Feature} = [];
+  @property({type: Boolean})
+  submitting = false;
 
   /* Add the form's event listener after Shoelace event listeners are attached
    * see more at https://github.com/GoogleChrome/chromium-dashboard/issues/2014 */
@@ -90,6 +92,7 @@ export class ChromedashGuideNewPage extends LitElement {
     // get the XSRF token and update it if it's expired before submission
     window.csClient.ensureTokenIsValid().then(() => {
       hiddenTokenField.value = window.csClient.token;
+      this.submitting = true;
       event.target.submit();
     });
   }
@@ -194,6 +197,8 @@ export class ChromedashGuideNewPage extends LitElement {
           `;
     };
 
+    const submitLabel = this.submitting ? 'Submitting...' :
+      (this.isEnterpriseFeature ? 'Continue' : 'Submit');
     return html`
       <section id="stage_form">
         <form name="overview_form" method="post" action=${postAction}>
@@ -208,7 +213,8 @@ export class ChromedashGuideNewPage extends LitElement {
           <input
             type="submit"
             class="primary"
-            value=${this.isEnterpriseFeature ? 'Continue' : 'Submit'}
+            ?disabled=${this.submitting}
+            value=${submitLabel}
           />
         </form>
       </section>


### PR DESCRIPTION
This should resolve #4563.

In the handler that submits the form, we now set a variable that disables the submit button.  So, the user cannot accidentally click it twice.

There is no logic to ever re-enable the button because the whole page is reconstructed if the user uses the "Create feature" button again to create a new feature.