### PR TITLE
Save survey text fields on first character.

### DIFF
--- a/client-src/elements/chromedash-gate-column.ts
+++ b/client-src/elements/chromedash-gate-column.ts
@@ -412,22 +412,36 @@ export class ChromedashGateColumn extends LitElement {
   }
 
   async handleReviewRequested() {
-    maybeOpenCertifyDialog(this.gate, VOTE_NA_SELF).then(selfCertifying => {
-      if (selfCertifying) {
-        this.handleSelfCertify(VOTE_NA_SELF);
-      } else {
-        this.handleFullReviewRequest();
+    const featureId = this.feature.id;
+    window.csClient.getGates(featureId).then(gatesRes => {
+      for (const g of gatesRes.gates) {
+        if (g.id == this.gate.id) this.gate = g;
       }
+
+      maybeOpenCertifyDialog(this.gate, VOTE_NA_SELF).then(selfCertifying => {
+        if (selfCertifying) {
+          this.handleSelfCertify(VOTE_NA_SELF);
+        } else {
+          this.handleFullReviewRequest();
+        }
+      });
     });
   }
 
   async handleNARequested() {
-    maybeOpenCertifyDialog(this.gate, VOTE_NA_SELF).then(selfCertifying => {
-      if (selfCertifying) {
-        this.handleSelfCertify(VOTE_NA_SELF);
-      } else {
-        this.handleFullNARequested();
+    const featureId = this.feature.id;
+    window.csClient.getGates(featureId).then(gatesRes => {
+      for (const g of gatesRes.gates) {
+        if (g.id == this.gate.id) this.gate = g;
       }
+
+      maybeOpenCertifyDialog(this.gate, VOTE_NA_SELF).then(selfCertifying => {
+        if (selfCertifying) {
+          this.handleSelfCertify(VOTE_NA_SELF);
+        } else {
+          this.handleFullNARequested();
+        }
+      });
     });
   }
 

--- a/client-src/elements/chromedash-survey-questions.ts
+++ b/client-src/elements/chromedash-survey-questions.ts
@@ -85,6 +85,17 @@ export class ChromedashSurveyQuestions extends LitElement {
       });
   }
 
+  /* Immediately save string values when it changes between empty to non-empty,
+  because that affects eligibility for self-certification,
+  but don't refetch yet because that would overwrite subsequent keystrokes. */
+  handleFieldKeyup(name: string, value: string) {
+    if ((value || '').trim().length <= 1) {
+      window.csClient.updateGate(this.feature.id, this.gate.id, null, {
+        [name]: value,
+      });
+    }
+  }
+
   renderBooleanField(name: string, desc: TemplateResult): TemplateResult {
     const value: boolean = this.gate.survey_answers?.[name];
     return html`
@@ -111,6 +122,7 @@ export class ChromedashSurveyQuestions extends LitElement {
           value=${value}
           ?disabled=${!this.canEditSurvey()}
           @sl-change=${e => this.handleFieldChange(name, e.target?.value)}
+          @keyup=${e => this.handleFieldKeyup(name, e.target?.value)}
         ></sl-input>
       </li>
     `;
@@ -128,6 +140,7 @@ export class ChromedashSurveyQuestions extends LitElement {
           value=${value}
           ?disabled=${!this.canEditSurvey()}
           @sl-change=${e => this.handleFieldChange(name, e.target?.value)}
+          @keyup=${e => this.handleFieldKeyup(name, e.target?.value)}
         ></sl-input>
       </li>
     `;


### PR DESCRIPTION
This is a fix for a bug with the explanation field that I encountered while testing more locally.  The assumption was that the `sl-change` event fires when a form field loses focus, which happens after the user types and then presses the "Request review" button.  That assumption is true, but there is no timing dependency between those two events, so handling the "Request review" button can happen before saving operations have completed. Specifically, the user's fully explained request to self-certify a gate could fail because their explanation was still being saved at that moment.

The reason that this works reliably for checkboxes is that the user can only click so fast.  The checkbox state is saved and updated in the client before they can move their mouse to click on the "Request review" button.

The solution for text fields is to save earlier, while the user is typing, long before they can move to click on the button.  So, we save on `keyup`, but we only need to do that for the first character because that is what determines eligibility.  But, we can't refresh state from the server on each keystroke because the user will lose keystrokes if they type fast.  Instead we just update the server on keystrokes, then update the client when they press the button.