### PR TITLE
Add test delay after feature creation, and use bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VARIANT=3.13-bullseye
+ARG PYTHON_VARIANT=3.13-bookworm
 FROM python:${PYTHON_VARIANT} as app
 
 RUN groupadd -g 1001 appuser && \

--- a/packages/playwright/tests/test_utils.js
+++ b/packages/playwright/tests/test_utils.js
@@ -366,6 +366,7 @@ export async function createNewFeature(page) {
   await page.waitForURL('**/feature/*');
   await delay(1500);
   await page.locator('chromedash-feature-detail');
+  await delay(1500);
 }
 
 export async function gotoNewFeatureList(page) {


### PR DESCRIPTION
Fairly often our tests fail on this step.  Looking at the actual screenshots, I see that the skeletons are still showing, which should not be possible given that the test code awaits for the element the replaces the skeletons.  However, maybe there is a slight delay between updating the DOM and updating the rendered page.  So, I am adding a delay.