### PR TITLE
Add automation_spec field

### DIFF
--- a/api/api_specs.py
+++ b/api/api_specs.py
@@ -28,6 +28,7 @@ FEATURE_FIELD_DATA_TYPES: FIELD_INFO_DATA_TYPE = [
   ('all_platforms_descr', 'str'),
   ('anticipated_spec_changes', 'str'),
   ('api_spec', 'bool'),
+  ('automation_spec', 'bool'),
   ('availability_expectation', 'str'),
   ('blink_components', 'split_str'),
   ('enterprise_impact', 'int'),

--- a/api/converters.py
+++ b/api/converters.py
@@ -404,6 +404,7 @@ def feature_entry_to_json_verbose(
     'requires_embedder_support': fe.requires_embedder_support,
     'spec_link': fe.spec_link,
     'api_spec': fe.api_spec,
+    'automation_spec': fe.automation_spec,
     'interop_compat_risks': fe.interop_compat_risks,
     'all_platforms': fe.all_platforms,
     'all_platforms_descr': fe.all_platforms_descr,

--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -305,6 +305,7 @@ class FeatureConvertersTest(testing_config.CustomTestCase):
       'summary': 'sum',
       'unlisted': False,
       'api_spec': False,
+      'automation_spec': False,
       'enterprise_impact': ENTERPRISE_IMPACT_NONE,
       'enterprise_product_category': 0,
       'shipping_year': 2024,

--- a/client-src/elements/form-definition.ts
+++ b/client-src/elements/form-definition.ts
@@ -270,6 +270,7 @@ const FLAT_PROTOTYPE_FIELDS: MetadataFields = {
         'spec_link',
         'standard_maturity',
         'api_spec',
+        'automation_spec',
         'spec_mentors',
         'intent_to_implement_url',
       ],

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -793,6 +793,16 @@ export const ALL_FIELDS: Record<string, Field> = {
     such as Web IDL, or there is an existing MDN page.`,
   },
 
+  automation_spec: {
+    type: 'checkbox',
+    initial: false,
+    label: 'Automation spec',
+    help_text: html` The platform has sufficient automation features for
+    website authors to test use of this new feature. These automation features
+    can include new automation APIs, like WebDriver BiDi modules, that are
+    defined in this feature's specification.`,
+  },
+
   spec_mentors: {
     type: 'input',
     name: 'spec_mentor_emails',

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -797,10 +797,10 @@ export const ALL_FIELDS: Record<string, Field> = {
     type: 'checkbox',
     initial: false,
     label: 'Automation spec',
-    help_text: html` The platform has sufficient automation features for
-    website authors to test use of this new feature. These automation features
-    can include new automation APIs, like WebDriver BiDi modules, that are
-    defined in this feature's specification.`,
+    help_text: html` The platform has sufficient automation features for website
+    authors to test use of this new feature. These automation features can
+    include new automation APIs, like WebDriver BiDi modules, that are defined
+    in this feature's specification.`,
   },
 
   spec_mentors: {

--- a/client-src/elements/gate-details.ts
+++ b/client-src/elements/gate-details.ts
@@ -162,8 +162,13 @@ const DEBUGGABILITY_ORIGIN_TRIAL_QUESTIONNAIRE: TemplateResult = html`
   </p>
 
   <p>
-    When in doubt, please check out https://goo.gle/devtools-checklist for
-    details!
+    (4) Can the feature be tested with a WebDriver BiDi module or other
+    appropriate automation?
+  </p>
+
+  <p>
+    When in doubt, please check out <a href="https://goo.gle/devtools-checklist"
+    target="_blank">https://goo.gle/devtools-checklist</a> for details!
   </p>
 `;
 

--- a/client-src/elements/gate-details.ts
+++ b/client-src/elements/gate-details.ts
@@ -167,8 +167,11 @@ const DEBUGGABILITY_ORIGIN_TRIAL_QUESTIONNAIRE: TemplateResult = html`
   </p>
 
   <p>
-    When in doubt, please check out <a href="https://goo.gle/devtools-checklist"
-    target="_blank">https://goo.gle/devtools-checklist</a> for details!
+    When in doubt, please check out
+    <a href="https://goo.gle/devtools-checklist" target="_blank"
+      >https://goo.gle/devtools-checklist</a
+    >
+    for details!
   </p>
 `;
 

--- a/client-src/elements/queriable-fields.ts
+++ b/client-src/elements/queriable-fields.ts
@@ -131,6 +131,7 @@ export const QUERIABLE_FIELDS: QueryField[] = [
   // 'standards.maturity': Feature.standard_maturity,
   // 'standards.spec': Feature.spec_link,
   // 'api_spec': Feature.api_spec,
+  // 'automation_spec': Feature.automation_spec,
   // 'spec_mentors': Feature.spec_mentors,
   // 'security_review_status': Feature.security_review_status,
   // 'privacy_review_status': Feature.privacy_review_status,

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -134,6 +134,7 @@ class FeatureEntry(ndb.Model):  # Copy from Feature
   standard_maturity = ndb.IntegerProperty(required=True, default=UNSET_STD)
   spec_link = ndb.StringProperty()
   api_spec = ndb.BooleanProperty(default=False)
+  automation_spec = ndb.BooleanProperty(default=False)
   spec_mentor_emails = ndb.StringProperty(repeated=True)
   interop_compat_risks = ndb.TextProperty()
   prefixed = ndb.BooleanProperty()

--- a/internals/data_types.py
+++ b/internals/data_types.py
@@ -244,11 +244,12 @@ class VerboseFeatureDict(TypedDict):
   explainer_links: list[str]
   requires_embedder_support: bool
   spec_link: str | None
-  api_spec: str | None
-  prefixed: bool | None
+  api_spec: bool
+  automation_spec: bool
+  prefixed: bool
   interop_compat_risks: str | None
-  all_platforms: bool | None
-  all_platforms_descr: bool | None
+  all_platforms: bool
+  all_platforms_descr: str | None
   tag_review: str | None
   non_oss_deps: str | None
   anticipated_spec_changes: str | None

--- a/internals/search_queries.py
+++ b/internals/search_queries.py
@@ -296,6 +296,7 @@ QUERIABLE_FIELDS: dict[str, Property] = {
     'requires_embedder_support': FeatureEntry.requires_embedder_support,
     'standards.spec': FeatureEntry.spec_link,
     'api_spec': FeatureEntry.api_spec,
+    'automation_spec': FeatureEntry.automation_spec,
     'spec_mentors': FeatureEntry.spec_mentor_emails,
     'interop_compat_risks': FeatureEntry.interop_compat_risks,
     'browsers.chrome.prefixed': FeatureEntry.prefixed,

--- a/scripts/seed_datastore.py
+++ b/scripts/seed_datastore.py
@@ -142,6 +142,7 @@ def add_features(server: str, after: datetime, detailsAfter: datetime):
       fe.explainer_links = details['explainer_links']
       fe.requires_embedder_support = details['requires_embedder_support']
       fe.api_spec = details['api_spec']
+      fe.automation_spec = details['automation_spec']
       fe.interop_compat_risks = details['interop_compat_risks']
       fe.all_platforms = details['all_platforms']
       fe.all_platforms_descr = details['all_platforms_descr']


### PR DESCRIPTION
Resolves #4926.

In this PR:
* Define a new FeatureEntry field for `automation_spec` in datastore
* Add it to the list of fields so that the server will save it when editing
* Define a UI form field with the specified help text
* Position the new form field on the prototyping stage form.
* Add an item to the Debuggability gate survey question text to probe into this topic.