### PR TITLE
Update dependabot reviewers.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       # Prefix all commit messages with "npm"
       prefix: "npm"
     reviewers:
-      - "kyleju"
+      - "DanielRyanSmith"
       - "jrobbins"
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
This keep on keeping us in the loop for weekly depend-a-bot PRs.