### PR TITLE
Turn on Webdx features cron job

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -44,7 +44,6 @@ cron:
 - description: Check if any origin trials require activation
   url: /cron/activate_origin_trials
   schedule: every day 9:00
-# TODO(kyleju): Activate this when it is ready.
-# - description: Fetch a new copy of Webdx feature ID list
-#  url: /cron/fetch_webdx_feature_ids
-#  schedule: every day 9:00
+- description: Fetch a new copy of Webdx feature ID list
+  url: /cron/fetch_webdx_feature_ids
+  schedule: every day 9:00


### PR DESCRIPTION
Fix https://github.com/GoogleChrome/chromium-dashboard/issues/4666. Turn on Webdx features cron job. It is scheduled once a day at 9, a slight higher frequency than the [web-feature repo](https://github.com/web-platform-dx/web-features/releases) release schedule