### PR TITLE
Migrate the `rollout_milestone` field

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -188,6 +188,8 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
       changed_fields: CHANGED_FIELDS_LIST_TYPE
     ) -> list[Stage]:
     """Update stage fields with changes provided in the PATCH request."""
+    # TODO(DanielRyanSmith): This method should be updated to use the logic
+    # for basehandlers.update_stage(). This logic is mostly duplicated otherwise.
     stages_to_store: list[Stage] = []
     for change_info in stage_changes_list:
       stage_was_updated = False
@@ -223,6 +225,12 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
         form_field_name = change_info[field]['form_field_name']
         old_value = getattr(milestones, field)
         new_value = change_info[field]['value']
+        # If this is the rollout milestone, also save it to the old field.
+        # TODO(DanielRyanSmith): Remove this double-storage once the
+        # rollout_milestone field is deprecated.
+        if form_field_name == 'rollout_milestone':
+          self.update_field_value(stage, 'rollout_milestone', 'int', new_value)
+
         self.update_field_value(milestones, field, field_type, new_value)
         changed_fields.append((form_field_name, old_value, new_value))
         stage_was_updated = True

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -225,6 +225,9 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
         form_field_name = change_info[field]['form_field_name']
         old_value = getattr(milestones, field)
         new_value = change_info[field]['value']
+        # desktop_first will be the new default field for "start" milestone,
+        # like rollout_milestone.
+
         # If this is the rollout milestone, also save it to the old field.
         # TODO(DanielRyanSmith): Remove this double-storage once the
         # rollout_milestone field is deprecated.

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -146,6 +146,9 @@ class FeaturesAPITest(testing_config.CustomTestCase):
         stage_type=160, milestones=MilestoneSet(desktop_first=1))
     self.ship_stage_1.put()
     self.ship_stage_1_id = self.ship_stage_1.key.integer_id()
+    self.enterprise_stage = Stage(id=60, feature_id=self.feature_1_id,
+                                  stage_type=1061)
+    self.enterprise_stage.put()
 
     self.feature_2 = FeatureEntry(
         name='feature two', summary='sum K', feature_type=1,
@@ -604,6 +607,13 @@ class FeaturesAPITest(testing_config.CustomTestCase):
             'value': new_desktop_first,
           },
         },
+        {
+          'id': self.enterprise_stage.key.integer_id(),
+          'desktop_first': {
+            'form_field_name': 'rollout_milestone',
+            'value': 105,
+          },
+        },
       ],
     }
     request_path = f'{self.request_path}/update'
@@ -620,6 +630,9 @@ class FeaturesAPITest(testing_config.CustomTestCase):
     # Updater email field should be changed.
     self.assertIsNotNone(self.feature_1.updated)
     self.assertEqual(self.feature_1.updater_email, 'admin@example.com')
+    # The rollout milestone should be set in the milestones field and the rollout_milestone field.
+    self.assertEqual(self.enterprise_stage.rollout_milestone, 105)
+    self.assertEqual(self.enterprise_stage.milestones.desktop_first, 105)
 
   def test_patch__milestone_changes_null(self):
     """Valid PATCH updates milestone fields when milestones object is null."""

--- a/client-src/elements/form-field-enums.ts
+++ b/client-src/elements/form-field-enums.ts
@@ -478,6 +478,7 @@ export const STAGE_FIELD_NAME_MAPPING: Record<string, string> = {
   extension_desktop_last: 'desktop_last',
   extension_android_last: 'android_last',
   extension_webview_last: 'webview_last',
+  rollout_milestone: 'desktop_first',
 
   // Intent fields.
   intent_to_implement_url: 'intent_thread_url',

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -431,6 +431,13 @@ class EntitiesAPIHandler(APIHandler):
       form_field_name = change_info[field]['form_field_name']
       old_value = getattr(milestones, field)
       new_value = change_info[field].get('value')
+
+      # If this is the rollout milestone, also save it to the old field.
+      # TODO(DanielRyanSmith): Remove this double-storage once the
+      # rollout_milestone field is deprecated.
+      if form_field_name == 'rollout_milestone':
+        self.update_field_value(stage, 'rollout_milestone', 'int', new_value)
+
       self.update_field_value(milestones, field, field_type, new_value)
       changed_fields.append((form_field_name, old_value, new_value))
       stage_was_updated = True

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -363,6 +363,8 @@ class Stage(ndb.Model):
 
   #Enterprise
   rollout_impact = ndb.IntegerProperty(default=2) # default to "Medium impact"
+  # rollout_milestone will be migrated to milestones.desktop_first as the
+  # default "start" milestone.
   rollout_milestone = ndb.IntegerProperty()
   rollout_platforms = ndb.StringProperty(repeated=True)
   rollout_details = ndb.TextProperty()

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -1020,5 +1020,8 @@ class MigrateRolloutMilestones(FlaskHandler):
         stage.milestones = MilestoneSet()
       stage.milestones.desktop_first = stage.rollout_milestone
       changed_stages.append(stage)
+      if len(changed_stages) >= 200:
+        ndb.put_multi(changed_stages)
+        changed_stages = []
     if changed_stages:
       ndb.put_multi(changed_stages)

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -1004,3 +1004,21 @@ class GenerateReviewActivityFile(FlaskHandler):
 
     return (f'{len(csv_rows)} '
             'new rows added to chromestatus-review-activity.csv uploaded.')
+
+
+class MigrateRolloutMilestones(FlaskHandler):
+  """Migrate the rollout milestone field to be stored in the 'milestones' field."""
+
+  def get_template_data(self, **kwargs):
+    self.require_cron_header()
+    stages: list[Stage] = Stage.query(Stage.stage_type == STAGE_ENT_ROLLOUT).fetch()
+    changed_stages: list[Stage] = []
+    for stage in stages:
+      if stage.milestones and stage.milestones.desktop_first:
+        continue
+      if not stage.milestones:
+        stage.milestones = MilestoneSet()
+      stage.milestones.desktop_first = stage.rollout_milestone
+      changed_stages.append(stage)
+    if changed_stages:
+      ndb.put_multi(changed_stages)

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -1018,6 +1018,7 @@ class MigrateRolloutMilestones(FlaskHandler):
         continue
       if not stage.milestones:
         stage.milestones = MilestoneSet()
+      # desktop_first will be considered the default "start" milestone.
       stage.milestones.desktop_first = stage.rollout_milestone
       changed_stages.append(stage)
       if len(changed_stages) >= 200:

--- a/main.py
+++ b/main.py
@@ -369,6 +369,8 @@ internals_routes: list[Route] = [
         maintenance_scripts.SendManualOTCreatedEmail),
   Route('/scripts/send_ot_activation_email/<int:stage_id>',
         maintenance_scripts.SendManualOTActivatedEmail),
+  Route('/scripts/migrate_rollout_milestones',
+        maintenance_scripts.MigrateRolloutMilestones),
 ]
 
 dev_routes: list[Route] = []


### PR DESCRIPTION
Part of #3767, #4498, and #4988

A number of issues are being caused by the `rollout_milestone` field being stored in its own field, rather than in the `milestones` stage field. A lot of Chromestatus logic relies on checking for milestones in the `milestones` field, so this separate storage of a milestone has unintended consequences (see issues above).

This change adds a migration script that copies all `rollout_milestone` stage values into `milestones.desktop_first`. Additionally, new logic is added that saves any `rollout_milestone` changes to `milestones.desktop_first`. This will allow for the field to be completely migrated, so that references to `rollout_milestone` can be removed in a future PR.