### PR TITLE
Clarify the updated timestamp on the releasenotes page

### DIFF
--- a/client-src/elements/chromedash-enterprise-release-notes-page.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page.ts
@@ -14,6 +14,7 @@ import {
 import {
   parseRawQuery,
   renderHTMLIf,
+  renderRelativeDate,
   showToastMessage,
   updateURLParams,
 } from './utils.js';
@@ -537,6 +538,23 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
     this.editingFeatureIds = newEditing;
   }
 
+  nowString() {
+    const now = new Date();
+    const formatter = new Intl.DateTimeFormat('en-CA', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+      hour12: false,
+      timeZone: 'UTC',
+    });
+    let nowStr = formatter.format(now); // YYYY-MM-DD, HH:mm:ss
+    nowStr = nowStr.replace(',', '');
+    return nowStr;
+  }
+
   save(f: Feature) {
     let textarea: SlTextarea = this.shadowRoot?.querySelector(
       '#edit-feature-' + f.id
@@ -557,7 +575,7 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
       .updateFeature(submitBody)
       .then(resp => {
         f.summary = newSummary;
-        f.updated.when = (new Date()).toISOString();
+        f.updated.when = this.nowString();
       })
       .catch(() => {
         showToastMessage(
@@ -624,13 +642,16 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
             <p class="toremove">
               <b>< To remove</b>
               - <a target="_blank" href="/feature/${f.id}">Feature details</a> -
-              - <b>Owners:</b> ${f.browsers.chrome.owners.join(', ')}
-              - <b>Editors:</b> ${(f.editors || []).join(', ')}
-              - <b>First Notice:</b>
-              ${f.first_enterprise_notification_milestone}
+              - <b>Owners:</b> ${f.browsers.chrome.owners.join(', ')} -
+              <b>Editors:</b> ${(f.editors || []).join(', ')} -
+              <b>First Notice:</b> ${f.first_enterprise_notification_milestone}
               - <b>Last Updated:</b>
-              <a href="/feature/${f.id}/activity" target="_blank">
-              <sl-relative-time date=${f.updated.when}></sl-relative-time>
+              <a
+                href="/feature/${f.id}/activity"
+                target="_blank"
+                title=${f.updated.when}
+              >
+                ${renderRelativeDate(f.updated.when)}
               </a>
               <b>></b>
             </p>

--- a/client-src/elements/chromedash-enterprise-release-notes-page.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page.ts
@@ -642,7 +642,7 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
             <p class="toremove">
               <b>< To remove</b>
               - <a target="_blank" href="/feature/${f.id}">Feature details</a> -
-              - <b>Owners:</b> ${f.browsers.chrome.owners.join(', ')} -
+              <b>Owners:</b> ${f.browsers.chrome.owners.join(', ')} -
               <b>Editors:</b> ${(f.editors || []).join(', ')} -
               <b>First Notice:</b> ${f.first_enterprise_notification_milestone}
               - <b>Last Updated:</b>

--- a/client-src/elements/chromedash-enterprise-release-notes-page.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page.ts
@@ -125,7 +125,6 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
 
         .toremove {
           font-style: italic;
-          font-weight: bold;
         }
 
         td:not(:first-child),
@@ -558,6 +557,7 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
       .updateFeature(submitBody)
       .then(resp => {
         f.summary = newSummary;
+        f.updated.when = (new Date()).toISOString();
       })
       .catch(() => {
         showToastMessage(
@@ -622,12 +622,17 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
           html` <section class="feature">
             <strong>${f.name}</strong>
             <p class="toremove">
-              < To remove -
-              <a target="_blank" href="/feature/${f.id}">Feature details</a> -
-              Owners: ${f.browsers.chrome.owners.join(', ')} - Editors:
-              ${(f.editors || []).join(', ')} - First Notice:
-              ${f.first_enterprise_notification_milestone} - Last Updated:
-              ${f.updated.when} >
+              <b>< To remove</b>
+              - <a target="_blank" href="/feature/${f.id}">Feature details</a> -
+              - <b>Owners:</b> ${f.browsers.chrome.owners.join(', ')}
+              - <b>Editors:</b> ${(f.editors || []).join(', ')}
+              - <b>First Notice:</b>
+              ${f.first_enterprise_notification_milestone}
+              - <b>Last Updated:</b>
+              <a href="/feature/${f.id}/activity" target="_blank">
+              <sl-relative-time date=${f.updated.when}></sl-relative-time>
+              </a>
+              <b>></b>
             </p>
             ${this.renderOrEditFeatureSummary(f)}
             <ul>

--- a/client-src/elements/chromedash-enterprise-release-notes-page_test.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page_test.ts
@@ -32,7 +32,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
             },
           },
           updated: {
-            when: 'feature1 updated',
+            when: '2000-03-01 13:05:00',
           },
           screenshot_links: [],
         },
@@ -59,7 +59,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
             },
           },
           updated: {
-            when: 'updated when',
+            when: '2000-03-04 13:05:00',
           },
           screenshot_links: [],
         },
@@ -92,7 +92,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
             },
           },
           updated: {
-            when: 'updated when',
+            when: '2000-03-04 18:25:55',
           },
           screenshot_links: ['https://example.com/screenshot1'],
         },
@@ -129,7 +129,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
             },
           },
           updated: {
-            when: 'feature 4 updated',
+            when: '2000-03-04 13:05:12',
           },
           screenshot_links: ['https://example.com/screenshot1', 'https://example.com/screenshot2'],
         },
@@ -166,7 +166,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
             },
           },
           updated: {
-            when: 'updated when',
+            when: '2000-03-04 11:22:33',
           },
           screenshot_links: ['https://example.com/screenshot1'],
         },
@@ -195,7 +195,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
             },
           },
           updated: {
-            when: 'updated when',
+            when: '2000-03-04 22:33:44',
           },
           screenshot_links: [],
         },
@@ -228,7 +228,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
             },
           },
           updated: {
-            when: 'updated when',
+            when: '2000-03-04 00:11:22',
           },
           screenshot_links: [],
         },
@@ -257,7 +257,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
             },
           },
           updated: {
-            when: 'updated when',
+            when: '2000-03-04 55:44:33',
           },
           screenshot_links: [],
         },
@@ -348,7 +348,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
     assert.notInclude(children[13].textContent, '✓');
     assert.notInclude(children[14].textContent, '✓');
     assert.include(children[15].textContent, '✓');
-  
+
     assert.equal(children[16].textContent, 'normal feature with shipping stage');
     assert.notInclude(children[17].textContent, '✓');
     assert.notInclude(children[18].textContent, '✓');
@@ -361,7 +361,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
     assert.equal(children[23].textContent, 'Management');
 
     assert.equal(children[24].textContent, 'Nothing');
-  
+
     // Validate upcoming chrome browser updates
     assert.equal(children[25].textContent, 'Upcoming Chrome Browser updates');
     assert.equal(children[26].textContent, 'Security / Privacy');
@@ -415,7 +415,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
     //     assert.equal(
     //       '< To remove - Feature details - ' +
     //       'Owners: owner - Editors: editor1, editor2 - First Notice: n_milestone_feat_3 - ' +
-    //       'Last Updated: updated when >',
+    //       'Last Updated: ( ) >',
     //       normalizedTextContent(features[0].querySelector('.toremove')));
     //     assert.equal(
     //       'feature 3 summary',
@@ -466,7 +466,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
     //     assert.equal(screenshots[1].src, 'https://example.com/screenshot2');
     //     assert.equal(screenshots[1].alt, 'Feature screenshot 2');
     //   }
-    
+
     //   // Feature 2
     //   {
     //     assert.equal(
@@ -475,7 +475,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
     //     assert.equal(
     //       '< To remove - Feature details - ' +
     //       'Owners: owner - Editors: editor1, editor2 - First Notice: n_milestone_feat_7 - ' +
-    //       'Last Updated: updated when >',
+    //       'Last Updated: ( ) >',
     //       normalizedTextContent(features[1].querySelector('.toremove')));
     //     assert.equal(
     //       'normal feature summary',
@@ -500,7 +500,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
       const features = Array.from(releaseNotes[2].querySelectorAll('.feature'));
       assert.isEmpty(features);
     }
-  
+
     // Test Upcoming Chrome Browser updates
     {
       assert.equal(
@@ -514,7 +514,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
         assert.equal(
           '< To remove - Feature details - ' +
           'Owners: owner - Editors: editor1, editor2 - First Notice: n_milestone_feat_6 - ' +
-          'Last Updated: updated when >',
+            'Last Updated: ( ) >',
           normalizedTextContent(features[0].querySelector('.toremove')));
         assert.equal(
           'feature 6 summary',
@@ -528,7 +528,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
         assert.isEmpty(screenshots);
       }
     }
-    
+
     // Test Upcoming Chrome Enterprise Core
     {
       assert.equal(
@@ -552,7 +552,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
         assert.equal(
           '< To remove - Feature details - ' +
           'Owners: owner - Editors: editor1, editor2 - First Notice: n_milestone_feat_8 - ' +
-          'Last Updated: updated when >',
+            'Last Updated: >',
           normalizedTextContent(features[0].querySelector('.toremove')));
         assert.equal(
           'future premium feature summary',


### PR DESCRIPTION
The Enterprise team asked for the timestamp for editing a feature to be shown on the release notes page.  It was actually already there, but not in a very clear format.

In this PR:
* Instead of making that whole paragraph bold, just bold the labels so that the values and labels are more differentiated.
* Replace the timestamp string with `<sl-relative-time>` and link to the feature activity page for more details.
* When the user saves an edit, update the timestamp locally so that it will show `(this minute)` and they can see which ones they have already edited