### PR TITLE
Update chromedash-header.ts

### DIFF
--- a/client-src/elements/chromedash-header.ts
+++ b/client-src/elements/chromedash-header.ts
@@ -371,9 +371,9 @@ export class ChromedashHeader extends LitElement {
           <a href="/roadmap" target="_top">
             <h1>
               <img
-                src="/static/img/chrome_logo.svg" 
-                alt="" 
-                role="presentation" 
+                src="/static/img/chrome_logo.svg"
+                alt=""
+                role="presentation"
               />
               ${this.appTitle}
             </h1>

--- a/client-src/elements/chromedash-header.ts
+++ b/client-src/elements/chromedash-header.ts
@@ -370,7 +370,11 @@ export class ChromedashHeader extends LitElement {
         <aside>
           <a href="/roadmap" target="_top">
             <h1>
-              <img src="/static/img/chrome_logo.svg" alt="" role="presentation" />
+              <img
+                src="/static/img/chrome_logo.svg" 
+                alt="" 
+                role="presentation" 
+              />
               ${this.appTitle}
             </h1>
           </a>

--- a/client-src/elements/chromedash-header.ts
+++ b/client-src/elements/chromedash-header.ts
@@ -370,7 +370,7 @@ export class ChromedashHeader extends LitElement {
         <aside>
           <a href="/roadmap" target="_top">
             <h1>
-              <img src="/static/img/chrome_logo.svg" alt="Chrome logo" />
+              <img src="/static/img/chrome_logo.svg" alt="" role="presentation" />
               ${this.appTitle}
             </h1>
           </a>


### PR DESCRIPTION
fix(a11y): mark Chrome logo as decorative with empty alt and presentation role

The header logo was interpreted as meaningful content by screen readers. Setting alt="" and role="presentation" ensures it's treated as decorative, fixing the accessibility issue flagged by tools like axe and Lighthouse.

Related Issue: Accessibility bug in the header logo https://github.com/GoogleChrome/chromium-dashboard/issues/5154

I have signed the CLA