### PR TITLE
Fix OT requests admin page

### DIFF
--- a/pages/ot_requests.py
+++ b/pages/ot_requests.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+import logging
 from google.cloud import ndb
 
 from api.converters import stage_to_json_dict
@@ -53,6 +55,11 @@ class OriginTrialsRequests(basehandlers.FlaskHandler):
         if gate and gate.state in (Vote.NA, Vote.APPROVED):
           # Information will be needed from the original OT stage.
           ot_stage = Stage.get_by_id(stage_dict['ot_stage_id'])
+          if ot_stage is None:
+            logging.warning(
+              f'Extension stage {stage_dict["id"]} '
+              f'found with invalid OT stage ID {stage_dict["ot_stage_id"]}.')
+            continue
           ot_stage_dict = stage_to_json_dict(ot_stage)
           # Supply both the OT stage and the extension stage.
           extension_stages.append({

--- a/pages/ot_requests_test.py
+++ b/pages/ot_requests_test.py
@@ -95,7 +95,7 @@ class OriginTrialsRequestsTest(testing_config.CustomTestCase):
     self.app_admin.put()
 
   def tearDown(self):
-    for kind in [FeatureEntry, Stage, Gate]:
+    for kind in [AppUser, FeatureEntry, Stage, Gate]:
       for entity in kind.query():
         entity.key.delete()
     testing_config.sign_out()

--- a/pages/ot_requests_test.py
+++ b/pages/ot_requests_test.py
@@ -1,0 +1,192 @@
+# Copyright 2025 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testing_config  # Must be imported before the module under test.
+
+import flask
+import werkzeug
+from unittest import mock
+
+from pages import ot_requests
+from internals import core_enums
+from internals.core_models import FeatureEntry, Stage
+from internals.review_models import Gate, Vote
+from internals.user_models import AppUser
+import settings
+
+
+test_app = flask.Flask(__name__,
+  template_folder=settings.get_flask_template_path())
+
+
+class OriginTrialsRequestsTest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.feature_1 = FeatureEntry(name='feature one', summary='sum', category=1)
+    self.feature_1.put()
+    self.feature_id = self.feature_1.key.integer_id()
+
+    # 1. Stage with an action requested (will go into creation_stages)
+    self.creation_request_stage = Stage(
+        feature_id=self.feature_id, stage_type=150,
+        ot_action_requested=True)
+    self.creation_request_stage.put()
+
+    # 2. Stage ready for creation (will go into creation_stages)
+    self.ready_for_creation_stage = Stage(
+        feature_id=self.feature_id, stage_type=150,
+        ot_setup_status=core_enums.OT_READY_FOR_CREATION)
+    self.ready_for_creation_stage.put()
+
+    # 3. An extension stage request needs an original OT stage and a valid Gate.
+    self.ot_stage_for_extension = Stage(
+        feature_id=self.feature_id, stage_type=150)
+    self.ot_stage_for_extension.put()
+    # The extension stage itself (will go into extension_stages).
+    self.extension_stage = Stage(
+        feature_id=self.feature_id,
+        stage_type=core_enums.STAGE_BLINK_EXTEND_ORIGIN_TRIAL,
+        ot_action_requested=True,
+        ot_stage_id=self.ot_stage_for_extension.key.integer_id())
+    self.extension_stage.put()
+    # Add the required Gate for the extension stage.
+    self.extension_gate = Gate(
+        feature_id=self.feature_id,
+        stage_id=self.extension_stage.key.integer_id(),
+        gate_type=core_enums.GATE_API_EXTEND_ORIGIN_TRIAL,
+        state=Vote.APPROVED)
+    self.extension_gate.put()
+
+
+    # 4. Stage awaiting activation (will go into activation_pending_stages)
+    self.awaiting_activation_stage = Stage(
+        feature_id=self.feature_id, stage_type=150,
+        ot_setup_status=core_enums.OT_CREATED)
+    self.awaiting_activation_stage.put()
+
+    # 5. Stage with activation failure (will go into failed_stages)
+    self.activation_failed_stage = Stage(
+        feature_id=self.feature_id, stage_type=150,
+        ot_setup_status=core_enums.OT_ACTIVATION_FAILED)
+    self.activation_failed_stage.put()
+
+    # 6. Stage with creation failure (will go into failed_stages)
+    self.creation_failed_stage = Stage(
+        feature_id=self.feature_id, stage_type=150,
+        ot_setup_status=core_enums.OT_CREATION_FAILED)
+    self.creation_failed_stage.put()
+
+    self.handler = ot_requests.OriginTrialsRequests()
+    self.request_path = '/admin/features/ot_requests'
+
+    self.app_admin = AppUser(email='admin@example.com')
+    self.app_admin.is_admin = True
+    self.app_admin.put()
+
+  def tearDown(self):
+    for kind in [FeatureEntry, Stage, Gate]:
+      for entity in kind.query():
+        entity.key.delete()
+    testing_config.sign_out()
+
+  def test_get__anon(self):
+    """Anon user is redirected to the login page."""
+    testing_config.sign_out()
+    with test_app.test_request_context(self.request_path):
+      response = self.handler.get()
+    self.assertEqual(302, response.status_code)
+
+  def test_get__non_admin(self):
+    """A non-admin user receives a 403 Forbidden error."""
+    testing_config.sign_in('user@example.com', 111)
+    with test_app.test_request_context(self.request_path):
+      with self.assertRaises(werkzeug.exceptions.Forbidden):
+        self.handler.get()
+
+  def test_get_template_data__no_stages(self):
+    """Admin user sees empty lists when no stages match the queries."""
+    # Remove all stages created in setUp.
+    for kind in [Stage, Gate]:
+      for entity in kind.query():
+        entity.key.delete()
+
+    testing_config.sign_in('admin@example.com', 222)
+    with test_app.test_request_context(self.request_path):
+      template_data = self.handler.get_template_data()
+
+    self.assertEqual([], template_data['creation_stages'])
+    self.assertEqual([], template_data['extension_stages'])
+    self.assertEqual([], template_data['activation_pending_stages'])
+    self.assertEqual([], template_data['failed_stages'])
+
+  def test_get_template_data__all_stages(self):
+    """Admin user sees all relevant stages, correctly categorized."""
+    testing_config.sign_in('admin@example.com', 222)
+    with test_app.test_request_context(self.request_path):
+      actual_data = self.handler.get_template_data()
+
+    # Test that the extension stage (with an approved gate) is present.
+    self.assertEqual(1, len(actual_data['extension_stages']))
+    self.assertEqual(
+        self.extension_stage.key.integer_id(),
+        actual_data['extension_stages'][0]['extension_stage']['id'])
+
+    # Test that all other stage categories are also correctly populated.
+    self.assertEqual(2, len(actual_data['creation_stages']))
+    self.assertEqual(1, len(actual_data['activation_pending_stages']))
+    self.assertEqual(2, len(actual_data['failed_stages']))
+
+  def test_get_template_data__non_approved_extension_is_ignored(self):
+    """An extension stage with a denied gate is not included."""
+    self.extension_gate.state = Vote.DENIED
+    self.extension_gate.put()
+
+    testing_config.sign_in('admin@example.com', 222)
+    with test_app.test_request_context(self.request_path):
+      actual_data = self.handler.get_template_data()
+
+    self.assertEqual([], actual_data['extension_stages'])
+
+  def test_get_template_data__extension_with_na_gate_is_included(self):
+    """An extension stage with a gate state of N/A is included."""
+    self.extension_gate.state = Vote.NA
+    self.extension_gate.put()
+
+    testing_config.sign_in('admin@example.com', 222)
+    with test_app.test_request_context(self.request_path):
+      actual_data = self.handler.get_template_data()
+
+    self.assertEqual(1, len(actual_data['extension_stages']))
+    self.assertEqual(
+        self.extension_stage.key.integer_id(),
+        actual_data['extension_stages'][0]['extension_stage']['id'])
+
+  @mock.patch('logging.warning')
+  def test_get_template_data__extension_with_bad_ot_stage_id(
+      self, mock_logging_warning):
+    """An extension stage with a bad ot_stage_id is skipped and logs a warning."""
+    # Set the ot_stage_id to a non-existent ID
+    self.extension_stage.ot_stage_id = 99999
+    self.extension_stage.put()
+
+    testing_config.sign_in('admin@example.com', 222)
+    with test_app.test_request_context(self.request_path):
+      actual_data = self.handler.get_template_data()
+
+    # The malformed extension request should not be included.
+    self.assertEqual([], actual_data['extension_stages'])
+    # A warning should have been logged.
+    mock_logging_warning.assert_called_once()
+    self.assertIn('found with invalid OT stage ID 99999',
+                  mock_logging_warning.call_args[0][0])

--- a/static/css/ot_requests.css
+++ b/static/css/ot_requests.css
@@ -1,0 +1,242 @@
+/*
+ * ot_requests.css
+ * Styles for the Origin Trial Requests admin page.
+ */
+
+:root {
+  --blue-600: #2563eb;
+  --blue-700: #1d4ed8;
+  --slate-100: #f1f5f9;
+  --slate-200: #e2e8f0;
+  --slate-500: #64748b;
+  --slate-600: #475569;
+  --slate-800: #1e293b;
+  --green-100: #dcfce7;
+  --green-700: #15803d;
+  --red-100: #fee2e2;
+  --red-700: #b91c1c;
+  --orange-100: #ffedd5;
+  --orange-500: #f97316;
+  --blue-100: #dbeafe;
+  --blue-500: #3b82f6;
+  --white: #ffffff;
+  --border-radius-md: 0.5rem;
+  --border-radius-lg: 0.75rem;
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+}
+
+/* --- Main Layout & Headers --- */
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem 2rem;
+}
+
+.page-header {
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--slate-200);
+  margin-bottom: 2rem;
+}
+
+.page-header h1 {
+  font-size: 2.25rem;
+  color: var(--slate-800);
+  margin-bottom: 0.25rem;
+}
+
+.page-header p {
+  font-size: 1.125rem;
+  color: var(--slate-500);
+}
+
+.section-header {
+  margin-bottom: 1.5rem;
+  margin-top: 2.5rem;
+}
+
+.section-header h2 {
+  font-size: 1.75rem;
+  color: var(--slate-800);
+  margin-bottom: 0.25rem;
+}
+
+.section-header p {
+  color: var(--slate-600);
+}
+
+.section-header a {
+  color: var(--blue-600);
+  text-decoration: none;
+}
+.section-header a:hover {
+  text-decoration: underline;
+}
+
+/* --- Card Styles --- */
+
+.ot-card {
+  background-color: var(--white);
+  border-radius: var(--border-radius-lg);
+  border: 1px solid var(--slate-200);
+  box-shadow: var(--shadow-md);
+  margin-bottom: 1.5rem;
+  overflow: hidden;
+  transition: box-shadow 0.2s ease-in-out;
+}
+
+.ot-card:hover {
+  box-shadow: var(--shadow-lg);
+}
+
+.ot-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background-color: var(--slate-100);
+  border-bottom: 1px solid var(--slate-200);
+}
+
+.ot-card-header h3,
+.ot-card-header h4 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: var(--slate-800);
+}
+
+.ot-card-body {
+  padding: 1.5rem;
+}
+
+.ot-card.mini-card .ot-card-body {
+    padding: 1rem 1.5rem;
+}
+
+/* --- Data Display --- */
+
+.data-section {
+  margin-bottom: 1.5rem;
+}
+.data-section:last-child {
+    margin-bottom: 0;
+}
+.data-section h4 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--blue-700);
+  margin-top: 0;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--slate-200);
+  padding-bottom: 0.5rem;
+}
+
+.data-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  gap: 1rem;
+}
+
+.data-grid.data-grid-full {
+  grid-template-columns: 1fr;
+}
+
+.data-grid.data-grid-trio {
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+
+.data-pair {
+  display: flex;
+  flex-direction: column;
+}
+
+.data-pair .label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--slate-500);
+  margin-bottom: 0.25rem;
+}
+
+.data-pair .value {
+  font-size: 1rem;
+  color: var(--slate-800);
+  word-break: break-all;
+}
+
+.data-pair .value a {
+  color: var(--blue-600);
+  text-decoration: none;
+}
+.data-pair .value a:hover {
+  text-decoration: underline;
+}
+
+/* --- Buttons and Tags --- */
+
+.copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: var(--blue-600);
+  color: var(--white);
+  border: none;
+  border-radius: var(--border-radius-md);
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.copy-btn iron-icon {
+    --iron-icon-height: 20px;
+    --iron-icon-width: 20px;
+}
+
+.copy-btn:hover {
+  background-color: var(--blue-700);
+}
+
+.tag {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    border-radius: var(--border-radius-md);
+    font-weight: 600;
+    text-align: center;
+}
+
+.tag-yes {
+    background-color: var(--green-100);
+    color: var(--green-700);
+}
+
+.tag-no {
+    background-color: var(--red-100);
+    color: var(--red-700);
+}
+
+.status-pill {
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  vertical-align: middle;
+  margin-left: 0.5rem;
+}
+.status-pending {
+  background-color: var(--orange-100);
+  color: var(--orange-500);
+}
+.status-progress {
+  background-color: var(--blue-100);
+  color: var(--blue-500);
+}
+
+/* --- Card Deck for smaller cards --- */
+.card-deck {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  gap: 1.5rem;
+}
+

--- a/static/css/ot_requests.css
+++ b/static/css/ot_requests.css
@@ -174,30 +174,6 @@
 
 /* --- Buttons and Tags --- */
 
-.copy-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  background-color: var(--blue-600);
-  color: var(--white);
-  border: none;
-  border-radius: var(--border-radius-md);
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background-color 0.2s ease-in-out;
-}
-
-.copy-btn iron-icon {
-    --iron-icon-height: 20px;
-    --iron-icon-width: 20px;
-}
-
-.copy-btn:hover {
-  background-color: var(--blue-700);
-}
-
 .tag {
     display: inline-block;
     padding: 0.5rem 1rem;

--- a/templates/admin/features/ot_requests.html
+++ b/templates/admin/features/ot_requests.html
@@ -28,27 +28,7 @@
 
   {% if failed_stages %}
     {% for stage in failed_stages %}
-      {# This data attribute holds the tab-separated string for easy spreadsheet pasting. #}
-      {% set copy_data = [
-        stage.ot_display_name,
-        'Pending',
-        stage.ot_owner_email,
-        stage.ot_emails | join('; '),
-        stage.desktop_first,
-        stage.desktop_last,
-        '',
-        stage.ot_chromium_trial_name,
-        stage.ot_webfeature_use_counter,
-        stage.intent_thread_url,
-        stage.ot_documentation_url,
-        'https://chromestatus.com/feature/' ~ stage.feature_id,
-        stage.ot_feedback_submission_url,
-        stage.ot_description,
-        'Yes' if stage.ot_has_third_party_support else 'No',
-        'Yes' if stage.ot_is_critical_trial else 'No',
-        'Yes' if stage.ot_is_deprecation_trial else 'No'
-      ] | join('\t') %}
-      <article class="ot-card" data-copy-text="{{ copy_data }}">
+      <article class="ot-card">
         <header class="ot-card-header">
           <h3>{{ stage.ot_display_name }}</h3>
         </header>

--- a/templates/admin/features/ot_requests.html
+++ b/templates/admin/features/ot_requests.html
@@ -51,10 +51,6 @@
       <article class="ot-card" data-copy-text="{{ copy_data }}">
         <header class="ot-card-header">
           <h3>{{ stage.ot_display_name }}</h3>
-          <button class="copy-btn" title="Copy row data for spreadsheet">
-            <iron-icon icon="chromestatus:content_copy"></iron-icon>
-            <span>Copy for Spreadsheet</span>
-          </button>
         </header>
         <div class="ot-card-body">
           <div class="data-section">
@@ -171,31 +167,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   // Remove loading spinner at page load.
   document.body.classList.remove('loading');
-
-  const toastEl = document.querySelector('chromedash-toast');
-
-  // Add "copy to clipboard" functionality for all copy buttons.
-  const copyButtons = document.querySelectorAll('.copy-btn');
-
-  copyButtons.forEach(button => {
-    button.addEventListener('click', (e) => {
-      const card = e.currentTarget.closest('.ot-card');
-      const textToCopy = card.dataset.copyText;
-
-      if (!textToCopy || !navigator.clipboard) {
-        if (toastEl) toastEl.showMessage('Could not copy text.');
-        return;
-      }
-
-      // Use the modern clipboard API
-      navigator.clipboard.writeText(textToCopy).then(() => {
-        if (toastEl) toastEl.showMessage('Row data copied!');
-      }).catch(err => {
-        console.error('Failed to copy text: ', err);
-        if (toastEl) toastEl.showMessage('Failed to copy text.');
-      });
-    });
-  });
 });
 </script>
 {% endblock %}

--- a/templates/admin/features/ot_requests.html
+++ b/templates/admin/features/ot_requests.html
@@ -1,136 +1,201 @@
 {% extends "_base.html" %}
 
-{% block page_title %}OT Requests - {% endblock %}
+{% block page_title %}OT Requests Admin Page - {% endblock %}
 
 {% block css %}
 <link rel="stylesheet" href="/static/css/forms.css?v={{app_version}}">
+<link rel="stylesheet" href="/static/css/ot_requests.css?v={{app_version}}">
 {% endblock %}
 
 {% block content %}
-
-<div id="subheader">
-  <div>
-    <h2>Origin Trial Requests with errors</h2>
+<div class="container">
+  <div class="page-header">
+    <h1>OT Requests</h1>
+    <p>Review new requests, pending extensions, and trial statuses.</p>
   </div>
-</div>
 
-<div id="subheader">
-  <div>
-    <h2>Copy row directly into "Trials - Validated" spreadsheet (
-      <a href="https://goto.google.com/ot-pipeline-internal" target="_blank">
-        go/ot-pipeline-internal
-      </a>)
-    </h2>
-  </div>
-</div>
-
-{% for stage in failed_stages %}
-<section>
-  <h3>
-    Creation request for: {{stage.ot_display_name}}
-    <span class="tooltip copy-text" style="float:right" title="Copy text to clipboard">
-      <a href="#" data-tooltip>
-        <iron-icon icon="chromestatus:content_copy" id="copy-body-{{loop.index}}"></iron-icon>
+<!-- SECTION: Origin Trial Requests with Errors -->
+  <div class="section-header">
+    <h2>Requests With Errors</h2>
+    <p>
+      These origin trials had an error occur during the creation process.
+      Investigate the issues using
+      <a href="https://g3doc.corp.google.com/chrome/origin_trials/g3doc/trial_admin.md#troubleshooting-automated-origin-trial-creation-failures" target="_blank" rel="noopener noreferrer">
+        the troubleshooting guide.
       </a>
-    </span>
-  </h3>
-  <div id="row-{{loop.index}}">
-    <table>
-      <tr>
-        <td>{{stage.ot_display_name}}</td>
-        <td>Pending</td>
-        <td>{{stage.ot_owner_email}}</td>
-        <td>{% for contact in stage.ot_emails %}{{contact}}<br>{% endfor %}</td>
-        <td>{{stage.desktop_first}}</td>
-        <td>{{stage.desktop_last}}</td>
-        <td></td>
-        <td>{{stage.ot_chromium_trial_name}}</td>
-        <td>{{stage.ot_webfeature_use_counter}}</td>
-        <td>{{stage.intent_thread_url}}</td>
-        <td>{{stage.ot_documentation_url}}</td>
-        <td>https://chromestatus.com/feature/{{stage.feature_id}}</td>
-        <td>{{stage.ot_feedback_submission_url}}</td>
-        <td>{{stage.ot_description}}</td>
-        <td>{% if stage.ot_has_third_party_support %}Yes{% else %}No{% endif %}</td>
-        <td>{% if stage.ot_is_critical_trial %}Yes{% else %}No{% endif %}</td>
-        <td>{% if stage.ot_is_deprecation_trial %}Yes{% else %}No{% endif %}</td>
-      </tr>
-    </table>
+    </p>
   </div>
-</section>
-{% endfor %}
-<hr>
 
-<h2>Extensions awaiting initiation</h2>
-{% for stage_info in extension_stages %}
-<section>
-  <p>Name: {{stage_info.ot_stage.ot_display_name}}</p>
-  <br>
-  <p>Origin trial ID: {{stage_info.ot_stage.origin_trial_id}}</p>
-  <br>
-  <p>Chromestatus feature ID: {{stage_info.ot_stage.feature_id}}</p>
-  <br>
-  <p>Intent to Extend Experiment: {{stage_info.extension_stage.intent_thread_url}}</p>
-  <br>
-  <p>New end milestone: {{stage_info.extension_stage.desktop_last}}</p>
-  <br>
-  <p>Additional comments: {{stage_info.extension_stage.ot_request_note}}</p>
-  <br>
-</section>
-{% endfor %}
-<hr>
+  {% if failed_stages %}
+    {% for stage in failed_stages %}
+      {# This data attribute holds the tab-separated string for easy spreadsheet pasting. #}
+      {% set copy_data = [
+        stage.ot_display_name,
+        'Pending',
+        stage.ot_owner_email,
+        stage.ot_emails | join('; '),
+        stage.desktop_first,
+        stage.desktop_last,
+        '',
+        stage.ot_chromium_trial_name,
+        stage.ot_webfeature_use_counter,
+        stage.intent_thread_url,
+        stage.ot_documentation_url,
+        'https://chromestatus.com/feature/' ~ stage.feature_id,
+        stage.ot_feedback_submission_url,
+        stage.ot_description,
+        'Yes' if stage.ot_has_third_party_support else 'No',
+        'Yes' if stage.ot_is_critical_trial else 'No',
+        'Yes' if stage.ot_is_deprecation_trial else 'No'
+      ] | join('\t') %}
+      <article class="ot-card" data-copy-text="{{ copy_data }}">
+        <header class="ot-card-header">
+          <h3>{{ stage.ot_display_name }}</h3>
+          <button class="copy-btn" title="Copy row data for spreadsheet">
+            <iron-icon icon="chromestatus:content_copy"></iron-icon>
+            <span>Copy for Spreadsheet</span>
+          </button>
+        </header>
+        <div class="ot-card-body">
+          <div class="data-section">
+            <h4>Key Information</h4>
+            <div class="data-grid">
+              <div class="data-pair"><span class="label">Owner</span><span class="value">{{ stage.ot_owner_email }}</span></div>
+              <div class="data-pair"><span class="label">Contacts</span><span class="value">{{ stage.ot_emails | join(', ') }}</span></div>
+              <div class="data-pair"><span class="label">Chromium Trial Name</span><span class="value">{{ stage.ot_chromium_trial_name or 'Not specified' }}</span></div>
+              <div class="data-pair"><span class="label">Use Counter</span><span class="value">{{ stage.ot_webfeature_use_counter or 'Not specified' }}</span></div>
+              <div class="data-pair"><span class="label">Feature ID</span><span class="value"><a href="https://chromestatus.com/feature/{{stage.feature_id}}" target="_blank" rel="noopener noreferrer">{{stage.feature_id}}</a></span></div>
+            </div>
+          </div>
 
-<h2>Origin Trials pending activation</h2>
-{% for stage in activation_pending_stages %}
-<section>
-  <p>Name: {{stage.ot_display_name}}</p>
-  <br>
-  <p>Origin trial ID: {{stage.origin_trial_id}}</p>
-  <br>
-  <p>Chromestatus feature ID: {{stage.feature_id}}</p>
-  <br>
-  <p>Activation date: {{stage.ot_activation_date}}</p>
-</section>
-{% endfor %}
-<hr>
+          <div class="data-section">
+            <h4>Timeline</h4>
+            <div class="data-grid">
+              <div class="data-pair"><span class="label">Start Milestone</span><span class="value">{{ stage.desktop_first }}</span></div>
+              <div class="data-pair"><span class="label">End Milestone</span><span class="value">{{ stage.desktop_last }}</span></div>
+            </div>
+          </div>
 
-<h2>Origin Trials with creation in progress</h2>
-{% for stage in creation_stages %}
-<section>
-  <p>Name: {{stage.ot_display_name}}</p>
-  <br>
-  <p>Origin trial ID: {{stage.origin_trial_id}}</p>
-  <br>
-  <p>Chromestatus feature ID: {{stage.feature_id}}</p>
-</section>
-{% endfor %}
+          <div class="data-section">
+            <h4>Details & Links</h4>
+            <div class="data-grid data-grid-full">
+              <div class="data-pair"><span class="label">Description</span><span class="value">{{ stage.ot_description }}</span></div>
+              <div class="data-pair"><span class="label">Intent Thread</span><span class="value"><a href="{{ stage.intent_thread_url }}" target="_blank" rel="noopener noreferrer">{{ stage.intent_thread_url }}</a></span></div>
+              <div class="data-pair"><span class="label">Documentation</span><span class="value"><a href="{{ stage.ot_documentation_url }}" target="_blank" rel="noopener noreferrer">{{ stage.ot_documentation_url }}</a></span></div>
+              <div class="data-pair"><span class="label">Feedback URL</span><span class="value"><a href="{{ stage.ot_feedback_submission_url }}" target="_blank" rel="noopener noreferrer">{{ stage.ot_feedback_submission_url }}</a></span></div>
+            </div>
+          </div>
 
+          <div class="data-section">
+            <h4>Trial Attributes</h4>
+            <div class="data-grid data-grid-trio">
+                <div class="tag {% if stage.ot_has_third_party_support %}tag-yes{% else %}tag-no{% endif %}">Third-party Support</div>
+                <div class="tag {% if stage.ot_is_critical_trial %}tag-yes{% else %}tag-no{% endif %}">Critical Trial</div>
+                <div class="tag {% if stage.ot_is_deprecation_trial %}tag-yes{% else %}tag-no{% endif %}">Deprecation Trial</div>
+            </div>
+          </div>
+        </div>
+      </article>
+    {% endfor %}
+  {% else %}
+    <p>No requests with validation errors found.</p>
+  {% endif %}
+
+  <!-- SECTION: Extensions Awaiting Initiation -->
+  <div class="section-header">
+    <h2>Extensions Awaiting Initiation</h2>
+    <p>These extensions have been requested, but are not yet initiated.</p>
+  </div>
+  {% if extension_stages %}
+    <div class="card-deck">
+    {% for stage_info in extension_stages %}
+      <article class="ot-card mini-card">
+        <header class="ot-card-header">
+          <h4>{{ stage_info.ot_stage.ot_display_name }}</h4>
+        </header>
+        <div class="ot-card-body">
+          <div class="data-pair"><span class="label">Trial ID</span><span class="value">{{ stage_info.ot_stage.origin_trial_id }}</span></div>
+          <div class="data-pair"><span class="label">Feature ID</span><span class="value"><a href="https://chromestatus.com/feature/{{stage_info.ot_stage.feature_id}}" target="_blank" rel="noopener noreferrer">{{stage_info.ot_stage.feature_id}}</a></span></div>
+          <div class="data-pair"><span class="label">New End Milestone</span><span class="value">{{ stage_info.extension_stage.desktop_last }}</span></div>
+          <div class="data-pair"><span class="label">Intent to Extend</span><span class="value"><a href="{{ stage_info.extension_stage.intent_thread_url }}" target="_blank" rel="noopener noreferrer">View Thread</a></span></div>
+          <div class="data-pair"><span class="label">Comments</span><span class="value">{{ stage_info.extension_stage.ot_request_note or 'None' }}</span></div>
+        </div>
+      </article>
+    {% endfor %}
+    </div>
+  {% else %}
+    <p>No extensions awaiting initiation.</p>
+  {% endif %}
+
+  <!-- Combined Section for Pending Activation and Creation In Progress -->
+  <div class="section-header">
+      <h2>Trials Pending Creation or Activation</h2>
+  </div>
+  <div class="card-deck">
+    <!-- subsection: Pending Activation -->
+    {% for stage in activation_pending_stages %}
+      <article class="ot-card mini-card">
+        <header class="ot-card-header">
+          <h4>{{ stage.ot_display_name }} <span class="status-pill status-pending">Pending Activation</span></h4>
+        </header>
+        <div class="ot-card-body">
+          <div class="data-pair"><span class="label">Trial ID</span><span class="value">{{ stage.origin_trial_id }}</span></div>
+          <div class="data-pair"><span class="label">Feature ID</span><span class="value"><a href="https://chromestatus.com/feature/{{stage.feature_id}}" target="_blank" rel="noopener noreferrer">{{stage.feature_id}}</a></span></div>
+          <div class="data-pair"><span class="label">Activation Date</span><span class="value">{{ stage.ot_activation_date }}</span></div>
+        </div>
+      </article>
+    {% endfor %}
+
+    <!-- subsection: Creation in Progress -->
+    {% for stage in creation_stages %}
+      <article class="ot-card mini-card">
+        <header class="ot-card-header">
+          <h4>{{ stage.ot_display_name }} <span class="status-pill status-progress">Creation in Progress</span></h4>
+        </header>
+        <div class="ot-card-body">
+          <div class="data-pair"><span class="label">Trial ID</span><span class="value">{{ stage.origin_trial_id }}</span></div>
+          <div class="data-pair"><span class="label">Feature ID</span><span class="value"><a href="https://chromestatus.com/feature/{{stage.feature_id}}" target="_blank" rel="noopener noreferrer">{{stage.feature_id}}</a></span></div>
+        </div>
+      </article>
+    {% endfor %}
+    
+    {% if not activation_pending_stages and not creation_stages %}
+      <p>No trials pending activation or in creation.</p>
+    {% endif %}
+  </div>
+</div>
 {% endblock %}
 
 {% block js %}
 <script nonce="{{nonce}}">
+document.addEventListener('DOMContentLoaded', () => {
   // Remove loading spinner at page load.
   document.body.classList.remove('loading');
 
-  // Add "copy to clipboard" functionality.
   const toastEl = document.querySelector('chromedash-toast');
-  let counter = 1;
-  let copyButtonEl;
-  do {
-    const i = counter;
-    copyButtonEl = document.querySelector(`#copy-body-${counter}`);
-    counter++;
-    if (copyButtonEl) {
-      copyButtonEl.addEventListener('click', () => {
-        window.getSelection().removeAllRanges();
-        const range = document.createRange();
-        range.selectNode(document.querySelector(`#row-${i}`));
-        window.getSelection().addRange(range);
-        document.execCommand('copy');
-        toastEl.showMessage('Row copied!');
-      });
-    }
 
-  } while (copyButtonEl);
+  // Add "copy to clipboard" functionality for all copy buttons.
+  const copyButtons = document.querySelectorAll('.copy-btn');
+
+  copyButtons.forEach(button => {
+    button.addEventListener('click', (e) => {
+      const card = e.currentTarget.closest('.ot-card');
+      const textToCopy = card.dataset.copyText;
+
+      if (!textToCopy || !navigator.clipboard) {
+        if (toastEl) toastEl.showMessage('Could not copy text.');
+        return;
+      }
+
+      // Use the modern clipboard API
+      navigator.clipboard.writeText(textToCopy).then(() => {
+        if (toastEl) toastEl.showMessage('Row data copied!');
+      }).catch(err => {
+        console.error('Failed to copy text: ', err);
+        if (toastEl) toastEl.showMessage('Failed to copy text.');
+      });
+    });
+  });
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
This change updates the OT requests admin page to be more visually useful for long-term use. The data is partitioned in a more effective way and is more actionable.

The "Copy to Spreadsheet" functionality has been completely removed, since the OT Pipeline spreadsheet has been completely deprecated.

Additionally, only extension stages that have been approved but not initiated are now displayed on the page, rather than all OT extension requests.

This was an attempt to use Gemini to upgrade this page. Everything seems to function as expected here, but there could be something I've overlooked. The risk is low here since this is a page visible only to admins.

## New View Examples
![Screenshot from 2025-06-16 21-43-04](https://github.com/user-attachments/assets/6c1a9b27-6b92-4fe6-bdd4-c2264f042f14)

![Screenshot from 2025-06-16 21-39-18](https://github.com/user-attachments/assets/e5a81202-063e-4e84-957d-ae3430bce064)
