### PR TITLE
Use the origin trial display name in trial extension emails

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -840,21 +840,22 @@ class OTExtensionApprovedHandler(basehandlers.FlaskHandler):
   def process_post_data(self, **kwargs):
     self.require_task_header()
     feature = self.get_param('feature')
-    if feature is None:
-      self.abort(400, 'No feature provided.')
     gate_id = self.get_param('gate_id')
-    if gate_id is None:
-      self.abort(400, 'Extension gate ID not provided.')
     requester_email = self.get_param('requester_email')
-    if not requester_email:
-      self.abort(400, 'Extension requester\'s email address not provided.')
+    ot_display_name = self.get_param('ot_display_name')
     logging.info('Starting to notify about successful origin trial extension.')
-    send_emails([self.build_email(feature, requester_email, gate_id)])
+    send_emails([self.build_email(
+        feature, requester_email, gate_id,ot_display_name)])
 
     return {'message': 'OK'}
 
   def build_email(
-      self, feature: FeatureEntry, requester_email: str, gate_id: int):
+      self,
+      feature: FeatureEntry,
+      requester_email: str,
+      gate_id: int,
+      ot_display_name: str
+    ):
     body_data = {
       'feature': feature,
       'id': feature['id'],
@@ -866,8 +867,8 @@ class OTExtensionApprovedHandler(basehandlers.FlaskHandler):
     return {
       'to': requester_email,
       'cc': [OT_SUPPORT_EMAIL],
-      'subject': ('Origin trial extension approved and ready to be initiated: '
-                  f'{feature["name"]}'),
+      'subject': ('Origin trial extension approved and ready to be '
+                  f'initiated: {ot_display_name}'),
       'reply_to': None,
       'html': body,
     }

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -845,7 +845,7 @@ class OTExtensionApprovedHandler(basehandlers.FlaskHandler):
     ot_display_name = self.get_param('ot_display_name')
     logging.info('Starting to notify about successful origin trial extension.')
     send_emails([self.build_email(
-        feature, requester_email, gate_id,ot_display_name)])
+        feature, requester_email, gate_id, ot_display_name)])
 
     return {'message': 'OK'}
 

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -212,15 +212,11 @@ def send_ot_creation_notification(stage: Stage):
 def send_trial_extension_approved_notification(
     fe: 'FeatureEntry', stage: Stage, gate_id: int) -> None:
   """Notify that a trial extension is ready to be finalized."""
-  # If we don't have an OT owner email, don't send the email out.
-  # This should always be set, and is collected during the extension request.
-  if not stage.ot_owner_email:
+  # If we don't have an OT owner email or stage ID, don't send the email out.
+  # These should always be set, and are collected during the extension request.
+  if not stage.ot_owner_email or not stage.ot_stage_id:
     return
 
-  if stage.ot_stage_id is None:
-    logging.error(f'Extension stage {stage.key.integer_id()}'
-                  ' is not associated with any origin trial stage')
-    return
   ot_stage: Stage|None = Stage.get_by_id(stage.ot_stage_id)
   if ot_stage is None:
     logging.error('No origin trial stage found for given OT stage ID',

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import TYPE_CHECKING
 import settings
 from api import converters
@@ -216,8 +217,19 @@ def send_trial_extension_approved_notification(
   if not stage.ot_owner_email:
     return
 
+  if stage.ot_stage_id is None:
+    logging.error(f'Extension stage {stage.key.integer_id()}'
+                  ' is not associated with any origin trial stage')
+    return
+  ot_stage: Stage|None = Stage.get_by_id(stage.ot_stage_id)
+  if ot_stage is None:
+    logging.error('No origin trial stage found for given OT stage ID',
+                  stage.ot_stage_id)
+    return
+
   params = {
     'feature': converters.feature_entry_to_json_verbose(fe),
+    'ot_display_name': ot_stage.ot_display_name,
     'requester_email': stage.ot_owner_email,
     'gate_id': gate_id,
   }

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -1124,7 +1124,8 @@ class OTExtensionApprovedHandlerTest(testing_config.CustomTestCase):
   def setUp(self):
     self.feature = FeatureEntry(
         id=1, name='A feature', summary='summary', category=1)
-    self.ot_stage = Stage(id=2, feature_id=1, stage_type=150)
+    self.ot_stage = Stage(id=2, feature_id=1, stage_type=150,
+                          ot_display_name='OT Display Name')
     self.extension_stage = Stage(
       feature_id=1, ot_stage_id=2, stage_type=151,
       milestones=MilestoneSet(desktop_last=106),
@@ -1150,12 +1151,13 @@ class OTExtensionApprovedHandlerTest(testing_config.CustomTestCase):
       handler = notifier.OTExtensionApprovedHandler()
       email_task = handler.build_email(feature_dict,
                                        self.extension_stage.ot_owner_email,
-                                       self.extension_gate.key.integer_id())
+                                       self.extension_gate.key.integer_id(),
+                                       self.ot_stage.ot_display_name)
       # TESTDATA.make_golden(email_task['html'], 'test_make_extension_approved_email.html')
       self.assertEqual(
           email_task['subject'],
           ('Origin trial extension approved and ready to be initiated: '
-           'A feature'))
+           'OT Display Name'))
       self.assertEqual(email_task['html'],
         TESTDATA['test_make_extension_approved_email.html'])
 


### PR DESCRIPTION
This change fixes a small problem where the feature name is being used in the origin trial extension emails rather than the origin trial name. The origin trial name is now passed with the email task parameters to populate the subject line in the email.