### PR TITLE
Correct the cron task URL for CSV generation

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -48,5 +48,5 @@ cron:
   url: /cron/fetch_webdx_feature_ids
   schedule: every day 9:00
 - description: Generate a CSV of all review activities in ChromeStatus.
-  url: /cron/generate_review_activity
+  url: /cron/generate_review_activities
   schedule: every day 8:00


### PR DESCRIPTION
This makes cron.yaml match the URL defined in main.py.