### PR TITLE
Add bulk edit to admin menu and improve instructions.

### DIFF
--- a/client-src/elements/chromedash-bulk-edit-page.ts
+++ b/client-src/elements/chromedash-bulk-edit-page.ts
@@ -272,11 +272,8 @@ export class ChromedashBulkEditPage extends LitElement {
         <p id="instructions">
           Select a CSV file to see the preview. The CSV file should have one
           column labeled "Chrome Status Entry" and one column labled "Feature
-          ID". Once the file is parsed, the table below will preview changes
-          that will be made. Your
-          <a href="/admin/users/new" target="_blank">chromestatus account</a>
-          must have "site editor" or "admin" permission to successfully complete
-          the edits.
+          ID", although some variations may work. Once the file is parsed, the
+          table below will preview changes that will be made.
         </p>
       `;
     }

--- a/client-src/elements/chromedash-drawer.ts
+++ b/client-src/elements/chromedash-drawer.ts
@@ -361,6 +361,7 @@ export class ChromedashDrawer extends LitElement {
       <div class="section-header">Admin</div>
       ${this.renderNavItem('/admin/users/new', 'Users')}
       ${this.renderNavItem('/admin/ot_requests', 'OT requests')}
+      ${this.renderNavItem('/admin/bulk_edit', 'Bulk edit')}
       ${this.renderNavItem('/admin/feature_links', 'Feature links')}
       ${this.renderNavItem('/reports/feature-latency', 'Feature latency')}
       ${this.renderNavItem('/reports/review-latency', 'Review latency')}


### PR DESCRIPTION
This makes it easier for the intended users to navigate to this page.
Also, update the instructions to clarify that we are somewhat flexible about the column headings.
And, don't document permissions because the user must be a site admin to view this page in the first place.