### PR TITLE
Search web feature names in link

### DIFF
--- a/client-src/elements/chromedash-form-field.ts
+++ b/client-src/elements/chromedash-form-field.ts
@@ -479,7 +479,7 @@ export class ChromedashFormField extends LitElement {
               <td colspan="2" class="webdx">
                 See web feature
                 <a
-                  href="https://webstatus.dev/features/${this.value}"
+                  href="https://webstatus.dev/?q=${this.value}"
                   target="_blank"
                 >
                   ${this.value}

--- a/client-src/elements/chromedash-form-field.ts
+++ b/client-src/elements/chromedash-form-field.ts
@@ -479,7 +479,9 @@ export class ChromedashFormField extends LitElement {
               <td colspan="2" class="webdx">
                 See web feature
                 <a
-                  href="https://webstatus.dev/features/${this.value.toLowerCase()}"
+                  href="https://webstatus.dev/features/${enumLabelToFeatureKey(
+                    this.value
+                  )}"
                   target="_blank"
                 >
                   ${this.value}
@@ -491,6 +493,31 @@ export class ChromedashFormField extends LitElement {
         : nothing}
     `;
   }
+}
+
+/**
+ * enumLabelToFeatureKey converts Webdx enum labels to
+ * web feature IDs. This function is rewritten from
+ * https://github.com/GoogleChrome/webstatus.dev/blob/6ae7ecf7c26e2563a6e1685cc6d92fc12bcc7941/lib/gcpspanner/spanneradapters/chromium_historgram_enum_consumer.go#L102-L125
+ */
+export function enumLabelToFeatureKey(label: string) {
+  let result = '';
+  for (let i = 0; i < label.length; i++) {
+    const char = label[i];
+    if (i === 0) {
+      result += char.toLowerCase();
+      continue;
+    }
+    if (char === char.toUpperCase()) {
+      result += '-' + char.toLowerCase();
+      continue;
+    }
+    if (i > 0 && /[a-zA-Z]/.test(label[i - 1]) && char >= '0' && char <= '9') {
+      result += '-';
+    }
+    result += char;
+  }
+  return result;
 }
 
 /**

--- a/client-src/elements/chromedash-form-field.ts
+++ b/client-src/elements/chromedash-form-field.ts
@@ -479,7 +479,7 @@ export class ChromedashFormField extends LitElement {
               <td colspan="2" class="webdx">
                 See web feature
                 <a
-                  href="https://webstatus.dev/?q=${this.value}"
+                  href="https://webstatus.dev/features/${this.value.toLowerCase()}"
                   target="_blank"
                 >
                   ${this.value}

--- a/client-src/elements/chromedash-form-field.ts
+++ b/client-src/elements/chromedash-form-field.ts
@@ -508,7 +508,7 @@ export function enumLabelToFeatureKey(label: string) {
       result += char.toLowerCase();
       continue;
     }
-    if (char === char.toUpperCase()) {
+    if (char === char.toUpperCase() && /[a-zA-Z]/.test(char)) {
       result += '-' + char.toLowerCase();
       continue;
     }

--- a/client-src/elements/chromedash-form-field_test.ts
+++ b/client-src/elements/chromedash-form-field_test.ts
@@ -1,7 +1,10 @@
 import {assert, fixture} from '@open-wc/testing';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
 import {html} from 'lit';
-import {ChromedashFormField} from './chromedash-form-field';
+import {
+  ChromedashFormField,
+  enumLabelToFeatureKey,
+} from './chromedash-form-field';
 import {
   STAGE_BLINK_INCUBATE,
   STAGE_BLINK_ORIGIN_TRIAL,
@@ -228,6 +231,36 @@ describe('chromedash-form-field', () => {
         {text: 'Origin trial 2', value: '3'},
         {text: 'Prepare to ship', value: '4'},
       ]);
+    });
+  });
+
+  describe('enumLabelToFeatureKey', () => {
+    it('should handle empty string', () => {
+      assert.equal(enumLabelToFeatureKey(''), '');
+    });
+
+    it('should convert first character to lowercase', () => {
+      assert.equal(enumLabelToFeatureKey('FooBar'), 'foo-bar');
+      assert.equal(enumLabelToFeatureKey('Baz'), 'baz');
+    });
+
+    it('should add hyphen before uppercase letters', () => {
+      assert.equal(enumLabelToFeatureKey('FooBarBaz'), 'foo-bar-baz');
+      assert.equal(enumLabelToFeatureKey('ABC'), 'a-b-c');
+    });
+
+    it('should add hyphen before digits if preceded by a letter', () => {
+      assert.equal(enumLabelToFeatureKey('Foo123'), 'foo-123');
+      assert.equal(enumLabelToFeatureKey('AB1CD2'), 'a-b-1-c-d-2');
+    });
+
+    it('should not add hyphen before digits if not preceded by a letter', () => {
+      assert.equal(enumLabelToFeatureKey('123ABC'), '123-a-b-c');
+      assert.equal(enumLabelToFeatureKey('1A2B3C'), '1-a-2-b-3-c');
+    });
+
+    it('should handle mixed-case input', () => {
+      assert.equal(enumLabelToFeatureKey('fOoBaR123'), 'foo-ba-r-123');
     });
   });
 });

--- a/client-src/elements/chromedash-form-field_test.ts
+++ b/client-src/elements/chromedash-form-field_test.ts
@@ -260,7 +260,7 @@ describe('chromedash-form-field', () => {
     });
 
     it('should handle mixed-case input', () => {
-      assert.equal(enumLabelToFeatureKey('fOoBaR123'), 'foo-ba-r-123');
+      assert.equal(enumLabelToFeatureKey('fOoBaR123'), 'f-oo-ba-r-123');
     });
   });
 });


### PR DESCRIPTION
A part of https://github.com/GoogleChrome/chromium-dashboard/issues/4799. In #4807, it is using a list of available feature names from [enums.xml](https://source.corp.google.com/piper///depot/google3/analysis/uma/ukm/aggregation/webdx_features/enums.xml;bpv=1), however it does not provide the exact Web feature ID. Update the webstatus.dev link to use search instead.

The downside of this change is that some feature names cannot be found, e.g.  https://webstatus.dev/?q=OverflowShorthand