### PR TITLE
Don't ping reviewers for reviews on deleted features.

### DIFF
--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -428,6 +428,8 @@ class SLOOverdueHandler(basehandlers.FlaskHandler):
       gate_id = gate.key.integer_id()
       appr_def = approval_defs.APPROVAL_FIELDS_BY_ID[gate.gate_type]
       fe = relevant_features[gate.feature_id]
+      if fe.deleted:
+        continue
       feature_id = fe.key.integer_id()
       gate_url = settings.SITE_URL + f'feature/{feature_id}?gate={gate_id}'
       if is_initial_response:

--- a/internals/reminders_test.py
+++ b/internals/reminders_test.py
@@ -689,6 +689,19 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
     self.assert_equal_ignoring_ids(
       TESTDATA['test_build_gate_email_tasks__initial_due.html'], task['html'])
 
+  def test_build_gate_email_tasks__no_deleted(self):
+    """We don't send reminders for gates on deleted features."""
+    self.gate_1.assignee_emails = [
+        'b_assignee@example.com', 'a_assignee@example.com']
+    self.feature_1.deleted = True
+    with test_app.app_context():
+      actual = self.handler.build_gate_email_tasks(
+        [self.gate_1],
+        {self.feature_1.key.integer_id(): self.feature_1},
+        False, True)
+
+    self.assertEqual([], actual)
+
   def test_build_gate_email_tasks__initial_overdue(self):
     """Check the email sent when an initial respose is overdue."""
     self.gate_1.assignee_emails = [


### PR DESCRIPTION
This should resolve #5044.  Basically, when going through the list of gates that should generate a reminder email, skip any that belong to a deleted feature entry.