### PR TITLE
Automatically set active_stage_id

### DIFF
--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -195,11 +195,6 @@ export class ChromedashFeatureDetail extends LitElement {
           padding: var(--content-padding-half);
         }
 
-        .active .card {
-          border: var(--spot-card-border);
-          box-shadow: var(--spot-card-box-shadow);
-        }
-
         #new-stage {
           margin-left: 8px;
           margin-bottom: 4px;
@@ -458,16 +453,13 @@ export class ChromedashFeatureDetail extends LitElement {
     defaultOpen = false,
     isStage = true
   ) {
-    if (isActive) {
-      summary += ' - Active';
-    }
     return html`
       <sl-details
         summary=${summary}
         @sl-after-show=${this.updateCollapsed}
         @sl-after-hide=${this.updateCollapsed}
         ?open=${isActive || defaultOpen}
-        class="${isActive ? 'active' : ''} ${isStage ? 'stage' : ''}"
+        class="${isStage ? 'stage' : ''}"
       >
         ${content}
       </sl-details>

--- a/client-src/elements/chromedash-guide-stage-page.ts
+++ b/client-src/elements/chromedash-guide-stage-page.ts
@@ -150,7 +150,11 @@ export class ChromedashGuideStagePage extends LitElement {
 
   handleFormSubmit(e, hiddenTokenField) {
     e.preventDefault();
-    const submitBody = formatFeatureChanges(this.fieldValues, this.featureId);
+    const submitBody = formatFeatureChanges(
+      this.fieldValues,
+      this.featureId,
+      this.stageId
+    );
 
     // get the XSRF token and update it if it's expired before submission
     window.csClient
@@ -284,35 +288,6 @@ export class ChromedashGuideStagePage extends LitElement {
 
   renderSections(formattedFeature, stageSections) {
     const formSections: (typeof nothing | TemplateResult)[] = [];
-    if (!formattedFeature.is_enterprise_feature) {
-      // Add the field to this component's stage before creating the field component.
-      const index = this.fieldValues.length;
-      this.fieldValues.push({
-        name: 'active_stage_id',
-        touched: false,
-        value: this.isActiveStage,
-        implicitValue: this.stage.id,
-      });
-
-      // Don't show "set_stage" field for extension stages.
-      if (!OT_EXTENSION_STAGE_TYPES.has(this.stage.stage_type)) {
-        formSections.push(
-          html` <section class="stage_form">
-            <chromedash-form-field
-              name="set_stage"
-              index=${index}
-              value=${this.isActiveStage}
-              .fieldValues=${this.fieldValues}
-              .feature=${formattedFeature}
-              ?disabled=${this.isActiveStage}
-              ?forEnterprise=${formattedFeature.is_enterprise_feature}
-              @form-field-update="${this.handleFormFieldUpdate}"
-            >
-            </chromedash-form-field>
-          </section>`
-        );
-      }
-    }
 
     stageSections.forEach(section => {
       if (section.isImplementationSection) {

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -554,18 +554,8 @@ export const ALL_FIELDS: Record<string, Field> = {
       return result;
     },
     label: 'Active stage',
-    help_text: html`The active stage sets which stage opens by default in this
-    feature's page. This is equivalent to editing the named stage and checking
-    the "Set to this stage" checkbox.`,
-  },
-
-  set_stage: {
-    name: 'active_stage_id',
-    type: 'checkbox',
-    label: 'Set to this stage',
-    help_text: html` Check this box to move this feature to this stage in the
-    process. Leave it unchecked if you are adding draft information or revising
-    a previous stage.`,
+    help_text: html`The active stage opens by default in this feature's page.
+    And, it roughly indicates progress in the process.`,
   },
 
   search_tags: {

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -581,11 +581,20 @@ interface FeatureUpdateInfo {
 }
 
 // Prepare feature/stage changes to be submitted.
-export function formatFeatureChanges(fieldValues, featureId): UpdateSubmitBody {
+export function formatFeatureChanges(
+  fieldValues,
+  featureId,
+  formStageId?: number
+): UpdateSubmitBody {
   let hasChanges = false;
   const featureChanges = {id: featureId};
   // Multiple stages can be mutated, so this object is a stage of stages.
   const stages = {};
+  // When editing an individual stage, always provide stage ID so that
+  // active_stage_id can be set by the server.
+  if (formStageId) {
+    stages[formStageId] = {id: formStageId};
+  }
   for (const {name, touched, value, stageId, implicitValue} of fieldValues) {
     // Only submit changes for touched fields or accuracy verification updates.
     if (!touched) {

--- a/packages/playwright/tests/chromedash-guide-feature-page_pwtest.js
+++ b/packages/playwright/tests/chromedash-guide-feature-page_pwtest.js
@@ -77,29 +77,3 @@ test('add an origin trial stage', async ({ page }) => {
         mask: [page.locator('section[id="history"]')]
     });
 });
-
-test('set the active stage', async ({page}) => {
-  await createNewFeature(page);
-
-  // Edit the metadata.
-  const metadataSection = page.locator('sl-details[summary="Metadata"]');
-  await metadataSection.click();
-
-  await metadataSection.getByRole('link', {name: 'Edit fields'}).click();
-
-  // Select the origin trial stage.
-  const activeStageSelect = page.locator('sl-select[name="active_stage_id"]');
-  await activeStageSelect.click();
-  await activeStageSelect
-    .locator('sl-option', {hasText: 'Origin Trial'})
-    .click();
-  // Save.
-  await page.getByRole('button', {name: 'Submit'}).click();
-
-  // Check the origin trial is active.
-  await expect(
-    page
-      .locator('sl-details')
-      .getByRole('button', {name: 'Origin Trial - Active', expanded: true})
-  ).toBeVisible();
-});


### PR DESCRIPTION
Closes #4792.

Instead of asking users to check a checkbox to set the active stage, we now try to do it automatically.  The rule that we use is that whenever the user edits any stage, if that is higher than the current active stage, it becomes the new active stage.  That is not perfect, but it is better than the current situation because many feature owners don't update active stage.  It is still possible to set the active stage via the metadata form.  Since we are de-emphasizing the concept of active stage, we no longer highlight it on the feature detail page, but we do automatically open that accordion section.

In this PR:
* Server side: when processing feature edits, look for stage IDs and choose a new active stage if one is higher.
* Client side: Send the stage ID when editing a single stage, even if no stage fields were changed.  Remove the "Set to this stage" checkbox, and don't highlight the active stage accordion (but still open it).