### PR TITLE
Remove dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,6 @@ updates:
     commit-message:
       # Prefix all commit messages with "npm"
       prefix: "npm"
-    reviewers:
-      - "DanielRyanSmith"
-      - "jrobbins"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -22,9 +19,6 @@ updates:
     commit-message:
       # Prefix all commit messages with "docker"
       prefix: "docker"
-    reviewers:
-      - "jrobbins"
-      - "jcscottiii"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Our recent dependabot PRs have had a comment warning us that the `reviewers` field is deprecated and that we should use a more general owners specification file.  However, I don't think that our dependabot PRs really need a reviewer specified because anyone on the team could see them in the pending pull request list.