### PR TITLE
Add activity log record when archiving a feature

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -32,7 +32,7 @@ from internals.core_models import FeatureEntry, MilestoneSet, Stage
 from internals.data_types import CHANGED_FIELDS_LIST_TYPE
 from internals import feature_links
 from internals import notifier_helpers
-from internals.review_models import Gate
+from internals.review_models import Gate, Activity
 from internals.data_types import VerboseFeatureDict
 from internals import feature_helpers
 from internals import search
@@ -391,6 +391,15 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
     feature: FeatureEntry = self.get_specified_feature(feature_id=feature_id)
     feature.deleted = True
     feature.put()
+    
+    user = users.get_current_user()
+    email = user.email() if user else None
+    activity = Activity(
+        feature_id=feature_id,
+        author=email,
+        content=f'Feature "{feature.name}" was archived.')
+    activity.put()
+    
     rediscache.delete_keys_with_prefix(FeatureEntry.DEFAULT_CACHE_KEY)
     rediscache.delete_keys_with_prefix(FeatureEntry.SEARCH_CACHE_KEY)
 

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -22,7 +22,7 @@ import werkzeug.exceptions  # Flask HTTP stuff.
 from api import features_api
 from internals import core_enums
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
-from internals.review_models import Gate
+from internals.review_models import Gate, Activity
 from internals import user_models
 from framework import rediscache
 
@@ -73,6 +73,15 @@ class FeaturesAPITestDelete(testing_config.CustomTestCase):
 
     revised_feature = FeatureEntry.get_by_id(self.feature_id)
     self.assertTrue(revised_feature.deleted)
+    
+    # Check that an activity log record was created
+    activities = Activity.get_activities(self.feature_id)
+    archive_activities = [a for a in activities if 'archived' in a.content.lower()]
+    self.assertEqual(1, len(archive_activities))
+    archive_activity = archive_activities[0]
+    self.assertEqual(email, archive_activity.author)
+    self.assertIn('feature one', archive_activity.content)
+    self.assertIn('archived', archive_activity.content)
 
   def test_delete__valid_admin(self):
     """Admin wants to soft-delete a feature."""


### PR DESCRIPTION
Add activity log record when archiving a feature entry

Fixes [#5364](https://github.com/GoogleChrome/chromium-dashboard/issues/5364)
