### PR TITLE
Implement Webdx Feature IDs datastore and endpoint

### DIFF
--- a/api/webdx_feature_api.py
+++ b/api/webdx_feature_api.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from collections import OrderedDict
 
 from framework import basehandlers
 from internals.webdx_feature_models import WebdxFeatures
 
 MISSING_FEATURE_ID = 'N/A'
-MISSING_FEATURE_TEXT = 'Missing feature'
+TBD_FEATURE_ID = 'TBD'
 
 
 class WebdxFeatureAPI(basehandlers.APIHandler):
@@ -29,15 +30,17 @@ class WebdxFeatureAPI(basehandlers.APIHandler):
     """Returns an ordered dict with Webdx feature id as both keys and values."""
     webdx_features = WebdxFeatures.get_webdx_feature_id_list()
     if not webdx_features:
-        self.abort(500, 'Error obtaining Webdx feature ID list.')
+        logging.error('Webdx feature id list is empty.')
+        return {}
 
     feature_ids_dict = OrderedDict()
     # The first key, value pair is the id when features are missing from the list.
-    feature_ids_dict.update({MISSING_FEATURE_ID: [MISSING_FEATURE_TEXT, MISSING_FEATURE_ID]})
+    feature_ids_dict[MISSING_FEATURE_ID] = [MISSING_FEATURE_ID, MISSING_FEATURE_ID]
+    feature_ids_dict[TBD_FEATURE_ID] = [TBD_FEATURE_ID, TBD_FEATURE_ID]
 
     feature_list = webdx_features.feature_ids
     feature_list.sort()
     for id in feature_list:
-      feature_ids_dict.update({id: [id, id]})
+      feature_ids_dict[id] = [id, id]
 
     return feature_ids_dict

--- a/api/webdx_feature_api.py
+++ b/api/webdx_feature_api.py
@@ -1,0 +1,43 @@
+# Copyright 2025 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import OrderedDict
+
+from framework import basehandlers
+from internals.webdx_feature_models import WebdxFeatures
+
+MISSING_FEATURE_ID = 'N/A'
+MISSING_FEATURE_TEXT = 'Missing feature'
+
+
+class WebdxFeatureAPI(basehandlers.APIHandler):
+  """The list of ordered webdx feature ID populates the "Web Feature ID" select field
+  in the guide form"""
+
+  def do_get(self, **kwargs):
+    """Returns an ordered dict with Webdx feature id as both keys and values."""
+    webdx_features = WebdxFeatures.get_webdx_feature_id_list()
+    if not webdx_features:
+        self.abort(500, 'Error obtaining Webdx feature ID list.')
+
+    feature_ids_dict = OrderedDict()
+    # The first key, value pair is the id when features are missing from the list.
+    feature_ids_dict.update({MISSING_FEATURE_ID: [MISSING_FEATURE_TEXT, MISSING_FEATURE_ID]})
+
+    feature_list = webdx_features.feature_ids
+    feature_list.sort()
+    for id in feature_list:
+      feature_ids_dict.update({id: [id, id]})
+
+    return feature_ids_dict

--- a/api/webdx_feature_api_test.py
+++ b/api/webdx_feature_api_test.py
@@ -1,0 +1,51 @@
+# Copyright 2025 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config
+from collections import OrderedDict
+
+import flask
+
+from api.webdx_feature_api import WebdxFeatureAPI
+from internals.webdx_feature_models import WebdxFeatures
+
+test_app = flask.Flask(__name__)
+
+class WebdxFeatureAPITest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.webdx_features = WebdxFeatures(feature_ids = ['zzz', 'aaa'])
+    self.webdx_features.put()
+
+    self.handler = WebdxFeatureAPI()
+    self.request_path = '/api/v0/webdxfeatures'
+
+  def tearDown(self):
+    for entity in WebdxFeatures.query():
+      entity.key.delete()
+
+  def test_do_get__success(self):
+    testing_config.sign_out()
+
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_get()
+
+    expected = OrderedDict(
+      [
+        ('N/A', ['Missing feature', 'N/A']),
+        ('aaa', ['aaa', 'aaa']),
+        ('zzz', ['zzz', 'zzz']),
+      ]
+    )
+    self.assertEqual(actual, expected)

--- a/api/webdx_feature_api_test.py
+++ b/api/webdx_feature_api_test.py
@@ -43,9 +43,19 @@ class WebdxFeatureAPITest(testing_config.CustomTestCase):
 
     expected = OrderedDict(
       [
-        ('N/A', ['Missing feature', 'N/A']),
+        ('N/A', ['N/A', 'N/A']),
+        ('TBD', ['TBD', 'TBD']),
         ('aaa', ['aaa', 'aaa']),
         ('zzz', ['zzz', 'zzz']),
       ]
     )
     self.assertEqual(actual, expected)
+
+  def test_do_get__empty_data(self):
+    testing_config.sign_out()
+    self.webdx_features.key.delete()
+
+    with test_app.test_request_context(self.request_path):
+      actual = self.handler.do_get()
+
+    self.assertEqual(actual, {})

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -30,6 +30,7 @@ from internals.review_models import Gate, Vote, Activity
 from internals.core_enums import *
 from internals.feature_links import batch_index_feature_entries
 from internals import stage_helpers
+from internals.webdx_feature_models import WebdxFeatures
 from webstatus_openapi import ApiClient, DefaultApi, Configuration, ApiException, Feature
 import settings
 
@@ -832,9 +833,8 @@ class FetchWebdxFeatureId(FlaskHandler):
           )
           return 'Running FetchWebdxFeatureId() job failed.'
 
-    # TODO(kyleju): save it to datastore.
     feature_ids_list = [feature_data.feature_id for feature_data in all_data_list]
-    feature_ids_list.sort()
+    WebdxFeatures.store_webdx_feature_id_list(feature_ids_list)
     return (f'{len(feature_ids_list)} feature ids are successfully stored.')
 
 

--- a/internals/webdx_feature_models.py
+++ b/internals/webdx_feature_models.py
@@ -1,0 +1,37 @@
+# Copyright 2025 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.cloud import ndb  # type: ignore
+
+
+class WebdxFeatures(ndb.Model):
+  """A singleton model to store Webdx feature IDs"""
+  feature_ids = ndb.StringProperty(repeated=True)
+
+  @classmethod
+  def get_webdx_feature_id_list(cls):
+    fetch_results = cls.query().fetch(1)
+    if not fetch_results:
+      return None
+
+    return fetch_results[0]
+
+  @classmethod
+  def store_webdx_feature_id_list(cls, new_list: list[str]):
+    webdx_features = WebdxFeatures.get_webdx_feature_id_list()
+    if not webdx_features:
+      webdx_features = WebdxFeatures(feature_ids=new_list)
+    else:
+      webdx_features.feature_ids = new_list
+    webdx_features.put()

--- a/internals/webdx_feature_models_test.py
+++ b/internals/webdx_feature_models_test.py
@@ -1,0 +1,51 @@
+# Copyright 2025 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config
+
+from internals.webdx_feature_models import WebdxFeatures
+
+
+class WebdxFeaturesTest(testing_config.CustomTestCase):
+  def setUp(self):
+    self.webdx = WebdxFeatures(feature_ids=['abc'])
+    self.webdx.put()
+
+  def tearDown(self):
+    self.webdx.key.delete()
+
+  def test_get_webdx_feature_id_list(self):
+    result = WebdxFeatures.get_webdx_feature_id_list()
+
+    self.assertIsNotNone(result)
+    self.assertEqual(len(result.feature_ids), 1)
+    self.assertEqual(result.feature_ids[0], 'abc')
+
+  def test_store_webdx_feature_id_list__success(self):
+    WebdxFeatures.store_webdx_feature_id_list(['foo'])
+
+    result = WebdxFeatures.query().fetch()
+    self.assertIsNotNone(result)
+    self.assertEqual(len(result), 1)
+    self.assertEqual(result[0].feature_ids[0], 'foo')
+
+  def test_store_webdx_feature_id_list__success_from_empty(self):
+    self.webdx.key.delete()
+
+    WebdxFeatures.store_webdx_feature_id_list(['foo'])
+
+    result = WebdxFeatures.query().fetch()
+    self.assertIsNotNone(result)
+    self.assertEqual(len(result), 1)
+    self.assertEqual(result[0].feature_ids[0], 'foo')

--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ from api import (
   stages_api,
   stars_api,
   token_refresh_api,
+  webdx_feature_api,
 )
 from framework import basehandlers, csp, sendemail
 from internals import (
@@ -177,6 +178,8 @@ api_routes: list[Route] = [
           origin_trials_api.OriginTrialsAPI),
     Route(f'{API_BASE}/origintrials/<int:feature_id>/<int:extension_stage_id>/extend',
           origin_trials_api.OriginTrialsAPI),
+
+    Route(f'{API_BASE}/webdxfeatures', webdx_feature_api.WebdxFeatureAPI),
 ]
 
 # The Routes below that have no handler specified use SPAHandler.


### PR DESCRIPTION
A part of https://github.com/GoogleChrome/chromium-dashboard/issues/4666. Implement `/webdxfeatures` backend API and return a sorted dictionary of feature IDs. Also create a singleton ndb model to store the feature ID list.