### PR TITLE
Add checks and tests for manual OT emails

### DIFF
--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -849,11 +849,19 @@ class SendManualOTCreatedEmail(FlaskHandler):
     stage: Stage|None = Stage.get_by_id(stage_id)
     if not stage:
       return f'Stage {stage_id} not found'
+    if stage.stage_type not in ALL_ORIGIN_TRIAL_STAGE_TYPES:
+      return f'Stage {stage_id} is not an origin trial stage'
+    if not stage.ot_owner_email and not stage.ot_emails:
+      return f'Stage {stage_id} has no OT contacts set'
+    if not stage.ot_display_name:
+      return f'Stage {stage_id} does not have ot_display_name set'
+    if stage.ot_activation_date is None:
+      return f'Stage {stage_id} does not have ot_activation_date set'
 
     cloud_tasks_helpers.enqueue_task(
         '/tasks/email-ot-creation-processed',
         {'stage': converters.stage_to_json_dict(stage)})
-    return 'Email task enqueued.'
+    return 'Email task enqueued'
 
 
 class SendManualOTActivatedEmail(FlaskHandler):
@@ -867,8 +875,14 @@ class SendManualOTActivatedEmail(FlaskHandler):
     stage: Stage|None = Stage.get_by_id(stage_id)
     if not stage:
       return f'Stage {stage_id} not found'
+    if stage.stage_type not in ALL_ORIGIN_TRIAL_STAGE_TYPES:
+      return f'Stage {stage_id} is not an origin trial stage'
+    if not stage.ot_owner_email and not stage.ot_emails:
+      return f'Stage {stage_id} has no OT contacts set'
+    if not stage.ot_display_name:
+      return f'Stage {stage_id} does not have ot_display_name set'
 
     cloud_tasks_helpers.enqueue_task(
         '/tasks/email-ot-activated',
         {'stage': converters.stage_to_json_dict(stage)})
-    return 'Email task enqueued.'
+    return 'Email task enqueued'

--- a/internals/maintenance_scripts_test.py
+++ b/internals/maintenance_scripts_test.py
@@ -947,7 +947,7 @@ class SendManualOTCreatedEmailTest(testing_config.CustomTestCase):
       entity.key.delete()
 
   @mock.patch('framework.cloud_tasks_helpers.enqueue_task')
-  def test_send__no_display_name(self, mock_enqueue):
+  def test_send__valid(self, mock_enqueue):
     """An email is sent if the stage meets all requirements."""
     result = self.handler.get_template_data(stage_id=self.ot_stage_id)
     self.assertEqual('Email task enqueued', result)
@@ -1015,7 +1015,7 @@ class SendManualOTActivatedEmailTest(testing_config.CustomTestCase):
       entity.key.delete()
 
   @mock.patch('framework.cloud_tasks_helpers.enqueue_task')
-  def test_send__no_display_name(self, mock_enqueue):
+  def test_send__valid(self, mock_enqueue):
     """An email is sent if the stage meets all requirements."""
     result = self.handler.get_template_data(stage_id=self.ot_stage_id)
     self.assertEqual('Email task enqueued', result)

--- a/internals/maintenance_scripts_test.py
+++ b/internals/maintenance_scripts_test.py
@@ -933,6 +933,9 @@ class SendManualOTCreatedEmailTest(testing_config.CustomTestCase):
 
   def setUp(self):
     self.handler = maintenance_scripts.SendManualOTCreatedEmail()
+    self.feature_1 = FeatureEntry(
+        id=1, name='feature a', summary='sum', category=1)
+    self.feature_1.put()
     self.ot_stage = Stage(id=111,
         feature_id=1, stage_type=150, ot_owner_email='owner1@google.com',
         ot_emails=['editor1@example.com'], ot_display_name='Example trial',
@@ -943,8 +946,9 @@ class SendManualOTCreatedEmailTest(testing_config.CustomTestCase):
     self.non_ot_stage.put()
 
   def tearDown(self):
-    for entity in Stage.query():
-      entity.key.delete()
+    for kind in [Stage, FeatureEntry]:
+      for entity in kind.query():
+        entity.key.delete()
 
   @mock.patch('framework.cloud_tasks_helpers.enqueue_task')
   def test_send__valid(self, mock_enqueue):
@@ -1002,6 +1006,9 @@ class SendManualOTActivatedEmailTest(testing_config.CustomTestCase):
 
   def setUp(self):
     self.handler = maintenance_scripts.SendManualOTActivatedEmail()
+    self.feature_1 = FeatureEntry(
+        id=1, name='feature a', summary='sum', category=1)
+    self.feature_1.put()
     self.ot_stage = Stage(id=111,
         feature_id=1, stage_type=150, ot_owner_email='owner1@google.com',
         ot_emails=['editor1@example.com'], ot_display_name='Example trial')
@@ -1011,8 +1018,9 @@ class SendManualOTActivatedEmailTest(testing_config.CustomTestCase):
     self.non_ot_stage.put()
 
   def tearDown(self):
-    for entity in Stage.query():
-      entity.key.delete()
+    for kind in [Stage, FeatureEntry]:
+      for entity in kind.query():
+        entity.key.delete()
 
   @mock.patch('framework.cloud_tasks_helpers.enqueue_task')
   def test_send__valid(self, mock_enqueue):


### PR DESCRIPTION
This change adds a number of checks to ensure that the manual OT email request will be processed correctly. The checks ensure that the stage is an OT stage and that the required fields are set in order to populate the email.