### PR TITLE
Allow feature editors to edit summaries on release notes page.

### DIFF
--- a/client-src/elements/chromedash-app.ts
+++ b/client-src/elements/chromedash-app.ts
@@ -286,7 +286,7 @@ export class ChromedashApp extends LitElement {
     window.setTimeout(() => {
       // Timeout required since the form may not be created yet.
       // Allow form submit to proceed without warning.
-      const form = this.pageComponent.shadowRoot.querySelector('form');
+      const form = this.pageComponent.shadowRoot?.querySelector('form');
       if (form) {
         this.addBeforeUnloadHandler();
 

--- a/client-src/elements/chromedash-enterprise-release-notes-page.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page.ts
@@ -527,13 +527,13 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
   }
 
   startEditing(featureId) {
-    let newEditing = new Set(this.editingFeatureIds);
+    const newEditing = new Set(this.editingFeatureIds);
     newEditing.add(featureId);
     this.editingFeatureIds = newEditing;
   }
 
   cancel(featureId) {
-    let newEditing = new Set(this.editingFeatureIds);
+    const newEditing = new Set(this.editingFeatureIds);
     newEditing.delete(featureId);
     this.editingFeatureIds = newEditing;
   }


### PR DESCRIPTION
This resolves a request from the Chrome Enterprise team to speed up editing of multiple feature summaries by allowing editing directly on the /enterprise/releasenotes page.

In this PR:
* Make chromedash-app more robust to cope with an error that I hit while testing.
* In chromedash-enterprise-releasenotes add a set of IDs of the features being edited, and buttons to add and remove features from that set.  When a feature is being edited, render it as a textarea offer a save button.