### PR TITLE
Automatically expand stages that have reviews in progress.

### DIFF
--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -36,6 +36,9 @@ import {GateDict} from './chromedash-gate-chip';
 import {Process, ProgressItem} from './chromedash-gate-column';
 import {
   DEPRECATED_FIELDS,
+  GATE_ACTIVE_REVIEW_STATES,
+  GATE_FINISHED_REVIEW_STATES,
+  GATE_PREPARING,
   GATE_TEAM_ORDER,
   GATE_TYPES,
   STAGE_PSA_SHIPPING,
@@ -74,7 +77,7 @@ export const DETAILS_STYLES = [
 
 const LONG_TEXT = 60;
 
-class ChromedashFeatureDetail extends LitElement {
+export class ChromedashFeatureDetail extends LitElement {
   @property({type: String})
   appTitle = '';
   @property({attribute: false})
@@ -522,6 +525,19 @@ class ChromedashFeatureDetail extends LitElement {
     `;
   }
 
+  hasActiveGates(feStage) {
+    const gatesForStage = this.gates.filter(g => g.stage_id == feStage.id);
+    return gatesForStage.some(g => GATE_ACTIVE_REVIEW_STATES.includes(g.state));
+  }
+
+  hasMixedGates(feStage) {
+    const gatesForStage = this.gates.filter(g => g.stage_id == feStage.id);
+    return (
+      gatesForStage.some(g => GATE_FINISHED_REVIEW_STATES.includes(g.state)) &&
+      gatesForStage.some(g => GATE_PREPARING == g.state)
+    );
+  }
+
   renderGateChips(feStage) {
     const gatesForStage = this.gates.filter(g => g.stage_id == feStage.id);
     gatesForStage.sort(
@@ -646,7 +662,10 @@ class ChromedashFeatureDetail extends LitElement {
       </section>
     `;
     const defaultOpen =
-      this.feature.is_enterprise_feature || feStage.id == this.openStage;
+      this.feature.is_enterprise_feature ||
+      feStage.id == this.openStage ||
+      this.hasActiveGates(feStage) ||
+      this.hasMixedGates(feStage);
     return this.renderSection(name, content, isActive, defaultOpen);
   }
 

--- a/client-src/elements/chromedash-feature-detail_test.ts
+++ b/client-src/elements/chromedash-feature-detail_test.ts
@@ -1,0 +1,69 @@
+import {assert, fixture} from '@open-wc/testing';
+import {html} from 'lit';
+import {ChromedashFeatureDetail} from './chromedash-feature-detail';
+import {
+  GATE_PREPARING,
+  GATE_REVIEW_REQUESTED,
+  VOTE_OPTIONS,
+} from './form-field-enums';
+
+describe('chromedash-feature-detail', () => {
+  const stageNoGates = {id: 1};
+  const stagePreparing = {id: 2};
+  const stageActive = {id: 3};
+  const stageMixed = {id: 4};
+  const stageResolved = {id: 5};
+
+  const gates = [
+    {stage_id: stagePreparing.id, state: GATE_PREPARING},
+    {stage_id: stageActive.id, state: GATE_PREPARING},
+    {stage_id: stageActive.id, state: GATE_REVIEW_REQUESTED},
+    {stage_id: stageMixed.id, state: GATE_PREPARING},
+    {stage_id: stageMixed.id, state: VOTE_OPTIONS.APPROVED[0]},
+    {stage_id: stageResolved.id, state: VOTE_OPTIONS.APPROVED[0]},
+  ];
+
+  const feature = {
+    id: 123456789,
+    is_enterprise_feature: false,
+    stages: [],
+  };
+
+  it('renders with mimial data', async () => {
+    const component = await fixture(
+      html`<chromedash-feature-detail
+        .feature=${feature}
+      ></chromedash-feature-detail>`
+    );
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashFeatureDetail);
+  });
+
+  it('can identify active gates', async () => {
+    const component: ChromedashFeatureDetail = (await fixture(
+      html`<chromedash-feature-detail
+        .feature=${feature}
+        .gates=${gates}
+      ></chromedash-feature-detail>`
+    )) as ChromedashFeatureDetail;
+    assert.isFalse(component.hasActiveGates(stageNoGates));
+    assert.isFalse(component.hasActiveGates(stagePreparing));
+    assert.isTrue(component.hasActiveGates(stageActive));
+    assert.isFalse(component.hasActiveGates(stageMixed));
+    assert.isFalse(component.hasActiveGates(stageResolved));
+  });
+
+  it('can identify mixed gates', async () => {
+    const component: ChromedashFeatureDetail = (await fixture(
+      html`<chromedash-feature-detail
+        .feature=${feature}
+        .gates=${gates}
+      ></chromedash-feature-detail>`
+    )) as ChromedashFeatureDetail;
+    assert.isFalse(component.hasMixedGates(stageNoGates));
+    assert.isFalse(component.hasMixedGates(stagePreparing));
+    assert.isFalse(component.hasMixedGates(stageActive));
+    assert.isTrue(component.hasMixedGates(stageMixed));
+    assert.isFalse(component.hasMixedGates(stageResolved));
+  });
+});


### PR DESCRIPTION
This is a step toward supporting more fine-grained SLO measurements.  Now that feature owners need to explicitly re-request reviews that were marked NEEDS_WORK, it is important that they can easily notice such reviews on the feature detail page.

Previously, the only open stage accordion sections were for the stage that the user had marked as active, or the stage containing a gate mentioned in the URL.  Now, the app will also automatically expand any section that has a gate in an active review state, or a mixed combination of PREPARING and APPROVED gates.

In this PR:
* Add the conditional logic and helper functions
* Add unit tests
