### PR TITLE
Add clarification about mailing lists as contacts for OT creation

### DIFF
--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -1462,9 +1462,11 @@ export const ALL_FIELDS: Record<string, Field> = {
     label: 'Origin trial contacts',
     help_text: html` List any other individuals or groups to include on the
       contact list (e.g. for reminders on trial milestones). Mailing list emails
-      can be used here, but only email addresses of individuals
-      will receive access to view registrant data on <a target="_blank"
-      href="http://go/ot-registrants-dashboard">go/ot-registrants-dashboard</a>.
+      can be used here, but only email addresses of individuals will receive
+      access to view registrant data on
+      <a target="_blank" href="http://go/ot-registrants-dashboard"
+        >go/ot-registrants-dashboard</a
+      >.
       <p>
         <strong>
           Please prefer using "@google.com" domain email addresses for any

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -1461,7 +1461,10 @@ export const ALL_FIELDS: Record<string, Field> = {
     required: false,
     label: 'Origin trial contacts',
     help_text: html` List any other individuals or groups to include on the
-      contact list (e.g. for reminders on trial milestones).
+      contact list (e.g. for reminders on trial milestones). Mailing list emails
+      can be used here, but only email addresses of individuals
+      will receive access to view registrant data on <a target="_blank"
+      href="http://go/ot-registrants-dashboard">go/ot-registrants-dashboard</a>.
       <p>
         <strong>
           Please prefer using "@google.com" domain email addresses for any


### PR DESCRIPTION
Fixes #4531 

Adds an additional caveat to the instructions about supplying mailing lists as OT contacts.