### PR TITLE
Offer a "Re-request Review" button

### DIFF
--- a/client-src/elements/chromedash-gate-column.ts
+++ b/client-src/elements/chromedash-gate-column.ts
@@ -550,6 +550,26 @@ export class ChromedashGateColumn extends LitElement {
     `;
   }
 
+  renderReviewStatusNeedsWork() {
+    const rereviewButton = !this.userCanRequestReview()
+      ? nothing
+      : html`
+          <div>
+            <sl-button
+              size="small"
+              variant="primary"
+              @click=${this.handleReviewRequested}
+              >Re-request review</sl-button
+            >
+          </div>
+        `;
+
+    return html`
+      <div>Reviewer has indicated a need for rework.</div>
+      ${rereviewButton}
+    `;
+  }
+
   renderReviewRequest() {
     for (const v of this.votes) {
       if (v.state === GATE_REVIEW_REQUESTED || v.state === GATE_NA_REQUESTED) {
@@ -587,6 +607,8 @@ export class ChromedashGateColumn extends LitElement {
   renderReviewStatus() {
     if (this.gate.state == GATE_PREPARING) {
       return this.renderReviewStatusPreparing();
+    } else if (this.gate.state == VOTE_OPTIONS.NEEDS_WORK[0]) {
+      return this.renderReviewStatusNeedsWork();
     } else if (this.gate.state == VOTE_OPTIONS.APPROVED[0]) {
       return this.renderReviewStatusApproved();
     } else if (this.gate.state == VOTE_OPTIONS.DENIED[0]) {


### PR DESCRIPTION
This is another step toward having more fine-grained SLO measurements.  

Already, when a gate is in NEEDS_WORK state, that time is not counted against the reviewer's SLO.   Instead of the old assumption that the reviewers would periodically check on any NEEDS_WORK gates to see if the work had been done, or the assumption that the feature owners would contact the reviewer outside of chromestatus, the new workflow is that the feature owner must press the "Re-request review" button to explicitly end their turn and put the gate back in the reviewer's hands.

In this PR:
* Offer a new button to "Re-request review" when a gate is in the NEEDS_WORK state.  This button simply allows the feature owner to vote REVIEW_REQUESTED again.  

A feature owner voting REVIEW_REQUESTED is already allowed by the permission checks in reviews_api.

There is already logic to handle the vote and do the needed gate state transitions from NEEDS_WORK to REVIEW_REQUESTED, and for that to stop counting time spent in the NEEDS_WORK state so that additional time is counted against the reviewer's SLO again.

There is no new kind of email notification sent to the reviewers because they will already get an email notification as a side-effect of feature owner's vote.