### PR TITLE
Exclude deleted features from API responses.

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -352,7 +352,7 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
     """Delete the specified feature."""
     # TODO(jrobbins): implement undelete UI.  For now, use cloud console.
     feature_id = kwargs.get('feature_id', None)
-    feature = self.get_specified_feature(feature_id=feature_id)
+    feature: FeatureEntry = self.get_specified_feature(feature_id=feature_id)
     if feature is None:
       return {'message': 'ID does not match any feature.'}
 
@@ -365,12 +365,5 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
     feature.put()
     rediscache.delete_keys_with_prefix(FeatureEntry.DEFAULT_CACHE_KEY)
     rediscache.delete_keys_with_prefix(FeatureEntry.SEARCH_CACHE_KEY)
-
-    # Write for new FeatureEntry entity.
-    feature_entry: FeatureEntry | None = (
-        FeatureEntry.get_by_id(feature_id))
-    if feature_entry:
-      feature_entry.deleted = True
-      feature_entry.put()
 
     return {'message': 'Done'}

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -353,9 +353,6 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
     # TODO(jrobbins): implement undelete UI.  For now, use cloud console.
     feature_id = kwargs.get('feature_id', None)
     feature: FeatureEntry = self.get_specified_feature(feature_id=feature_id)
-    if feature is None:
-      return {'message': 'ID does not match any feature.'}
-
     user = users.get_current_user()
     app_user = AppUser.get_app_user(user.email())
     if ((app_user is None or not app_user.is_admin)

--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -133,13 +133,11 @@ class GatesAPI(basehandlers.APIHandler):
   def do_get(self, **kwargs) -> dict[str, Any]:
     """Return a list of all gates associated with the given feature."""
     feature_id = kwargs.get('feature_id', None)
-    gates: list[Gate] = Gate.query(Gate.feature_id == feature_id).fetch()
+    feature: FeatureEntry = self.get_specified_feature(feature_id=feature_id)
+    gates: list[Gate] = []
 
-    # No gates associated with this feature.
-    if len(gates) == 0:
-      return {
-          'gates': [],
-          }
+    if not feature.deleted or self.get_bool_arg('include_deleted'):
+      gates = Gate.query(Gate.feature_id == feature_id).fetch()
 
     dicts = [converters.gate_value_to_json_dict(g) for g in gates]
     for g in dicts:

--- a/api/reviews_api_test.py
+++ b/api/reviews_api_test.py
@@ -352,14 +352,43 @@ class GatesAPITest(testing_config.CustomTestCase):
   def test_do_get__empty_gates(self, mock_get_approvers):
     """Handler cannnot find any gates."""
     mock_get_approvers.return_value = ['reviewer1@example.com']
+    gateless_feature = core_models.FeatureEntry(
+        name='gateless feature', summary='sum', category=1,
+        owner_emails=['owner1@example.com'])
+    gateless_feature.put()
+    gateless_feature_id = gateless_feature.key.integer_id()
 
     with test_app.test_request_context(self.request_path):
-      actual = self.handler.do_get(feature_id=999)
+      actual = self.handler.do_get(feature_id=gateless_feature_id)
 
     expected = {
         'gates': [],
     }
     self.assertEqual(actual, expected)
+
+  def test_do_get__deleted(self):
+    """If a feature is deleted, don't return any gates."""
+    self.feature_1.deleted = True
+    self.feature_1.put()
+
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_get(feature_id=self.feature_id)
+
+    expected = {
+        'gates': [],
+    }
+    self.assertEqual(actual, expected)
+
+  def test_do_get__include_deleted(self):
+    """If a feature is deleted, return gates if include_deleted=1."""
+    self.feature_1.deleted = True
+    self.feature_1.put()
+
+    with test_app.test_request_context(
+        self.request_path + '?include_deleted=1'):
+      actual = self.handler.do_get(feature_id=self.feature_id)
+
+    self.assertEqual(1, len(actual['gates']))
 
 
 class XfnGatesAPITest(testing_config.CustomTestCase):

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -530,7 +530,7 @@ export class ChromeStatusClient {
   }
 
   getGates(featureId) {
-    return this.doGet(`/features/${featureId}/gates`);
+    return this.doGet(`/features/${featureId}/gates?include_deleted=1`);
   }
 
   getPendingGates() {

--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -476,6 +476,7 @@ def get_features_by_impl_status(limit: int | None=None, update_cache: bool=False
     feature_list = []
     for section in query_results:
       if len(section) > 0:
+        section = [f for f in section if not f.deleted]
         section = [f for f in section if f.feature_type != FEATURE_TYPE_ENTERPRISE_ID]
         section = [converters.feature_entry_to_json_basic(
             f, all_stages[f.key.integer_id()]) for f in section]

--- a/internals/feature_helpers_test.py
+++ b/internals/feature_helpers_test.py
@@ -572,3 +572,25 @@ class FeatureHelpersTest(testing_config.CustomTestCase):
     rediscache.delete(cache_key)
     self.assertEqual(cached_result, features)
 
+  def test_get_features_by_impl_status__normal(self):
+    """We can get JSON dicts for /features_v2.json."""
+    features = feature_helpers.get_features_by_impl_status()
+    self.assertEqual(4, len(features))
+    self.assertEqual({'feature a', 'feature b', 'feature c', 'feature d'},
+                     set(f['name'] for f in features))
+    self.assertEqual('feature a', features[2]['name'])
+    self.assertEqual('feature b', features[3]['name'])
+
+
+  def test_get_features_by_impl_status__deleted(self):
+    """Deleted features are not included in /features_v2.json."""
+    self.feature_3.deleted = True
+    self.feature_3.put()
+
+    features = feature_helpers.get_features_by_impl_status()
+
+    self.assertEqual(3, len(features))
+    self.assertEqual({'feature a', 'feature b', 'feature d'},
+                     set(f['name'] for f in features))
+    self.assertEqual('feature a', features[1]['name'])
+    self.assertEqual('feature b', features[2]['name'])


### PR DESCRIPTION
This should resolve issue #4587.

Basically, we should exclude deleted feature info from API responses, unless it is specifically requested.

In this PR:
* Delete old duplicate feature deletion code that was left over from when we were doing double writes for `Feature` and `FeatureEntry` two years ago.
* When requesting the gates of a feature, reply with an empty list if the feature was deleted, unless the request has query string parameter include_deleted=1.
* Make our API always request gates with include_deleted=1 so that a user who knows the URL of a deleted feature entry can view a complete feature entry and possibly decide to undelete it.
* Exclude deleted features from the `features_v2.json` response.