### PR TITLE
Sort release notes items by enterprise_impact.

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -230,7 +230,7 @@ def stage_to_json_dict(
     'rollout_milestone': stage.rollout_milestone,
     'rollout_platforms': stage.rollout_platforms,
     'rollout_details': stage.rollout_details,
-    'rollout_impact': stage.rollout_impact,
+    'rollout_impact': stage.rollout_impact,  # Deprecated
     'enterprise_policies': stage.enterprise_policies,
 
     # Milestone fields to be populated later.

--- a/api/converters.py
+++ b/api/converters.py
@@ -230,6 +230,7 @@ def stage_to_json_dict(
     'rollout_milestone': stage.rollout_milestone,
     'rollout_platforms': stage.rollout_platforms,
     'rollout_details': stage.rollout_details,
+    # TODO(jrobbins): remove this in the next deployment.
     'rollout_impact': stage.rollout_impact,  # Deprecated
     'enterprise_policies': stage.enterprise_policies,
 

--- a/client-src/elements/chromedash-enterprise-release-notes-page.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page.ts
@@ -12,6 +12,7 @@ import {Feature, User, StageDict} from '../js-src/cs-client.js';
 import {
   ENTERPRISE_FEATURE_CATEGORIES,
   ENTERPRISE_PRODUCT_CATEGORY,
+  ENTERPRISE_IMPACT_DISPLAYNAME,
   PLATFORM_CATEGORIES,
   PLATFORMS_DISPLAYNAME,
   STAGE_ENT_ROLLOUT,
@@ -264,7 +265,6 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
         stage_type: STAGE_ENT_ROLLOUT,
         rollout_milestone: Number(milestone),
         rollout_platforms: Array.from(platforms).map(String),
-        rollout_impact: 1,
       })
     );
   }
@@ -311,19 +311,8 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
         stages.some(s => s.rollout_milestone === this.selectedMilestone)
       )
       .sort((a, b) => {
-        // Highest impact of the stages from feature A.
-        const impactA = Math.max(
-          ...a.stages
-            .filter(s => s.rollout_milestone === this.selectedMilestone)
-            .map(s => s.rollout_impact ?? 0)
-        );
-        // Highest impact of the stages from feature B.
-        const impactB = Math.max(
-          ...b.stages
-            .filter(s => s.rollout_milestone === this.selectedMilestone)
-            .map(s => s.rollout_impact ?? 0)
-        );
-        return impactB - impactA;
+        // Descending order
+        return b.enterprise_impact - a.enterprise_impact;
       });
 
     this.currentChromeBrowserUpdates = currentFeatures.filter(
@@ -672,8 +661,11 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
         - <a target="_blank" href="/feature/${f.id}">Feature details</a> -
         <b>Owners:</b> ${f.browsers.chrome.owners?.join(', ')} -
         <b>Editors:</b> ${(f.editors || []).join(', ')} -
-        <b>First Notice:</b> ${f.first_enterprise_notification_milestone} -
-        <b>Last Updated:</b>
+        <b>Enterprise impact:</b> ${ENTERPRISE_IMPACT_DISPLAYNAME[
+          f.enterprise_impact
+        ]}
+        - <b>First notice:</b> ${f.first_enterprise_notification_milestone} -
+        <b>Last updated:</b>
         <a
           href="/feature/${f.id}/activity"
           target="_blank"

--- a/client-src/elements/chromedash-enterprise-release-notes-page_test.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page_test.ts
@@ -529,8 +529,8 @@ describe('chromedash-enterprise-release-notes-page', () => {
           features[0].querySelector('strong')!.textContent);
         assert.equal(
           '< To remove - Feature details - ' +
-          'Owners: owner - Editors: editor1, editor2 - First Notice: n_milestone_feat_6 - ' +
-            'Last Updated: ( ) by updater6 >',
+            'Owners: owner - Editors: editor1, editor2 - Enterprise impact: Medium - First notice: n_milestone_feat_6 - ' +
+            'Last updated: ( ) by updater6 >',
           normalizedTextContent(features[0].querySelector('.toremove')));
         assert.equal(
           'feature 6 summary',
@@ -567,8 +567,8 @@ describe('chromedash-enterprise-release-notes-page', () => {
           features[0].querySelector('strong')!.textContent);
         assert.equal(
           '< To remove - Feature details - ' +
-          'Owners: owner - Editors: editor1, editor2 - First Notice: n_milestone_feat_8 - ' +
-            'Last Updated: by updater8 >',
+            'Owners: owner - Editors: editor1, editor2 - Enterprise impact: Medium - First notice: n_milestone_feat_8 - ' +
+            'Last updated: by updater8 >',
           normalizedTextContent(features[0].querySelector('.toremove')));
         assert.equal(
           'future premium feature summary',

--- a/client-src/elements/chromedash-enterprise-release-notes-page_test.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page_test.ts
@@ -2,6 +2,7 @@ import {html} from 'lit';
 import {assert, fixture, nextFrame} from '@open-wc/testing';
 import {SlButton} from '@shoelace-style/shoelace';
 import {ChromedashEnterpriseReleaseNotesPage} from './chromedash-enterprise-release-notes-page';
+import {ENTERPRISE_IMPACT} from './form-field-enums.js';
 import {parseRawQuery, clearURLParams} from './utils.js';
 import './chromedash-toast';
 import {ChromeStatusClient} from '../js-src/cs-client';
@@ -81,6 +82,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
           editors: ['editor1', 'editor2'],
           enterprise_feature_categories: ['1', '2', '3'],
           enterprise_product_category: 0,
+          enterprise_impact: ENTERPRISE_IMPACT.IMPACT_LOW[0],
           first_enterprise_notification_milestone: 'n_milestone_feat_3',
           stages: [
             {
@@ -88,7 +90,6 @@ describe('chromedash-enterprise-release-notes-page', () => {
               stage_type: 1061,
               rollout_milestone: 100,
               rollout_details: 'fake rollout details 100',
-              rollout_impact: 1,
               rollout_platforms: [],
             },
             {
@@ -115,6 +116,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
           editors: ['editor1'],
           enterprise_feature_categories: ['3'],
           enterprise_product_category: 1,
+          enterprise_impact: ENTERPRISE_IMPACT.IMPACT_MEDIUM[0],
           first_enterprise_notification_milestone: 'n_milestone_feat_4',
           stages: [
             {
@@ -122,7 +124,6 @@ describe('chromedash-enterprise-release-notes-page', () => {
               stage_type: 1061,
               rollout_milestone: 100,
               rollout_details: 'fake rollout details 100',
-              rollout_impact: 2,
               rollout_platforms: [],
             },
             {
@@ -130,7 +131,6 @@ describe('chromedash-enterprise-release-notes-page', () => {
               stage_type: 1061,
               rollout_milestone: 101,
               rollout_details: 'fake rollout details 101',
-              rollout_impact: 2,
               rollout_platforms: [],
             },
           ],
@@ -153,6 +153,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
           editors: ['editor1', 'editor2'],
           enterprise_feature_categories: ['2'],
           enterprise_product_category: 3,
+          enterprise_impact: ENTERPRISE_IMPACT.IMPACT_HIGH[0],
           first_enterprise_notification_milestone: 'n_milestone_feat_5',
           stages: [
             {
@@ -160,7 +161,6 @@ describe('chromedash-enterprise-release-notes-page', () => {
               stage_type: 1061,
               rollout_milestone: 1,
               rollout_details: 'fake rollout details 1',
-              rollout_impact: 3,
               rollout_platforms: [],
             },
             {
@@ -168,7 +168,6 @@ describe('chromedash-enterprise-release-notes-page', () => {
               stage_type: 1061,
               rollout_milestone: 1000,
               rollout_details: 'fake rollout details 1000',
-              rollout_impact: 2,
               rollout_platforms: [],
             },
           ],
@@ -191,6 +190,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
           editors: ['editor1', 'editor2'],
           enterprise_feature_categories: ['2'],
           enterprise_product_category: 0,
+          enterprise_impact: ENTERPRISE_IMPACT.IMPACT_MEDIUM[0],
           first_enterprise_notification_milestone: 'n_milestone_feat_6',
           stages: [
             {
@@ -198,7 +198,6 @@ describe('chromedash-enterprise-release-notes-page', () => {
               stage_type: 1061,
               rollout_milestone: 999,
               rollout_details: 'fake rollout details 999',
-              rollout_impact: 2,
               rollout_platforms: [],
             },
           ],
@@ -221,6 +220,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
           editors: ['editor1', 'editor2'],
           enterprise_feature_categories: [],
           enterprise_product_category: 1,
+          enterprise_impact: ENTERPRISE_IMPACT.IMPACT_NONE[0],
           first_enterprise_notification_milestone: 'n_milestone_feat_7',
           stages: [
             {
@@ -255,6 +255,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
           editors: ['editor1', 'editor2'],
           enterprise_feature_categories: [],
           enterprise_product_category: 2,
+          enterprise_impact: ENTERPRISE_IMPACT.IMPACT_MEDIUM[0],
           first_enterprise_notification_milestone: 'n_milestone_feat_8',
           stages: [
             {
@@ -262,7 +263,6 @@ describe('chromedash-enterprise-release-notes-page', () => {
               stage_type: 1061,
               rollout_milestone: 1000,
               rollout_details: 'fake rollout details 1000',
-              rollout_impact: 2,
               rollout_platforms: [],
             },
           ],

--- a/client-src/elements/chromedash-guide-stage-page_test.ts
+++ b/client-src/elements/chromedash-guide-stage-page_test.ts
@@ -77,7 +77,6 @@ describe('chromedash-guide-stage-page', () => {
     ot_stage_id: null,
     announcement_url: null,
     finch_url: null,
-    rollout_impact: null,
     rollout_milestone: null,
     rollout_platforms: [],
     rollout_details: null,

--- a/client-src/elements/form-field-enums.ts
+++ b/client-src/elements/form-field-enums.ts
@@ -80,18 +80,6 @@ export const ENTERPRISE_IMPACT: Record<string, [number, string]> = {
   IMPACT_HIGH: [4, 'High'],
 };
 
-export const ROLLOUT_IMPACT: Record<string, [number, string]> = {
-  IMPACT_LOW: [1, 'Low'],
-  IMPACT_MEDIUM: [2, 'Medium'],
-  IMPACT_HIGH: [3, 'High'],
-};
-
-export const ROLLOUT_IMPACT_DISPLAYNAME: Record<number, string> = {
-  1: 'Low', // IMPACT_LOW
-  2: 'Medium', // IMPACT_MEDIUM
-  3: 'High', // IMPACT_HIGH
-};
-
 export const ROLLOUT_PLAN: Record<string, [number, string]> = {
   ROLLOUT_100: [0, 'Will ship enabled for all users'],
   ROLLOUT_0_THEN_100: [1, '(RARE) Ships disabled, then flips on for all users'],
@@ -446,7 +434,6 @@ export const STAGE_SPECIFIC_FIELDS = new Set<string>([
   'experiment_goals',
   'experiment_risks',
   'experiment_extension_reason',
-  'rollout_impact',
   'rollout_milestone',
   'rollout_platforms',
   'rollout_details',

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -13,7 +13,6 @@ import {
   OT_MILESTONE_START_FIELDS,
   PLATFORM_CATEGORIES,
   REVIEW_STATUS_CHOICES,
-  ROLLOUT_IMPACT,
   ROLLOUT_PLAN,
   SHIPPED_MILESTONE_FIELDS,
   STAGE_TYPES_DEV_TRIAL,
@@ -2125,16 +2124,6 @@ export const ALL_FIELDS: Record<string, Field> = {
     introduces a breaking change on the stable channel, or seriously changes the
     experience of using Chrome. Use your judgment; Enterprise reviewers can help
     judge risk if you're unsure.`,
-  },
-
-  rollout_impact: {
-    type: 'select',
-    choices: ROLLOUT_IMPACT,
-    initial: ROLLOUT_IMPACT.IMPACT_MEDIUM[0],
-    label: 'Impact',
-    help_text: html` A stage is probably high impact if it introduces a breaking
-    change on the stable channel, or seriously changes the experience of using
-    Chrome. Use your judgment; if you're unsure, most stages are Medium impact.`,
   },
 
   rollout_milestone: {

--- a/client-src/elements/queriable-fields.ts
+++ b/client-src/elements/queriable-fields.ts
@@ -9,7 +9,6 @@ import {
   IMPLEMENTATION_STATUS,
   INTENT_STAGES,
   REVIEW_STATUS_CHOICES,
-  ROLLOUT_IMPACT,
   VENDOR_VIEWS_COMMON,
   VENDOR_VIEWS_GECKO,
   WEB_DEV_VIEWS,
@@ -222,12 +221,6 @@ export const QUERIABLE_FIELDS: QueryField[] = [
     kind: ENUM_KIND,
     doc: 'Spec process stage',
     choices: INTENT_STAGES,
-  },
-  {
-    name: 'rollout_impact',
-    kind: ENUM_KIND,
-    doc: 'Impact',
-    choices: ROLLOUT_IMPACT,
   },
   // TODO: rollout_platforms is not yet supported.
   // {name: 'rollout_platforms', kind: ENUM_KIND,

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -14,7 +14,6 @@ import {
   OT_MILESTONE_END_FIELDS,
   OT_SETUP_STATUS_OPTIONS,
   PLATFORMS_DISPLAYNAME,
-  ROLLOUT_IMPACT_DISPLAYNAME,
   ROLLOUT_PLAN_DISPLAYNAME,
   STAGE_FIELD_NAME_MAPPING,
   STAGE_SPECIFIC_FIELDS,
@@ -239,9 +238,6 @@ export function getFieldValueFromFeature(
 ) {
   if (STAGE_SPECIFIC_FIELDS.has(fieldName)) {
     const value = getStageValue(feStage, fieldName);
-    if (fieldName === 'rollout_impact' && value) {
-      return ROLLOUT_IMPACT_DISPLAYNAME[value];
-    }
     if (fieldName === 'rollout_platforms' && value) {
       return value.map(platformId => PLATFORMS_DISPLAYNAME[platformId]);
     } else if (fieldName in OT_MILESTONE_END_FIELDS) {

--- a/client-src/js-src/cs-client.js
+++ b/client-src/js-src/cs-client.js
@@ -80,7 +80,6 @@
  * @property {string} [experiment_extension_reason]
  * @property {string} [finch_url]
  * @property {string} [rollout_details]
- * @property {number} [rollout_impact]
  * @property {number} [rollout_milestone]
  * @property {string[]} rollout_platforms
  * @property {string[]} enterprise_policies

--- a/internals/core_models.py
+++ b/internals/core_models.py
@@ -362,8 +362,8 @@ class Stage(ndb.Model):
   # Origin trial stage id that this stage extends, if trial extension stage.
   ot_stage_id = ndb.IntegerProperty()
 
-  #Enterprise
-  rollout_impact = ndb.IntegerProperty(default=2) # default to "Medium impact"
+  # Enterprise
+  rollout_impact = ndb.IntegerProperty(default=2) # deprecated
   # rollout_milestone will be migrated to milestones.desktop_first as the
   # default "start" milestone.
   rollout_milestone = ndb.IntegerProperty()

--- a/pages/guide.py
+++ b/pages/guide.py
@@ -178,6 +178,7 @@ class EnterpriseFeatureCreateHandler(FeatureCreateHandler):
         blink_components=[settings.DEFAULT_ENTERPRISE_COMPONENT],
         confidential=self.form.get('confidential') == 'on',
         enterprise_product_category=int(self.form.get('enterprise_product_category', '0')),
+        enterprise_impact=int(self.form.get('enterprise_impact', '1')),
         tag_review_status=core_enums.REVIEW_NA)
     key: ndb.Key = feature_entry.put()
     search_fulltext.index_feature(feature_entry)


### PR DESCRIPTION
This should resolve #5486.

In 2023, we used rollout_impact that was specified on each stage, but in 2024 we started to phase that out and use feature.enterprise_impact instead.  A few places were missed in removing rollout_impact, so this makes progress on finishing that work.

In this PR:
* Mark the field as deprecated in the server source code and add a TODO to remove it entirely.
* On the release notes page, sort features by enterprise_impact rather than rollout_impact.  And, add it to the "to remove" section for visibility.
* On the client-side, remove the rollout_impact field spec, because it was not used in any form, and remove it from the list of searchable fields.
* Fix the enterprise feature creation page to actually store the entered enterprise_impact.