### PR TITLE
Remove Explainer from intent for Chromium catch-up features

### DIFF
--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -7,7 +7,7 @@
   {%- endfor -%}
 {%- endif -%}
 
-{%- if feature.explainer_links or feature.feature_type_int != 2 -%}
+{% if feature.explainer_links or (feature.feature_type_int != 1 and feature.feature_type_int != 2) %}
 <br>
 <br>
 <div><b>Explainer</b></div>


### PR DESCRIPTION
Fixes #4839

Remove the "Explainer" section from the intent template of "Fast" feature types (Chromium catches up). This field cannot be edited for this feature type, so it should not be a part of the intent template.