### PR TITLE
update devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,8 +4,8 @@
 # Update 'VARIANT' to pick a version of Python: 3, 3.10, 3.9, 3.8, 3.7, 3.6
 # Append -bullseye or -buster to pin to an OS version.
 # Use -bullseye variants on local arm64/Apple Silicon.
-ARG VARIANT="3.12-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT} as ide
+ARG VARIANT="3.12-bookworm"
+FROM mcr.microsoft.com/devcontainers/python:${VARIANT} as ide
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="18"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -82,9 +82,7 @@
 
 	"features": {
 		// https://github.com/devcontainers/features/tree/main/src/docker-in-docker
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {
-			"dockerDashComposeVersion": "v2"
-		},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {}
 	}
 }


### PR DESCRIPTION
When rebuilding my devcontainer environment for python 3.12, I saw that it failed to start because the previous location for the python image has been archived and did not receive anymore updates after python 3.11
https://github.com/microsoft/vscode-dev-containers

Updated the image to the one in the updated location. README: https://github.com/devcontainers/images/blob/main/src/python/README.md

Also, updated the docker-compose setup in the config to get that working. (Maybe it was needed when moving from bullseye to bookworm?)