### PR TITLE
Offer NA_VERIFIED for review audits.

### DIFF
--- a/client-src/elements/chromedash-gate-chip.ts
+++ b/client-src/elements/chromedash-gate-chip.ts
@@ -16,6 +16,7 @@ const GATE_STATE_TO_NAME = {
   8: 'Internal review', // INTERNAL_REVIEW
   9: 'N/A requested', // NA_REQUESTED
   10: 'N/A (self-certified)', //  NA_SELF
+  11: 'N/A (self-certified then verified)', //  NA_VERIFIED
 };
 
 const GATE_STATE_TO_ICON = {
@@ -29,13 +30,15 @@ const GATE_STATE_TO_ICON = {
   // TODO(jrobbins): COMPLETE for auto-approved also check_circle_filled_20px.
   // INTERNAL_REVIEW has no icon.
   // NA_SELF has no icon.
+  // NA_VERIFIED has no icon.
 };
 
 const GATE_STATE_TO_ABBREV = {
   1: 'N/A', //  NA
   8: 'INT', // INTERNAL_REVIEW
-  9: 'N/A?', // INTERNAL_REVIEW
+  9: 'N/A?', // NA_REQUESTED
   10: 'N/A (self)', //  NA_SELF
+  11: 'N/A (ver)', //  NA_VERIFIED
 };
 
 export interface GateDict {
@@ -113,6 +116,10 @@ class ChromedashGateChip extends LitElement {
 
         sl-button.not_applicable::part(base),
         sl-button.na_self-certified::part(base) {
+          background: var(--gate-not-applicable-background);
+          color: var(--gate-not-applicable-color);
+        }
+        sl-button.na_self-certified_then_verified::part(base) {
           background: var(--gate-not-applicable-background);
           color: var(--gate-not-applicable-color);
         }

--- a/client-src/elements/chromedash-gate-column.ts
+++ b/client-src/elements/chromedash-gate-column.ts
@@ -17,6 +17,7 @@ import {
   GATE_REVIEW_REQUESTED,
   VOTE_OPTIONS,
   VOTE_NA_SELF,
+  VOTE_NA_VERIFIED,
 } from './form-field-enums';
 import {
   autolink,
@@ -643,6 +644,15 @@ export class ChromedashGateColumn extends LitElement {
     `;
   }
 
+  renderReviewStatusNaVerified() {
+    return html`
+      <div class="status approved">
+        <sl-icon library="material" name="check_circle_filled_20px"></sl-icon>
+        N/a (self-certified then verified)
+      </div>
+    `;
+  }
+
   renderReviewStatusDenied() {
     // TODO(jrobbins): Show date of denial.
     return html`
@@ -662,6 +672,8 @@ export class ChromedashGateColumn extends LitElement {
       return this.renderReviewStatusNa();
     } else if (this.gate.state == VOTE_NA_SELF) {
       return this.renderReviewStatusNaSelf();
+    } else if (this.gate.state == VOTE_NA_VERIFIED) {
+      return this.renderReviewStatusNaVerified();
     } else if (this.gate.state == VOTE_OPTIONS.APPROVED[0]) {
       return this.renderReviewStatusApproved();
     } else if (this.gate.state == VOTE_OPTIONS.DENIED[0]) {
@@ -812,6 +824,9 @@ export class ChromedashGateColumn extends LitElement {
     if (state == VOTE_NA_SELF) {
       return 'N/a (self-certified)';
     }
+    if (state == VOTE_NA_VERIFIED) {
+      return 'N/a (verified)';
+    }
     for (const item of Object.values(VOTE_OPTIONS)) {
       if (item[0] == state) {
         return item[1];
@@ -839,6 +854,13 @@ export class ChromedashGateColumn extends LitElement {
         hoist
         size="small"
       >
+        ${this.votes.some(
+          v => v.state === VOTE_NA_SELF || v.state === VOTE_NA_VERIFIED
+        )
+          ? html` <sl-option value="${VOTE_NA_VERIFIED}"
+              >N/a verified</sl-option
+            >`
+          : nothing}
         ${Object.values(VOTE_OPTIONS).map(
           valName =>
             html` <sl-option value="${valName[0]}">${valName[1]}</sl-option>`

--- a/client-src/elements/form-field-enums.ts
+++ b/client-src/elements/form-field-enums.ts
@@ -509,6 +509,7 @@ export const VOTE_OPTIONS: Record<string, [number, string]> = {
   DENIED: [6, 'Denied'],
 };
 export const VOTE_NA_SELF = 10;
+export const VOTE_NA_VERIFIED = 11;
 export const GATE_ACTIVE_REVIEW_STATES: number[] = [
   GATE_REVIEW_REQUESTED,
   VOTE_OPTIONS.REVIEW_STARTED[0],

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -255,6 +255,7 @@ RS = Vote.REVIEW_STARTED
 NA = Vote.NA
 IR = Vote.INTERNAL_REVIEW
 NA_SELF = Vote.NA_SELF
+NA_VERIFIED = Vote.NA_VERIFIED
 GATE_VALUES= Vote.VOTE_VALUES.copy()
 GATE_VALUES.update({Gate.PREPARING: 'preparing'})
 
@@ -362,12 +363,25 @@ class CalcGateStateTest(testing_config.CustomTestCase):
     """A feature owner self-certified but a reviewer disagreed."""
     self.assertEqual(('needs_work', 'needs_work'),
                      self.do_calc(NA_SELF, NW))
+    self.assertEqual(('needs_work', 'needs_work'),
+                     self.do_calc(NA_SELF, NR, NW, NR))
     self.assertEqual(('review_started', 'review_started'),
                      self.do_calc(NA_SELF, RS))
     self.assertEqual(('internal_review', 'internal_review'),
                      self.do_calc(NA_SELF, IR))
     self.assertEqual(('denied', 'denied'),
                      self.do_calc(NA_SELF, DN))
+
+  def test_self_cert_verified(self):
+    """A feature owner self-certified and a reviewer verfied."""
+    self.assertEqual(('na (verified)', 'preparing'),
+                     self.do_calc(NA_SELF, NA_VERIFIED))
+    self.assertEqual(('na (verified)', 'preparing'),
+                     self.do_calc(NA_SELF, NR, NA_VERIFIED, NR))
+    self.assertEqual(('na (verified)', 'needs_work'),
+                     self.do_calc(NA_SELF, RS, NW, NA_VERIFIED))
+    self.assertEqual(('na (verified)', 'review_started'),
+                     self.do_calc(NA_SELF, NA_VERIFIED, IR, RS))
 
 
 class UpdateTest(testing_config.CustomTestCase):

--- a/internals/approval_defs_test.py
+++ b/internals/approval_defs_test.py
@@ -247,6 +247,7 @@ class IsApprovedTest(testing_config.CustomTestCase):
         set_on=datetime.datetime.now(),
         set_by='three@example.com')
 
+NR = Vote.NO_RESPONSE
 RR = Vote.REVIEW_REQUESTED
 AP = Vote.APPROVED
 DN = Vote.DENIED

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -96,6 +96,7 @@ class Vote(ndb.Model):
   INTERNAL_REVIEW = 8
   NA_REQUESTED = 9
   NA_SELF = 10
+  NA_VERIFIED = 11
   VOTE_VALUES = {
       # Not used: PREPARING: 'preparing',
       NA: 'na',
@@ -108,6 +109,7 @@ class Vote(ndb.Model):
       INTERNAL_REVIEW: 'internal_review',
       NA_REQUESTED: 'na_requested',
       NA_SELF: 'na (self-certified)',
+      NA_VERIFIED: 'na (verified)',
   }
 
   REQUESTING_STATES = [REVIEW_REQUESTED, NA_REQUESTED, NA_SELF]
@@ -175,8 +177,9 @@ class Gate(ndb.Model):
   PENDING_STATES = [
       Vote.REVIEW_REQUESTED, Vote.REVIEW_STARTED, Vote.NEEDS_WORK,
       Vote.INTERNAL_REVIEW, Vote.NA_REQUESTED]
-  FINAL_STATES = [Vote.NA, Vote.APPROVED, Vote.DENIED, Vote.NA_SELF]
-  APPROVED_STATES = [Vote.NA, Vote.APPROVED, Vote.NA_SELF]
+  FINAL_STATES = [Vote.NA, Vote.APPROVED, Vote.DENIED, Vote.NA_SELF,
+                  Vote.NA_VERIFIED]
+  APPROVED_STATES = [Vote.NA, Vote.APPROVED, Vote.NA_SELF, Vote.NA_VERIFIED]
 
   feature_id = ndb.IntegerProperty(required=True)
   stage_id = ndb.IntegerProperty(required=True)


### PR DESCRIPTION
As part of our support for self-certification, we need to support reviewers doing audits to double-check that a self-certified N/A is actually valid.  This PR adds support for a new Vote value NA_VERIFIED.

In this PR:
* In review_models.py: Define the new vote value.
* In reviews_api.py: check that NA_VERIFIED is being cast only if the gate state was NA_SELF (or NA_VERIFIED, in case two reviewers both verify).
* In chromestatus-gate-chip.ts: Display NA_VERIFIED as "N/a (ver)" with a green background and checkmark icon.
* In chromestatus-gate-column.ts: Display an explanation at the top of the column for gates in the NA_VERIFIED state, and offer the option to vote NA_VERIFIED only if there was some NA_SELF or NA_VERIFIED vote already.
* In approvals_defs.py: Simply the vote counting logic by using `collections.Counter` and add logic to make the gate verified if there are any relevant NA_VERIFIED votes.