### PR TITLE
Optionally render summary as markdown.

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -342,6 +342,7 @@ def feature_entry_to_json_verbose(
     'id': id,
     'name': fe.name,
     'summary': fe.summary,
+    'markdown_fields': fe.markdown_fields or [],
     'blink_components': fe.blink_components or [],
     'star_count': fe.star_count,
     'search_tags': fe.search_tags or [],

--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -304,6 +304,7 @@ class FeatureConvertersTest(testing_config.CustomTestCase):
       'id': 123,
       'name': 'feature template',
       'summary': 'sum',
+      'markdown_fields': [],
       'unlisted': False,
       'api_spec': False,
       'automation_spec': False,

--- a/client-src/elements/autolink.ts
+++ b/client-src/elements/autolink.ts
@@ -2,6 +2,7 @@
 // for use with text entries in WebStatus. Use this directly via './utils.js'
 // See: https://chromium.googlesource.com/infra/infra/+/refs/heads/main/appengine/monorail/static_src/autolink.js
 
+import {TemplateResult, html} from 'lit';
 import {FeatureLink} from '../js-src/cs-client';
 import {enhanceAutolink} from './chromedash-link.js';
 
@@ -176,19 +177,22 @@ function createIssueRefRun(projectName, localId, content, commentId) {
   };
 }
 
-export function markupAutolinks(plainString, featureLinks: FeatureLink[] = []) {
+export function markupAutolinks(
+  plainString,
+  featureLinks: FeatureLink[] = []
+): TemplateResult[] {
   plainString = plainString || '';
   const chunks = [plainString.trim()];
   const textRuns: TextRun[] = [];
   chunks.filter(Boolean).forEach(chunk => {
     textRuns.push(...autolinkChunk(chunk));
   });
-  const result = textRuns.map(part => {
+  const result: TemplateResult[] = textRuns.map(part => {
     if (part.tag === 'a') {
       // if the link is a feature link, enhance it to provide more information
       return enhanceAutolink(part, featureLinks);
     }
-    return part.content;
+    return html`${part.content}`;
   });
   return result;
 }

--- a/client-src/elements/chromedash-enterprise-release-notes-page.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page.ts
@@ -13,6 +13,7 @@ import {
   STAGE_TYPES_SHIPPING,
 } from './form-field-enums.js';
 import {
+  autolink,
   FieldInfo,
   formatFeatureChanges,
   parseRawQuery,
@@ -703,7 +704,12 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
   }
 
   renderFeatureSummary(f: Feature): TemplateResult {
-    return html` <p class="summary preformatted">${f.summary}</p>`;
+    const markup = autolink(
+      f.summary,
+      [],
+      (f.markdown_fields || []).includes('summary')
+    );
+    return html` <p class="summary preformatted">${markup}</p>`;
   }
 
   renderEditableFeatureSummary(f: Feature): TemplateResult {

--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -344,9 +344,13 @@ export class ChromedashFeatureDetail extends LitElement {
     `;
   }
 
-  renderText(value) {
+  renderText(value, isMarkdown: boolean = false): TemplateResult {
     value = String(value);
-    const markup = autolink(value, this.featureLinks);
+    const markup: TemplateResult[] = autolink(
+      value,
+      this.featureLinks,
+      isMarkdown
+    );
     if (value.length > LONG_TEXT || value.includes('\n')) {
       return html`<span class="longtext">${markup}</span>`;
     }
@@ -364,7 +368,7 @@ export class ChromedashFeatureDetail extends LitElement {
     return this.renderText(value);
   }
 
-  renderValue(fieldType, value) {
+  renderValue(fieldType, value, isMarkdown: boolean): TemplateResult {
     if (fieldType == 'checkbox') {
       return this.renderText(value ? 'True' : 'False');
     } else if (fieldType == 'url') {
@@ -376,7 +380,7 @@ export class ChromedashFeatureDetail extends LitElement {
         </ul>
       `;
     }
-    return this.renderText(value);
+    return this.renderText(value, isMarkdown);
   }
 
   renderField(fieldDef, feStage) {
@@ -386,6 +390,7 @@ export class ChromedashFeatureDetail extends LitElement {
     if (!isDefined && deprecated) {
       return nothing;
     }
+    const isMarkdown = (this.feature.markdown_fields || []).includes(fieldId);
 
     const icon = isDefined
       ? html`<sl-icon library="material" name="check_circle_20px"></sl-icon>`
@@ -395,7 +400,7 @@ export class ChromedashFeatureDetail extends LitElement {
       <dt id=${fieldId}>${icon} ${fieldDisplayName}</dt>
       <dd>
         ${isDefined
-          ? this.renderValue(fieldType, value)
+          ? this.renderValue(fieldType, value, isMarkdown)
           : html`<i>No information provided yet</i>`}
       </dd>
     `;

--- a/client-src/elements/chromedash-feature-highlights.ts
+++ b/client-src/elements/chromedash-feature-highlights.ts
@@ -88,35 +88,30 @@ export class ChromedashFeatureHighlights extends LitElement {
     this.dispatchEvent(new Event('resume', {bubbles: true, composed: true}));
   }
 
+  renderSummary() {
+    if (this.feature.summary) {
+      const markup = autolink(
+        this.feature.summary,
+        this.featureLinks,
+        (this.feature.markdown_fields || []).includes('summary')
+      );
+      return html`
+        <section id="summary">
+          <p class="preformatted">${markup}</p>
+        </section>
+      `;
+    } else {
+      return html``;
+    }
+  }
+
   renderEnterpriseFeatureContent() {
-    return html`
-      ${this.feature.summary
-        ? html`
-            <section id="summary">
-              <!-- prettier-ignore -->
-              <p class="preformatted">${autolink(
-                this.feature.summary,
-                this.featureLinks
-              )}</p>
-            </section>
-          `
-        : nothing}
-    `;
+    return this.renderSummary();
   }
 
   renderFeatureContent() {
     return html`
-      ${this.feature.summary
-        ? html`
-            <section id="summary">
-              <!-- prettier-ignore -->
-              <p class="preformatted">${autolink(
-                this.feature.summary,
-                this.featureLinks
-              )}</p>
-            </section>
-          `
-        : nothing}
+      ${this.renderSummary()}
       ${this.feature.motivation
         ? html`
             <section id="motivation">

--- a/client-src/elements/chromedash-link.ts
+++ b/client-src/elements/chromedash-link.ts
@@ -627,6 +627,6 @@ export function enhanceUrl(url, featureLinks: FeatureLink[] = [], text?) {
 }
 
 // prettier-ignore
-export function enhanceAutolink(part, featureLinks: FeatureLink[]) {
+export function enhanceAutolink(part, featureLinks: FeatureLink[]): TemplateResult {
   return html`<chromedash-link href=${part.href} .featureLinks=${featureLinks} .ignoreHttpErrorCodes=${[404]}>${part.content}</chromedash-link>`;
 }

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -1,6 +1,9 @@
 // This file contains helper functions for our elements.
 
-import {html, nothing} from 'lit';
+import {html, nothing, TemplateResult} from 'lit';
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+import DOMPurify from 'dompurify';
+import {marked} from 'marked';
 import {Feature, FeatureLink, StageDict} from '../js-src/cs-client.js';
 import {markupAutolinks} from './autolink.js';
 import {FORMS_BY_STAGE_TYPE, FormattedFeature} from './form-definition.js';
@@ -36,11 +39,22 @@ export const IS_MOBILE = (() => {
 })();
 
 /* Convert user-entered text into safe HTML with clickable links
- * where appropriate.  Returns an array with text and anchor tags.
+ * where appropriate.
  */
-export function autolink(s, featureLinks: FeatureLink[] = []) {
-  const withLinks = markupAutolinks(s, featureLinks);
-  return withLinks;
+export function autolink(
+  s,
+  featureLinks: FeatureLink[] = [],
+  isMarkdown: boolean = false
+): TemplateResult[] {
+  if (isMarkdown) {
+    const rendered: string = marked.parse(s) as string;
+    const sanitized: string = DOMPurify.sanitize(rendered);
+    const markup: TemplateResult = html`${unsafeHTML(sanitized)}`;
+    return [markup];
+  } else {
+    const withLinks = markupAutolinks(s, featureLinks);
+    return withLinks;
+  }
 }
 
 export function showToastMessage(msg) {

--- a/client-src/elements/utils_test.ts
+++ b/client-src/elements/utils_test.ts
@@ -30,31 +30,31 @@ AKA issue 1234 #c3. https://example.com/ --- testing. bug 1234 also.
 https://example.com#testing https://example.com/test?querystring=here&q=1234 ??.
 send requests to user@example.com or just check out request.net`;
       const expected = [
-        'This is a test & result of the autolinking.',
-        '\n',
+        html`${'This is a test & result of the autolinking.'}`,
+        html`${'\n'}`,
         html`<chromedash-link href=${'http://go/this-is-a-test'} .featureLinks=${[]} .ignoreHttpErrorCodes=${[404]}>${'go/this-is-a-test'}</chromedash-link>`,
-        '.',
-        '\nA bug',
-        ' ',
+        html`${'.'}`,
+        html`${'\nA bug'}`,
+        html`${' '}`,
         html`<chromedash-link href=${'http://cr/1234'} .featureLinks=${[]} .ignoreHttpErrorCodes=${[404]}>${'cr/1234'}</chromedash-link>`,
-        ' exists and also',
-        ' ',
+        html`${' exists and also'}`,
+        html`${' '}`,
         html`<chromedash-link href=${'http://cl/1234'} .featureLinks=${[]} .ignoreHttpErrorCodes=${[404]}>${'cl/1234'}</chromedash-link>`,
-        '. Info at ',
+        html`${'. Info at '}`,
         html`<chromedash-link href=${'https://bugs.chromium.org/p/chromium/issues/detail?id=1234#c3'} .featureLinks=${[]} .ignoreHttpErrorCodes=${[404]}>${'issue 1234 comment 3'}</chromedash-link>`,
-        '.\nAKA ',
+        html`${'.\nAKA '}`,
         html`<chromedash-link href=${'https://bugs.chromium.org/p/chromium/issues/detail?id=1234#c3'} .featureLinks=${[]} .ignoreHttpErrorCodes=${[404]}>${'issue 1234 #c3'}</chromedash-link>`,
-        '. ',
+        html`${'. '}`,
         html`<chromedash-link href=${'https://example.com/'} .featureLinks=${[]} .ignoreHttpErrorCodes=${[404]}>${'https://example.com/'}</chromedash-link>`,
-        ' --- testing. ',
+        html`${' --- testing. '}`,
         html`<chromedash-link href=${'https://bugs.chromium.org/p/chromium/issues/detail?id=1234'} .featureLinks=${[]} .ignoreHttpErrorCodes=${[404]}>${'bug 1234'}</chromedash-link>`,
-        ' ',
-        'also.\n',
+        html`${' '}`,
+        html`${'also.\n'}`,
         html`<chromedash-link href=${'https://example.com#testing'} .featureLinks=${[]} .ignoreHttpErrorCodes=${[404]}>${'https://example.com#testing'}</chromedash-link>`,
-        ' ',
+        html`${' '}`,
         html`<chromedash-link href=${'https://example.com/test?querystring=here&q=1234'} .featureLinks=${[]} .ignoreHttpErrorCodes=${[404]}>${'https://example.com/test?querystring=here&q=1234'}</chromedash-link>`,
-        ' ??.\nsend requests to user@example.com or just check out',
-        ' ',
+        html`${' ??.\nsend requests to user@example.com or just check out'}`,
+        html`${' '}`,
         html`<chromedash-link href=${'https://request.net'} .featureLinks=${[]} .ignoreHttpErrorCodes=${[404]}>${'request.net'}</chromedash-link>`,
       ];
 
@@ -68,10 +68,10 @@ go this-is-a-test.
 A bug cr /1234 exists and also /1234. This is an example sentence.
 AKA issue here 1234. example com --- testing.`;
       const expected = [
-        'This is a test of the autolinking.\n' +
+        html`${'This is a test of the autolinking.\n' +
           'go this-is-a-test.\n' +
           'A bug cr /1234 exists and also /1234. This is an example sentence.\n' +
-          'AKA issue here 1234. example com --- testing.',
+          'AKA issue here 1234. example com --- testing.'}`,
       ];
 
       const result = autolink(before);
@@ -84,10 +84,10 @@ go/this-is-a-test
 <p>Do not convert this</p>
 <script>Dangerous stuff</script>`;
       const expected = [
-        '<b>Test</b>',
-        '\n',
+        html`${'<b>Test</b>'}`,
+        html`${'\n'}`,
         html`<chromedash-link href=${'http://go/this-is-a-test'} .featureLinks=${[]} .ignoreHttpErrorCodes=${[404]}>${'go/this-is-a-test'}</chromedash-link>`,
-        '\n<p>Do not convert this</p>\n<script>Dangerous stuff</script>',
+        html`${'\n<p>Do not convert this</p>\n<script>Dangerous stuff</script>'}`,
       ];
 
       const result = autolink(before);

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -193,6 +193,7 @@
  * Descriptive info.
  * @property {string} name
  * @property {string} summary
+ * @property {string[]} markdown_fields
  * @property {string} category
  * @property {number} category_int
  * @property {string=} web_feature

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -87,6 +87,7 @@ class FeatureEntry(ndb.Model):  # Copy from Feature
   # Descriptive info.
   name = ndb.StringProperty(required=True)
   summary = ndb.TextProperty(required=True)
+  markdown_fields = ndb.StringProperty(repeated=True)
   category = ndb.IntegerProperty(required=True)
   enterprise_product_category = ndb.IntegerProperty(required=False, default=ENTERPRISE_PRODUCT_CATEGORY_CHROME_BROWSER_UPDATE)
   enterprise_feature_categories = ndb.StringProperty(repeated=True)

--- a/internals/data_types.py
+++ b/internals/data_types.py
@@ -197,6 +197,7 @@ class VerboseFeatureDict(TypedDict):
   # Descriptive info.
   name: str
   summary: str
+  markdown_fields: list[str]
   category: str
   category_int: int
   blink_components: list[str]

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "@types/google.accounts": "^0.0.18",
         "@types/google.visualization": "^0.0.74",
         "csv-parse": "^6.1.0",
+        "dompurify": "^3.2.7",
         "lit": "^3",
+        "marked": "^16.3.0",
         "node-fetch": ">=3.3.2",
         "page": "^1.11.6",
         "urijs": ">=1.19.11",
@@ -6870,6 +6872,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/dot-prop": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
@@ -11118,6 +11129,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.3.0.tgz",
+      "integrity": "sha512-K3UxuKu6l6bmA5FUwYho8CfJBlsUWAooKtdGgMcERSpF7gcBUrCGsLH7wDaaNOzwq18JzSUDyoEb/YsrqMac3w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/marky": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,8 @@
     "@polymer/iron-iconset-svg": "^3.0.1",
     "@types/google.accounts": "^0.0.18",
     "@types/google.visualization": "^0.0.74",
+    "dompurify": "^3.2.7",
+    "marked": "^16.3.0",
     "csv-parse": "^6.1.0",
     "lit": "^3",
     "node-fetch": ">=3.3.2",


### PR DESCRIPTION
This is some initial progress on #5212.

There is no user-visible change yet, but this adds the possibility that a feature that was opted into using markdown in the summary could render it as markdown in all the places where it appears.

In this PR:
* Add an NDB field to FeatureEntry for markdown_fields.  This it initially always empty, but in an upcoming PR there will be a way to add `'summary'` as a value, and later other field names.  This list of strings is returned in JSON reponses for features.
* Change the existing auto-linking functions to add some type information and to always return `TemplateResult`s rather than a mix of `string` and `TemplateResult`.
* If the current field value should be rendered as markdown, `autolink()` will do that now.  It uses a sanitizer as recommended on marked.js.org.
 