### PR TITLE
Speed up release notes API by narrowing sooner.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -88,6 +88,10 @@ indexes:
   - name: created
 - kind: FeatureEntry
   properties:
+  - name: deleted
+  - name: enterprise_impact
+- kind: FeatureEntry
+  properties:
   - name: impl_status_chrome
   - name: name
 - kind: FeatureEntry


### PR DESCRIPTION
This should resolve b/441927391.

Last week's attempted speed-up was still slow for older milestones.  Logging showed that most of the time was spent fetching stages for feature entries that were later discarded by a result narrowing condition in python code.  E.g., Stages for 843 features were fetched, but that was narrowed down to just 41 results, meaning that the time to process the others was wasted.

In this PR:
* Early in the process, fetch the IDs of all enterprise and enterprise-impacting features.  This can be a somewhat long list, but we are only getting the keys and we are doing it in parallel with other work.
* Use those keys to do an intersection on the feature IDs that need to be fetched.  That does most of the narrowing, and it happens before fetching the result feature stages, so far fewer stages are fetched.
* Add an index for the new query.  This is already deployed on staging and prod.

Measuring this on prod I see this speedup:

| Milestone | Old latency | New latency |
| :------- | :------: | -------: |
| 140  | 1s  | 1s  |
| 138  | 4s  | 1s  |
| 132  | 14s  | 4s  |
| 121  | 42s  | 9s  |
| 119  | 56s  | 11s  |
| 105  | 80s  | 12s  |


