### PR TITLE
Set definitive entity IDs for reminder tests

### DIFF
--- a/internals/testdata/reminders_test/test_build_gate_email_tasks__initial_due.html
+++ b/internals/testdata/reminders_test/test_build_gate_email_tasks__initial_due.html
@@ -1,6 +1,6 @@
 
 
-  <p><a href="http://127.0.0.1:7777/feature/3590?gate=3608"
+  <p><a href="http://127.0.0.1:7777/feature/1?gate=11"
       >The Enterprise review</a>
   of <b>feature one</b>
   is now due for an initial response.</p>

--- a/internals/testdata/reminders_test/test_build_gate_email_tasks__initial_overdue.html
+++ b/internals/testdata/reminders_test/test_build_gate_email_tasks__initial_overdue.html
@@ -1,6 +1,6 @@
 
 
-  <p><a href="http://127.0.0.1:7777/feature/3609?gate=3627"
+  <p><a href="http://127.0.0.1:7777/feature/1?gate=11"
       >The Enterprise review</a>
   of <b>feature one</b>
   is now overdue for an initial response.</p>

--- a/internals/testdata/reminders_test/test_build_gate_email_tasks__resolution_due.html
+++ b/internals/testdata/reminders_test/test_build_gate_email_tasks__resolution_due.html
@@ -1,6 +1,6 @@
 
 
-  <p><a href="http://127.0.0.1:7777/feature/3628?gate=3646"
+  <p><a href="http://127.0.0.1:7777/feature/1?gate=11"
       >The Enterprise review</a>
   of <b>feature one</b>
   is now due for a resolution.</p>

--- a/internals/testdata/reminders_test/test_build_gate_email_tasks__resolution_overdue.html
+++ b/internals/testdata/reminders_test/test_build_gate_email_tasks__resolution_overdue.html
@@ -1,6 +1,6 @@
 
 
-  <p><a href="http://127.0.0.1:7777/feature/3647?gate=3665"
+  <p><a href="http://127.0.0.1:7777/feature/1?gate=11"
       >The Enterprise review</a>
   of <b>feature one</b>
   is now overdue for a resolution.</p>


### PR DESCRIPTION
This change updates the reminder tests to always generate entities with the same set of IDs for each run, which removes the need to check the template outputs in a way that specifically ignores the generated entity IDs.