### PR TITLE
Remind users to link directly to screenshot images.

### DIFF
--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -627,7 +627,9 @@ export const ALL_FIELDS: Record<string, Field> = {
     required: false,
     label: 'Screenshot link(s)',
     help_text: html` Optional: Links to screenshots showcasing this feature (one
-    URL per line). Use the upload button to upload an image to be served from
+    URL per line). Be sure to link directly to the image with a URL ending in
+    .png, .gif, or .jpg, rather than linking to an HTML page that contains the
+    image.  Or, use the upload button to upload an image to be served from
     chromestatus.com. These will be shared publicly.`,
   },
 

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -629,7 +629,7 @@ export const ALL_FIELDS: Record<string, Field> = {
     help_text: html` Optional: Links to screenshots showcasing this feature (one
     URL per line). Be sure to link directly to the image with a URL ending in
     .png, .gif, or .jpg, rather than linking to an HTML page that contains the
-    image.  Or, use the upload button to upload an image to be served from
+    image. Or, use the upload button to upload an image to be served from
     chromestatus.com. These will be shared publicly.`,
   },
 


### PR DESCRIPTION
This should help with a situation reported by the enterprise team.  Previously, these links were displayed as links and the person preparing the enterprise release notes would manually follow the links to get the images, which worked OK if the feature owner had actually linked to an HTML page that contain the image.

Now, the release notes include the images directly as `<img src="...">`, so the feature owners need to put in the URL of the actual image, not the URL of an HTML page.