### PR TITLE
Change `yyyymmdd` to `date` in `blink_features` example query

### DIFF
--- a/client-src/elements/chromedash-timeline.ts
+++ b/client-src/elements/chromedash-timeline.ts
@@ -300,11 +300,11 @@ class ChromedashTimeline extends LitElement {
         '#bigquery'
       ) as HTMLElement;
       bigqueryEl!.textContent = `#standardSQL
-SELECT yyyymmdd, client, pct_urls, sample_urls
+SELECT date, client, pct_urls, sample_urls
 FROM \`httparchive.blink_features.usage\`
 WHERE feature = '${featureName}'
-AND yyyymmdd = (SELECT MAX(yyyymmdd) FROM \`httparchive.blink_features.usage\`)
-ORDER BY yyyymmdd DESC, client`;
+AND date = (SELECT MAX(date) FROM \`httparchive.blink_features.usage\`)
+ORDER BY date DESC, client`;
     }
   }
 


### PR DESCRIPTION
Due to some changes on the HTTP Archive side, the `blink_features` example query needs a slight tweak.