### PR TITLE
Handle case where survey answers have not been provided yet.

### DIFF
--- a/client-src/elements/chromedash-survey-questions.ts
+++ b/client-src/elements/chromedash-survey-questions.ts
@@ -77,7 +77,7 @@ export class ChromedashSurveyQuestions extends LitElement {
   }
 
   renderBooleanField(name: string, desc: string): TemplateResult {
-    const value: boolean = this.gate.survey_answers[name];
+    const value: boolean = this.gate.survey_answers?.[name];
     return html`
       <li class="question">
         <sl-checkbox
@@ -91,7 +91,7 @@ export class ChromedashSurveyQuestions extends LitElement {
   }
 
   renderStringField(name: string, desc: string): TemplateResult {
-    const value: string = this.gate.survey_answers[name];
+    const value: string = this.gate.survey_answers?.[name];
     return html`
       <li class="question">
         ${desc}

--- a/client-src/elements/chromedash-survey-questions_test.ts
+++ b/client-src/elements/chromedash-survey-questions_test.ts
@@ -102,8 +102,7 @@ describe('chromedash-survey-questions', () => {
     assert.isFalse(checkbox2.checked);
   });
 
-  it('displays the privacy surveys even when nothing has been entered',
-    async () => {
+  it('displays the privacy surveys even when nothing has been entered', async () => {
     const component = (await fixture(
       html`<chromedash-survey-questions
         .feature=${feature}

--- a/client-src/elements/chromedash-survey-questions_test.ts
+++ b/client-src/elements/chromedash-survey-questions_test.ts
@@ -30,6 +30,13 @@ describe('chromedash-survey-questions', () => {
     },
   };
 
+  const uneditedPrivacyGate = {
+    stage_id: 1,
+    gate_id: 13,
+    gate_type: GATE_TYPES.PRIVACY_SHIP,
+    survey_answers: null,
+  };
+
   const feature = {
     id: 123456789,
   };
@@ -88,6 +95,31 @@ describe('chromedash-survey-questions', () => {
     );
     assert.instanceOf(checkbox1, SlCheckbox);
     assert.isTrue(checkbox1.checked);
+    const checkbox2 = component.shadowRoot!.querySelector(
+      '[name=is_api_polyfill]'
+    );
+    assert.instanceOf(checkbox2, SlCheckbox);
+    assert.isFalse(checkbox2.checked);
+  });
+
+  it('displays the privacy surveys even when nothing has been entered',
+    async () => {
+    const component = (await fixture(
+      html`<chromedash-survey-questions
+        .feature=${feature}
+        .gate=${uneditedPrivacyGate}
+        .loading=${false}
+      ></chromedash-survey-questions>`
+    )) as ChromedashSurveyQuestions;
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashSurveyQuestions);
+    assert.notInclude(component.shadowRoot!.innerHTML, 'Loading...');
+    assert.include(component.shadowRoot!.innerHTML, 'JS language construct');
+    const checkbox1 = component.shadowRoot!.querySelector(
+      '[name=is_language_polyfill]'
+    );
+    assert.instanceOf(checkbox1, SlCheckbox);
+    assert.isFalse(checkbox1.checked);
     const checkbox2 = component.shadowRoot!.querySelector(
       '[name=is_api_polyfill]'
     );


### PR DESCRIPTION
This PR tweaks the code to handle the case where `gate.survey_answers` is `null`.  That's an important case because all existing gates will have that in the API response at first. I guess I must have been testing with a gate that I had previously used to test the API for saving answers before implementing the UI.  