### PR TITLE
feat: delete repeated code and move it to a method redirect current page

### DIFF
--- a/client-src/elements/chromedash-header.ts
+++ b/client-src/elements/chromedash-header.ts
@@ -375,7 +375,7 @@ export class ChromedashHeader extends LitElement {
         <aside>
           <a href="/roadmap" target="_top">
             <h1>
-              <img src="/static/img/chrome_logo.svg"/>
+              <img src="/static/img/chrome_logo.svg" />
               ${this.appTitle}
             </h1>
           </a>

--- a/client-src/elements/chromedash-header.ts
+++ b/client-src/elements/chromedash-header.ts
@@ -150,6 +150,12 @@ export class ChromedashHeader extends LitElement {
   @state()
   loading = false;
 
+  /**
+ * Redirects the user to the current page without query parameters.
+ * This is typically used after login or logout to refresh the page state.
+ *
+ * Removes any query string from the current URL and reloads the page.
+ */
   private _redirectToCurrentPage(): void {
     const url = window.location.href.split('?')[0];
     window.location.href = url;

--- a/client-src/elements/chromedash-header.ts
+++ b/client-src/elements/chromedash-header.ts
@@ -375,7 +375,7 @@ export class ChromedashHeader extends LitElement {
         <aside>
           <a href="/roadmap" target="_top">
             <h1>
-              <img src="/static/img/chrome_logo.svg" alt=""/>
+              <img src="/static/img/chrome_logo.svg"/>
               ${this.appTitle}
             </h1>
           </a>

--- a/client-src/elements/chromedash-header.ts
+++ b/client-src/elements/chromedash-header.ts
@@ -150,6 +150,11 @@ export class ChromedashHeader extends LitElement {
   @state()
   loading = false;
 
+  private _redirectToCurrentPage(): void {
+    const url = window.location.href.split('?')[0];
+    window.location.href = url;
+  }
+
   connectedCallback() {
     super.connectedCallback();
 
@@ -244,8 +249,7 @@ export class ChromedashHeader extends LitElement {
         })
         .then(() => {
           setTimeout(() => {
-            const url = window.location.href.split('?')[0];
-            window.location.href = url;
+            this._redirectToCurrentPage();
           }, 1000);
         })
         .catch(error => {
@@ -263,14 +267,13 @@ export class ChromedashHeader extends LitElement {
       this.insertAdjacentElement('afterbegin', signInTestingButton); // for MPA
     }
   }
-
+  
   handleCredentialResponse(credentialResponse) {
     window.csClient
       .signIn(credentialResponse)
       .then(() => {
         setTimeout(() => {
-          const url = window.location.href.split('?')[0];
-          window.location = url as string & Location;
+          this._redirectToCurrentPage();
         }, 1000);
       })
       .catch(() => {
@@ -372,7 +375,7 @@ export class ChromedashHeader extends LitElement {
         <aside>
           <a href="/roadmap" target="_top">
             <h1>
-              <img src="/static/img/chrome_logo.svg" />
+              <img src="/static/img/chrome_logo.svg" alt=""/>
               ${this.appTitle}
             </h1>
           </a>

--- a/client-src/elements/chromedash-header.ts
+++ b/client-src/elements/chromedash-header.ts
@@ -151,11 +151,11 @@ export class ChromedashHeader extends LitElement {
   loading = false;
 
   /**
- * Redirects the user to the current page without query parameters.
- * This is typically used after login or logout to refresh the page state.
- *
- * Removes any query string from the current URL and reloads the page.
- */
+   * Redirects the user to the current page without query parameters.
+   * This is typically used after login or logout to refresh the page state.
+   *
+   * Removes any query string from the current URL and reloads the page.
+   */
   private _redirectToCurrentPage(): void {
     const url = window.location.href.split('?')[0];
     window.location.href = url;
@@ -273,7 +273,7 @@ export class ChromedashHeader extends LitElement {
       this.insertAdjacentElement('afterbegin', signInTestingButton); // for MPA
     }
   }
-  
+
   handleCredentialResponse(credentialResponse) {
     window.csClient
       .signIn(credentialResponse)


### PR DESCRIPTION
Description

- Refactored the login/logout redirection logic by extracting repeated code into a private method: _redirectToCurrentPage
- Both Google authentication and testing sign-in flows now use this method for consistent redirection.
- Improved code readability and maintainability in the chromedash-header component.
- No functional or UI changes were introduced, only internal refactoring.

Notes
- The _redirectToCurrentPage method encapsulates the logic for reloading/redirecting the page after login or logout.
- User experience remains unchanged.
