### PR TITLE
Use filled check-circle icon on roadmap page.

### DIFF
--- a/client-src/elements/chromedash-review-status-icon.ts
+++ b/client-src/elements/chromedash-review-status-icon.ts
@@ -16,7 +16,7 @@ const STATUS_TO_ICON_NAME: Record<statusEnum, string> = {
   'Not started': 'arrow_circle_right_20px',
   'In-progress': 'pending_20px',
   'Needs work': 'autorenew_20px',
-  Approved: 'check_circle_20px',
+  Approved: 'check_circle_filled_20px',
   Denied: 'block_20px',
 };
 

--- a/client-src/elements/chromedash-review-status-icon_test.ts
+++ b/client-src/elements/chromedash-review-status-icon_test.ts
@@ -207,7 +207,7 @@ describe('chromedash-review-status-icon', () => {
     assert.instanceOf(component, ChromedashReviewStatusIcon);
     const icon = component.shadowRoot!.querySelector('sl-icon');
     assert.exists(icon);
-    assert.equal(icon.getAttribute('name'), 'check_circle_20px');
+    assert.equal(icon.getAttribute('name'), 'check_circle_filled_20px');
   });
 
   it('renders "denied" if any gate is denied', async () => {


### PR DESCRIPTION
I used the wrong checkmark icon on the roadmap page.   This PR corrects it to use the filled checked circle icon, which is easier to see and more distinct from the other icons used on that page.

For the record, we use:
* Outlined checked circle to indicate that a specific field value is valid.
* Filled checked circle to indicate that a gate has been approved.

Screenshot:
![image](https://github.com/user-attachments/assets/35076631-9299-4bd7-ae06-0a56abc112bb)
