### PR TITLE
Fix and move a simple redirect helper function.

### DIFF
--- a/client-src/elements/chromedash-header.ts
+++ b/client-src/elements/chromedash-header.ts
@@ -1,5 +1,5 @@
 import {LitElement, html, css, nothing} from 'lit';
-import {showToastMessage, IS_MOBILE} from './utils';
+import {showToastMessage, IS_MOBILE, redirectToCurrentPage} from './utils';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {customElement, property, state} from 'lit/decorators.js';
 import {User} from '../js-src/cs-client';
@@ -150,17 +150,6 @@ export class ChromedashHeader extends LitElement {
   @state()
   loading = false;
 
-  /**
-   * Redirects the user to the current page without query parameters.
-   * This is typically used after login or logout to refresh the page state.
-   *
-   * Removes any query string from the current URL and reloads the page.
-   */
-  private _redirectToCurrentPage(): void {
-    const url = window.location.href.split('?')[0];
-    window.location.href = url;
-  }
-
   connectedCallback() {
     super.connectedCallback();
 
@@ -255,7 +244,7 @@ export class ChromedashHeader extends LitElement {
         })
         .then(() => {
           setTimeout(() => {
-            this._redirectToCurrentPage();
+            redirectToCurrentPage();
           }, 1000);
         })
         .catch(error => {
@@ -279,7 +268,7 @@ export class ChromedashHeader extends LitElement {
       .signIn(credentialResponse)
       .then(() => {
         setTimeout(() => {
-          this._redirectToCurrentPage();
+          redirectToCurrentPage();
         }, 1000);
       })
       .catch(() => {

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -363,6 +363,17 @@ export function setupScrollToHash(pageElement) {
   }
 }
 
+/**
+ * Redirects the user to the current page without query parameters.
+ * This is typically used after login or logout to refresh the page state.
+ *
+ * Removes any query string from the current URL and reloads the page.
+ */
+export function redirectToCurrentPage(): void {
+  const url = window.location.href.split('?')[0];
+  window.location.href = url;
+}
+
 /* Returns a html template if the condition is true, otherwise returns an empty html */
 export function renderHTMLIf(condition, originalHTML) {
   return condition ? originalHTML : nothing;


### PR DESCRIPTION
This is a followup to #5156 to fix a bug and place the function in utils.ts.  The bug was that `this` is not available in the body of `handleCredentialResponse()` because it is called as a callback function from Google Sign In.  `this` could be made to be bound, but the function is generic enough to be a utils function rather than a method anyway.