### PR TITLE
Fix syntax error in intent template

### DIFF
--- a/internals/testdata/notifier_test/test_make_intent_email.html
+++ b/internals/testdata/notifier_test/test_make_intent_email.html
@@ -50,6 +50,7 @@ None
     Does this intent deprecate or change behavior of existing APIs,
     such that it has potentially high risk for Android WebView-based
     applications?
+  </p>
   None
 
 </div> <!-- end risks -->

--- a/pages/testdata/intentpreview_test/test_html_ot_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_ot_rendering.html
@@ -53,6 +53,7 @@ None
     Does this intent deprecate or change behavior of existing APIs,
     such that it has potentially high risk for Android WebView-based
     applications?
+  </p>
   None
 
 </div> <!-- end risks -->

--- a/pages/testdata/intentpreview_test/test_html_prototype_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_prototype_rendering.html
@@ -53,6 +53,7 @@ None
     Does this intent deprecate or change behavior of existing APIs,
     such that it has potentially high risk for Android WebView-based
     applications?
+  </p>
   None
 
 </div> <!-- end risks -->

--- a/pages/testdata/intentpreview_test/test_html_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_rendering.html
@@ -226,6 +226,7 @@ None
     Does this intent deprecate or change behavior of existing APIs,
     such that it has potentially high risk for Android WebView-based
     applications?
+  </p>
   None
 
 </div> <!-- end risks -->

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -193,6 +193,7 @@
     Does this intent deprecate or change behavior of existing APIs,
     such that it has potentially high risk for Android WebView-based
     applications?
+  </p>
   {{feature.webview_risks|urlize}}
 
 </div> <!-- end risks -->
@@ -344,6 +345,7 @@
     Does the feature depend on any code or APIs outside the Chromium
     open source repository and its open-source dependencies to
     function?
+  </p>
   {{feature.non_oss_deps|urlize}}
 {%- endif -%}
 
@@ -374,6 +376,7 @@
     issues in the project for the feature specification) whose resolution
     may introduce web compat/interop risk (e.g., changing to naming or
     structure of the API in a non-backward-compatible way).
+  </p>
   {{feature.anticipated_spec_changes|urlize}}
 {%- endif -%}
 


### PR DESCRIPTION
Fixes #5423 

A heavy-handed change on my part caused this issue where existing p tags in the intent template are not closed. This change addresses that.