### PR TITLE
Soft-delete attachments when link is removed.

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -24,6 +24,7 @@ from framework import basehandlers
 from framework import permissions
 from framework import rediscache
 from framework import users
+from internals import attachments
 from internals.enterprise_helpers import *
 from internals.core_enums import *
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
@@ -251,6 +252,10 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
       feature.accurate_as_of = now
       feature.outstanding_notifications = 0
       has_updated = True
+
+    if 'screenshot_links' in feature_changes:
+      attachments.delete_orphan_attachments(
+          feature.key.integer_id(), feature_changes['screenshot_links'])
 
     # Set enterprise first notification milestones.
     if is_update_first_notification_milestone(feature, feature_changes):

--- a/internals/attachments.py
+++ b/internals/attachments.py
@@ -137,6 +137,16 @@ def mark_attachment_deleted(attachment: Attachment) -> None:
   attachment.put()
 
 
+def delete_orphan_attachments(feature_id: int, new_value: str) -> None:
+  """Soft delete attachments on a feature that are no longer referenced."""
+  attachments = Attachment.query(
+      Attachment.feature_id == feature_id).fetch()
+  for a in attachments:
+    uri = 'feature/%r/attachment/%r' % (feature_id, a.key.integer_id())
+    if uri not in new_value:
+      mark_attachment_deleted(a)
+
+
 def get_thumbnail(attachment_id: int) -> Thumbnail|None:
   """Return a Thumbnail, if it exsits."""
   thumbnail = Thumbnail.query(


### PR DESCRIPTION
This should resolve #4630.

When the user removes the link to an attachment and saves the change, the attachment itself is marked deleted (and is no longer viewable).

In this PR:
* Add logic to take a post-PATCH action when the screenshot_links field is edited.
* Implement a helper function to mark those attachments deleted.
* Add unit tests.
* Also, make the SLO reminder emails tests more robust because other tests can change the specific NDB ID numbers that occur in the URLs in the golden.