### PR TITLE
Mock getFeatureLinks in frontend tests.

### DIFF
--- a/client-src/elements/chromedash-feature-page_test.ts
+++ b/client-src/elements/chromedash-feature-page_test.ts
@@ -39,6 +39,7 @@ describe('chromedash-feature-page', () => {
     'Spec link': 'fake spec link',
     'Web developer signals': 'True',
   });
+  const featureLinksPromise = Promise.resolve(undefined);
   const channels = {
     canary_asan: {
       version: 81,
@@ -155,12 +156,14 @@ describe('chromedash-feature-page', () => {
     sinon.stub(window.csClient, 'getStars');
     sinon.stub(window.csClient, 'getFeatureProgress');
     sinon.stub(window.csClient, 'getSpecifiedChannels');
+    sinon.stub(window.csClient, 'getFeatureLinks');
     window.csClient.getGates.returns(gatesPromise);
     window.csClient.getComments.returns(commentsPromise);
     window.csClient.getFeatureProcess.returns(processPromise);
     window.csClient.getStars.returns(starsPromise);
     window.csClient.getFeatureProgress.returns(progressPromise);
     window.csClient.getSpecifiedChannels.returns(channelsPromise);
+    window.csClient.getFeatureLinks.returns(featureLinksPromise);
 
     // For the child component - chromedash-gantt
     sinon.stub(window.csClient, 'getChannels');
@@ -173,6 +176,7 @@ describe('chromedash-feature-page', () => {
     window.csClient.getStars.restore();
     window.csClient.getChannels.restore();
     window.csClient.getSpecifiedChannels.restore();
+    window.csClient.getFeatureLinks.restore();
   });
 
   it('renders with no data', async () => {


### PR DESCRIPTION
The `webtests` target is increasingly failing now.  I think part of the problem is that some of the pages try to make outside web requests to, e.g., check on the status of GitHub issues, and we hit the no-token rate limit.  These tests don't need those requests, so we can just stub them out.