### PR TITLE
Turn off autocomplete for usercounter datalists.

### DIFF
--- a/client-src/elements/chromedash-stack-rank-page.ts
+++ b/client-src/elements/chromedash-stack-rank-page.ts
@@ -105,6 +105,7 @@ export class ChromedashStackRankPage extends LitElement {
         id="datalist-input"
         type="search"
         list="features"
+        autocomplete="off"
         placeholder=${this.viewList.length
           ? 'Select or search a property for detailed stats'
           : 'loading...'}

--- a/client-src/elements/chromedash-timeline.ts
+++ b/client-src/elements/chromedash-timeline.ts
@@ -326,6 +326,7 @@ ORDER BY date DESC, client`;
         id="datalist-input"
         type="search"
         list="features"
+        autocomplete="off"
         placeholder="Select or search a property"
         @change="${this.updateSelectedBucketId}"
       />


### PR DESCRIPTION
This should resolve the remaining part of #5381.

It just adds `autocomplete="off"` to disable the addition of options that the user has typed into the same field previously.  Those are not needed because the datalist provides a complete list of all valid options.  The autocomplete options caused confusing duplicate options to be listed, and it caused cross-talk between what was offered for various kinds of usecounters.