### PR TITLE
Phase out LaCrOS enum value

### DIFF
--- a/client-src/elements/chromedash-form-field.ts
+++ b/client-src/elements/chromedash-form-field.ts
@@ -296,6 +296,9 @@ export class ChromedashFormField extends LitElement {
       `;
     } else if (type === 'multiselect') {
       const valueArray: string[] = fieldValue.split(',');
+      const availableOptions = Object.values(choices).filter(
+        ([value, label, obsolete]) => (
+          !obsolete || valueArray.includes('' + value)));
       fieldHTML = html`
         <sl-select
           name="${fieldName}"
@@ -309,9 +312,9 @@ export class ChromedashFormField extends LitElement {
           ?disabled=${fieldDisabled || this.disabled || this.loading}
           @sl-change="${this.handleFieldUpdated}"
         >
-          ${Object.values(choices).map(
+          ${availableOptions.map(
             ([value, label]) => html`
-              <sl-option value="${value}"> ${label} </sl-option>
+            <sl-option value="${value}"> ${label} </sl-option>
             `
           )}
         </sl-select>

--- a/client-src/elements/chromedash-form-field.ts
+++ b/client-src/elements/chromedash-form-field.ts
@@ -297,8 +297,9 @@ export class ChromedashFormField extends LitElement {
     } else if (type === 'multiselect') {
       const valueArray: string[] = fieldValue.split(',');
       const availableOptions = Object.values(choices).filter(
-        ([value, label, obsolete]) => (
-          !obsolete || valueArray.includes('' + value)));
+        ([value, label, obsolete]) =>
+          !obsolete || valueArray.includes('' + value)
+      );
       fieldHTML = html`
         <sl-select
           name="${fieldName}"
@@ -314,7 +315,7 @@ export class ChromedashFormField extends LitElement {
         >
           ${availableOptions.map(
             ([value, label]) => html`
-            <sl-option value="${value}"> ${label} </sl-option>
+              <sl-option value="${value}"> ${label} </sl-option>
             `
           )}
         </sl-select>

--- a/client-src/elements/chromedash-form-field_test.ts
+++ b/client-src/elements/chromedash-form-field_test.ts
@@ -138,6 +138,36 @@ describe('chromedash-form-field', () => {
     assert.include(renderElement.innerHTML, 'cleareable');
   });
 
+  it('skips unused obsolete multiselect choices', async () => {
+    const component = await fixture(
+      html` <chromedash-form-field name="rollout_platforms">
+      </chromedash-form-field>`
+    );
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashFormField);
+
+    const slSelect = component.renderRoot.querySelector('sl-select');
+    const inner = slSelect?.innerHTML;
+    assert.include(inner, 'Android');
+    assert.notInclude(inner, 'LaCrOS'); // It is obsolete.
+    assert.include(inner, 'iOS');
+  });
+
+  it('includes used obsolete multiselect choices', async () => {
+    const component = await fixture(
+      html` <chromedash-form-field name="rollout_platforms" value="1,2,4">
+      </chromedash-form-field>`
+    );
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashFormField);
+
+    const slSelect = component.renderRoot.querySelector('sl-select');
+    const inner = slSelect?.innerHTML;
+    assert.include(inner, 'Android');
+    assert.include(inner, 'LaCrOS'); // Obsoelete, but used.
+    assert.include(inner, 'iOS');
+  });
+
   describe('complex fields', async () => {
     it('active_stage_id depends on the available stages', async () => {
       /** @type {import('./form-definition').FormattedFeature} */

--- a/client-src/elements/form-field-enums.ts
+++ b/client-src/elements/form-field-enums.ts
@@ -44,11 +44,11 @@ export const ENTERPRISE_FEATURE_CATEGORIES_DISPLAYNAME: Record<number, string> =
     3: 'Management', // MANAGEMENT
   };
 
-export const PLATFORM_CATEGORIES: Record<string, [number, string]> = {
+export const PLATFORM_CATEGORIES: Record<string, [number, string, boolean?]> = {
   PLATFORM_ANDROID: [1, 'Android'],
   PLATFORM_IOS: [2, 'iOS'],
   PLATFORM_CHROMEOS: [3, 'ChromeOS'],
-  PLATFORM_LACROS: [4, 'LaCrOS'],
+  PLATFORM_LACROS: [4, 'LaCrOS', true], // Obsolete. Cannot be added.
   PLATFORM_LINUX: [5, 'Linux'],
   PLATFORM_MAC: [6, 'MacOS'],
   PLATFORM_WINDOWS: [7, 'Windows'],

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -81,7 +81,10 @@ interface ResolvedField {
   check?: CheckFunction | CheckFunction[];
   initial?: number | boolean;
   enterprise_initial?: number;
-  choices?: Record<string, [number, string, (boolean | string | TemplateResult)?]>;
+  choices?: Record<
+    string,
+    [number, string, (boolean | string | TemplateResult)?]
+  >;
   displayLabel?: string;
   disabled?: boolean;
 }

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -81,7 +81,7 @@ interface ResolvedField {
   check?: CheckFunction | CheckFunction[];
   initial?: number | boolean;
   enterprise_initial?: number;
-  choices?: Record<string, [number, string, (string | TemplateResult)?]>;
+  choices?: Record<string, [number, string, (boolean | string | TemplateResult)?]>;
   displayLabel?: string;
   disabled?: boolean;
 }


### PR DESCRIPTION
The enterprise team requested that the LaCrOS platform option should no longer be offered when rolling out features, but it should still remain for past rollouts.

We cannot simply remove the LaCrOS option, because it is still needed for old rollouts to display a string rather than an int or nothing. 

In this PR:
* Introduce the concept of an obsolete enum value, and mark LaCrOS as obsolete.
* When constructing `sl-select` options, don't include obsolete options unless they are part of the current field value.

