### PR TITLE
Upgrade to python3.12

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@
 # Update 'VARIANT' to pick a version of Python: 3, 3.10, 3.9, 3.8, 3.7, 3.6
 # Append -bullseye or -buster to pin to an OS version.
 # Use -bullseye variants on local arm64/Apple Silicon.
-ARG VARIANT="3.11-bullseye"
+ARG VARIANT="3.12-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT} as ide
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Continuous Integration
 env:
- CLOUDSDK_PYTHON: python3.11
+ CLOUDSDK_PYTHON: python3.12
 on:
   push:
     branches:
@@ -20,7 +20,7 @@ jobs:
       - name: set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: pre-installation
         run: |

--- a/.github/workflows/web_tests.yml
+++ b/.github/workflows/web_tests.yml
@@ -1,6 +1,6 @@
 name: Continuous Integration Web Tests
 env:
- CLOUDSDK_PYTHON: python3.11
+ CLOUDSDK_PYTHON: python3.12
 on:
   push:
     branches:
@@ -29,7 +29,7 @@ jobs:
       - name: set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: pre-installation
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-ARG PYTHON_VARIANT=3.11-bullseye
+ARG PYTHON_VARIANT=3.12-bullseye
 FROM python:${PYTHON_VARIANT} as app
 
 RUN groupadd -g 1001 appuser && \
     useradd appuser -u 1001 -g 1001 -m -d /home/appuser -s /bin/bash
 
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \ 
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # openapi-generator-cli dependencies
     && apt-get install -y openjdk-17-jre
 

--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -1,6 +1,6 @@
 # This GAE service contains most of the app, including all UI pages.
 
-runtime: python311
+runtime: python312
 service: default
 instance_class: F4_1G
 

--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,6 @@
 # This GAE service contains most of the app, including all UI pages.
 
-runtime: python311
+runtime: python312
 service: default
 instance_class: F4_1G
 

--- a/internals/search.py
+++ b/internals/search.py
@@ -208,7 +208,7 @@ LOGICAL_OPERATORS_PATTERN = r'OR\s+|-'
 # Structured terms look like: FIELD OPERATOR VALUE.
 # Full-text terms look like: SINGLE_WORD, or like: "QUOTED STRING".
 TERM_RE = re.compile(
-    '(?P<logical>%s)?(?:(?P<field>%s)(?P<op>%s)(?P<val>%s)|(?P<textterm>%s))\s+' % (
+    r'(?P<logical>%s)?(?:(?P<field>%s)(?P<op>%s)(?P<val>%s)|(?P<textterm>%s))\s+' % (
         LOGICAL_OPERATORS_PATTERN, FIELD_NAME_PATTERN, OPERATORS_PATTERN,
         VALUES_PATTERN, TEXT_PATTERN),
     re.I)

--- a/notifier.staging.yaml
+++ b/notifier.staging.yaml
@@ -1,4 +1,4 @@
-runtime: python311
+runtime: python312
 service: notifier
 instance_class: F4_1G
 

--- a/notifier.yaml
+++ b/notifier.yaml
@@ -1,4 +1,4 @@
-runtime: python311
+runtime: python312
 service: notifier
 instance_class: F4_1G
 

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "./gen/js/*"
   ],
   "scripts": {
-    "setup": "npm ci; python3.11 -m venv cs-env; npm run deps",
+    "setup": "npm ci; python3.12 -m venv cs-env; npm run deps",
     "clean-setup": "rm -rf node_modules cs-env; npm run setup",
     "deps": ". cs-env/bin/activate; pip install -r requirements.txt --upgrade && pip install -r requirements.dev.txt --upgrade",
     "dev-deps": "echo 'dev-deps is no longer needed'",
     "dev-ot-key": "gcloud secrets versions access latest --secret=DEV_OT_API_KEY  --out-file=ot_api_key.txt --project=cr-status-staging",
-    "do-tests": ". cs-env/bin/activate; curl -X POST 'http://localhost:15606/reset' && python3.11 -m unittest discover -p '*_test.py'  -b",
+    "do-tests": ". cs-env/bin/activate; curl -X POST 'http://localhost:15606/reset' && python3.12 -m unittest discover -p '*_test.py'  -b",
     "start-emulator-persist": "gcloud beta emulators datastore start --project=cr-status-staging --host-port=:15606 --use-firestore-in-datastore-mode",
     "start-emulator": "gcloud beta emulators datastore start --project=cr-status-staging --host-port=:15606 --no-store-on-disk --use-firestore-in-datastore-mode",
     "stop-emulator": "curl -X POST 'http://localhost:15606/shutdown'; pkill -f \"CloudDatastore.jar\"",
@@ -35,7 +35,7 @@
     "webtest-coverage": "npm run build && web-test-runner \"build/**/*_test.js\" --node-resolve --playwright --coverage --browsers chromium firefox",
     "do-coverage": "coverage3 erase && coverage3 run -m unittest discover -p '*_test.py' -b && coverage3 html",
     "coverage": ". cs-env/bin/activate; (npm run start-emulator > /dev/null 2>&1 &); sleep 3; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-coverage;  npm run stop-emulator",
-    "view-coverage": "pushd htmlcov/; python3.11 -m http.server 8080; popd",
+    "view-coverage": "pushd htmlcov/; python3.12 -m http.server 8080; popd",
     "mypy": ". cs-env/bin/activate; mypy --ignore-missing-imports --exclude cs-env/ --exclude appengine_config.py --exclude gen/py/chromestatus_openapi/build/ --exclude gen/py/chromestatus_openapi/chromestatus_openapi/test --exclude appengine_config.py --no-namespace-packages --disable-error-code \"annotation-unchecked\" .",
     "lint": "prettier client-src/js-src client-src/elements --check && eslint \"client-src/js-src/**/*.{js,ts}\" && tsc -p tsconfig.json && lit-analyzer \"client-src/elements/chromedash-!(featurelist)*.js\"",
     "lint-fix": "prettier client-src/js-src client-src/elements --write && eslint \"client-src/js-src/**/*.{js,ts}\" --fix",


### PR DESCRIPTION
Our cloudtop machines seem to have removed python3.11 so we need to upgrade to 3.12.
I am also upgrading the GAE runtime to match the python version we will use when running locally.

This change seems pretty simple, and I didn't see anything urgent in the python release notes, but it is possible that there is something that I missed and that we will hit some problems with some part of the app.

All developers will need to be sure to have python3.12 on their local machines, and they will need to run `npm run clean-setup`.

Also, add an `r` to a regex to make it a raw string.  The need for this was caught by the 3.12 regex library.