### PR TITLE
Make enterprise_feature_categories conditionally required.

### DIFF
--- a/client-src/elements/chromedash-guide-new-page.ts
+++ b/client-src/elements/chromedash-guide-new-page.ts
@@ -7,7 +7,7 @@ import {
   NEW_FEATURE_FORM_FIELDS,
   ENTERPRISE_NEW_FEATURE_FORM_FIELDS,
 } from './form-definition';
-import {FEATURE_TYPES} from './form-field-enums';
+import {FEATURE_TYPES, ENTERPRISE_IMPACT} from './form-field-enums';
 
 import {ALL_FIELDS} from './form-field-specs';
 import {SHARED_STYLES} from '../css/shared-css.js';
@@ -108,6 +108,25 @@ export class ChromedashGuideNewPage extends LitElement {
       featureType == FEATURE_TYPES.FEATURE_TYPE_EXISTING_ID[0];
   }
 
+  maybeMakeEnterpriseFeatureCategoriesRequired() {
+    const enterpriseFeatureCategoriesField =
+      this.shadowRoot?.querySelector<ChromedashFormField>(
+        'chromedash-form-field[name="enterprise_feature_categories"]'
+      );
+    if (!enterpriseFeatureCategoriesField) {
+      return;
+    }
+    let enterpriseImpact = ENTERPRISE_IMPACT.IMPACT_NONE[0];
+    for (const fv of this.fieldValues) {
+      if (fv.name == 'enterprise_impact' && fv.value !== undefined) {
+        enterpriseImpact = fv.value;
+        break;
+      }
+    }
+    enterpriseFeatureCategoriesField.forceRequired =
+      enterpriseImpact > ENTERPRISE_IMPACT.IMPACT_NONE[0];
+  }
+
   // Handler to update form values when a field update event is fired.
   handleFormFieldUpdate(event) {
     const value = event.detail.value;
@@ -120,6 +139,7 @@ export class ChromedashGuideNewPage extends LitElement {
     this.fieldValues[index].touched = true;
     this.fieldValues[index].value = value;
     this.maybeMakeWebFeatureRequired();
+    this.maybeMakeEnterpriseFeatureCategoriesRequired();
   }
 
   renderSubHeader() {

--- a/client-src/elements/form-definition.ts
+++ b/client-src/elements/form-definition.ts
@@ -163,6 +163,7 @@ export const NEW_FEATURE_FORM_FIELDS = [
   'summary',
   'unlisted',
   'enterprise_impact',
+  'enterprise_feature_categories',
   'shipping_year',
   'owner',
   'editors',

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -2105,8 +2105,10 @@ export const ALL_FIELDS: Record<string, Field> = {
     type: 'multiselect',
     choices: ENTERPRISE_FEATURE_CATEGORIES,
     required: false,
-    label: 'Categories',
-    help_text: html` Select all that apply.`,
+    label: 'Enterprise feature categories',
+    help_text: html` If your feature impacts enterprise users, select at least
+    one.`,
+    enterprise_help_text: html` Select all that apply.`,
   },
 
   enterprise_impact: {


### PR DESCRIPTION
This should resolve b/446658199.

In this PR:
* Add the field `enterprise_feature_category` to the feature entry creation page, and give it new non-enterprise help text.
* Add logic to make that field required based on the value of `enterprise_impact`.