### PR TITLE
Allow sending of OT creation/activation emails manually

### DIFF
--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -801,3 +801,37 @@ class BackfillGateDates(FlaskHandler):
 
     return max(v.set_on for v in votes
                if v.state == Vote.NEEDS_WORK)
+
+
+class SendManualOTCreatedEmail(FlaskHandler):
+  """Manually send an email to origin trial contacts that an origin trial has
+  been created but not yet activated."""
+  def get_template_data(self):
+    self.require_cron_header()
+
+    stage_id = self.get_param('stage_id')
+    stage: Stage|None = Stage.get_by_id(stage_id)
+    if not stage:
+      self.abort(400, f'Stage {stage_id} not found')
+
+    cloud_tasks_helpers.enqueue_task(
+        '/tasks/email-ot-creation-processed',
+        {'stage': converters.stage_to_json_dict(stage)})
+    return 'Email task enqueued.'
+
+
+class SendManualOTActivatedEmail(FlaskHandler):
+  """Manually send an email to origin trial contacts that an origin trial has
+  been created and also activated."""
+  def get_template_data(self):
+    self.require_cron_header()
+
+    stage_id = self.get_param('stage_id')
+    stage: Stage|None = Stage.get_by_id(stage_id)
+    if not stage:
+      self.abort(400, f'Stage {stage_id} not found')
+
+    cloud_tasks_helpers.enqueue_task(
+        '/tasks/email-ot-activated',
+        {'stage': converters.stage_to_json_dict(stage)})
+    return 'Email task enqueued.'

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -806,13 +806,14 @@ class BackfillGateDates(FlaskHandler):
 class SendManualOTCreatedEmail(FlaskHandler):
   """Manually send an email to origin trial contacts that an origin trial has
   been created but not yet activated."""
-  def get_template_data(self):
+
+  def get_template_data(self, **kwargs):
     self.require_cron_header()
 
-    stage_id = self.get_param('stage_id')
+    stage_id = kwargs.get('stage_id')
     stage: Stage|None = Stage.get_by_id(stage_id)
     if not stage:
-      self.abort(400, f'Stage {stage_id} not found')
+      return f'Stage {stage_id} not found'
 
     cloud_tasks_helpers.enqueue_task(
         '/tasks/email-ot-creation-processed',
@@ -823,13 +824,14 @@ class SendManualOTCreatedEmail(FlaskHandler):
 class SendManualOTActivatedEmail(FlaskHandler):
   """Manually send an email to origin trial contacts that an origin trial has
   been created and also activated."""
-  def get_template_data(self):
+
+  def get_template_data(self, **kwargs):
     self.require_cron_header()
 
-    stage_id = self.get_param('stage_id')
+    stage_id = kwargs.get('stage_id')
     stage: Stage|None = Stage.get_by_id(stage_id)
     if not stage:
-      self.abort(400, f'Stage {stage_id} not found')
+      return f'Stage {stage_id} not found'
 
     cloud_tasks_helpers.enqueue_task(
         '/tasks/email-ot-activated',

--- a/main.py
+++ b/main.py
@@ -348,6 +348,10 @@ internals_routes: list[Route] = [
         maintenance_scripts.BackfillShippingYear),
   Route('/scripts/backfill_gate_dates',
         maintenance_scripts.BackfillGateDates),
+  Route('/scripts/send_ot_creation_email/<int:stage_id>',
+        maintenance_scripts.SendManualOTCreatedEmail),
+  Route('/scripts/send_ot_activation_email/<int:stage_id>',
+        maintenance_scripts.SendManualOTActivatedEmail),
 ]
 
 dev_routes: list[Route] = []


### PR DESCRIPTION
Fixes #4533 

This change allows two new script paths that manually create email tasks to send notice to origin trial owners regarding two scenarios:
- An origin trial has been created and its activation is pending a later branch date.
- An origin trial has been created and activated and is ready for use.

These will  be available in the event that a failure occurs during the automated OT creation/activation process, so that OT support members can send these emails out after following the manual process.