### PR TITLE
Make self-certification always give NA rather than Approval.

### DIFF
--- a/client-src/elements/chromedash-gate-column.ts
+++ b/client-src/elements/chromedash-gate-column.ts
@@ -411,10 +411,10 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   async handleReviewRequested() {
-    maybeOpenCertifyDialog(this.gate, VOTE_OPTIONS.APPROVED[0]).then(
+    maybeOpenCertifyDialog(this.gate, VOTE_OPTIONS.NA[0]).then(
       selfCertifying => {
         if (selfCertifying) {
-          this.handleSelfCertify(VOTE_OPTIONS.APPROVED[0]);
+          this.handleSelfCertify(VOTE_OPTIONS.NA[0]);
         } else {
           this.handleFullReviewRequest();
         }
@@ -451,6 +451,8 @@ export class ChromedashGateColumn extends LitElement {
 
   async handleSelfCertify(voteValue: number) {
     await window.csClient.setVote(this.feature.id, this.gate.id, voteValue);
+    const commentText = 'This "N/A" was self-certified.';
+    await this.postComment(commentText);
     this._fireEvent('refetch-needed', {});
   }
 


### PR DESCRIPTION
Yesterday's meeting with the privacy review team reminded me that they had requested that self-approval always generate an NA result rather than Approved.  Also, the app will now add a comment after a self-certification vote to leave a better record of what happened.