### PR TITLE
Add the channels API to the CORS configuration.

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -845,7 +845,10 @@ def FlaskApplication(import_name, routes, pattern_base='', debug=False):
   CORS(app, resources={
       r'/data/.*': {'origins': '*'},
       r'/api/v0/features.*': {'origins': ALLOWED_API_ORIGINS,
-                              'methods': ['GET']}})
+                              'methods': ['GET']},
+      r'/api/v0/channels.*': {'origins': ALLOWED_API_ORIGINS,
+                              'methods': ['GET']},
+  })
 
   # Set cookie headers in Flask; see
   # https://flask.palletsprojects.com/en/2.0.x/config/


### PR DESCRIPTION
This should resolve b/445661275.

This is needed by the enterprise team because they are building a new consumer-facing page that uses our APIs to present release notes information.  We previously allowed /api/v0/feature.*, but they also need channel info to select the current chrome milestone. 