### PR TITLE
Fix the "Add Step" button on the edit-all page.

### DIFF
--- a/client-src/elements/chromedash-guide-editall-page.ts
+++ b/client-src/elements/chromedash-guide-editall-page.ts
@@ -421,7 +421,9 @@ export class ChromedashGuideEditallPage extends LitElement {
   // Create a stage requested on the edit all page.
   createNewStage(newStage) {
     window.csClient
-      .createStage(this.featureId, {stage_type: newStage.stage_type})
+      .createStage(this.featureId, {
+        stage_type: {form_field_name: 'stage_type', value: newStage.stage_type},
+      })
       .then(() => window.csClient.getFeature(this.featureId))
       .then(feature => {
         this.feature = feature;


### PR DESCRIPTION
This resolves #4302.  The working version of the Add Stage (or Add Step) button on the feature detail page POSTs data with a form field name and value.  This PR just makes the corresponding button on the edit-all page POST in the same format that the API handler expects.