### PR TITLE
Don't automatically select 0th autocomplete candidate.

### DIFF
--- a/client-src/elements/chromedash-typeahead.ts
+++ b/client-src/elements/chromedash-typeahead.ts
@@ -470,7 +470,7 @@ export class ChromedashTypeaheadItem extends LitElement {
 
   render() {
     if (this.value === NONSELECTABLE_ITEM_VALUE) {
-      return nothing;
+      return html`${nothing}`;
     }
     const highlightedValue = this.highlight(this.value);
     const highlightedDoc = this.highlight(this.doc);

--- a/client-src/elements/chromedash-typeahead.ts
+++ b/client-src/elements/chromedash-typeahead.ts
@@ -478,7 +478,7 @@ export class ChromedashTypeaheadItem extends LitElement {
 
   render(): TemplateResult {
     if (this.value === NONSELECTABLE_ITEM_VALUE) {
-      return html`{nothing}`;
+      return html`${nothing}`;
     }
     const highlightedValue = this.highlight(this.value);
     const highlightedDoc = this.highlight(this.doc);

--- a/client-src/elements/chromedash-typeahead_test.ts
+++ b/client-src/elements/chromedash-typeahead_test.ts
@@ -1,6 +1,11 @@
 import {assert, fixture} from '@open-wc/testing';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
-import SlInput from '@shoelace-style/shoelace/dist/components/input/input.js';
+import {
+  SlInput,
+  SlDropdown,
+  type SlMenu,
+  type SlMenuItem,
+} from '@shoelace-style/shoelace';
 import '@shoelace-style/shoelace/dist/components/menu/menu.js';
 import {html} from 'lit';
 import {
@@ -184,12 +189,12 @@ describe('chromedash-typeahead-dropdown', () => {
     `);
     assert.exists(component);
     assert.instanceOf(component, ChromedashTypeaheadDropdown);
-    const item0 = component.querySelector('#item0');
-    const item1 = component.querySelector('#item1');
+    const item0 = component.querySelector<SlMenuItem>('#item0');
+    const item1 = component.querySelector<SlMenuItem>('#item1');
 
     assert.equal(item0, component.getCurrentItem());
 
-    component.setCurrentItem(item1);
+    component.setCurrentItem(item1!);
     assert.equal(item1, component.getCurrentItem());
 
     component.resetSelection();


### PR DESCRIPTION
This is the chromestatus change to the typeahead component to make it less aggressive at selecting an autocomplete item.

The root cause is that the shoelace component `sl-menu` automatically selects the 0th menu item whenever the menu items are set.  It is not clear how we could differentiate that from a desired user selection without further complicating a UI element that already has a lot of state.  And, it is not possible to subclass `SlMenu` to override just that behavior because that class uses many `private` methods.

In this PR, I nerf the undesired behavior by prepending an invisible 0th item to the menu.  It is automatically selected, but if the user hits `Enter` when it is selected we do not treat it as an autocomplete completion and instead assume that the user wants to submit the search to the server.  This achieves the desired behavior of only performing a completion after the user hits the down arrow (to move the selection to the 1st or later item) or clicks an item in the menu.