### PR TITLE
Allow reviewers to override a self-certified NA.

### DIFF
--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -71,7 +71,6 @@ class VotesAPI(basehandlers.APIHandler):
     old_state = old_votes[0].state if old_votes else Vote.NO_RESPONSE
     self.require_permissions(user, fe, gate, new_state)
 
-    # Note: We no longer write Approval entities.
     old_gate_state = gate.state
     new_gate_state = approval_defs.set_vote(feature_id, None, new_state,
         user.email(), gate_id)
@@ -113,7 +112,7 @@ class VotesAPI(basehandlers.APIHandler):
   def require_permissions(self, user, feature, gate, new_state):
     """Abort the request if the user lacks permission to set this vote."""
     is_requesting_review = new_state in (Vote.REVIEW_REQUESTED, Vote.NA_REQUESTED)
-    is_approving = new_state in (Vote.APPROVED, Vote.NA)
+    is_approving = new_state in (Vote.APPROVED, Vote.NA, Vote.NA_SELF)
     is_editor = permissions.can_edit_feature(user, feature.key.integer_id())
     approvers = approval_defs.get_approvers(gate.gate_type)
     is_approver = permissions.can_review_gate(user, feature, gate, approvers)

--- a/client-src/elements/chromedash-gate-column.ts
+++ b/client-src/elements/chromedash-gate-column.ts
@@ -16,6 +16,7 @@ import {
   GATE_PREPARING,
   GATE_REVIEW_REQUESTED,
   VOTE_OPTIONS,
+  VOTE_NA_SELF,
 } from './form-field-enums';
 import {
   autolink,
@@ -411,10 +412,10 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   async handleReviewRequested() {
-    maybeOpenCertifyDialog(this.gate, VOTE_OPTIONS.NA[0]).then(
+    maybeOpenCertifyDialog(this.gate, VOTE_NA_SELF).then(
       selfCertifying => {
         if (selfCertifying) {
-          this.handleSelfCertify(VOTE_OPTIONS.NA[0]);
+          this.handleSelfCertify(VOTE_NA_SELF);
         } else {
           this.handleFullReviewRequest();
         }
@@ -423,10 +424,10 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   async handleNARequested() {
-    maybeOpenCertifyDialog(this.gate, VOTE_OPTIONS.NA[0]).then(
+    maybeOpenCertifyDialog(this.gate, VOTE_NA_SELF).then(
       selfCertifying => {
         if (selfCertifying) {
-          this.handleSelfCertify(VOTE_OPTIONS.NA[0]);
+          this.handleSelfCertify(VOTE_NA_SELF);
         } else {
           this.handleFullNARequested();
         }
@@ -774,11 +775,15 @@ export class ChromedashGateColumn extends LitElement {
     if (state == GATE_REVIEW_REQUESTED) {
       return 'Review requested';
     }
+    if (state == VOTE_NA_SELF) {
+      return 'N/a (self-certified)';
+    }
     for (const item of Object.values(VOTE_OPTIONS)) {
       if (item[0] == state) {
         return item[1];
       }
     }
+
     // This should not normally be seen by users, but it will help us
     // cope with data migration.
     return `State ${state}`;

--- a/client-src/elements/chromedash-gate-column.ts
+++ b/client-src/elements/chromedash-gate-column.ts
@@ -412,27 +412,23 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   async handleReviewRequested() {
-    maybeOpenCertifyDialog(this.gate, VOTE_NA_SELF).then(
-      selfCertifying => {
-        if (selfCertifying) {
-          this.handleSelfCertify(VOTE_NA_SELF);
-        } else {
-          this.handleFullReviewRequest();
-        }
+    maybeOpenCertifyDialog(this.gate, VOTE_NA_SELF).then(selfCertifying => {
+      if (selfCertifying) {
+        this.handleSelfCertify(VOTE_NA_SELF);
+      } else {
+        this.handleFullReviewRequest();
       }
-    );
+    });
   }
 
   async handleNARequested() {
-    maybeOpenCertifyDialog(this.gate, VOTE_NA_SELF).then(
-      selfCertifying => {
-        if (selfCertifying) {
-          this.handleSelfCertify(VOTE_NA_SELF);
-        } else {
-          this.handleFullNARequested();
-        }
+    maybeOpenCertifyDialog(this.gate, VOTE_NA_SELF).then(selfCertifying => {
+      if (selfCertifying) {
+        this.handleSelfCertify(VOTE_NA_SELF);
+      } else {
+        this.handleFullNARequested();
       }
-    );
+    });
   }
 
   handleFullNARequested() {

--- a/client-src/elements/form-field-enums.ts
+++ b/client-src/elements/form-field-enums.ts
@@ -508,6 +508,7 @@ export const VOTE_OPTIONS: Record<string, [number, string]> = {
   APPROVED: [5, 'Approved'],
   DENIED: [6, 'Denied'],
 };
+export const VOTE_NA_SELF = 10;
 export const GATE_ACTIVE_REVIEW_STATES: number[] = [
   GATE_REVIEW_REQUESTED,
   VOTE_OPTIONS.REVIEW_STARTED[0],

--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -423,6 +423,10 @@ def get_gate_by_type(feature_id: int, gate_type: int):
 
 def _calc_gate_state(votes: list[Vote], rule: str) -> int:
   """Returns the state that a gate should have based on its votes."""
+  # A self-certified NA counts iff it is the only vote.
+  if len(votes) == 1 and votes[0].state == Vote.NA_SELF and rule == ONE_LGTM:
+    return Vote.NA
+
   # If enough reviewed APPROVED or said it is NA, then that is used.
   num_lgtms = sum((1 if v.state in (Vote.APPROVED, Vote.NA) else 0)
                   for v in votes)

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -324,6 +324,7 @@ NW = Vote.NEEDS_WORK
 RS = Vote.REVIEW_STARTED
 NA = Vote.NA
 IR = Vote.INTERNAL_REVIEW
+NA_SELF = Vote.NA_SELF
 GATE_VALUES= Vote.VOTE_VALUES.copy()
 GATE_VALUES.update({Gate.PREPARING: 'preparing'})
 
@@ -417,6 +418,26 @@ class CalcGateStateTest(testing_config.CustomTestCase):
                      self.do_calc(RS, RR, AP, NW))
     self.assertEqual(('approved', 'approved'),
                      self.do_calc(AP, AP, RS, AP))
+
+  def test_self_cert_stands(self):
+    """A feature owner self-certified and no one disagrees."""
+    self.assertEqual(('na', 'preparing'),
+                     self.do_calc(NA_SELF))
+    self.assertEqual(('na', 'review_requested'),
+                     self.do_calc(NA_SELF, NA))
+    self.assertEqual(('approved', 'review_requested'),
+                     self.do_calc(NA_SELF, AP))
+
+  def test_self_cert_reversed(self):
+    """A feature owner self-certified but a reviewer disagreed."""
+    self.assertEqual(('needs_work', 'needs_work'),
+                     self.do_calc(NA_SELF, NW))
+    self.assertEqual(('review_started', 'review_started'),
+                     self.do_calc(NA_SELF, RS))
+    self.assertEqual(('internal_review', 'internal_review'),
+                     self.do_calc(NA_SELF, IR))
+    self.assertEqual(('denied', 'denied'),
+                     self.do_calc(NA_SELF, DN))
 
 
 class UpdateTest(testing_config.CustomTestCase):

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -107,7 +107,7 @@ class Vote(ndb.Model):
       NO_RESPONSE: 'no_response',
       INTERNAL_REVIEW: 'internal_review',
       NA_REQUESTED: 'na_requested',
-      NA_SELF: 'na',
+      NA_SELF: 'na (self-certified)',
   }
 
   REQUESTING_STATES = [REVIEW_REQUESTED, NA_REQUESTED]

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -95,6 +95,7 @@ class Vote(ndb.Model):
   NO_RESPONSE = 7
   INTERNAL_REVIEW = 8
   NA_REQUESTED = 9
+  NA_SELF = 10
   VOTE_VALUES = {
       # Not used: PREPARING: 'preparing',
       NA: 'na',
@@ -106,6 +107,7 @@ class Vote(ndb.Model):
       NO_RESPONSE: 'no_response',
       INTERNAL_REVIEW: 'internal_review',
       NA_REQUESTED: 'na_requested',
+      NA_SELF: 'na',
   }
 
   REQUESTING_STATES = [REVIEW_REQUESTED, NA_REQUESTED]


### PR DESCRIPTION
Feature owners can self-certify an NA, but it needs to be possible to a reviewer to look at it afterwards and override the gate state.

In this PR:
* Make feature owners who are doing self-certifications vote NA_SELF instead of NA.  But, still allow permissions to vote NA for backward compatibility.
* Count NA_SELF as an NA for the gate state only if it is the only vote on the gate.  Otherwise, use the regular logic, which ignores NA_SELF.
* Render NA_SELF as "N/a (self-certified)" in the UI and "na (self-certified)" in notifications.