### PR TITLE
Remove the link to the old search page.

### DIFF
--- a/client-src/elements/chromedash-app.ts
+++ b/client-src/elements/chromedash-app.ts
@@ -626,14 +626,6 @@ export class ChromedashApp extends LitElement {
   }
 
   renderRolloutBanner(currentPage) {
-    if (currentPage.startsWith('/features')) {
-      return html`
-        <p style="padding: 2em 6em">
-          <a href="/oldfeatures">Use the old features page</a>
-        </p>
-      `;
-    }
-
     return nothing;
   }
 


### PR DESCRIPTION
We launched the new search page months ago.   No one has said that they need the old page.  So, let's start phasing out the old search page by removing the link to it.