### PR TITLE
Fix security review imports

### DIFF
--- a/api/security_review_api.py
+++ b/api/security_review_api.py
@@ -17,20 +17,13 @@ This module provides the API handler for creating security review issues.
 """
 
 import logging
-
 import requests
+
 from chromestatus_openapi.models import (
   CreateLaunchIssueRequest,
   SuccessMessage,
   VerifyContinuityIssueResponse
 )
-
-from framework import basehandlers, origin_trials_client, permissions
-
-import requests
-
-import requests
-from chromestatus_openapi.models import CreateLaunchIssueRequest, SuccessMessage
 
 from framework import basehandlers, origin_trials_client, permissions
 from internals.core_models import FeatureEntry


### PR DESCRIPTION
I seemed to have made a mistake resolving conflicts around the imports for one of the recent security review API PRs, since they were originally based on top of each other for ease of review. This doesn't cause any errors and there's not any immediate risk here, but this change does clean up these duplicated imports.