### PR TITLE
Fix use counter reference variable

### DIFF
--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -189,8 +189,8 @@ def _send_create_trial_request(
       'bucket_number': ot_stage.ot_use_counter_bucket_number,
       'histogram_id': BlinkHistogramID.web_feature.value
     }
-    if (ot_stage.ot_chromium_trial_name
-        and ot_stage.ot_chromium_trial_name.startswith('WebDXFeature::')):
+    if (ot_stage.ot_webfeature_use_counter
+        and ot_stage.ot_webfeature_use_counter.startswith('WebDXFeature::')):
       config['histogram_id'] = BlinkHistogramID.webdx_feature.value
     json['trial']['blink_use_counter_config'] = config
 

--- a/framework/origin_trials_client_test.py
+++ b/framework/origin_trials_client_test.py
@@ -269,7 +269,7 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
       self, mock_requests_post, mock_get_trial_end_time,
       mock_get_ot_access_token, mock_api_key_get, mock_get_admin_group):
     """WebDXFeature use counters should have different config in request."""
-    self.ot_stage.ot_chromium_trial_name = 'WebDXFeature::Example'
+    self.ot_stage.ot_webfeature_use_counter = 'WebDXFeature::Example'
     self.ot_stage.put()
     mock_requests_post.return_value = mock.MagicMock(
         status_code=200, json=lambda : (


### PR DESCRIPTION
Sections of the code were erroneously referencing `ot_chromium_trial_name` rather than `ot_webfeature_use_counter`.