### PR TITLE
Fix handling of true initial value for checkboxes.

### DIFF
--- a/client-src/elements/chromedash-form-field.ts
+++ b/client-src/elements/chromedash-form-field.ts
@@ -303,7 +303,7 @@ export class ChromedashFormField extends LitElement {
           name="${fieldName}"
           id="id_${this.name}"
           size="small"
-          ?checked=${fieldValue === 'true' || fieldValue === 'True'}
+          ?checked=${fieldValue === true || fieldValue === 'true' || fieldValue === 'True'}
           ?disabled=${this.disabled || fieldDisabled}
           @sl-change="${this.handleFieldUpdated}"
         >

--- a/client-src/elements/chromedash-form-field_test.ts
+++ b/client-src/elements/chromedash-form-field_test.ts
@@ -36,6 +36,24 @@ describe('chromedash-form-field', () => {
     assert.include(renderElement.innerHTML, 'A specific label');
   });
 
+  it('initially checks a checkbox based on initial', async () => {
+    const component = await fixture(
+      html` <chromedash-form-field
+        name="confidential"
+      >
+      </chromedash-form-field>`
+    );
+    assert.exists(component);
+    assert.instanceOf(component, ChromedashFormField);
+    const fieldRow = component.renderRoot.querySelector('tr');
+    assert.exists(fieldRow);
+
+    const renderElement = component.renderRoot as HTMLElement;
+    assert.include(renderElement.innerHTML, 'Confidential');
+    assert.include(renderElement.innerHTML, 'sl-checkbox');
+    assert.include(renderElement.innerHTML, 'checked');
+  });
+
   it('renders a select type of field', async () => {
     const component = await fixture(
       html` <chromedash-form-field name="category" value="0">


### PR DESCRIPTION
This fixes a problem found while testing #5449.  I had marked the form field definition as a checkbox that would be checked by default, however the logic to set the `checked` attribute was looking for a string value passed from the server rather than correctly handling a TS boolean constant.