### PR TITLE
Backfill resolved_on and needs_work_started_on.

### DIFF
--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -758,7 +758,7 @@ class BackfillGateDates(FlaskHandler):
     for vote in Vote.query():
       votes_by_gate[vote.gate_id].append(vote)
     for gate in Gate.query():
-      gate_votes = votes_by_gate.get(gate.key.integer_id())
+      gate_votes = votes_by_gate.get(gate.key.integer_id()) or []
       if self.calc_dates(gate, gate_votes):
         batch.append(gate)
         count += 1

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -743,3 +743,57 @@ class BackfillShippingYear(FlaskHandler):
 
     ndb.put_multi(batch)
     return f'{count} Features entities updated.'
+
+
+class BackfillGateDates(FlaskHandler):
+
+  def get_template_data(self, **kwargs) -> str:
+    """Backfill resolved_on and needs_work_started_on for all Gates."""
+    self.require_cron_header()
+
+    count = 0
+    batch: list[Gate] = []
+    BATCH_SIZE = 100
+    votes_by_gate = collections.defaultdict(list)
+    for vote in Vote.query():
+      votes_by_gate[vote.gate_id].append(vote)
+    for gate in Gate.query():
+      gate_votes = votes_by_gate.get(gate.key.integer_id())
+      if self.calc_dates(gate, gate_votes):
+        batch.append(gate)
+        count += 1
+        if len(batch) > BATCH_SIZE:
+          ndb.put_multi(batch)
+          batch = []
+
+    ndb.put_multi(batch)
+    return f'{count} Gate entities updated.'
+
+  def calc_dates(self, gate: Gate, votes: list[Vote]) -> bool:
+    """Set resolved_on and needs_work_started_on if needed."""
+    if not votes:
+      return False
+    new_resolved_on = self.calc_resolved_on(gate, votes)
+    new_needs_work_started_on = self.calc_needs_work_started_on(gate, votes)
+    if new_resolved_on is not None:
+      gate.resolved_on = new_resolved_on
+    if new_needs_work_started_on is not None:
+      gate.needs_work_started_on = new_needs_work_started_on
+    return bool(new_resolved_on or new_needs_work_started_on)
+
+  def calc_resolved_on(self, gate: Gate, votes: list[Vote]) -> datetime | None:
+    """Return the date on which the gate was resolved, or None."""
+    if gate.state not in Vote.FINAL_STATES:
+      return None
+
+    return max(v.set_on for v in votes
+               if v.state in Vote.FINAL_STATES)
+
+  def calc_needs_work_started_on(
+      self, gate: Gate, votes: list[Vote]) -> datetime | None:
+    """Return the latest date on which the gate entered NEEDS_WORK."""
+    if gate.state != Vote.NEEDS_WORK:
+      return None
+
+    return max(v.set_on for v in votes
+               if v.state == Vote.NEEDS_WORK)

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -786,7 +786,7 @@ class BackfillGateDates(FlaskHandler):
     if gate.state not in Vote.FINAL_STATES:
       return None
     if gate.resolved_on:
-      return False
+      return None
 
     return max(v.set_on for v in votes
                if v.state in Vote.FINAL_STATES)
@@ -797,7 +797,7 @@ class BackfillGateDates(FlaskHandler):
     if gate.state != Vote.NEEDS_WORK:
       return None
     if gate.needs_work_started_on:
-      return False
+      return None
 
     return max(v.set_on for v in votes
                if v.state == Vote.NEEDS_WORK)

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -785,6 +785,8 @@ class BackfillGateDates(FlaskHandler):
     """Return the date on which the gate was resolved, or None."""
     if gate.state not in Vote.FINAL_STATES:
       return None
+    if gate.resolved_on:
+      return False
 
     return max(v.set_on for v in votes
                if v.state in Vote.FINAL_STATES)
@@ -794,6 +796,8 @@ class BackfillGateDates(FlaskHandler):
     """Return the latest date on which the gate entered NEEDS_WORK."""
     if gate.state != Vote.NEEDS_WORK:
       return None
+    if gate.needs_work_started_on:
+      return False
 
     return max(v.set_on for v in votes
                if v.state == Vote.NEEDS_WORK)

--- a/main.py
+++ b/main.py
@@ -346,6 +346,8 @@ internals_routes: list[Route] = [
         maintenance_scripts.DeleteEmptyExtensionStages),
   Route('/scripts/backfill_shipping_year',
         maintenance_scripts.BackfillShippingYear),
+  Route('/scripts/backfill_gate_dates',
+        maintenance_scripts.BackfillGateDates),
 ]
 
 dev_routes: list[Route] = []


### PR DESCRIPTION
Testing on staging highlighted the fact that existing gates don't have these new date fields, so they give odd-looking SLO status.  This PR backfills the resolved_on and needs_work_started_on for most existing gates that need them.