### PR TITLE
Use NA_SELF as a Gate.state.

### DIFF
--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -261,7 +261,7 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
 
     gates: list[Gate] = Gate.query(Gate.stage_id == ot_stage_id)
     for gate in gates:
-      if gate.state not in (Vote.APPROVED, Vote.NA):
+      if gate.state not in Gate.APPROVED_STATES:
         self.abort(400, 'Unapproved gate found for trial stage.')
 
     #TODO(markxiong0122): remove to_dict() when PR#4213 is merged
@@ -313,7 +313,7 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
                        f'{intent_url}'))
 
     gate = Gate.query(Gate.stage_id == extension_stage.key.integer_id()).get()
-    if not gate or (gate.state != Vote.APPROVED and gate.state != Vote.NA):
+    if not gate or (gate.state not in Gate.APPROVED_STATES):
       self.abort(400, 'Extension has not received the required approvals.')
 
   def do_patch(self, **kwargs):

--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -78,8 +78,8 @@ class VotesAPI(basehandlers.APIHandler):
     fe.put()
 
     # Send any notifications necessary if the gate is newly approved.
-    recently_approved = (old_gate_state not in (Vote.APPROVED, Vote.NA) and
-                         new_gate_state in (Vote.APPROVED, Vote.NA))
+    recently_approved = (old_gate_state not in Gate.APPROVED_STATES and
+                         new_gate_state in Gate.APPROVED_STATES)
     if recently_approved:
       stage = Stage.get_by_id(gate.stage_id)
       notifier_helpers.notify_approvals(fe, stage, gate)
@@ -112,7 +112,7 @@ class VotesAPI(basehandlers.APIHandler):
   def require_permissions(self, user, feature, gate, new_state):
     """Abort the request if the user lacks permission to set this vote."""
     is_requesting_review = new_state in (Vote.REVIEW_REQUESTED, Vote.NA_REQUESTED)
-    is_approving = new_state in (Vote.APPROVED, Vote.NA, Vote.NA_SELF)
+    is_approving = new_state in Gate.APPROVED_STATES
     is_editor = permissions.can_edit_feature(user, feature.key.integer_id())
     approvers = approval_defs.get_approvers(gate.gate_type)
     is_approver = permissions.can_review_gate(user, feature, gate, approvers)

--- a/client-src/elements/chromedash-gate-chip.ts
+++ b/client-src/elements/chromedash-gate-chip.ts
@@ -15,6 +15,7 @@ const GATE_STATE_TO_NAME = {
   // TODO(jrobbins): COMPLETE for auto-approved.
   8: 'Internal review', // INTERNAL_REVIEW
   9: 'N/A requested', // NA_REQUESTED
+  10: 'N/A (self-certified)', //  NA_SELF
 };
 
 const GATE_STATE_TO_ICON = {
@@ -27,12 +28,14 @@ const GATE_STATE_TO_ICON = {
   6: 'block_20px', // DENIED
   // TODO(jrobbins): COMPLETE for auto-approved also check_circle_filled_20px.
   // INTERNAL_REVIEW has no icon.
+  // NA_SELF has no icon.
 };
 
 const GATE_STATE_TO_ABBREV = {
   1: 'N/A', //  NA
   8: 'INT', // INTERNAL_REVIEW
   9: 'N/A?', // INTERNAL_REVIEW
+  10: 'N/A (self)', //  NA_SELF
 };
 
 export interface GateDict {
@@ -108,11 +111,13 @@ class ChromedashGateChip extends LitElement {
           text-decoration: underline;
         }
 
-        sl-button.not_applicable::part(base) {
+        sl-button.not_applicable::part(base),
+        sl-button.na_self-certified::part(base) {
           background: var(--gate-not-applicable-background);
           color: var(--gate-not-applicable-color);
         }
-        sl-button.not_applicable::part(prefix) {
+        sl-button.not_applicable::part(prefix),
+        sl-button.na_self-certified::part(prefix) {
           align-items: baseline;
         }
 
@@ -213,6 +218,8 @@ class ChromedashGateChip extends LitElement {
     const className = stateName
       .toLowerCase()
       .replaceAll(' ', '_')
+      .replaceAll('(', '')
+      .replaceAll(')', '')
       .replaceAll('/', '');
     const selected = this.gate.id == this.selectedGateId ? 'selected' : '';
 

--- a/client-src/elements/chromedash-gate-column.ts
+++ b/client-src/elements/chromedash-gate-column.ts
@@ -609,6 +609,26 @@ export class ChromedashGateColumn extends LitElement {
     `;
   }
 
+  renderReviewStatusNa() {
+    // TODO(jrobbins): Show date of N/a.
+    return html`
+      <div class="status approved">
+        <sl-icon library="material" name="check_circle_filled_20px"></sl-icon>
+        N/a
+      </div>
+    `;
+  }
+
+  renderReviewStatusNaSelf() {
+    // TODO(jrobbins): Show date of N/a.
+    return html`
+      <div class="status approved">
+        <sl-icon library="material" name="check_circle_filled_20px"></sl-icon>
+        N/a (self-certified)
+      </div>
+    `;
+  }
+
   renderReviewStatusDenied() {
     // TODO(jrobbins): Show date of denial.
     return html`
@@ -624,6 +644,10 @@ export class ChromedashGateColumn extends LitElement {
       return this.renderReviewStatusPreparing();
     } else if (this.gate.state == VOTE_OPTIONS.NEEDS_WORK[0]) {
       return this.renderReviewStatusNeedsWork();
+    } else if (this.gate.state == VOTE_OPTIONS.NA[0]) {
+      return this.renderReviewStatusNa();
+    } else if (this.gate.state == VOTE_NA_SELF) {
+      return this.renderReviewStatusNaSelf();
     } else if (this.gate.state == VOTE_OPTIONS.APPROVED[0]) {
       return this.renderReviewStatusApproved();
     } else if (this.gate.state == VOTE_OPTIONS.DENIED[0]) {

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -247,76 +247,6 @@ class IsApprovedTest(testing_config.CustomTestCase):
         set_on=datetime.datetime.now(),
         set_by='three@example.com')
 
-  @mock.patch('internals.approval_defs.APPROVAL_FIELDS_BY_ID',
-              MOCK_APPROVALS_BY_ID)
-  def test_is_approved(self):
-    """We know if an approval rule has been satisfied."""
-
-    # Field requires 1 LGTM
-    self.assertFalse(approval_defs.is_approved([], 1))
-    self.assertFalse(approval_defs.is_approved([self.appr_nr], 1))
-    self.assertFalse(approval_defs.is_approved([self.appr_no], 1))
-    self.assertTrue(approval_defs.is_approved([self.appr_yes], 1))
-    self.assertTrue(approval_defs.is_approved([self.appr_na], 1))
-    self.assertFalse(approval_defs.is_approved([self.appr_nr, self.appr_no], 1))
-    self.assertFalse(approval_defs.is_approved(
-        [self.appr_nr, self.appr_no, self.appr_yes], 1))
-    self.assertTrue(approval_defs.is_approved([self.appr_nr, self.appr_yes], 1))
-    self.assertTrue(approval_defs.is_approved([self.appr_nr, self.appr_na], 1))
-
-    # Field requires 3 LGTMs
-    self.assertFalse(approval_defs.is_approved([], 2))
-    self.assertFalse(approval_defs.is_approved([self.appr_nr], 2))
-    self.assertFalse(approval_defs.is_approved([self.appr_no], 2))
-    self.assertFalse(approval_defs.is_approved([self.appr_yes], 2))
-    self.assertFalse(approval_defs.is_approved([self.appr_na], 2))
-    self.assertFalse(approval_defs.is_approved([self.appr_nr, self.appr_no], 2))
-    self.assertFalse(approval_defs.is_approved(
-        [self.appr_nr, self.appr_no, self.appr_yes], 2))
-    self.assertFalse(approval_defs.is_approved([self.appr_nr, self.appr_yes], 2))
-
-    self.assertTrue(approval_defs.is_approved(
-        [self.appr_yes, self.appr_yes, self.appr_yes], 2))
-    self.assertTrue(approval_defs.is_approved(
-        [self.appr_yes, self.appr_yes, self.appr_na], 2))
-    self.assertTrue(approval_defs.is_approved(
-        [self.appr_na, self.appr_na, self.appr_na], 2))
-    self.assertFalse(approval_defs.is_approved(
-        [self.appr_yes, self.appr_yes, self.appr_yes, self.appr_no], 2))
-    self.assertFalse(approval_defs.is_approved(
-        [self.appr_na, self.appr_yes, self.appr_yes, self.appr_no], 2))
-
-  @mock.patch('internals.approval_defs.APPROVAL_FIELDS_BY_ID',
-              MOCK_APPROVALS_BY_ID)
-  def test_is_resolved(self):
-    """We know if an approval request has been resolved."""
-    # Field requires 1 LGTM
-    self.assertFalse(approval_defs.is_resolved([], 1))
-    self.assertFalse(approval_defs.is_resolved([self.appr_nr], 1))
-    self.assertTrue(approval_defs.is_resolved([self.appr_no], 1))
-    self.assertTrue(approval_defs.is_resolved([self.appr_yes], 1))
-    self.assertTrue(approval_defs.is_resolved([self.appr_nr, self.appr_no], 1))
-    self.assertTrue(approval_defs.is_resolved(
-        [self.appr_nr, self.appr_no, self.appr_yes], 1))
-    self.assertTrue(approval_defs.is_resolved([self.appr_nr, self.appr_yes], 1))
-
-    # Field requires 3 LGTMs
-    self.assertFalse(approval_defs.is_resolved([], 2))
-    self.assertFalse(approval_defs.is_resolved([self.appr_nr], 2))
-    self.assertTrue(approval_defs.is_resolved([self.appr_no], 2))
-    self.assertFalse(approval_defs.is_resolved([self.appr_yes], 2))
-    self.assertTrue(approval_defs.is_resolved([self.appr_nr, self.appr_no], 2))
-    self.assertTrue(approval_defs.is_resolved(
-        [self.appr_nr, self.appr_no, self.appr_yes], 2))
-    self.assertFalse(approval_defs.is_resolved([self.appr_nr, self.appr_yes], 2))
-
-    self.assertTrue(approval_defs.is_resolved(
-        [self.appr_yes, self.appr_yes, self.appr_yes], 2))
-    self.assertTrue(approval_defs.is_resolved(
-        [self.appr_yes, self.appr_yes, self.appr_yes, self.appr_no], 2))
-
-
-
 RR = Vote.REVIEW_REQUESTED
 AP = Vote.APPROVED
 DN = Vote.DENIED
@@ -421,7 +351,7 @@ class CalcGateStateTest(testing_config.CustomTestCase):
 
   def test_self_cert_stands(self):
     """A feature owner self-certified and no one disagrees."""
-    self.assertEqual(('na', 'preparing'),
+    self.assertEqual(('na (self-certified)', 'preparing'),
                      self.do_calc(NA_SELF))
     self.assertEqual(('na', 'review_requested'),
                      self.do_calc(NA_SELF, NA))

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -374,8 +374,8 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
       new_gate_state = approval_defs.set_vote(
           feature_id, gate_info.gate_type, Vote.APPROVED, from_addr,
           gate.key.integer_id())
-      recently_approved = (old_gate_state not in (Vote.APPROVED, Vote.NA) and
-                           new_gate_state in (Vote.APPROVED, Vote.NA))
+      recently_approved = (old_gate_state not in Gate.APPROVED_STATES and
+                           new_gate_state in Gate.APPROVED_STATES)
       if recently_approved:
         notifier_helpers.notify_approvals(feature, stage, gate)
 

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -783,13 +783,13 @@ class BackfillGateDates(FlaskHandler):
 
   def calc_resolved_on(self, gate: Gate, votes: list[Vote]) -> datetime | None:
     """Return the date on which the gate was resolved, or None."""
-    if gate.state not in Vote.FINAL_STATES:
+    if gate.state not in Gate.FINAL_STATES:
       return None
     if gate.resolved_on:
       return None
 
     return max(v.set_on for v in votes
-               if v.state in Vote.FINAL_STATES)
+               if v.state in Gate.FINAL_STATES)
 
   def calc_needs_work_started_on(
       self, gate: Gate, votes: list[Vote]) -> datetime | None:

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -223,7 +223,7 @@ def notify_approvals(feature: 'FeatureEntry', stage: Stage, gate: Gate) -> None:
     # approved or N/A.
     all_ot_gates: list[Gate] = Gate.query(
         Gate.stage_id == stage.key.integer_id()).fetch()
-    if all(g.state in (Vote.APPROVED, Vote.NA) for g in all_ot_gates): 
+    if all(g.state in Gate.APPROVED_STATES for g in all_ot_gates):
       send_trial_creation_approved_notification(
           feature, stage)
 

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -114,7 +114,6 @@ class Vote(ndb.Model):
   RESPONSE_STATES = [
       NA, APPROVED, DENIED, REVIEW_STARTED, NEEDS_WORK, INTERNAL_REVIEW,
       NA_SELF]
-  FINAL_STATES = [NA, APPROVED, DENIED, NA_SELF]
 
   feature_id = ndb.IntegerProperty(required=True)
   gate_id = ndb.IntegerProperty(required=True)
@@ -176,7 +175,8 @@ class Gate(ndb.Model):
   PENDING_STATES = [
       Vote.REVIEW_REQUESTED, Vote.REVIEW_STARTED, Vote.NEEDS_WORK,
       Vote.INTERNAL_REVIEW, Vote.NA_REQUESTED]
-  FINAL_STATES = [Vote.NA, Vote.APPROVED, Vote.DENIED]
+  FINAL_STATES = [Vote.NA, Vote.APPROVED, Vote.DENIED, Vote.NA_SELF]
+  APPROVED_STATES = [Vote.NA, Vote.APPROVED, Vote.NA_SELF]
 
   feature_id = ndb.IntegerProperty(required=True)
   stage_id = ndb.IntegerProperty(required=True)
@@ -201,14 +201,6 @@ class Gate(ndb.Model):
   additional_review = ndb.BooleanProperty(default=False)
 
   survey_answers = ndb.StructuredProperty(SurveyAnswers)
-
-  def is_resolved(self) -> bool:
-    """Return if the Gate's outcome has been decided."""
-    return self.state == Vote.APPROVED or self.state == Vote.DENIED
-
-  def is_approved(self) -> bool:
-    """Return if the Gate approval requirements have been met."""
-    return self.state == Vote.APPROVED
 
   @classmethod
   def get_feature_gates(cls, feature_id: int) -> dict[int, list[Gate]]:

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -93,7 +93,7 @@ class ActivityTest(testing_config.CustomTestCase):
 
 
 class GateTest(testing_config.CustomTestCase):
-  # TODO(jrobbins): Add tests for is_resolved, is_approved, get_feature_gates.
+  # TODO(jrobbins): Add tests for get_feature_gates.
   pass
 
 

--- a/internals/slo.py
+++ b/internals/slo.py
@@ -98,8 +98,8 @@ def record_vote(gate: Gate, votes: list[Vote], old_gate_state: int) -> bool:
       gate.state != Vote.NEEDS_WORK and
       gate.needs_work_started_on is not None)
   resolved = (
-      old_gate_state not in Vote.FINAL_STATES and
-      gate.state in Vote.FINAL_STATES and
+      old_gate_state not in Gate.FINAL_STATES and
+      gate.state in Gate.FINAL_STATES and
       gate.resolved_on is None)
 
   if finished_rework:


### PR DESCRIPTION
The privacy team had requested that gates that were self-approved should be easily differentiated from gates that were approved by reviewers.  Previously, a Vote of `NA` or `NA_SELF` resulted in the containing `Gate` having a state of `NA`.

In this PR:
* When a `NA_SELF` vote is the only vote, set the gate state to `NA_SELF`
* In all the places in the code where we check if a gate was approved, check for membership in `Gate.APPROVED_STATES` rather than listing out individual states.
* Move `APPROVED_STATES` and `FINAL_STATES` into class `Gate` because they are more closely associated with it.
* Delete dead code for `is_approved()` and `is_resolved()`
* Add UI logic to display `(X) N/a` or `(X) N/a (self-certified)` at the top of the gate column with a green checkmark icon.
* Add logic to display the abbreviated state `N/A (self)` on gate chips when the state is NA_SELF.