### PR TITLE
Don't calculate slo_resolve_remaining for old gates that were already resolved

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -663,7 +663,7 @@ def gate_value_to_json_dict(gate: Gate) -> dict[str, Any]:
     if gate.resolved_on:
       slo_resolve_took = max(0, slo.weekdays_between(
           gate.requested_on, gate.resolved_on) - (gate.needs_work_elapsed or 0))
-    else:
+    elif gate.state != Vote.NEEDS_WORK and gate.state not in Gate.FINAL_STATES:
       slo_resolve_remaining = slo.remaining_days(
           gate.requested_on, slo_resolve) + (gate.needs_work_elapsed or 0)
 

--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -583,7 +583,7 @@ class GateConvertersTest(testing_config.CustomTestCase):
       'slo_initial_response_remaining': -1,  # One weekday overdue.
       'slo_resolve': approval_defs.DEFAULT_SLO_RESOLVE_LIMIT,
       'slo_resolve_took': None,
-      'slo_resolve_remaining': 3,
+      'slo_resolve_remaining': None,
       'needs_work_started_on': None,
       }
     self.assertEqual(expected, actual)

--- a/client-src/elements/chromedash-gate-column.ts
+++ b/client-src/elements/chromedash-gate-column.ts
@@ -621,7 +621,11 @@ export class ChromedashGateColumn extends LitElement {
   renderSLOStatusSkeleton() {
     return html`
       <details>
-        <summary>Reviewer SLO status:</summary>
+        <summary>SLO initial response:</summary>
+        Loading...
+      </details>
+      <details>
+        <summary>SLO resolution:</summary>
         Loading...
       </details>
     `;


### PR DESCRIPTION
Demo'ing the new SLO functionality on staging uncovered that we have a lot of old gates that have already been resolved but never had the resolved_on date set.   I will work on a script to backfill that data, but just in case anything slips through, here is a small code change to simply not calculate the remaining days for such gates.

Also, I updated the skeleton display for the SLO status lines so that it matches the actual display. This should avoid a visual pop once the data loads.