### PR TITLE
Filter confidential features from cached results in release notes and re-order filters to improve performance

### DIFF
--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -77,10 +77,12 @@ def get_features_in_release_notes(milestone: int):
 
   cached_features = rediscache.get(cache_key)
   if cached_features:
-    return cached_features
+    return filter_confidential(cached_features)
 
   stages = Stage.query(
           Stage.archived == False,
+      Stage.stage_type.IN([STAGE_BLINK_SHIPPING, STAGE_PSA_SHIPPING,
+          STAGE_FAST_SHIPPING, STAGE_DEP_SHIPPING, STAGE_ENT_ROLLOUT]),
       ndb.OR(Stage.milestones.desktop_first >= milestone,
           Stage.milestones.android_first >= milestone,
           Stage.milestones.ios_first >= milestone,
@@ -88,9 +90,7 @@ def get_features_in_release_notes(milestone: int):
           Stage.milestones.desktop_last >= milestone,
           Stage.milestones.ios_last >= milestone,
           Stage.milestones.webview_last >= milestone,
-          Stage.rollout_milestone >= milestone),
-      Stage.stage_type.IN([STAGE_BLINK_SHIPPING, STAGE_PSA_SHIPPING,
-          STAGE_FAST_SHIPPING, STAGE_DEP_SHIPPING, STAGE_ENT_ROLLOUT])).filter().fetch()
+          Stage.rollout_milestone >= milestone)).filter().fetch()
 
   feature_ids = list(set({
       *[s.feature_id for s in stages]}))


### PR DESCRIPTION
- Filter confidential features from cached results in release notes
- Re-order filters for release note features to improve performance by putting the faster filters first