### PR TITLE
Add legend dialog to roadmap page.

### DIFF
--- a/client-src/elements/chromedash-roadmap-help-dialog.ts
+++ b/client-src/elements/chromedash-roadmap-help-dialog.ts
@@ -111,7 +111,7 @@ export class ChromedashRoadmapHelpDialog extends LitElement {
               name="block_20px"
             ></sl-icon>
             <span>Denied</span>
-            <td>Reviewers suggested directional change</td>
+            <td>Reviewers suggested directional changes</td>
           </li>
         </ul>
       </div>

--- a/client-src/elements/chromedash-roadmap-help-dialog.ts
+++ b/client-src/elements/chromedash-roadmap-help-dialog.ts
@@ -1,0 +1,128 @@
+import {LitElement, css, html} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import {SHARED_STYLES} from '../css/shared-css.js';
+
+let roadmapHelpDialogEl;
+
+export async function openRoadmapHelpDialog() {
+  if (!roadmapHelpDialogEl) {
+    roadmapHelpDialogEl = document.createElement(
+      'chromedash-roadmap-help-dialog'
+    );
+    document.body.appendChild(roadmapHelpDialogEl);
+    await roadmapHelpDialogEl.updateComplete;
+  }
+  roadmapHelpDialogEl.show();
+}
+
+@customElement('chromedash-roadmap-help-dialog')
+export class ChromedashRoadmapHelpDialog extends LitElement {
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      css`
+        #dialog-content {
+          max-width: 60rem;
+        }
+        #legend li {
+          padding: var(--content-padding-quarter);
+          white-space: nowrap;
+        }
+        #legend span {
+          display: inline-block;
+          width: 8em;
+        }
+
+        #legend sl-icon {
+          width: 26px;
+          height: 18px;
+        }
+        sl-icon.not-started {
+          color: var(--gate-preparing-icon-color);
+        }
+        sl-icon.in-progress {
+          color: var(--gate-pending-icon-color);
+        }
+        sl-icon.needs-work {
+          color: var(--gate-needs-work-icon-color);
+        }
+        sl-icon.approved {
+          color: var(--gate-approved-icon-color);
+        }
+        sl-icon.denied {
+          color: var(--gate-denied-icon-color);
+        }
+      `,
+    ];
+  }
+
+  show() {
+    this.renderRoot.querySelector('sl-dialog')?.show();
+  }
+
+  hide() {
+    this.renderRoot.querySelector('sl-dialog')?.hide();
+  }
+
+  renderDialogContent() {
+    return html`
+      <div id="dialog-content">
+        <ul id="legend">
+          <li>
+            <sl-icon
+              library="material"
+              class="approved"
+              name="check_circle_filled_20px"
+            ></sl-icon>
+            <span>Approved</span>
+            <td>Reviewers approved feature at this stage</td>
+          </li>
+          <li>
+            <sl-icon
+              library="material"
+              class="not-started"
+              name="arrow_circle_right_20px"
+            ></sl-icon>
+            <span>Not started</span>
+            <td>Feature owners have not requested reviews yet</td>
+          </li>
+          <li>
+            <sl-icon
+              library="material"
+              class="in-progress"
+              name="pending_20px"
+            ></sl-icon>
+            <span>In-progress</span>
+            <td>Not all reviews have finished</td>
+          </li>
+          <li>
+            <sl-icon
+              library="material"
+              class="needs-work"
+              name="autorenew_20px"
+            ></sl-icon>
+            <span>Needs work</span>
+            <td>Reviewers have asked for changes</td>
+          </li>
+          <li>
+            <sl-icon
+              library="material"
+              class="denied"
+              name="block_20px"
+            ></sl-icon>
+            <span>Denied</span>
+            <td>Reviewers suggested directional change</td>
+          </li>
+        </ul>
+      </div>
+    `;
+  }
+
+  render() {
+    return html`
+      <sl-dialog label="Roadmap legend" style="--width:fit-content">
+        ${this.renderDialogContent()}
+      </sl-dialog>
+    `;
+  }
+}

--- a/client-src/elements/chromedash-roadmap-page.ts
+++ b/client-src/elements/chromedash-roadmap-page.ts
@@ -12,7 +12,6 @@ import {SlDialog} from '@shoelace-style/shoelace';
 export class ChromedashRoadmapPage extends LitElement {
   sectionRef = createRef<HTMLElement>();
   roadmapRef = createRef<ChromedashRoadmap>();
-  helpDialogRef = createRef<SlDialog>();
 
   static get styles() {
     return [
@@ -34,6 +33,7 @@ export class ChromedashRoadmapPage extends LitElement {
         .timeline-controls {
           text-align: center;
           padding-bottom: var(--content-padding);
+          margin: 0 var(--content-padding-half);
         }
       `,
     ];

--- a/client-src/elements/chromedash-roadmap-page.ts
+++ b/client-src/elements/chromedash-roadmap-page.ts
@@ -5,11 +5,14 @@ import {SHARED_STYLES} from '../css/shared-css.js';
 import {User} from '../js-src/cs-client';
 import './chromedash-roadmap';
 import {ChromedashRoadmap} from './chromedash-roadmap';
+import {openRoadmapHelpDialog} from './chromedash-roadmap-help-dialog';
+import {SlDialog} from '@shoelace-style/shoelace';
 
 @customElement('chromedash-roadmap-page')
 export class ChromedashRoadmapPage extends LitElement {
   sectionRef = createRef<HTMLElement>();
   roadmapRef = createRef<ChromedashRoadmap>();
+  helpDialogRef = createRef<SlDialog>();
 
   static get styles() {
     return [
@@ -17,6 +20,11 @@ export class ChromedashRoadmapPage extends LitElement {
       css`
         .animate {
           transition: margin 0.4s ease;
+        }
+        #help-button {
+          font-size: 1.4rem;
+          color: var(--unimportant-text-color);
+          float: right;
         }
 
         #releases-section {
@@ -110,6 +118,18 @@ export class ChromedashRoadmapPage extends LitElement {
     roadmap.style.left = roadmap.cardOffset * (this.cardWidth + margin) + 'px';
   }
 
+  renderHelpIcon() {
+    return html`
+      <sl-icon
+        id="help-button"
+        library="material"
+        name="help_20px"
+        @click="${openRoadmapHelpDialog}"
+      >
+      </sl-icon>
+    `;
+  }
+
   render() {
     return html`
       <div id="subheader">
@@ -133,6 +153,7 @@ export class ChromedashRoadmapPage extends LitElement {
           >
             Next
           </button>
+          ${this.renderHelpIcon()}
         </div>
         <chromedash-roadmap
           ${ref(this.roadmapRef)}


### PR DESCRIPTION
This is intended to address some feedback from Dharani on the new roadmap review status icons.  It adds a `(?)` help icon to the corner of the page and that opens a dialog box that shows the meaning of each of the review icons.