### PR TITLE
Add CORS header for enterprise team.

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -803,7 +803,16 @@ def FlaskApplication(import_name, routes, pattern_base='', debug=False):
   app.config['MAX_CONTENT_LENGTH'] = settings.MAX_REQUEST_CONTENT_LENGTH
 
   # Set the CORS HEADERS.
-  CORS(app, resources={r'/data/*': {'origins': '*'}})
+  ALLOWED_API_ORIGINS = [
+      'https://chromeenterprise.google',
+      'https://chromeenterprise-staging.corp.google.com',
+      r'https://[a-z]+-dot-xl-chrome-enterprise-staging\.uc\.r\.appspot\.com',
+      r'http://locallhost:\d+',
+  ]
+  CORS(app, resources={
+      r'/data/.*': {'origins': '*'},
+      r'/api/v0/features.*': {'origins': ALLOWED_API_ORIGINS,
+                              'methods': ['GET']}})
 
   # Set cookie headers in Flask; see
   # https://flask.palletsprojects.com/en/2.0.x/config/

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -1351,6 +1351,13 @@ class FlaskApplicationTests(testing_config.CustomTestCase):
         '*',
         actual_response.headers['Access-Control-Allow-Origin'])
 
+  def test_cors_with_api(self):
+    """If the request hits a /api/v0/features path, they get a CORS header."""
+    with test_app.test_request_context('/api/v0/features'):
+      actual_response = test_app.full_dispatch_request()
+
+    self.assertIn('Access-Control-Allow-Origin', actual_response.headers)
+
   def test_cors_without_allow_origin(self):
     """If the request hits any non-/data path, they get no header."""
     with test_app.test_request_context('/test'):


### PR DESCRIPTION
Allow GETs from the listed origins to hit our features API.