### PR TITLE
Remove finch fields from I2P

### DIFF
--- a/pages/intentpreview_test.py
+++ b/pages/intentpreview_test.py
@@ -266,9 +266,9 @@ class IntentEmailPreviewTemplateTest(testing_config.CustomTestCase):
                        gate_type=3, state=Vote.NA)
     self.gate_1.put()
 
-    self.stage_2 = Stage(id=200, feature_id=234, stage_type=110)
+    self.stage_2 = Stage(id=200, feature_id=234, stage_type=120)
     self.stage_2.put()
-    self.gate_2 = Gate(id=201, feature_id=234, stage_id=100,
+    self.gate_2 = Gate(id=201, feature_id=234, stage_id=200,
                        gate_type=1, state=Vote.NA)
     self.gate_2.put()
     self.request_path = '/admin/features/launch/%d/%d?intent' % (

--- a/pages/testdata/intentpreview_test/test_html_prototype_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_prototype_rendering.html
@@ -21,6 +21,13 @@ sum
 
 <br>
 <br>
+<div><b>Motivation</b></div>
+  None
+<br>
+<br>
+<div><b>Initial public proposal</b></div>
+  None<br>
+<br>
 <div><b>TAG review</b></div>
 None
 
@@ -60,34 +67,12 @@ None
 
 <br>
 <br>
-<div><b>Goals for experimentation</b></div>
-  <br>
-<br>
-<div><b>Ongoing technical constraints</b></div>
-  None<br>
-<br>
 <div><b>Debuggability</b></div>
 None
 
 <br>
 <br>
-<div><b>Will this feature be supported on all six Blink platforms
-      (Windows, Mac, Linux, ChromeOS, Android, and Android WebView)?</b></div>No<br>
-<br>
 <div><b>Is this feature fully tested by <a href="https://chromium.googlesource.com/chromium/src/+/main/docs/testing/web_platform_tests.md">web-platform-tests</a>?</b></div>YesWe love WPT!<br>
-<br>
-<div><b>Flag name on about://flags</b></div>
-None
-
-<br>
-<br>
-<div><b>Finch feature name</b></div>
-None
-
-<br>
-<br>
-<div><b>Non-finch justification</b></div>
-  None<br>
 <br>
 <div><b>Requires code in //chrome?</b></div>
 False<br>

--- a/pages/testdata/intentpreview_test/test_html_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_rendering.html
@@ -240,19 +240,6 @@ None
 <br>
 <div><b>Is this feature fully tested by <a href="https://chromium.googlesource.com/chromium/src/+/main/docs/testing/web_platform_tests.md">web-platform-tests</a>?</b></div>YesWe love WPT!<br>
 <br>
-<div><b>Flag name on about://flags</b></div>
-None
-
-<br>
-<br>
-<div><b>Finch feature name</b></div>
-None
-
-<br>
-<br>
-<div><b>Non-finch justification</b></div>
-  None<br>
-<br>
 <div><b>Requires code in //chrome?</b></div>
 False<br>
 <br>

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -261,6 +261,7 @@
      >{{feature.devtrial_instructions}}</a>
 {%- endif -%}
 
+{%- if 'experiment' in sections_to_show or 'ship' in sections_to_show -%}
 <br>
 <br>
 <div><b>Flag name on about://flags</b></div>
@@ -281,6 +282,7 @@
 <br>
 <div><b>Non-finch justification</b></div>
   None
+{%- endif -%}
 {%- endif -%}
 
 {%- if 'ship' in sections_to_show -%}


### PR DESCRIPTION
Fixes #4485

This change adds finch fields to intent templates only if the "experiment" or "ship" sections are flagged to be shown, which hides the value in I2P's.

Additionally, a small change is made to the IDs in intentpreview_test to fix a bug in the tests (the intent prototype test was testing the wrong stage type).