### PR TITLE
Implement self certify dialog

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -667,6 +667,7 @@ def gate_value_to_json_dict(gate: Gate) -> dict[str, Any]:
       slo_resolve_remaining = slo.remaining_days(
           gate.requested_on, slo_resolve) + (gate.needs_work_elapsed or 0)
 
+  self_certify_possible = self_certify.is_possible(gate)
   self_certify_eligible = self_certify.is_eligible(gate)
   survey_answers = to_dict(gate.survey_answers) if gate.survey_answers else None
 
@@ -692,6 +693,7 @@ def gate_value_to_json_dict(gate: Gate) -> dict[str, Any]:
       'slo_resolve_remaining': slo_resolve_remaining,
       # YYYY-MM-DD HH:MM:SS or None
       'needs_work_started_on': needs_work_started_on,
+      'self_certify_possible': self_certify_possible,
       'self_certify_eligible': self_certify_eligible,
       'survey_answers': survey_answers,
       }

--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -547,6 +547,7 @@ class GateConvertersTest(testing_config.CustomTestCase):
       'slo_resolve_remaining': None,
       'needs_work_started_on': None,
       'self_certify_eligible': False,
+      'self_certify_possible': False,
       'survey_answers': None,
       }
     self.assertEqual(expected, actual)
@@ -590,6 +591,7 @@ class GateConvertersTest(testing_config.CustomTestCase):
       'slo_resolve_remaining': None,
       'needs_work_started_on': None,
       'self_certify_eligible': True,
+      'self_certify_possible': True,
       'survey_answers': {
           'is_api_polyfill': False,
           'is_language_polyfill': True,

--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -113,11 +113,15 @@ class VotesAPI(basehandlers.APIHandler):
   def require_permissions(self, user, feature, gate, new_state):
     """Abort the request if the user lacks permission to set this vote."""
     is_requesting_review = new_state in (Vote.REVIEW_REQUESTED, Vote.NA_REQUESTED)
+    is_approving = new_state in (Vote.APPROVED, Vote.NA)
     is_editor = permissions.can_edit_feature(user, feature.key.integer_id())
     approvers = approval_defs.get_approvers(gate.gate_type)
     is_approver = permissions.can_review_gate(user, feature, gate, approvers)
 
     if is_requesting_review and is_editor:
+      return
+
+    if is_approving and is_editor and self_certify.is_eligible(gate):
       return
 
     if is_approver:

--- a/api/reviews_api_test.py
+++ b/api/reviews_api_test.py
@@ -347,6 +347,7 @@ class GatesAPITest(testing_config.CustomTestCase):
                 "next_action": None,
                 "additional_review": False,
                 'self_certify_eligible': False,
+                'self_certify_possible': False,
                 'slo_initial_response': 5,
                 'slo_initial_response_took': None,
                 'slo_initial_response_remaining': None,

--- a/api/reviews_api_test.py
+++ b/api/reviews_api_test.py
@@ -24,7 +24,7 @@ from api import reviews_api
 from internals import approval_defs
 from internals.core_enums import *
 from internals import core_models
-from internals.review_models import Gate, Vote
+from internals.review_models import Gate, Vote, SurveyAnswers
 
 test_app = flask.Flask(__name__)
 
@@ -275,7 +275,7 @@ class VotesAPITest(testing_config.CustomTestCase):
   @mock.patch('internals.notifier_helpers.notify_approvers_of_reviews')
   @mock.patch('internals.approval_defs.get_approvers')
   def test_post__request_review(self, mock_get_approvers, mock_notifier):
-    """Handler allows a feature owner to rquest a review."""
+    """Handler allows a feature owner to request a review."""
     mock_get_approvers.return_value = ['reviewer1@example.com']
     testing_config.sign_in('owner1@example.com', 123567890)
 
@@ -296,6 +296,50 @@ class VotesAPITest(testing_config.CustomTestCase):
     mock_notifier.assert_called_once_with(
         self.feature_1, self.gate_1, Vote.REVIEW_REQUESTED,
         'owner1@example.com')
+
+  @mock.patch('internals.notifier_helpers.notify_subscribers_of_vote_changes')
+  @mock.patch('internals.approval_defs.get_approvers')
+  def test_post__self_cert__ineligible(self, mock_get_approvers, mock_notifier):
+    """Handler allows a feature owner to self-approve if eligible."""
+    mock_get_approvers.return_value = ['reviewer1@example.com']
+    testing_config.sign_in('owner1@example.com', 123567890)
+    self.gate_1.gate_type = GATE_PRIVACY_SHIP
+    # No survey answers filled in.
+    self.gate_1.put()
+
+    params = {'state': Vote.APPROVED}
+    with test_app.test_request_context(self.request_path, json=params):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
+        self.handler.do_post(
+            feature_id=self.feature_id, gate_id=self.gate_1_id)
+
+  @mock.patch('internals.notifier_helpers.notify_subscribers_of_vote_changes')
+  @mock.patch('internals.approval_defs.get_approvers')
+  def test_post__self_cert__eligible(self, mock_get_approvers, mock_notifier):
+    """Handler allows a feature owner to self-approve if eligible."""
+    mock_get_approvers.return_value = ['reviewer1@example.com']
+    testing_config.sign_in('owner1@example.com', 123567890)
+    self.gate_1.gate_type = GATE_PRIVACY_SHIP
+    self.gate_1.survey_answers = SurveyAnswers(is_language_polyfill=True)
+    self.gate_1.put()
+
+    params = {'state': Vote.APPROVED}
+    with test_app.test_request_context(self.request_path, json=params):
+      actual = self.handler.do_post(
+          feature_id=self.feature_id, gate_id=self.gate_1_id)
+
+    self.assertEqual(actual, {'message': 'Done'})
+    updated_votes = Vote.get_votes(feature_id=self.feature_id)
+    self.assertEqual(1, len(updated_votes))
+    vote = updated_votes[0]
+    self.assertEqual(vote.feature_id, self.feature_id)
+    self.assertEqual(vote.gate_id, 1)
+    self.assertEqual(vote.set_by, 'owner1@example.com')
+    self.assertEqual(vote.state, Vote.APPROVED)
+
+    mock_notifier.assert_called_once_with(
+        self.feature_1, self.gate_1, 'owner1@example.com',
+        Vote.APPROVED, Vote.NO_RESPONSE)
 
 
 class GatesAPITest(testing_config.CustomTestCase):

--- a/client-src/elements/chromedash-feature-page.ts
+++ b/client-src/elements/chromedash-feature-page.ts
@@ -346,7 +346,6 @@ export class ChromedashFeaturePage extends LitElement {
   }
 
   refetch() {
-    this.loading = true;
     Promise.all([
       window.csClient.getFeature(this.featureId),
       window.csClient.getGates(this.featureId),
@@ -356,7 +355,6 @@ export class ChromedashFeaturePage extends LitElement {
         this.feature = feature;
         this.gates = gatesRes.gates;
         this.comments = commentRes.comments;
-        this.loading = false;
       })
       .catch(error => {
         if (error instanceof FeatureNotFoundError) {

--- a/client-src/elements/chromedash-gate-chip.ts
+++ b/client-src/elements/chromedash-gate-chip.ts
@@ -57,6 +57,7 @@ export interface GateDict {
   slo_resolve_remaining: number;
   needs_work_started_on: string;
   possible_assignee_emails: string[];
+  self_certify_possible: boolean;
   self_certify_eligible: boolean;
   survey_answers: {
     is_language_polyfill: boolean;

--- a/client-src/elements/chromedash-gate-column.ts
+++ b/client-src/elements/chromedash-gate-column.ts
@@ -273,7 +273,6 @@ export class ChromedashGateColumn extends LitElement {
         this.votes = votesRes.votes.filter(v => v.gate_id == this.gate.id);
         this.comments = commentRes.comments;
         this.needsSave = false;
-        this.loading = false;
       })
       .catch(() => {
         showToastMessage(
@@ -412,22 +411,36 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   async handleReviewRequested() {
-    maybeOpenCertifyDialog(this.gate).then(selfCertifying => {
-      if (selfCertifying) {
-        this.handleSelfCertify();
-      } else {
-        this.handleReviewRequestSubmitted();
+    maybeOpenCertifyDialog(this.gate, VOTE_OPTIONS.APPROVED[0]).then(
+      selfCertifying => {
+        if (selfCertifying) {
+          this.handleSelfCertify(VOTE_OPTIONS.APPROVED[0]);
+        } else {
+          this.handleFullReviewRequest();
+        }
       }
-    });
+    );
   }
 
-  handleNARequested() {
+  async handleNARequested() {
+    maybeOpenCertifyDialog(this.gate, VOTE_OPTIONS.NA[0]).then(
+      selfCertifying => {
+        if (selfCertifying) {
+          this.handleSelfCertify(VOTE_OPTIONS.NA[0]);
+        } else {
+          this.handleFullNARequested();
+        }
+      }
+    );
+  }
+
+  handleFullNARequested() {
     openNaRationaleDialog(this.gate).then(rationale => {
       this.handleNARequestSubmitted(rationale);
     });
   }
 
-  async handleReviewRequestSubmitted() {
+  async handleFullReviewRequest() {
     await window.csClient.setVote(
       this.feature.id,
       this.gate.id,
@@ -436,12 +449,8 @@ export class ChromedashGateColumn extends LitElement {
     this._fireEvent('refetch-needed', {});
   }
 
-  async handleSelfCertify() {
-    await window.csClient.setVote(
-      this.feature.id,
-      this.gate.id,
-      VOTE_OPTIONS.APPROVED[0]
-    );
+  async handleSelfCertify(voteValue: number) {
+    await window.csClient.setVote(this.feature.id, this.gate.id, voteValue);
     this._fireEvent('refetch-needed', {});
   }
 

--- a/client-src/elements/chromedash-gate-column.ts
+++ b/client-src/elements/chromedash-gate-column.ts
@@ -3,6 +3,7 @@ import {createRef, ref} from 'lit/directives/ref.js';
 import './chromedash-activity-log';
 import './chromedash-survey-questions';
 import {openNaRationaleDialog} from './chromedash-na-rationale-dialog';
+import {maybeOpenCertifyDialog} from './chromedash-self-certify-dialog';
 import {
   openPreflightDialog,
   somePendingGates,
@@ -411,6 +412,22 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   async handleReviewRequested() {
+    maybeOpenCertifyDialog(this.gate).then(selfCertifying => {
+      if (selfCertifying) {
+        this.handleSelfCertify();
+      } else {
+        this.handleReviewRequestSubmitted();
+      }
+    });
+  }
+
+  handleNARequested() {
+    openNaRationaleDialog(this.gate).then(rationale => {
+      this.handleNARequestSubmitted(rationale);
+    });
+  }
+
+  async handleReviewRequestSubmitted() {
     await window.csClient.setVote(
       this.feature.id,
       this.gate.id,
@@ -419,10 +436,13 @@ export class ChromedashGateColumn extends LitElement {
     this._fireEvent('refetch-needed', {});
   }
 
-  handleNARequested() {
-    openNaRationaleDialog(this.gate).then(rationale => {
-      this.handleNARequestSubmitted(rationale);
-    });
+  async handleSelfCertify() {
+    await window.csClient.setVote(
+      this.feature.id,
+      this.gate.id,
+      VOTE_OPTIONS.APPROVED[0]
+    );
+    this._fireEvent('refetch-needed', {});
   }
 
   async handleNARequestSubmitted(rationale) {

--- a/client-src/elements/chromedash-self-certify-dialog.ts
+++ b/client-src/elements/chromedash-self-certify-dialog.ts
@@ -1,0 +1,132 @@
+import {LitElement, css, html} from 'lit';
+import {SHARED_STYLES} from '../css/shared-css.js';
+import {customElement, property} from 'lit/decorators.js';
+import {GateDict} from './chromedash-gate-chip.js';
+
+let certifyDialogEl;
+
+function shouldShowCertifyDialog(gate: GateDict): boolean {
+  return gate.self_certify_possible;
+}
+
+export async function maybeOpenCertifyDialog(gate: GateDict) {
+  if (shouldShowCertifyDialog(gate)) {
+    return new Promise(resolve => {
+      openCertifyDialog(gate, resolve);
+    });
+  } else {
+    return Promise.resolve();
+  }
+}
+
+async function openCertifyDialog(gate, resolve) {
+  if (!certifyDialogEl) {
+    certifyDialogEl = document.createElement('chromedash-self-certify-dialog');
+    document.body.appendChild(certifyDialogEl);
+  }
+  await certifyDialogEl.updateComplete;
+  certifyDialogEl.gate = gate;
+  certifyDialogEl.resolve = resolve;
+  certifyDialogEl.show();
+}
+
+
+@customElement('chromedash-self-certify-dialog')
+class ChromedashSelfCertifyDialog extends LitElement {
+  @property({type: Object})
+  gate!: GateDict;
+  @property({attribute: false})
+  resolve: (value?: boolean) => void = () => {
+    console.log('Missing resolve action');
+  };
+
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      css`
+        #prereqs-list li {
+          margin-left: 8px;
+          margin-bottom: 8px;
+          list-style: circle;
+        }
+        #prereqs-header {
+          margin-bottom: 8px;
+        }
+        sl-button {
+          float: right;
+          margin: var(--content-padding-half);
+        }
+      `,
+    ];
+  }
+
+  show() {
+    this.renderRoot.querySelector('sl-dialog')?.show();
+  }
+
+  hide() {
+    this.renderRoot.querySelector('sl-dialog')?.hide();
+  }
+
+  handleCancel() {
+    // Note: promise is never resolved.
+    this.hide();
+  }
+
+  handleSelfCertify() {
+    this.resolve(true);
+    this.hide();
+  }
+
+  handleFullReview() {
+    this.resolve(false);
+    this.hide();
+  }
+
+  renderContentWhenNotEligible() {
+    return html`
+      <div id="prereqs-header">
+    This review gate allows for self-certification rather than a full
+    review.  However, the answers to the survey questions do not qualify
+    for self-certification.
+      </div>
+      <br />
+      <sl-button size="small" @click=${this.handleFullReview}
+        >Request full review</sl-button
+      >
+      <sl-button size="small" @click=${this.handleCancel}
+        >Go back to survey answers</sl-button
+      >
+    `;
+  }
+
+  renderContentWhenEligible() {
+    return html`
+      <div id="prereqs-header">
+    Based on your answers to the survey questions, you may self-certify
+    an approval for this gate.  Alternatively, if you want to start a
+    consulation with the review team, you may request a full review.
+      </div>
+      <br />
+      <sl-button size="small" @click=${this.handleFullReview}
+        >Request full review</sl-button
+      >
+      <sl-button size="small" variant="primary" @click=${this.handleSelfCertify}
+        >Self-certify approval</sl-button
+      >
+    `;
+  }
+
+
+  render() {
+    if (this.gate === undefined) {
+      return html`Loading gates...`;
+    }
+
+    return html`
+    <sl-dialog label="Self-certification">
+    ${this.gate.self_certify_eligible ? this.renderContentWhenEligible() :
+      this.renderContentWhenNotEligible()}
+    </sl-dialog>`;
+  }
+}

--- a/client-src/elements/chromedash-self-certify-dialog.ts
+++ b/client-src/elements/chromedash-self-certify-dialog.ts
@@ -2,6 +2,7 @@ import {LitElement, css, html} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {customElement, property} from 'lit/decorators.js';
 import {GateDict} from './chromedash-gate-chip.js';
+import {VOTE_OPTIONS} from './form-field-enums';
 
 let certifyDialogEl;
 
@@ -9,32 +10,37 @@ function shouldShowCertifyDialog(gate: GateDict): boolean {
   return gate.self_certify_possible;
 }
 
-export async function maybeOpenCertifyDialog(gate: GateDict) {
+export async function maybeOpenCertifyDialog(
+  gate: GateDict,
+  voteValue: number
+) {
   if (shouldShowCertifyDialog(gate)) {
     return new Promise(resolve => {
-      openCertifyDialog(gate, resolve);
+      openCertifyDialog(gate, voteValue, resolve);
     });
   } else {
     return Promise.resolve();
   }
 }
 
-async function openCertifyDialog(gate, resolve) {
+async function openCertifyDialog(gate, voteValue, resolve) {
   if (!certifyDialogEl) {
     certifyDialogEl = document.createElement('chromedash-self-certify-dialog');
     document.body.appendChild(certifyDialogEl);
   }
-  await certifyDialogEl.updateComplete;
   certifyDialogEl.gate = gate;
+  certifyDialogEl.voteValue = voteValue;
   certifyDialogEl.resolve = resolve;
+  await certifyDialogEl.updateComplete;
   certifyDialogEl.show();
 }
-
 
 @customElement('chromedash-self-certify-dialog')
 class ChromedashSelfCertifyDialog extends LitElement {
   @property({type: Object})
   gate!: GateDict;
+  @property({type: Number})
+  voteValue!: number;
   @property({attribute: false})
   resolve: (value?: boolean) => void = () => {
     console.log('Missing resolve action');
@@ -86,9 +92,9 @@ class ChromedashSelfCertifyDialog extends LitElement {
   renderContentWhenNotEligible() {
     return html`
       <div id="prereqs-header">
-    This review gate allows for self-certification rather than a full
-    review.  However, the answers to the survey questions do not qualify
-    for self-certification.
+        This review gate allows for self-certification rather than a full
+        review. However, the answers to the survey questions do not qualify for
+        self-certification.
       </div>
       <br />
       <sl-button size="small" @click=${this.handleFullReview}
@@ -101,32 +107,33 @@ class ChromedashSelfCertifyDialog extends LitElement {
   }
 
   renderContentWhenEligible() {
+    const voteWord =
+      this.voteValue == VOTE_OPTIONS.APPROVED[0] ? 'approval' : 'N/A';
     return html`
       <div id="prereqs-header">
-    Based on your answers to the survey questions, you may self-certify
-    an approval for this gate.  Alternatively, if you want to start a
-    consulation with the review team, you may request a full review.
+        Based on your answers to the survey questions, you may self-certify an
+        ${voteWord} for this gate. Alternatively, if you want to start a
+        consulation with the review team, you may request a full review.
       </div>
       <br />
       <sl-button size="small" @click=${this.handleFullReview}
         >Request full review</sl-button
       >
       <sl-button size="small" variant="primary" @click=${this.handleSelfCertify}
-        >Self-certify approval</sl-button
+        >Self-certify ${voteWord}</sl-button
       >
     `;
   }
-
 
   render() {
     if (this.gate === undefined) {
       return html`Loading gates...`;
     }
 
-    return html`
-    <sl-dialog label="Self-certification">
-    ${this.gate.self_certify_eligible ? this.renderContentWhenEligible() :
-      this.renderContentWhenNotEligible()}
+    return html` <sl-dialog label="Self-certification">
+      ${this.gate.self_certify_eligible
+        ? this.renderContentWhenEligible()
+        : this.renderContentWhenNotEligible()}
     </sl-dialog>`;
   }
 }

--- a/client-src/elements/chromedash-survey-questions.ts
+++ b/client-src/elements/chromedash-survey-questions.ts
@@ -50,15 +50,13 @@ export class ChromedashSurveyQuestions extends LitElement {
   @state()
   loading = true;
 
-  refetch() {
-    window.csClient.getGates(this.feature.id).then(resp => {
-      for (const g of resp.gates) {
-        if (g.id === this.gate.id) {
-          this.gate = g;
-          break;
-        }
-      }
+  _fireEvent(eventName, detail) {
+    const event = new CustomEvent(eventName, {
+      bubbles: true,
+      composed: true,
+      detail,
     });
+    this.dispatchEvent(event);
   }
 
   renderQuestionnaireSkeleton(): TemplateResult {
@@ -72,7 +70,8 @@ export class ChromedashSurveyQuestions extends LitElement {
     window.csClient
       .updateGate(this.feature.id, this.gate.id, null, {[name]: value})
       .then(() => {
-        this.refetch();
+        this._fireEvent('refetch-needed', {});
+        // this.refetch();
       });
   }
 

--- a/gen/js/chromestatus-openapi/package.json
+++ b/gen/js/chromestatus-openapi/package.json
@@ -16,6 +16,6 @@
     "prepare": "npm run build"
   },
   "devDependencies": {
-    "typescript": "^4.0 || ^5.0"
+    "typescript": "^5.7"
   }
 }

--- a/gen/js/chromestatus-openapi/package.json
+++ b/gen/js/chromestatus-openapi/package.json
@@ -16,6 +16,6 @@
     "prepare": "npm run build"
   },
   "devDependencies": {
-    "typescript": "^5.7"
+    "typescript": "^4.0 || ^5.0"
   }
 }

--- a/gen/js/chromestatus-openapi/src/models/Gate.ts
+++ b/gen/js/chromestatus-openapi/src/models/Gate.ts
@@ -160,6 +160,12 @@ export interface Gate {
     self_certify_eligible?: boolean;
     /**
      * 
+     * @type {boolean}
+     * @memberof Gate
+     */
+    self_certify_possible?: boolean;
+    /**
+     * 
      * @type {SurveyAnswers}
      * @memberof Gate
      */
@@ -205,6 +211,7 @@ export function GateFromJSONTyped(json: any, ignoreDiscriminator: boolean): Gate
         'needs_work_started_on': json['needs_work_started_on'] == null ? undefined : (new Date(json['needs_work_started_on'])),
         'possible_assignee_emails': json['possible_assignee_emails'] == null ? undefined : json['possible_assignee_emails'],
         'self_certify_eligible': json['self_certify_eligible'] == null ? undefined : json['self_certify_eligible'],
+        'self_certify_possible': json['self_certify_possible'] == null ? undefined : json['self_certify_possible'],
         'survey_answers': json['survey_answers'] == null ? undefined : SurveyAnswersFromJSON(json['survey_answers']),
     };
 }
@@ -237,6 +244,7 @@ export function GateToJSON(value?: Gate | null): any {
         'needs_work_started_on': value['needs_work_started_on'] == null ? undefined : ((value['needs_work_started_on']).toISOString()),
         'possible_assignee_emails': value['possible_assignee_emails'],
         'self_certify_eligible': value['self_certify_eligible'],
+        'self_certify_possible': value['self_certify_possible'],
         'survey_answers': SurveyAnswersToJSON(value['survey_answers']),
     };
 }

--- a/gen/py/chromestatus_openapi/chromestatus_openapi/models/gate.py
+++ b/gen/py/chromestatus_openapi/chromestatus_openapi/models/gate.py
@@ -14,7 +14,7 @@ class Gate(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, id=None, feature_id=None, stage_id=None, gate_type=None, team_name=None, gate_name=None, escalation_email=None, state=None, requested_on=None, responded_on=None, assignee_emails=None, next_action=None, additional_review=None, slo_initial_response=5, slo_initial_response_took=None, slo_initial_response_remaining=None, slo_resolve=10, slo_resolve_took=None, slo_resolve_remaining=None, needs_work_started_on=None, possible_assignee_emails=None, self_certify_eligible=None, survey_answers=None):  # noqa: E501
+    def __init__(self, id=None, feature_id=None, stage_id=None, gate_type=None, team_name=None, gate_name=None, escalation_email=None, state=None, requested_on=None, responded_on=None, assignee_emails=None, next_action=None, additional_review=None, slo_initial_response=5, slo_initial_response_took=None, slo_initial_response_remaining=None, slo_resolve=10, slo_resolve_took=None, slo_resolve_remaining=None, needs_work_started_on=None, possible_assignee_emails=None, self_certify_eligible=None, self_certify_possible=None, survey_answers=None):  # noqa: E501
         """Gate - a model defined in OpenAPI
 
         :param id: The id of this Gate.  # noqa: E501
@@ -61,6 +61,8 @@ class Gate(Model):
         :type possible_assignee_emails: List[str]
         :param self_certify_eligible: The self_certify_eligible of this Gate.  # noqa: E501
         :type self_certify_eligible: bool
+        :param self_certify_possible: The self_certify_possible of this Gate.  # noqa: E501
+        :type self_certify_possible: bool
         :param survey_answers: The survey_answers of this Gate.  # noqa: E501
         :type survey_answers: SurveyAnswers
         """
@@ -87,6 +89,7 @@ class Gate(Model):
             'needs_work_started_on': datetime,
             'possible_assignee_emails': List[str],
             'self_certify_eligible': bool,
+            'self_certify_possible': bool,
             'survey_answers': SurveyAnswers
         }
 
@@ -113,6 +116,7 @@ class Gate(Model):
             'needs_work_started_on': 'needs_work_started_on',
             'possible_assignee_emails': 'possible_assignee_emails',
             'self_certify_eligible': 'self_certify_eligible',
+            'self_certify_possible': 'self_certify_possible',
             'survey_answers': 'survey_answers'
         }
 
@@ -138,6 +142,7 @@ class Gate(Model):
         self._needs_work_started_on = needs_work_started_on
         self._possible_assignee_emails = possible_assignee_emails
         self._self_certify_eligible = self_certify_eligible
+        self._self_certify_possible = self_certify_possible
         self._survey_answers = survey_answers
 
     @classmethod
@@ -616,6 +621,27 @@ class Gate(Model):
         """
 
         self._self_certify_eligible = self_certify_eligible
+
+    @property
+    def self_certify_possible(self) -> bool:
+        """Gets the self_certify_possible of this Gate.
+
+
+        :return: The self_certify_possible of this Gate.
+        :rtype: bool
+        """
+        return self._self_certify_possible
+
+    @self_certify_possible.setter
+    def self_certify_possible(self, self_certify_possible: bool):
+        """Sets the self_certify_possible of this Gate.
+
+
+        :param self_certify_possible: The self_certify_possible of this Gate.
+        :type self_certify_possible: bool
+        """
+
+        self._self_certify_possible = self_certify_possible
 
     @property
     def survey_answers(self) -> SurveyAnswers:

--- a/gen/py/chromestatus_openapi/chromestatus_openapi/openapi/openapi.yaml
+++ b/gen/py/chromestatus_openapi/chromestatus_openapi/openapi/openapi.yaml
@@ -1293,6 +1293,7 @@ components:
     Gate:
       example:
         feature_id: 6
+        self_certify_possible: true
         stage_id: 1
         slo_initial_response: 2
         needs_work_started_on: 2000-01-23T04:56:07.000+00:00
@@ -1405,6 +1406,9 @@ components:
         self_certify_eligible:
           title: self_certify_eligible
           type: boolean
+        self_certify_possible:
+          title: self_certify_possible
+          type: boolean
         survey_answers:
           $ref: '#/components/schemas/SurveyAnswers'
       title: Gate
@@ -1434,6 +1438,7 @@ components:
       example:
         gates:
         - feature_id: 6
+          self_certify_possible: true
           stage_id: 1
           slo_initial_response: 2
           needs_work_started_on: 2000-01-23T04:56:07.000+00:00
@@ -1465,6 +1470,7 @@ components:
           self_certify_eligible: true
           slo_resolve: 3
         - feature_id: 6
+          self_certify_possible: true
           stage_id: 1
           slo_initial_response: 2
           needs_work_started_on: 2000-01-23T04:56:07.000+00:00

--- a/internals/self_certify.py
+++ b/internals/self_certify.py
@@ -18,6 +18,9 @@ from internals.core_enums import GATE_PRIVACY_ORIGIN_TRIAL, GATE_PRIVACY_SHIP
 from internals.review_models import Gate, SurveyAnswers
 
 
+CERTIFIABLE_GATE_TYPES = [GATE_PRIVACY_ORIGIN_TRIAL, GATE_PRIVACY_SHIP]
+
+
 def update_survey_answers(gate: Gate, new_answers: OASurveyAnswers):
   """Modify the given SurveyAnswers with user-requested changes."""
   if gate.survey_answers is None:
@@ -44,7 +47,7 @@ def is_privacy_eligible(answers: SurveyAnswers) -> bool:
 
 
 def is_eligible(gate: Gate) -> bool:
-  """Return True if the feature owner can self-certify."""
+  """Return True if the feature owner can self-certify the gate now."""
   answers = gate.survey_answers
   if answers is None:
     return False
@@ -53,3 +56,8 @@ def is_eligible(gate: Gate) -> bool:
     return is_privacy_eligible(answers)
 
   return False
+
+
+def is_possible(gate: Gate) -> bool:
+  """Return True if the feature owner can ever self-certify this gate."""
+  return gate.gate_type in CERTIFIABLE_GATE_TYPES

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -1123,6 +1123,8 @@ components:
             format: email
         self_certify_eligible:
           type: boolean
+        self_certify_possible:
+          type: boolean
         survey_answers:
           $ref: '#/components/schemas/SurveyAnswers'
     SurveyAnswers:


### PR DESCRIPTION
This should resolve #4697.  For the privacy team's two gates, we will now offer the feature editors the ability to self-certify the gate if the survey answers make it eligible.

In this PR:
* Define another boolean in the OpenAPI response when getting Gates: `self_certify_possible` is true for gates where it is ever possible to self-certify.  For now, that is only the privacy gates.
* Change the VotesAPI to allow a feature editor to post an APPROVED or NA vote on a gate iff it is eligible.  This results in a normal vote Activity generation and email notification, as if a reviewer had voted.
* Change the `refetch()` method on the feature detail page to not set `this.loading` so as to avoid excessive blinking when page content is updated.  The whole page needs to refetch rather than just the survey questions form because the "Request review" button logic depends on it.
* Implement a self-certification dialog and have it open when the user presses "Request review" or "Request NA", but only if the self-certification is possible on that gate.  The buttons offered inside the dialog depend on whether the gate is eligible.
