### PR TITLE
Fix white-space and <code> for markdown.

### DIFF
--- a/client-src/css/shared-css.js
+++ b/client-src/css/shared-css.js
@@ -139,7 +139,6 @@ export const SHARED_STYLES = [
   }
 
   code {
-   white-space: nowrap;
    font-family: monospace;
   }
 

--- a/client-src/elements/chromedash-enterprise-release-notes-page.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page.ts
@@ -127,7 +127,7 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
           padding-inline-start: 1rem;
         }
 
-        li {
+        .stages li {
           margin-block-end: 16px;
         }
 
@@ -741,12 +741,13 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
   }
 
   renderFeatureSummary(f: Feature): TemplateResult {
-    const markup = autolink(
-      f.summary,
-      [],
-      (f.markdown_fields || []).includes('summary')
-    );
-    return html` <p class="summary preformatted">${markup}</p>`;
+    const isMarkdown = (f.markdown_fields || []).includes('summary');
+    const markup = autolink(f.summary, [], isMarkdown);
+    if (isMarkdown) {
+      return html`${markup}`;
+    } else {
+      return html`<p class="summary preformatted">${markup}</p>`;
+    }
   }
 
   renderEditableFeatureSummary(f: Feature): TemplateResult {
@@ -871,7 +872,7 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
       ${isEditing
         ? this.renderEditableFeatureSummary(f)
         : this.renderFeatureSummary(f)}
-      <ul>
+      <ul class="stages">
         ${f.stages.map(s =>
           isEditing && s.id
             ? this.renderEditableStageItem(f, s, shouldDisplayStageTitleInBold)

--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -187,7 +187,6 @@ export class ChromedashFeatureDetail extends LitElement {
         .longtext {
           display: block;
           white-space: pre-wrap;
-          padding: var(--content-padding-half);
         }
 
         .longurl {
@@ -351,6 +350,9 @@ export class ChromedashFeatureDetail extends LitElement {
       this.featureLinks,
       isMarkdown
     );
+    if (isMarkdown) {
+      return html`${markup}`;
+    }
     if (value.length > LONG_TEXT || value.includes('\n')) {
       return html`<span class="longtext">${markup}</span>`;
     }

--- a/client-src/elements/chromedash-feature-highlights.ts
+++ b/client-src/elements/chromedash-feature-highlights.ts
@@ -86,14 +86,18 @@ export class ChromedashFeatureHighlights extends LitElement {
 
   renderSummary() {
     if (this.feature.summary) {
+      const isMarkdown = (this.feature.markdown_fields || []).includes(
+        'summary'
+      );
+
       const markup = autolink(
         this.feature.summary,
         this.featureLinks,
-        (this.feature.markdown_fields || []).includes('summary')
+        isMarkdown
       );
       return html`
         <section id="summary">
-          <p class="preformatted">${markup}</p>
+          ${isMarkdown ? markup : html`<p class="preformatted">${markup}</p>`}
         </section>
       `;
     } else {


### PR DESCRIPTION
This is progress toward #5212.  It improves the display of rendered markdown.

Basically, in places where markdown will be rendered, we will insert it directly into the DOM of whatever element is doing that rendering.  Since all of our elements import shared CSS styles, those styles affect the rendered markdown too.  That is desired so that, e.g., link color is consistent with other links on the site.  But, it means that our shared CSS styles should not be too heavy-handed.

In this PR:
* Don't set `white-space: nowrap` for all `<code>` elements because some of them have newlines.  We don't use the `<code>` element elsewhere on the site (except in places where it is explicitly styled).
* Add a CSS class to the release notes stages `<ul>` so that it can be styled without adding a lot of space to bullet items in markdown.
* The rendered markdown usually starts with a `<p>` tag, so we don't want to place it inside another `<p>` tag like we were doing with the non-markdown autolink text.