### PR TITLE
Keep margin that is built into sl-relative-time on roadmap.

### DIFF
--- a/client-src/css/shared-css.js
+++ b/client-src/css/shared-css.js
@@ -252,6 +252,10 @@ export const SHARED_STYLES = [
     margin: 0 -3px;  // Mitigate spacing from unknown cause.
   }
 
+  sl-relative-time.no-squeeze {
+    margin: 0 0;
+  }
+
   @media only screen and (max-width: 700px) {
     h1 {
       font-size: 24px;

--- a/client-src/elements/chromedash-roadmap-milestone-card.ts
+++ b/client-src/elements/chromedash-roadmap-milestone-card.ts
@@ -132,7 +132,10 @@ export class ChromedashRoadmapMilestoneCard extends LitElement {
     if (diff.days < 1) {
       return 'coming soon';
     }
-    return html`<sl-relative-time class="no-squeeze" date="${date.toISOString()}">
+    return html`<sl-relative-time
+      class="no-squeeze"
+      date="${date.toISOString()}"
+    >
     </sl-relative-time>`;
   }
 

--- a/client-src/elements/chromedash-roadmap-milestone-card.ts
+++ b/client-src/elements/chromedash-roadmap-milestone-card.ts
@@ -132,7 +132,7 @@ export class ChromedashRoadmapMilestoneCard extends LitElement {
     if (diff.days < 1) {
       return 'coming soon';
     }
-    return html` <sl-relative-time date="${date.toISOString()}">
+    return html`<sl-relative-time class="no-squeeze" date="${date.toISOString()}">
     </sl-relative-time>`;
   }
 


### PR DESCRIPTION
This should resolve #5270.  The sl-relative-time element has some margin built into it, and we usually don't want that because it makes it impossible to use near punctuation, e.g. `(4 days ago)` looks better than `( 4 days ago )`.  However, in this case we do actually want that margin.