### PR TITLE
Add cron job to generate Review Activities CSV file

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -47,3 +47,6 @@ cron:
 - description: Fetch a new copy of Webdx feature ID list
   url: /cron/fetch_webdx_feature_ids
   schedule: every day 9:00
+- description: Generate a CSV of all review activities in ChromeStatus.
+  url: /cron/generate_review_activity
+  schedule: every day 8:00

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -946,10 +946,11 @@ class GenerateReviewActivityFile(FlaskHandler):
     return csv_rows
 
   def _get_last_run_timestamp(self, bucket):
-    """Get the starting timestamp for """
+    """Get the timestamp for the starting interval of querying for new
+    activities."""
     blob = bucket.blob('review-activity-last-timestamp.txt')
     if blob.exists():
-      with blob.open('r')as f:
+      with blob.open('r') as f:
         timestamp_str = f.read()
       return datetime.strptime(timestamp_str, self.DATE_FORMAT)
     # If no previous timestamp exists, start from the beginning.
@@ -960,9 +961,11 @@ class GenerateReviewActivityFile(FlaskHandler):
     does not exist."""
     blob = bucket.blob('chromestatus-review-activity.csv')
     csv_contents = ''
+    logging.info(f'adding {len(csv_rows)} new rows to CSV.')
     if blob.exists():
       with blob.open('r') as f:
         existing_csv = f.read()
+        logging.info(f'Existing csv is {existing_csv.count("\n")} lines long')
         csv_contents = existing_csv + '\n' + '\n'.join(csv_rows)
     else:
       csv_contents = (
@@ -988,4 +991,5 @@ class GenerateReviewActivityFile(FlaskHandler):
     self._write_csv(bucket, csv_rows)
     self._write_last_run_timestamp(bucket, now)
 
-    return f"File chromestatus-review-activity.csv uploaded."
+    return (f'{len(csv_rows)} '
+            'new rows added to chromestatus-review-activity.csv uploaded.')

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -963,10 +963,10 @@ class GenerateReviewActivityFile(FlaskHandler):
       with blob.open('a') as f:
         f.write('\n'.join(csv_rows))
     else:
-      csv_rows = [
+      csv_rows.insert(
+        0,
         'FeatureID,TeamName,EventType,EventDate,ReviewStatus,ReviewAssignee,'
-        'Author,Content'
-      ].extend(csv_rows)
+        'Author,Content')
       blob.upload_from_string('\n'.join(csv_rows))
 
   def _write_last_run_timestamp(self, bucket, timestamp: datetime) -> None:

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -897,12 +897,14 @@ class GenerateReviewActivityFile(FlaskHandler):
 
     # Filter deleted activities the user can't see, and activities that have
     # no gate ID, meaning they do not represent review activity.
+    # TODO(DanielRyanSmith): Confirm if deleted features should deleted features
+    # should have existing activity filtered and handle accordingly.
     activities = list(filter(
       lambda a: (a.deleted_by is None
                  and a.gate_id is not None),
       activities))
-    gate_ids = set([a.gate_id for a in activities])
-    gates = ndb.get_multi([ndb.Key('Gate', g_id) for g_id in gate_ids])
+    gate_ids = set(a.gate_id for a in activities)
+    gates = ndb.get_multi(ndb.Key('Gate', g_id) for g_id in gate_ids)
     gates_dict: dict[int, Gate] = {g.key.integer_id(): g for g in gates}
 
     # Add header rows to start.
@@ -921,7 +923,7 @@ class GenerateReviewActivityFile(FlaskHandler):
           review_status = a.amendments[0].new_value
         if a.amendments[0].field_name == 'review_assignee':
           review_assignee = a.amendments[0].new_value
-        # Handle CSV character escaping for the comment.
+      # Handle CSV character escaping for the comment.
       if comment:
         comment = comment.replace('"', '""')
         comment = f'"{comment}"'

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -915,6 +915,7 @@ class GenerateReviewActivityFile(FlaskHandler):
     for a in activities:
       review_status = ''
       review_assignee = ''
+      comment = a.content or ''
       gate_type = gates_dict[a.gate_id].gate_type
       if len(a.amendments):
         # There should only be 1 amendment for review changes.
@@ -922,6 +923,9 @@ class GenerateReviewActivityFile(FlaskHandler):
           review_status = a.amendments[0].new_value
         if a.amendments[0].field_name == 'review_assignee':
           review_assignee = a.amendments[0].new_value
+        # Handle CSV character escaping for the comment.
+        comment = comment.replace('"', '""')
+        comment = f'"{comment}"'
       csv_rows.append(','.join(
         [
           str(a.feature_id),

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -924,8 +924,8 @@ class GenerateReviewActivityFile(FlaskHandler):
         if a.amendments[0].field_name == 'review_assignee':
           review_assignee = a.amendments[0].new_value
         # Handle CSV character escaping for the comment.
-        comment = comment.replace('"', '""')
-        comment = f'"{comment}"'
+      comment = comment.replace('"', '""')
+      comment = f'"{comment}"'
       csv_rows.append(','.join(
         [
           str(a.feature_id),
@@ -935,7 +935,7 @@ class GenerateReviewActivityFile(FlaskHandler):
           review_status,
           review_assignee,
           a.author or '',
-          a.content or '',
+          comment,
         ]
       ))
 

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -959,15 +959,17 @@ class GenerateReviewActivityFile(FlaskHandler):
     """Append the rows to the review activity CSV, or create a new CSV if it
     does not exist."""
     blob = bucket.blob('chromestatus-review-activity.csv')
+    csv_contents = ''
     if blob.exists():
-      with blob.open('a') as f:
-        f.write('\n'.join(csv_rows))
+      with blob.open('r') as f:
+        existing_csv = f.read()
+        csv_contents = existing_csv + '\n' + '\n'.join(csv_rows)
     else:
-      csv_rows.insert(
-        0,
+      csv_contents = (
         'FeatureID,TeamName,EventType,EventDate,ReviewStatus,ReviewAssignee,'
-        'Author,Content')
-      blob.upload_from_string('\n'.join(csv_rows))
+        'Author,Content'
+      ) + '\n'.join(csv_rows)
+    blob.upload_from_string(csv_contents)
 
   def _write_last_run_timestamp(self, bucket, timestamp: datetime) -> None:
     """Store the date of the last review activity run."""

--- a/internals/maintenance_scripts_test.py
+++ b/internals/maintenance_scripts_test.py
@@ -1164,12 +1164,10 @@ class GenerateReviewActivityFileTest(testing_config.CustomTestCase):
       for entity in kind.query():
         entity.key.delete()
 
-  def test_generate_csv(self):
+  def test_generate_csv_all(self):
     """Generates CSV in the expected shape and format."""
-    csv_rows = self.handler._generate_csv()
+    csv_rows = self.handler._generate_csv(datetime(1970, 1, 1), datetime.now())
     expected_rows = [
-      'FeatureID,TeamName,EventType,EventDate,ReviewStatus,ReviewAssignee,'
-      'Author,Content',
       '1,API Owners,comment,2020-01-01T11:00:00,,,user1@example.com,"test comment"',
       '1,API Owners,review_status,2020-01-02T09:00:00,no_response,,user1@example.com,',
       '1,API Owners,comment,2020-01-03T08:00:00,,,user2@example.com,"test ""comment"" 2"',
@@ -1178,6 +1176,16 @@ class GenerateReviewActivityFileTest(testing_config.CustomTestCase):
       '2,Privacy,review_status,2020-01-11T09:00:00,approved,,user3@example.com,',
       '2,Privacy,review_assignee,2020-01-12T10:00:00,,user3@example.com,user4@example.com,',
       '2,Privacy,comment,2020-01-15T08:00:00,,,user3@example.com,"test comment 5"'
+    ]
+    self.assertEqual(expected_rows, csv_rows)
+
+  def test_generate_csv_subset(self):
+    """Generates a subset of rows based on the given timestamps."""
+    csv_rows = self.handler._generate_csv(
+        datetime(2020, 1, 4), datetime(2020, 1, 7))
+    expected_rows = [
+      '1,API Owners,review_status,2020-01-04T12:00:00,needs_work,,user1@example.com,',
+      '1,API Owners,review_status,2020-01-06T12:00:00,approved,,user2@example.com,',
     ]
     self.assertEqual(expected_rows, csv_rows)
   

--- a/main.py
+++ b/main.py
@@ -310,6 +310,8 @@ internals_routes: list[Route] = [
   Route('/cron/activate_origin_trials',
         maintenance_scripts.ActivateOriginTrials),
   Route('/cron/fetch_webdx_feature_ids', maintenance_scripts.FetchWebdxFeatureId),
+  Route('/cron/generate_review_activities',
+        maintenance_scripts.GenerateReviewActivityFile),
 
   Route('/admin/find_stop_words', search_fulltext.FindStopWords),
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ google-cloud-tasks==2.7.0
 google-cloud-ndb==1.11.1
 google-cloud-logging==3.6.0
 google-cloud-secret-manager==2.16.2
+google-cloud-storage==2.1.0
 google-auth==1.31.0
 requests==2.32.0
 redis==4.4.4

--- a/settings.py
+++ b/settings.py
@@ -102,6 +102,9 @@ DEV_MODE_OT_SUPPORT_EMAILS = 'user1@gmail.com,user2@gmail.com'
 # URL host for Webstatus.dev API endponts.
 API_WEBSTATUS_DEV_URL = 'https://api.webstatus.dev'
 
+# Bucket used for scheduled file uploads.
+FILES_BUCKET = 'cr-status-staging'
+
 if UNIT_TEST_MODE:
   APP_TITLE = 'Local testing'
   SITE_URL = 'http://127.0.0.1:7777/'
@@ -126,6 +129,7 @@ elif APP_ID == 'cr-status':
   INBOUND_EMAIL_ADDR = 'chromestatus@cr-status.appspotmail.com'
   REVIEW_COMMENT_MAILING_LIST = 'blink-dev@chromium.org'
   BACKUP_BUCKET = 'cr-status-backups'
+  FILES_BUCKET = 'cr-status'
 elif APP_ID == 'cr-status-staging':
   STAGING = True
   SEND_EMAIL = True


### PR DESCRIPTION
This change adds a new cron job that generates a new CSV file, `chromestatus-review-activity.csv` containing all review activity that has occurred in ChromeStatus. The file is uploaded to Google Cloud Storage, where it can be ingested by CDA feeds to make the data available for the Skyhook dashboard.

My original implementation exposed a new endpoint that generates the data on-demand, but after investigating the ingestion process further, this approach is a bit more feasible and streamlined. The file is regenerated every day, but we can adjust this cadence as needed.