### PR TITLE
Jules PR to identify opportunities for Object.groupBy()

### DIFF
--- a/client-src/elements/chromedash-enterprise-release-notes-page.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page.ts
@@ -153,7 +153,7 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
   }
 
   convertShippingStageToRolloutStages(stage) {
-// TODO: Consider using Object.groupBy() here to group items by milestone.
+    // TODO: Consider using Object.groupBy() here to group items by milestone.
     const milestones = [
       stage.desktop_first,
       stage.android_first,

--- a/client-src/elements/chromedash-enterprise-release-notes-page.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page.ts
@@ -153,6 +153,7 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
   }
 
   convertShippingStageToRolloutStages(stage) {
+// TODO: Consider using Object.groupBy() here to group items by milestone.
     const milestones = [
       stage.desktop_first,
       stage.android_first,
@@ -287,6 +288,7 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
         return impactB - impactA;
       });
 
+    // TODO: Consider using Object.groupBy() here to group items by enterprise_product_category.
     this.currentChromeBrowserUpdates = currentFeatures.filter(
       f =>
         f.enterprise_product_category ===
@@ -330,6 +332,7 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
           ) || 0;
         return minA - minB;
       });
+    // TODO: Consider using Object.groupBy() here to group items by enterprise_product_category.
     this.upcomingChromeBrowserUpdates = upcomingFeatures.filter(
       f =>
         f.enterprise_product_category ===

--- a/client-src/elements/chromedash-feature-row.ts
+++ b/client-src/elements/chromedash-feature-row.ts
@@ -139,6 +139,7 @@ class ChromedashFeatureRow extends LitElement {
     return GATE_ACTIVE_REVIEW_STATES.includes(gate.state);
   }
 
+  // TODO: Consider using Object.groupBy() here to group gates by stage_id first.
   getActiveStages(feature) {
     const featureGates: GateDict[] = this.gates[feature.id] || [];
     const activeGates = featureGates.filter(g => this.isActiveGate(g));

--- a/client-src/elements/chromedash-feature-table.ts
+++ b/client-src/elements/chromedash-feature-table.ts
@@ -92,6 +92,7 @@ export class ChromedashFeatureTable extends LitElement {
   loadGateData() {
     window.csClient
       .getPendingGates()
+      // TODO: Consider using Object.groupBy() here to group gates by feature_id.
       .then(res => {
         const gatesByFID: Record<number, GateDict[]> = {};
         for (const g of res.gates) {

--- a/client-src/elements/chromedash-gantt.ts
+++ b/client-src/elements/chromedash-gantt.ts
@@ -139,6 +139,7 @@ export class ChromedashGantt extends LitElement {
 
   // Get lists of all dev trial, origin trial, and shipping stages
   // associated with the feature.
+  // TODO: Consider using Object.groupBy() here to group stages by type (dev_trial, origin_trial, shipping).
   getByStageType() {
     const dtStages: StageDict[] = [];
     const otStages: StageDict[] = [];

--- a/client-src/elements/chromedash-report-external-reviews-page.ts
+++ b/client-src/elements/chromedash-report-external-reviews-page.ts
@@ -132,6 +132,7 @@ export class ChromedashReportExternalReviewsPage extends LitElement {
     args: () => [this.reviewer],
   });
 
+  // TODO: Consider using Object.groupBy() here to group reviews by current_stage.
   groupReviews(
     reviews: OutstandingReview[]
   ): Record<StageEnum, OutstandingReview[]> {

--- a/client-src/elements/chromedash-review-status-icon.ts
+++ b/client-src/elements/chromedash-review-status-icon.ts
@@ -71,6 +71,7 @@ export class ChromedashReviewStatusIcon extends LitElement {
     });
   }
 
+  // TODO: Consider using Object.groupBy() here to group gates by state, then determine overall status.
   calcStatus(): {status: statusEnum; targetGateId: number | undefined} {
     let status: statusEnum = 'Not started';
     let targetGateId: number | undefined = undefined;

--- a/client-src/elements/chromedash-typeahead.ts
+++ b/client-src/elements/chromedash-typeahead.ts
@@ -141,6 +141,9 @@ export class ChromedashTypeahead extends LitElement {
     return !COMPARE_OPS.some(op => s.includes(op));
   }
 
+  // TODO: Consider using Object.groupBy() here to group candidates by `c.group`.
+  // The subsequent logic to then create the `result` array would need to be adjusted
+  // to iterate over the grouped object and apply the "seen twice" logic.
   groupCandidates(candidates: Candidate[]): Candidate[] {
     const groupsSeen = new Set();
     const groupsSeenTwice = new Set();

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,7 @@ export default [
   },
   {
     languageOptions: {
-      ecmaVersion: 2022,
+      ecmaVersion: "latest",
       sourceType: "module",
       globals: {
         "ga": true,


### PR DESCRIPTION
Note: At first it complained that groupBy() was "not available in the execution environment".  I eventually figured out that our eslint was configured to generate code that would work for browsers in 2022, whereas groupBy() became newly available in 2024.

Here's Jules's PR description:

Specifically, I set `ecmaVersion` to "latest" in eslint.config.js.

I also identified and marked several locations in TypeScript files within `client-src/elements/` with TODO comments. These are places where I think `Object.groupBy()` could potentially be used to simplify code for grouping arrays of objects.

Here are the files I modified with TODOs:
- client-src/elements/chromedash-enterprise-release-notes-page.ts
- client-src/elements/chromedash-feature-row.ts
- client-src/elements/chromedash-feature-table.ts
- client-src/elements/chromedash-gantt.ts
- client-src/elements/chromedash-report-external-reviews-page.ts
- client-src/elements/chromedash-review-status-icon.ts
- client-src/elements/chromedash-typeahead.ts