### PR TITLE
Add feature detail button for OT registrants dashboard

### DIFF
--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -636,6 +636,7 @@ export class ChromedashFeatureDetail extends LitElement {
     const addExtensionButton = this.renderExtensionButton(feStage);
     const editButton = this.renderEditButton(feStage, processStage);
     const trialButton = this.renderOriginTrialButton(feStage);
+    const registrantsDashboardButton = this.renderRegistrantsDashboardButton(feStage);
     const extensionGateChips = feStage.extensions?.map(extension => {
       return html` <div class="gates">
         ${STAGE_SHORT_NAMES[extension.stage_type]}:
@@ -649,7 +650,7 @@ export class ChromedashFeatureDetail extends LitElement {
     }
     const content = html`
       <p class="description">
-        ${stageMenu} ${trialButton}
+        ${stageMenu} ${trialButton} ${registrantsDashboardButton}
         ${this.hasStageActions(processStage, feStage)
           ? this.renderStageActions(processStage, feStage)
           : nothing}
@@ -830,6 +831,26 @@ export class ChromedashFeatureDetail extends LitElement {
       @click="${() =>
         openPrereqsDialog(this.feature.id, feStage, dialogTypes.CREATION)}"
       >Request Trial Creation</sl-button
+    >`;
+  }
+
+  renderRegistrantsDashboardButton(feStage) {
+    // Don't render an origin trial button if this is not an OT stage.
+    if (!STAGE_TYPES_ORIGIN_TRIAL.has(feStage.stage_type) || !feStage.origin_trial_id) {
+      return nothing;
+    }
+    // Only Googlers will have access to this view.
+    if (!this.user || (
+        !this.user.email.endsWith('@chromium.org') && !this.user.email.endsWith('@google.com'))) {
+      return nothing;
+    }
+
+    return html`
+    <sl-button
+      size="small"
+      style="float:right"
+      href="http://go/ot-registrants-dashboard?f=trial_id:in:${feStage.origin_trial_id}"
+      >Registrant data</sl-button
     >`;
   }
 

--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -636,7 +636,8 @@ export class ChromedashFeatureDetail extends LitElement {
     const addExtensionButton = this.renderExtensionButton(feStage);
     const editButton = this.renderEditButton(feStage, processStage);
     const trialButton = this.renderOriginTrialButton(feStage);
-    const registrantsDashboardButton = this.renderRegistrantsDashboardButton(feStage);
+    const registrantsDashboardButton =
+      this.renderRegistrantsDashboardButton(feStage);
     const extensionGateChips = feStage.extensions?.map(extension => {
       return html` <div class="gates">
         ${STAGE_SHORT_NAMES[extension.stage_type]}:
@@ -836,17 +837,22 @@ export class ChromedashFeatureDetail extends LitElement {
 
   renderRegistrantsDashboardButton(feStage) {
     // Don't render an origin trial button if this is not an OT stage.
-    if (!STAGE_TYPES_ORIGIN_TRIAL.has(feStage.stage_type) || !feStage.origin_trial_id) {
+    if (
+      !STAGE_TYPES_ORIGIN_TRIAL.has(feStage.stage_type) ||
+      !feStage.origin_trial_id
+    ) {
       return nothing;
     }
     // Only Googlers will have access to this view.
-    if (!this.user || (
-        !this.user.email.endsWith('@chromium.org') && !this.user.email.endsWith('@google.com'))) {
+    if (
+      !this.user ||
+      (!this.user.email.endsWith('@chromium.org') &&
+        !this.user.email.endsWith('@google.com'))
+    ) {
       return nothing;
     }
 
-    return html`
-    <sl-button
+    return html` <sl-button
       size="small"
       style="float:right"
       href="http://go/ot-registrants-dashboard?f=trial_id:in:${feStage.origin_trial_id}"

--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -836,9 +836,11 @@ export class ChromedashFeatureDetail extends LitElement {
   }
 
   renderRegistrantsDashboardButton(feStage) {
-    // Don't render an origin trial button if this is not an OT stage.
+    // Registrants dashboard button is available on created OT stages,
+    // only to Google/Chromium users with edit access to the feature.
     if (
       !STAGE_TYPES_ORIGIN_TRIAL.has(feStage.stage_type) ||
+      !this.canEdit ||
       !feStage.origin_trial_id
     ) {
       return nothing;


### PR DESCRIPTION
Fixes #4478 

Adds a button that directs OT owners to the OT Registrants Dashboard.

![Screenshot from 2025-01-13 18-44-08](https://github.com/user-attachments/assets/c8e7fbaf-4cfb-4615-b273-6611c94f6c9a)

This button will only exist on features with created origin trials, and only feature owners with Google/Chromium accounts will see the button.
