### PR TITLE
Add pip to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,10 @@ updates:
     commit-message:
       # Prefix all commit messages with "gh-actions"
       prefix: "gh-actions"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      # Prefix all commit messages with "pip"
+      prefix: "pip"


### PR DESCRIPTION
This should help us keep our python package dependencies up to date.