### PR TITLE
Display survey forms read-only to non-editors.

### DIFF
--- a/client-src/elements/chromedash-gate-column.ts
+++ b/client-src/elements/chromedash-gate-column.ts
@@ -1075,6 +1075,7 @@ export class ChromedashGateColumn extends LitElement {
 
       <chromedash-survey-questions
         .loading=${this.loading}
+        .user=${this.user}
         .feature=${this.feature}
         .gate=${this.gate}
       ></chromedash-survey-questions>

--- a/client-src/elements/chromedash-prevote-dialog.ts
+++ b/client-src/elements/chromedash-prevote-dialog.ts
@@ -31,9 +31,9 @@ async function openPrevoteDialog(pendingGates, resolve) {
     prevoteDialogEl = document.createElement('chromedash-prevote-dialog');
     document.body.appendChild(prevoteDialogEl);
   }
-  await prevoteDialogEl.updateComplete;
   prevoteDialogEl.pendingGates = pendingGates;
   prevoteDialogEl.resolve = resolve;
+  await prevoteDialogEl.updateComplete;
   prevoteDialogEl.show();
 }
 

--- a/client-src/elements/chromedash-survey-questions.ts
+++ b/client-src/elements/chromedash-survey-questions.ts
@@ -43,6 +43,8 @@ export class ChromedashSurveyQuestions extends LitElement {
     ];
   }
 
+  @property({type: Object})
+  user!: User;
   @state()
   feature!: Feature;
   @state()
@@ -57,6 +59,15 @@ export class ChromedashSurveyQuestions extends LitElement {
       detail,
     });
     this.dispatchEvent(event);
+  }
+
+  /* A user that can edit the current feature can edit the survey. */
+  canEditSurvey() {
+    return (
+      this.user &&
+      (this.user.can_edit_all ||
+        this.user.editable_features.includes(this.feature.id))
+    );
   }
 
   renderQuestionnaireSkeleton(): TemplateResult {
@@ -81,6 +92,7 @@ export class ChromedashSurveyQuestions extends LitElement {
         <sl-checkbox
           name=${name}
           ?checked=${value}
+          ?disabled=${!this.canEditSurvey()}
           @sl-change=${e => this.handleFieldChange(name, e.target?.checked)}
         ></sl-checkbox>
         ${desc}
@@ -97,6 +109,7 @@ export class ChromedashSurveyQuestions extends LitElement {
           name="${name}"
           size="small"
           value=${value}
+          ?disabled=${!this.canEditSurvey()}
           @sl-change=${e => this.handleFieldChange(name, e.target?.value)}
         ></sl-input>
       </li>

--- a/client-src/elements/chromedash-survey-questions_test.ts
+++ b/client-src/elements/chromedash-survey-questions_test.ts
@@ -6,6 +6,32 @@ import {ChromeStatusClient} from '../js-src/cs-client';
 import {GATE_TYPES} from './form-field-enums';
 
 describe('chromedash-survey-questions', () => {
+  const featureOwner = {
+    can_create_feature: true,
+    can_edit_all: false,
+    is_admin: false,
+    email: 'example@google.com',
+    approvable_gate_types: [],
+    editable_features: [123456789],
+  };
+
+  const visitor = {
+    can_create_feature: true,
+    can_edit_all: false,
+    is_admin: false,
+    email: 'example@google.com',
+    approvable_gate_types: [],
+    editable_features: [],
+  };
+
+  const admin = {
+    can_create_feature: true,
+    can_edit_all: true,
+    is_admin: false,
+    email: 'example@google.com',
+    approvable_gate_types: [],
+  };
+
   const unknownGate = {
     stage_id: 1,
     gate_id: 11,
@@ -95,11 +121,13 @@ describe('chromedash-survey-questions', () => {
     );
     assert.instanceOf(checkbox1, SlCheckbox);
     assert.isTrue(checkbox1.checked);
+    assert.isTrue(checkbox1.disabled);
     const checkbox2 = component.shadowRoot!.querySelector(
       '[name=is_api_polyfill]'
     );
     assert.instanceOf(checkbox2, SlCheckbox);
     assert.isFalse(checkbox2.checked);
+    assert.isTrue(checkbox2.disabled);
   });
 
   it('displays the privacy surveys even when nothing has been entered', async () => {
@@ -119,10 +147,87 @@ describe('chromedash-survey-questions', () => {
     );
     assert.instanceOf(checkbox1, SlCheckbox);
     assert.isFalse(checkbox1.checked);
+    assert.isTrue(checkbox1.disabled);
     const checkbox2 = component.shadowRoot!.querySelector(
       '[name=is_api_polyfill]'
     );
     assert.instanceOf(checkbox2, SlCheckbox);
     assert.isFalse(checkbox2.checked);
+    assert.isTrue(checkbox2.disabled);
+  });
+
+  it('displays disabled widgets to non-editors', async () => {
+    const component = (await fixture(
+      html`<chromedash-survey-questions
+        .user=${visitor}
+        .feature=${feature}
+        .gate=${privacyGate}
+        .loading=${false}
+      ></chromedash-survey-questions>`
+    )) as ChromedashSurveyQuestions;
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashSurveyQuestions);
+    const checkbox1 = component.shadowRoot!.querySelector(
+      '[name=is_language_polyfill]'
+    );
+    assert.instanceOf(checkbox1, SlCheckbox);
+    assert.isTrue(checkbox1.checked);
+    assert.isTrue(checkbox1.disabled);
+    const checkbox2 = component.shadowRoot!.querySelector(
+      '[name=is_api_polyfill]'
+    );
+    assert.instanceOf(checkbox2, SlCheckbox);
+    assert.isFalse(checkbox2.checked);
+    assert.isTrue(checkbox2.disabled);
+  });
+
+  it('displays enabled widgets to feature editors', async () => {
+    const component = (await fixture(
+      html`<chromedash-survey-questions
+        .user=${featureOwner}
+        .feature=${feature}
+        .gate=${privacyGate}
+        .loading=${false}
+      ></chromedash-survey-questions>`
+    )) as ChromedashSurveyQuestions;
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashSurveyQuestions);
+    const checkbox1 = component.shadowRoot!.querySelector(
+      '[name=is_language_polyfill]'
+    );
+    assert.instanceOf(checkbox1, SlCheckbox);
+    assert.isTrue(checkbox1.checked);
+    assert.isFalse(checkbox1.disabled);
+    const checkbox2 = component.shadowRoot!.querySelector(
+      '[name=is_api_polyfill]'
+    );
+    assert.instanceOf(checkbox2, SlCheckbox);
+    assert.isFalse(checkbox2.checked);
+    assert.isFalse(checkbox2.disabled);
+  });
+
+  it('displays enabled widgets to site admins', async () => {
+    const component = (await fixture(
+      html`<chromedash-survey-questions
+        .user=${admin}
+        .feature=${feature}
+        .gate=${privacyGate}
+        .loading=${false}
+      ></chromedash-survey-questions>`
+    )) as ChromedashSurveyQuestions;
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashSurveyQuestions);
+    const checkbox1 = component.shadowRoot!.querySelector(
+      '[name=is_language_polyfill]'
+    );
+    assert.instanceOf(checkbox1, SlCheckbox);
+    assert.isTrue(checkbox1.checked);
+    assert.isFalse(checkbox1.disabled);
+    const checkbox2 = component.shadowRoot!.querySelector(
+      '[name=is_api_polyfill]'
+    );
+    assert.instanceOf(checkbox2, SlCheckbox);
+    assert.isFalse(checkbox2.checked);
+    assert.isFalse(checkbox2.disabled);
   });
 });


### PR DESCRIPTION
This fills in UI logic for a case that was previously missed.  When a user views the gate column and that user does not have permission to edit the feature, then the survey question widgets should be disabled.

In this PR:
* Small off-topic fix to the prevote-dialog.  While testing the LFC dialogs I discovered that the the position of the `await` matters. In the old location, the user's first click on the button did not open the dialog.
* Pass the signed in user object down to the survey questions element.
* When rendering survey question widgets, disabled them if the user is not allowed to fill them in.