### PR TITLE
Replace bit.ly links with direct links.

### DIFF
--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -1085,8 +1085,8 @@ export const ALL_FIELDS: Record<string, Field> = {
     initial: VENDOR_VIEWS_COMMON.NO_PUBLIC_SIGNALS[0],
     label: 'Safari views',
     help_text: html` See
-      <a target="_blank" href="https://bit.ly/blink-signals">
-        https://bit.ly/blink-signals</a
+      <a target="_blank" href="https://www.chromium.org/blink/launching-features/wide-review/ ">
+        chromium.org/blink/launching-features/wide-review </a
       >`,
   },
 
@@ -1114,8 +1114,8 @@ export const ALL_FIELDS: Record<string, Field> = {
     initial: VENDOR_VIEWS_GECKO.NO_PUBLIC_SIGNALS[0],
     label: 'Firefox views',
     help_text: html` See
-      <a target="_blank" href="https://bit.ly/blink-signals">
-        https://bit.ly/blink-signals</a
+      <a target="_blank" href="https://www.chromium.org/blink/launching-features/wide-review/ ">
+        chromium.org/blink/launching-features/wide-review </a
       >`,
   },
 

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -1085,9 +1085,12 @@ export const ALL_FIELDS: Record<string, Field> = {
     initial: VENDOR_VIEWS_COMMON.NO_PUBLIC_SIGNALS[0],
     label: 'Safari views',
     help_text: html` See
-      <a target="_blank" href="https://www.chromium.org/blink/launching-features/wide-review/ ">
-        chromium.org/blink/launching-features/wide-review </a
-      >`,
+      <a
+        target="_blank"
+        href="https://www.chromium.org/blink/launching-features/wide-review/"
+      >
+        chromium.org/blink/launching-features/wide-review
+      </a>`,
   },
 
   safari_views_link: {
@@ -1114,9 +1117,12 @@ export const ALL_FIELDS: Record<string, Field> = {
     initial: VENDOR_VIEWS_GECKO.NO_PUBLIC_SIGNALS[0],
     label: 'Firefox views',
     help_text: html` See
-      <a target="_blank" href="https://www.chromium.org/blink/launching-features/wide-review/ ">
-        chromium.org/blink/launching-features/wide-review </a
-      >`,
+      <a
+        target="_blank"
+        href="https://www.chromium.org/blink/launching-features/wide-review/ "
+      >
+        chromium.org/blink/launching-features/wide-review
+      </a>`,
   },
 
   ff_views_link: {

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -1119,7 +1119,7 @@ export const ALL_FIELDS: Record<string, Field> = {
     help_text: html` See
       <a
         target="_blank"
-        href="https://www.chromium.org/blink/launching-features/wide-review/ "
+        href="https://www.chromium.org/blink/launching-features/wide-review/"
       >
         chromium.org/blink/launching-features/wide-review
       </a>`,


### PR DESCRIPTION
The target google doc was replaced by https://www.chromium.org/blink/launching-features/wide-review/.