### PR TITLE
Allow trial requests for gates that have the new NA states

### DIFF
--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -232,7 +232,7 @@ export class ChromedashFeatureDetail extends LitElement {
     // Don't try to display dialog if we can't find the associated gate or the gate isn't approved.
     if (
       !extensionGate ||
-        !GATE_APPROVED_REVIEW_STATES.includes(extensionGate.state))
+      !GATE_APPROVED_REVIEW_STATES.includes(extensionGate.state)
     ) {
       return;
     }
@@ -723,8 +723,8 @@ export class ChromedashFeatureDetail extends LitElement {
       );
       return (
         e.ot_action_requested &&
-          extensionGate &&
-          GATE_APPROVED_REVIEW_STATES.includes(extensionGate.state)
+        extensionGate &&
+        GATE_APPROVED_REVIEW_STATES.includes(extensionGate.state)
       );
     });
     if (extensionReadyForFinalize) {

--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -20,7 +20,6 @@ import {
   OT_SETUP_STATUS_OPTIONS,
   STAGE_SHORT_NAMES,
   STAGE_TYPES_ORIGIN_TRIAL,
-  VOTE_OPTIONS,
   GATE_APPROVED_REVIEW_STATES,
 } from './form-field-enums';
 import {makeDisplaySpecs} from './form-field-specs';
@@ -233,8 +232,7 @@ export class ChromedashFeatureDetail extends LitElement {
     // Don't try to display dialog if we can't find the associated gate or the gate isn't approved.
     if (
       !extensionGate ||
-      (extensionGate.state !== VOTE_OPTIONS.APPROVED[0] &&
-        extensionGate.state !== VOTE_OPTIONS.NA[0])
+        !GATE_APPROVED_REVIEW_STATES.includes(extensionGate.state))
     ) {
       return;
     }
@@ -725,9 +723,8 @@ export class ChromedashFeatureDetail extends LitElement {
       );
       return (
         e.ot_action_requested &&
-        extensionGate &&
-        (extensionGate.state === VOTE_OPTIONS.APPROVED[0] ||
-          extensionGate.state === VOTE_OPTIONS.NA[0])
+          extensionGate &&
+          GATE_APPROVED_REVIEW_STATES.includes(extensionGate.state)
       );
     });
     if (extensionReadyForFinalize) {

--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -21,6 +21,7 @@ import {
   STAGE_SHORT_NAMES,
   STAGE_TYPES_ORIGIN_TRIAL,
   VOTE_OPTIONS,
+  GATE_APPROVED_REVIEW_STATES,
 } from './form-field-enums';
 import {makeDisplaySpecs} from './form-field-specs';
 import {getFieldValueFromFeature, hasFieldValue, isDefinedValue} from './utils';

--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -787,8 +787,7 @@ export class ChromedashFeatureDetail extends LitElement {
     const trialIsApproved = this.gates.every(g => {
       return (
         g.stage_id !== feStage.id ||
-        g.state === VOTE_OPTIONS.APPROVED[0] ||
-        g.state === VOTE_OPTIONS.NA[0]
+        GATE_APPROVED_REVIEW_STATES.includes(g.state)
       );
     });
     if (

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -8,7 +8,7 @@ import './chromedash-form-field.js';
 import {ORIGIN_TRIAL_CREATION_FIELDS} from './form-definition.js';
 import {
   OT_SETUP_STATUS_OPTIONS,
-  VOTE_OPTIONS,
+  GATE_APPROVED_REVIEW_STATES,
   USE_COUNTER_TYPE_WEBFEATURE,
   USE_COUNTER_TYPE_WEBDXFEATURE,
   USE_COUNTER_TYPE_CSS_PROPERTY_ID,
@@ -143,10 +143,7 @@ export class ChromedashOTCreationPage extends LitElement {
         g => g.stage_id === this.stage.id
       );
       relevantGates.forEach(g => {
-        if (
-          g.state !== VOTE_OPTIONS.APPROVED[0] &&
-          g.state !== VOTE_OPTIONS.NA[0]
-        ) {
+        if (!GATE_APPROVED_REVIEW_STATES.includes(g.state)) {
           // Redirect if approvals have not been obtained.
           window.location.href = `/feature/${this.featureId}`;
         }

--- a/client-src/elements/form-field-enums.ts
+++ b/client-src/elements/form-field-enums.ts
@@ -509,6 +509,7 @@ export const VOTE_OPTIONS: Record<string, [number, string]> = {
   DENIED: [6, 'Denied'],
 };
 export const VOTE_NA_SELF = 10;
+export const VOTE_NA_VERIFIED = 11;
 export const GATE_ACTIVE_REVIEW_STATES: number[] = [
   GATE_REVIEW_REQUESTED,
   VOTE_OPTIONS.REVIEW_STARTED[0],
@@ -520,6 +521,13 @@ export const GATE_FINISHED_REVIEW_STATES: number[] = [
   VOTE_OPTIONS.NA[0],
   VOTE_OPTIONS.APPROVED[0],
   VOTE_OPTIONS.DENIED[0],
+];
+
+export const GATE_APPROVED_REVIEW_STATES: number[] = [
+  VOTE_OPTIONS.APPROVED[0],
+  VOTE_OPTIONS.NA[0],
+  VOTE_NA_SELF,
+  VOTE_NA_VERIFIED,
 ];
 
 export const GATE_TEAM_ORDER = [


### PR DESCRIPTION
This fixes a bug that arose from adding new variations on the NA gate state for NA_SELF and NA_VERIFIED:  The server-side allowed requests to set up trials or extend them when the OT state gates had these states, but the client-side did not enable the button for the user to request that.  This changes the client-side conditions to account for these new gate states.

In this PR:
* Replace existing conditions that looked specifically for APPROVED and NA with ones that check for any value in GATE_APPROVED_REVIEW_STATES.
* Define constant GATE_APPROVED_REVIEW_STATES to include APPROVED, NA, NA_SELF, and NA_VERIFIED.