### PR TITLE
Update OT extension email to be more explicit about required action

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -903,8 +903,8 @@ class OTExtensionApprovedHandler(basehandlers.FlaskHandler):
     return {
       'to': requester_email,
       'cc': [OT_SUPPORT_EMAIL],
-      'subject': ('Origin trial extension approved and ready to be '
-                  f'initiated: {ot_display_name}'),
+      'subject': ('[Action Required] Initiate your origin trial extension '
+                  f'for {ot_display_name}'),
       'reply_to': None,
       'html': body,
     }

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -1171,7 +1171,7 @@ class OTExtensionApprovedHandlerTest(testing_config.CustomTestCase):
       # TESTDATA.make_golden(email_task['html'], 'test_make_extension_approved_email.html')
       self.assertEqual(
           email_task['subject'],
-          ('Origin trial extension approved and ready to be initiated: '
+          ('[Action Required] Initiate your origin trial extension for '
            'OT Display Name'))
       self.assertEqual(email_task['html'],
         TESTDATA['test_make_extension_approved_email.html'])

--- a/internals/testdata/notifier_test/test_make_extension_approved_email.html
+++ b/internals/testdata/notifier_test/test_make_extension_approved_email.html
@@ -16,7 +16,7 @@
     </tr>
     <tr>
       <td><a style="font-size: 140%;"
-             href="http://127.0.0.1:7777/feature/1"
+             href="http://127.0.0.1:7777/feature/1?gate=3&initiateExtension"
              >A feature</a>
       </td>
     </tr>

--- a/templates/origintrials/ot-extension-approved-email.html
+++ b/templates/origintrials/ot-extension-approved-email.html
@@ -11,7 +11,7 @@
     </tr>
     <tr>
       <td><a style="{{styles.feature_name}}"
-             href="{{SITE_URL}}feature/{{id}}"
+             href="{{SITE_URL}}feature/{{id}}?gate={{gate_id}}&initiateExtension"
              >{{feature.name}}</a>
       </td>
     </tr>


### PR DESCRIPTION
This is a small change that updates the OT extension approved email to more definitively state that an action is required by the recipient to initiate the trial extension. Also, both links in the email now link directly to where the user needs to go to initiate the extension.