### PR TITLE
Add note to NEEDS_WORK notifications.

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -99,16 +99,21 @@ def format_email_body(
     prop_name = escape(prop['prop_name'])  # Ensure to escape
     new_val = prop['new_val']
     old_val = prop['old_val']
+    note = prop.get('note')
 
     # Escaping values before passing to highlight_diff
     highlighted_old_val = highlight_diff(old_val, new_val, 'deletion')
     highlighted_new_val = highlight_diff(old_val, new_val, 'addition')
 
+    note_line = f'<b>Note:</b> {note}<br/>' if note else ''
+
     # Using f-strings for clear formatting
     formatted_changes += (
         f'<li><b>{prop_name}:</b><br/>'
-        f'<b>old:</b> {highlighted_old_val}<br/>'
-        f'<b>new:</b> {highlighted_new_val}<br/></li><br/>')
+        f'<b>Old:</b> {highlighted_old_val}<br/>'
+        f'<b>New:</b> {highlighted_new_val}<br/>'
+        f'{note_line}'
+        f'</li><br/>')
 
   if not formatted_changes:
     formatted_changes = '<li>None</li>'

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -144,6 +144,10 @@ def notify_subscribers_of_vote_changes(fe: 'FeatureEntry', gate: Gate,
       'old_val': old_state_name,
       'new_val': state_name,
   }
+  if new_state == Vote.NEEDS_WORK:
+    changed_props['note'] = (
+        'Feature owners must press the "Re-request review" button '
+        'after requested changes have been completed.')
 
   params = {
     'changes': [changed_props],

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -198,6 +198,21 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     self.assertEqual(body_html,
       TESTDATA['test_format_email_body__update_with_changes.html'])
 
+  def test_format_email_body__update_with_changes_and_note(self):
+    """Some property changes can include a note."""
+    self.changes.append({
+        'prop_name': 'Enterprise review status URL',
+        'old_val': 'review_started',
+        'new_val': 'needs_work',
+        'note': 'You need to press a button',
+        })
+    with test_app.app_context():
+      body_html = notifier.format_email_body(
+          'update-feature-email.html', self.template_fe, self.changes)
+    TESTDATA.make_golden(body_html, 'test_format_email_body__update_with_changes_and_note.html')
+    self.assertEqual(body_html,
+      TESTDATA['test_format_email_body__update_with_changes_and_note.html'])
+
   def test_accumulate_reasons(self):
     """We can accumulate lists of reasons why we sent a message to a user."""
     addr_reasons = collections.defaultdict(list)

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -209,7 +209,7 @@ class EmailFormattingTest(testing_config.CustomTestCase):
     with test_app.app_context():
       body_html = notifier.format_email_body(
           'update-feature-email.html', self.template_fe, self.changes)
-    TESTDATA.make_golden(body_html, 'test_format_email_body__update_with_changes_and_note.html')
+    # TESTDATA.make_golden(body_html, 'test_format_email_body__update_with_changes_and_note.html')
     self.assertEqual(body_html,
       TESTDATA['test_format_email_body__update_with_changes_and_note.html'])
 
@@ -1314,7 +1314,7 @@ class OTActivationFailedHandlerTest(testing_config.CustomTestCase):
       handler = notifier.OTActivationFailedHandler()
       stage_dict = converters.stage_to_json_dict(self.ot_stage)
       email_task = handler.build_email(stage_dict)
-      TESTDATA.make_golden(email_task['html'], 'test_make_activation_failed_email.html')
+      # TESTDATA.make_golden(email_task['html'], 'test_make_activation_failed_email.html')
       self.assertEqual(
         email_task['subject'],
         'Automated trial activation request failed for Example Trial')

--- a/internals/testdata/notifier_test/test_format_email_body__update_with_changes_and_note.html
+++ b/internals/testdata/notifier_test/test_format_email_body__update_with_changes_and_note.html
@@ -27,7 +27,7 @@
 <section id="details" style="margin: 16px; padding: 16px; background: white; border: 2px solid #ccc; border-radius:8px;">
   <div><b>Updates made by editor_template@example.com:</b></div>
   <ul>
-    <li><b>test_prop:</b><br/><b>Old:</b> test <span style="background:#FDD">old</span> value<br/><b>New:</b> test <span style="background:#DFD">new</span> value<br/></li><br/>
+    <li><b>test_prop:</b><br/><b>Old:</b> test <span style="background:#FDD">old</span> value<br/><b>New:</b> test <span style="background:#DFD">new</span> value<br/></li><br/><li><b>Enterprise review status URL:</b><br/><b>Old:</b> <span style="background:#FDD">review_started</span><br/><b>New:</b> <span style="background:#DFD">needs_work</span><br/><b>Note:</b> You need to press a button<br/></li><br/>
   </ul>
 </section>
 

--- a/packages/playwright/tests/test_utils.js
+++ b/packages/playwright/tests/test_utils.js
@@ -360,11 +360,11 @@ export async function createNewFeature(page) {
   // Submit the form.
   const submitButton = page.locator('input[type="submit"]');
   await submitButton.click();
-  await delay(500);
+  await delay(1500);
 
   // Wait until we are on the Feature page.
   await page.waitForURL('**/feature/*');
-  await delay(500);
+  await delay(1500);
 }
 
 export async function gotoNewFeatureList(page) {


### PR DESCRIPTION
Discussions with the API owners highlighted the need for chromestatus to inform feature owners that they need to press the "Re-request review" button to get the review back onto the reviewers' dashboard.

In this PR:
* Add the ability for any feature change diff to have a `note` field.
* Add a helpful note to the case where the vote is being set to NEEDS_WORK