### PR TITLE
Allow CSS_PROPERTY_ID use counters to be supplied during OT creation

### DIFF
--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -198,7 +198,7 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
       elif uc_type == BlinkHistogramID.css_property_id:
         formatted_use_counter = webfeature_use_counter[13:]
         if not formatted_use_counter:
-          validation_errors['oit_webfeature_use_counter'] = (
+          validation_errors['ot_webfeature_use_counter'] = (
               'No CSSSampleId use counter provided.')
         elif (f'{formatted_use_counter} = '
               not in chromium_files['css_property_id_file']):

--- a/api/origin_trials_api_test.py
+++ b/api/origin_trials_api_test.py
@@ -111,6 +111,17 @@ enum WebDXFeature {
 };
 """
 
+    self.mock_css_property_id_usecounters_file = """
+enum CSSSampleId {
+  kSomeFeature = 1,
+  kValidFeature = 2,
+  kNoThirdParty = 3,
+  kSample = 4,
+  kNoCriticalTrial = 5,
+  kValidTrial = 6,
+};
+"""
+
     self.mock_features_file = """
 {
   "data": [
@@ -160,6 +171,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
     self.mock_chromium_files_dict = {
       'webfeature_file': self.mock_web_usecounters_file,
       'webdxfeature_file': self.mock_webdx_usecounters_file,
+      'css_property_id_file': self.mock_css_property_id_usecounters_file,
       'enabled_features_text': self.mock_features_file,
       'grace_period_file': self.mock_grace_period_file,
     }
@@ -343,6 +355,42 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
       'ot_webfeature_use_counter': {
         'form_field_name': 'ot_webfeature_use_counter',
         'value': 'WebDXFeature::kValidFeature',
+      },
+      'ot_is_critical_trial': {
+        'form_field_name': 'ot_is_critical_trial',
+        'value': True,
+      },
+      'ot_is_deprecation_trial': {
+        'form_field_name': 'ot_is_deprecation_trial',
+        'value': False,
+      },
+      'ot_has_third_party_support': {
+        'form_field_name': 'ot_has_third_party_support',
+        'value': True,
+      },
+    }
+    # No exception should be raised.
+    with test_app.test_request_context(self.request_path):
+      result = self.handler._validate_creation_args(
+          body, self.mock_chromium_files_dict)
+    expected = {}
+    self.assertEqual(expected, result)
+
+  @mock.patch('framework.origin_trials_client.get_trials_list')
+  def test_validate_creation_args__valid_css_property_id(
+      self, mock_get_trials_list):
+    """No error messages should be returned if all args are valid using a
+    CSSSampleId use counter."""
+    mock_get_trials_list.return_value = self.mock_trials_list
+
+    body = {
+      'ot_chromium_trial_name': {
+        'form_field_name': 'ot_chromium_trial_name',
+        'value': 'ValidFeature',
+      },
+      'ot_webfeature_use_counter': {
+        'form_field_name': 'ot_webfeature_use_counter',
+        'value': 'CSSSampleId::kValidFeature',
       },
       'ot_is_critical_trial': {
         'form_field_name': 'ot_is_critical_trial',

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -10,6 +10,8 @@ import {
   OT_SETUP_STATUS_OPTIONS,
   VOTE_OPTIONS,
   USE_COUNTER_TYPE_WEBFEATURE,
+  USE_COUNTER_TYPE_WEBDXFEATURE,
+  USE_COUNTER_TYPE_CSS_PROPERTY_ID,
 } from './form-field-enums.js';
 import {ALL_FIELDS} from './form-field-specs.js';
 import {
@@ -364,11 +366,14 @@ export class ChromedashOTCreationPage extends LitElement {
 
     if ('ot_webfeature_use_counter' in stageSubmitBody) {
       // Add on the appropriate use counter prefix.
-      const useCounterPrefix =
-        this.webfeatureUseCounterType === USE_COUNTER_TYPE_WEBFEATURE
-          ? ''
-          : 'WebDXFeature::';
-      stageSubmitBody.ot_webfeature_use_counter.value = `${useCounterPrefix}${stageSubmitBody.ot_webfeature_use_counter.value}`;
+      let useCounterPrefix = '';
+      if (this.webfeatureUseCounterType === USE_COUNTER_TYPE_WEBDXFEATURE) {
+        useCounterPrefix = 'WebDXFeature::';
+      } else if (this.webfeatureUseCounterType === USE_COUNTER_TYPE_CSS_PROPERTY_ID) {
+        useCounterPrefix = 'CSSSampleId::'
+      }
+      stageSubmitBody.ot_webfeature_use_counter.value =
+        `${useCounterPrefix}${stageSubmitBody.ot_webfeature_use_counter.value}`;
     }
 
     this.submitting = true;

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -369,11 +369,12 @@ export class ChromedashOTCreationPage extends LitElement {
       let useCounterPrefix = '';
       if (this.webfeatureUseCounterType === USE_COUNTER_TYPE_WEBDXFEATURE) {
         useCounterPrefix = 'WebDXFeature::';
-      } else if (this.webfeatureUseCounterType === USE_COUNTER_TYPE_CSS_PROPERTY_ID) {
-        useCounterPrefix = 'CSSSampleId::'
+      } else if (
+        this.webfeatureUseCounterType === USE_COUNTER_TYPE_CSS_PROPERTY_ID
+      ) {
+        useCounterPrefix = 'CSSSampleId::';
       }
-      stageSubmitBody.ot_webfeature_use_counter.value =
-        `${useCounterPrefix}${stageSubmitBody.ot_webfeature_use_counter.value}`;
+      stageSubmitBody.ot_webfeature_use_counter.value = `${useCounterPrefix}${stageSubmitBody.ot_webfeature_use_counter.value}`;
     }
 
     this.submitting = true;

--- a/client-src/elements/form-field-enums.ts
+++ b/client-src/elements/form-field-enums.ts
@@ -94,6 +94,7 @@ export const ROLLOUT_IMPACT_DISPLAYNAME: Record<number, string> = {
 
 export const USE_COUNTER_TYPE_WEBFEATURE = 0;
 export const USE_COUNTER_TYPE_WEBDXFEATURE = 1;
+export const USE_COUNTER_TYPE_CSS_PROPERTY_ID = 2;
 export const WEBFEATURE_USE_COUNTER_TYPES: Record<
   string,
   [number, string, string | HTMLTemplateResult]
@@ -116,6 +117,16 @@ export const WEBFEATURE_USE_COUNTER_TYPES: Record<
         target="_blank"
         href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/use_counter/metrics/webdx_feature.mojom"
         >webdx_feature.mojom</a
+      >.`,
+  ],
+  CSS: [
+    USE_COUNTER_TYPE_CSS_PROPERTY_ID,
+    'CSSSampleID',
+    html`The feature's use counter has been added to
+      <a
+        target="_blank"
+        href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/use_counter/metrics/css_property_id.mojom"
+        >css_property_id.mojom</a
       >.`,
   ],
 };

--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -192,6 +192,9 @@ def _send_create_trial_request(
     if (ot_stage.ot_webfeature_use_counter
         and ot_stage.ot_webfeature_use_counter.startswith('WebDXFeature::')):
       config['histogram_id'] = BlinkHistogramID.webdx_feature.value
+    if (ot_stage.ot_webfeature_use_counter
+        and ot_stage.ot_webfeature_use_counter.startswith('CSSSampleId::')):
+      config['histogram_id'] = BlinkHistogramID.css_property_id.value
     json['trial']['blink_use_counter_config'] = config
 
   headers = {'Authorization': f'Bearer {access_token}'}


### PR DESCRIPTION
Fixes #4702 

Additionally, when checking Chromium files to ensure inputs are valid, only the relevant file contents are obtained.
i.e. we only obtain the file contents for the use counter type that we are checking for (WebFeature, WebDXFeature, CSSSampleId, etc.)