### PR TITLE
Hide create button on enterprise create page.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           # Remove existing google-cloud-sdk packages in Ubuntu.
           sudo rm -rf /usr/lib/google-cloud-sdk
-          curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-410.0.0-linux-x86_64.tar.gz | tar -zx > /dev/null
+          curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-497.0.0-linux-x86_64.tar.gz | tar -zx > /dev/null
           # Substitute the downloaded google-cloud-sdk packages, due to https://stackoverflow.com/questions/42697026/install-google-cloud-components-error-from-gcloud-command.
           sudo mv google-cloud-sdk /usr/lib/
           sudo gcloud components update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
       - name: set up Java JDK
         uses: actions/setup-java@v4
         with:
-         java-version: '21'
+          distribution: 'temurin'
+          java-version: '21'
 
       - name: set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           node-version: '18.x'
 
+      - name: set up Java JDK
+        uses: actions/setup-java@v4
+        with:
+         java-version: '21'
+
       - name: set up Python
         uses: actions/setup-python@v5
         with:

--- a/client-src/elements/chromedash-guide-new-page.ts
+++ b/client-src/elements/chromedash-guide-new-page.ts
@@ -117,7 +117,14 @@ export class ChromedashGuideNewPage extends LitElement {
 
   renderWarnings() {
     if (this.isEnterpriseFeature) {
-      return nothing;
+      return html`
+        <div class="process-notice">
+          <p>
+            Use this form if your feature should be mentioned in the Enterprise
+            Release Notes.
+          </p>
+        </div>
+      `;
     } else {
       return html`
         <div class="process-notice">

--- a/client-src/elements/chromedash-header.ts
+++ b/client-src/elements/chromedash-header.ts
@@ -308,10 +308,13 @@ export class ChromedashHeader extends LitElement {
   }
 
   renderAccountMenu() {
+    const alreadyOnNew =
+      this.isCurrentPage('/guide/new') ||
+      this.isCurrentPage('/guide/enterprise/new');
     return html`
       ${this.user
         ? html`
-            ${this.user.can_create_feature && !this.isCurrentPage('/guide/new')
+            ${this.user.can_create_feature && !alreadyOnNew
               ? html`
                   <sl-button
                     data-testid="create-feature-button"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "debug-app": "npm run build && curl --retry 4 http://${DATASTORE_EMULATOR_HOST:-localhost:15606}/ --retry-connrefused && ./scripts/debug_server.sh",
     "start": "npm stop; . cs-env/bin/activate; (npm run start-emulator-persist > /dev/null 2>&1 &); npm run start-app; status=$?; npm run stop-emulator; exit $status",
     "stop": "npm run pwtests-shutdown; kill `pgrep gunicorn`",
-    "test": "(npm run start-emulator &); sleep 30; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-tests; status=$?; npm run stop-emulator; exit $status",
+    "test": "(npm run start-emulator > /dev/null 2>&1 &); sleep 6; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-tests; status=$?; npm run stop-emulator; exit $status",
     "webtest": "npm run build && web-test-runner --playwright --browsers chromium firefox",
     "webtest:watch": "npm run build && web-test-runner \"build/**/*_test.{js,ts}\" --node-resolve --playwright --watch --browsers chromium",
     "webtestpuppeteer": "npm run build && web-test-runner --puppeteer --browsers chrome",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "debug-app": "npm run build && curl --retry 4 http://${DATASTORE_EMULATOR_HOST:-localhost:15606}/ --retry-connrefused && ./scripts/debug_server.sh",
     "start": "npm stop; . cs-env/bin/activate; (npm run start-emulator-persist > /dev/null 2>&1 &); npm run start-app; status=$?; npm run stop-emulator; exit $status",
     "stop": "npm run pwtests-shutdown; kill `pgrep gunicorn`",
-    "test": "(npm run start-emulator > /dev/null 2>&1 &); sleep 30; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-tests; status=$?; npm run stop-emulator; exit $status",
+    "test": "(npm run start-emulator &); sleep 30; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-tests; status=$?; npm run stop-emulator; exit $status",
     "webtest": "npm run build && web-test-runner --playwright --browsers chromium firefox",
     "webtest:watch": "npm run build && web-test-runner \"build/**/*_test.{js,ts}\" --node-resolve --playwright --watch --browsers chromium",
     "webtestpuppeteer": "npm run build && web-test-runner --puppeteer --browsers chrome",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "debug-app": "npm run build && curl --retry 4 http://${DATASTORE_EMULATOR_HOST:-localhost:15606}/ --retry-connrefused && ./scripts/debug_server.sh",
     "start": "npm stop; . cs-env/bin/activate; (npm run start-emulator-persist > /dev/null 2>&1 &); npm run start-app; status=$?; npm run stop-emulator; exit $status",
     "stop": "npm run pwtests-shutdown; kill `pgrep gunicorn`",
-    "test": "(npm run start-emulator > /dev/null 2>&1 &); sleep 6; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-tests; status=$?; npm run stop-emulator; exit $status",
+    "test": "(npm run start-emulator > /dev/null 2>&1 &); sleep 30; curl --retry 4 http://localhost:15606/ --retry-connrefused; npm run do-tests; status=$?; npm run stop-emulator; exit $status",
     "webtest": "npm run build && web-test-runner --playwright --browsers chromium firefox",
     "webtest:watch": "npm run build && web-test-runner \"build/**/*_test.{js,ts}\" --node-resolve --playwright --watch --browsers chromium",
     "webtestpuppeteer": "npm run build && web-test-runner --puppeteer --browsers chrome",


### PR DESCRIPTION
The enterprise team pointed out that it was confusing their users when they followed a link to /guide/enterprise/new and then saw a "Create feature" button on that page.  We always hid the create button on /guide/new and not hiding it on the enterprise version of that page was just an oversight.  Also, add a note to clarify that the enterprise users are in the right place.