### PR TITLE
Fix occasional missing login button bug

### DIFF
--- a/templates/spa.html
+++ b/templates/spa.html
@@ -45,7 +45,7 @@ limitations under the License.
   <link rel="stylesheet" href="/static/css/main.css?v={{app_version}}">
 
   {# Google Identity Services library for OAuth #}
-  <script src="https://accounts.google.com/gsi/client" async defer nonce="{{nonce}}"></script>
+  <script src="https://accounts.google.com/gsi/client" nonce="{{nonce}}"></script>
 
   {# Google Charts library for timeline pages #}
   <script src="https://www.gstatic.com/charts/loader.js"></script>


### PR DESCRIPTION
Fixes #4540 

This issue was due to the Google Identity Services library not being loaded in before the page is rendered.