### PR TITLE
Allow feature editors to archive.

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -381,7 +381,7 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
     # TODO(jrobbins): implement undelete UI.  For now, use cloud console.
     if 'feature_id' not in kwargs:
       self.abort(404, msg='Feature ID not specified')
-    feature_id: int = int(kwargs.get('feature_id', 0))
+    feature_id: int = kwargs['feature_id']
     # Validate the user has edit permissions and redirect if needed.
     redirect_resp = permissions.validate_feature_edit_permission(
         self, feature_id)

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -386,7 +386,7 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
     redirect_resp = permissions.validate_feature_edit_permission(
         self, feature_id)
     if redirect_resp:
-      return redirect_resp
+      self.abort(403, msg='User does not have permission to edit this feature.')
 
     feature: FeatureEntry = self.get_specified_feature(feature_id=feature_id)
     feature.deleted = True

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -288,7 +288,7 @@ def validate_feature_edit_permission(
 
   # Respond with 404 if feature is not found.
   # Load feature directly from NDB so as to never get a stale cached copy.
-  if FeatureEntry.get_by_id(int(feature_id)) is None:
+  if FeatureEntry.get_by_id(feature_id) is None:
     handler_obj.abort(404, msg='Feature not found')
 
   # Respond with 403 if user does not have edit permission for feature.


### PR DESCRIPTION
Resolves #4633.  This aligns the server-side permission check with what was already being done on the client-side.  Any user who can edit a feature can also archive it (which is a soft-delete).