### PR TITLE
New histogram ID enum for differentiating use counter types

### DIFF
--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -23,6 +23,7 @@ import requests
 
 from framework import secrets
 from framework import utils
+from internals.core_enums import BlinkHistogramID
 from internals.core_models import Stage
 from internals.data_types import OriginTrialInfo
 import settings
@@ -30,6 +31,7 @@ import settings
 
 class UseCounterConfig(TypedDict):
   bucket_number: int
+  histogram_id: str
 
 class RequestTrial(TypedDict):
   id: NotRequired[int]
@@ -46,7 +48,6 @@ class RequestTrial(TypedDict):
   type: str
   origin_trial_feature_name: NotRequired[str]
   blink_use_counter_config: NotRequired[UseCounterConfig]
-  blink_webdx_use_counter_config: NotRequired[UseCounterConfig]
 
 
 class InternalRegistrationConfig(TypedDict):
@@ -184,12 +185,14 @@ def _send_create_trial_request(
   if ot_stage.ot_is_deprecation_trial:
     json['registration_config']['allow_public_suffix_subdomains'] = True
   if ot_stage.ot_use_counter_bucket_number:
-    config: UseCounterConfig = {'bucket_number': ot_stage.ot_use_counter_bucket_number}
+    config: UseCounterConfig = {
+      'bucket_number': ot_stage.ot_use_counter_bucket_number,
+      'histogram_id': BlinkHistogramID.web_feature.value
+    }
     if (ot_stage.ot_chromium_trial_name
         and ot_stage.ot_chromium_trial_name.startswith('WebDXFeature::')):
-      json['trial']['blink_webdx_use_counter_config'] = config
-    else:
-      json['trial']['blink_use_counter_config'] = config
+      config['histogram_id'] = BlinkHistogramID.webdx_feature.value
+    json['trial']['blink_use_counter_config'] = config
 
   headers = {'Authorization': f'Bearer {access_token}'}
   url = f'{settings.OT_API_URL}/v1/trials:initialize'

--- a/framework/origin_trials_client_test.py
+++ b/framework/origin_trials_client_test.py
@@ -240,6 +240,7 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
           'type': 'DEPRECATION',
           'blink_use_counter_config': {
             'bucket_number': 11,
+            'histogram_id': 'WEB_FEATURE',
           }
         }, create_trial_json['trial'])
     self.assertEqual({
@@ -287,11 +288,9 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
     # Two separate POST requests made.
     self.assertEqual(2, mock_requests_post.call_count)
     create_trial_json = mock_requests_post.call_args_list[0][1]['json']
-    # WebFeature config should be null.
-    self.assertEqual(None, create_trial_json['trial'].get('blink_use_counter_config'))
     # WebDXFeature config should be populated.
-    self.assertEqual({'bucket_number': 11},
-                     create_trial_json['trial']['blink_webdx_use_counter_config'])
+    self.assertEqual({'bucket_number': 11, 'histogram_id': 'WEBDX_FEATURE'},
+                     create_trial_json['trial']['blink_use_counter_config'])
 
   @mock.patch('framework.secrets.get_ot_api_key')
   @mock.patch('requests.post')

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -15,6 +15,7 @@
 
 import collections
 import re
+from enum import Enum
 from typing import Optional
 
 
@@ -502,6 +503,12 @@ OT_CREATION_FAILED = 3
 OT_ACTIVATION_FAILED = 4
 OT_CREATED = 5
 OT_ACTIVATED = 6
+
+# Histogram IDs used for identifying origin trial use counters.
+class BlinkHistogramID(str, Enum):
+  web_feature = 'WEB_FEATURE'
+  webdx_feature = 'WEBDX_FEATURE'
+  css_property_id = 'CSS_PROPERTY_ID'
 
 NO_ACTIVE_DEV = 1
 PROPOSED = 2


### PR DESCRIPTION
This change is a follow-up to #4624 that updates the implementation to use new histogram ID enums to differentiate use counters rather than having different config types. Changes were made to the origin trials API and how it represents use counter types (histogram ID), and this change mirrors those changes.

This is not a breaking change and can be successfully deployed without request interruption between ChromeStatus and the OT API.

Note that the `css_property_id` histogram ID enum is not yet used, which will come at a later time when addressing #4702.