### PR TITLE
Fix the new usage of enterprise_feature_categories.

### DIFF
--- a/client-src/elements/chromedash-guide-new-page.ts
+++ b/client-src/elements/chromedash-guide-new-page.ts
@@ -124,7 +124,8 @@ export class ChromedashGuideNewPage extends LitElement {
       }
     }
     enterpriseFeatureCategoriesField.forceRequired =
-      enterpriseImpact > ENTERPRISE_IMPACT.IMPACT_NONE[0];
+      enterpriseImpact > ENTERPRISE_IMPACT.IMPACT_NONE[0] ||
+      this.isEnterpriseFeature;
   }
 
   // Handler to update form values when a field update event is fired.

--- a/client-src/elements/form-definition.ts
+++ b/client-src/elements/form-definition.ts
@@ -197,6 +197,7 @@ export const FLAT_METADATA_FIELDS: MetadataFields = {
         'summary',
         'unlisted',
         'enterprise_impact',
+        'enterprise_feature_categories',
         'shipping_year',
         'owner',
         'editors',

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -2108,7 +2108,7 @@ export const ALL_FIELDS: Record<string, Field> = {
     label: 'Enterprise feature categories',
     help_text: html` If your feature impacts enterprise users, select at least
     one.`,
-    enterprise_help_text: html` Select all that apply.`,
+    enterprise_help_text: html` Select at least one.`,
   },
 
   enterprise_impact: {

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -79,6 +79,8 @@ class FeatureCreateHandler(basehandlers.FlaskHandler):
     # Write for new FeatureEntry entity.
     feature_entry = FeatureEntry(
         category=int(self.form.get('category')),
+        enterprise_feature_categories=self.form.getlist(
+            'enterprise_feature_categories'),
         name=self.form.get('name'),
         feature_type=feature_type,
         summary=self.form.get('summary'),


### PR DESCRIPTION
This is a follow-up to #5447.  I had focused too much on making that field conditionally required and failed to think through how it would be saved and later edited.

In this PR:
* Also make the enterprise_feature_categories field required when creating an enterprise feature entry.  This is done through TS logic rather than simply marking the field always required because it is not always required for non-enterprise features.
* Add enterprise_feature_categories to the WP feature metadata editing form.  Without this, there would be no way so edit it after feature entry creation.
* Update the help text for enterprise feature creation to indicate that the user must choose at lease one value.
* Actually process the form field when submitted to the server.  I had though that this would go through features_api.py but this is still a full form submission.