### PR TITLE
Only show rollout_plan in I2S, not earlier intents.

### DIFF
--- a/internals/testdata/notifier_test/test_make_intent_email.html
+++ b/internals/testdata/notifier_test/test_make_intent_email.html
@@ -116,8 +116,7 @@ None
   
 
 
-<br><br><h4>Rollout plan</h4>
-Will ship enabled for all users
+
 
 
 

--- a/pages/testdata/intentpreview_test/test_html_ot_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_ot_rendering.html
@@ -124,8 +124,7 @@ None
   
 
 
-<br><br><h4>Rollout plan</h4>
-Will ship enabled for all users
+
 
 
 

--- a/pages/testdata/intentpreview_test/test_html_prototype_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_prototype_rendering.html
@@ -124,8 +124,7 @@ None
   
 
 
-<br><br><h4>Rollout plan</h4>
-Will ship enabled for all users
+
 
 
 

--- a/pages/testdata/intentpreview_test/test_html_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_rendering.html
@@ -277,8 +277,7 @@ None
   
 
 
-<br><br><h4>Rollout plan</h4>
-Will ship enabled for all users
+
 
 
 

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -199,8 +199,10 @@
   {% endif %}
 {% endif %}
 
-<br><br><h4>Rollout plan</h4>
-{{feature.rollout_plan_displayname}}
+{% if 'ship' in sections_to_show %}
+  <br><br><h4>Rollout plan</h4>
+  {{feature.rollout_plan_displayname}}
+{% endif %}
 
 
 


### PR DESCRIPTION
The rollout_plan field is only filled in for the shipping stage, so it should only be in the I2S email.  If it is included in an I2P or I2E, it will have the default value which could be misleading.
