### PR TITLE
Remove screenshot_links from enterprise creation page.

### DIFF
--- a/client-src/elements/form-definition.ts
+++ b/client-src/elements/form-definition.ts
@@ -179,7 +179,6 @@ export const ENTERPRISE_NEW_FEATURE_FORM_FIELDS = [
   'enterprise_feature_categories',
   'first_enterprise_notification_milestone',
   'enterprise_impact',
-  'screenshot_links',
 ];
 
 // The fields that are available to every feature.


### PR DESCRIPTION
The new attachments functionality stores attachments associated with a given feature entry ID.  So, the feature needs to already exist before we can attach anything to it.  On the feature creation page, we can't have this field yet because there is no defined feature ID.

It should be an OK UX to attach the screenshots on the next page after creating the feature entry.  The existing flow is already taking the user directly from the creation page to the editing page.  So, users can attach screenshots on a page that they already are automatically navigated to.