### PR TITLE
Refactor: Use Object.groupBy in feature table

### DIFF
--- a/client-src/elements/chromedash-feature-table.ts
+++ b/client-src/elements/chromedash-feature-table.ts
@@ -93,14 +93,7 @@ export class ChromedashFeatureTable extends LitElement {
     window.csClient
       .getPendingGates()
       .then(res => {
-        const gatesByFID: Record<number, GateDict[]> = {};
-        for (const g of res.gates) {
-          if (!gatesByFID.hasOwnProperty(g.feature_id)) {
-            gatesByFID[g.feature_id] = [];
-          }
-          gatesByFID[g.feature_id].push(g);
-        }
-        this.gates = gatesByFID;
+        this.gates = Object.groupBy(res.gates, ({feature_id}) => feature_id) as Record<number, GateDict[]>;
       })
       .catch(() => {
         showToastMessage(

--- a/client-src/elements/chromedash-feature-table.ts
+++ b/client-src/elements/chromedash-feature-table.ts
@@ -93,7 +93,10 @@ export class ChromedashFeatureTable extends LitElement {
     window.csClient
       .getPendingGates()
       .then(res => {
-        this.gates = Object.groupBy(res.gates, ({feature_id}) => feature_id) as Record<number, GateDict[]>;
+        this.gates = Object.groupBy(
+          res.gates,
+          ({feature_id}) => feature_id
+        ) as Record<number, GateDict[]>;
       })
       .catch(() => {
         showToastMessage(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
       "outDir": "build",
       "emitDeclarationOnly": false,
       "incremental": true,
-      "lib": ["ES2023", "DOM"],
+      "lib": ["es2024", "DOM"],
       "experimentalDecorators": true,
       "useDefineForClassFields": false,
       "target": "ES2022",


### PR DESCRIPTION
Refactored `loadGateData` in `chromedash-feature-table.ts` to use `Object.groupBy()` for improved readability and conciseness.

Updated `tsconfig.json` to use `es2024` lib to support `Object.groupBy`. Installed Playwright browser binaries to ensure tests run correctly.