### PR TITLE
Revert "Add check that user can view feature before sending change notification email"

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -454,10 +454,7 @@ class FeatureChangeHandler(basehandlers.FlaskHandler):
     # actually changes to it.
     # Load feature directly from NDB so as to never get a stale cached copy.
     fe = FeatureEntry.get_by_id(feature['id'])
-    user = users.User(email=triggering_user_email)
-    can_view_feature = permissions.can_view_feature(user, fe)
-
-    if fe and (is_update and len(changes) or not is_update) and can_view_feature:
+    if fe and (is_update and len(changes) or not is_update):
       email_tasks = make_feature_changes_email(
           fe, is_update=is_update, changes=changes,
           triggering_user_email=triggering_user_email)


### PR DESCRIPTION
Reverts GoogleChrome/chromium-dashboard#4676

This was causing an exception in the notification generation task.

Also, I think it is checking the permission for the user who made the edit rather than the person who is getting the email.