### PR TITLE
No repeated fields shown on edit-all page

### DIFF
--- a/client-src/elements/chromedash-guide-editall-page.ts
+++ b/client-src/elements/chromedash-guide-editall-page.ts
@@ -238,7 +238,7 @@ export class ChromedashGuideEditallPage extends LitElement {
     sectionBaseName,
     feStage,
     stageFields,
-    featureFieldsDisplayed: Set<string>,
+    featureFieldsDisplayed: Set<string>
   ) {
     if (!stageFields) return nothing;
 
@@ -357,7 +357,7 @@ export class ChromedashGuideEditallPage extends LitElement {
         FLAT_METADATA_FIELDS.name,
         {id: -1},
         fieldsOnly,
-        featureFieldsDisplayed,
+        featureFieldsDisplayed
       ),
     ];
 
@@ -405,7 +405,7 @@ export class ChromedashGuideEditallPage extends LitElement {
             sectionName,
             extensionStage,
             fieldsOnly,
-            featureFieldsDisplayed,
+            featureFieldsDisplayed
           )
         );
       });

--- a/client-src/elements/chromedash-guide-editall-page_test.ts
+++ b/client-src/elements/chromedash-guide-editall-page_test.ts
@@ -158,7 +158,9 @@ describe('chromedash-guide-editall-page', () => {
     await component.updateComplete;
 
     // Find all the sections for the duplicated stage type.
-    const sections = component.renderRoot.querySelectorAll('section[stage="160"]');
+    const sections = component.renderRoot.querySelectorAll(
+      'section[stage="160"]'
+    );
     assert.equal(
       sections.length,
       2,
@@ -166,10 +168,12 @@ describe('chromedash-guide-editall-page', () => {
     );
 
     // Get all the form fields within each section.
-    const firstSectionFields =
-      sections[0].querySelectorAll('chromedash-form-field');
-    const secondSectionFields =
-      sections[1].querySelectorAll('chromedash-form-field');
+    const firstSectionFields = sections[0].querySelectorAll(
+      'chromedash-form-field'
+    );
+    const secondSectionFields = sections[1].querySelectorAll(
+      'chromedash-form-field'
+    );
 
     assert.isAbove(
       firstSectionFields.length,


### PR DESCRIPTION
Fixes #5515

The previous logic avoided repeated features fields only in stages of the same type (for example, two origin trial stages). This change now avoids any non-stage field from being repeated on the edit-all page.