### PR TITLE
Clearer default value for fields with no value provided in intent templates

### DIFF
--- a/internals/testdata/notifier_test/test_make_intent_email.html
+++ b/internals/testdata/notifier_test/test_make_intent_email.html
@@ -2,7 +2,7 @@
 <br>
 
 <div><b>Specification</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -15,12 +15,12 @@ sum
 <a href="https://issues.chromium.org/issues?q=customfield1222907:%22Blink%22" target="_blank" rel="noopener">Blink</a><br>
 <br>
 <div><b>Web Feature ID</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
 <div><b>TAG review</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -32,7 +32,7 @@ sum
 <br>
 <br>
 <div><b>Interoperability and Compatibility</b></div>
-  <i>No value provided</i>
+  <i>No information provided</i>
 <br>
 <br>
 <i>Gecko</i>: No signal<br>
@@ -49,18 +49,18 @@ sum
     such that it has potentially high risk for Android WebView-based
     applications?
   </p>
-  <i>No value provided</i>
+  <i>No information provided</i>
 
 </div> <!-- end risks --> <br>
 <br>
 <div><b>Goals for experimentation</b></div>
-  <i>No value provided</i><br>
+  <i>No information provided</i><br>
 <br>
 <div><b>Ongoing technical constraints</b></div>
-  <i>No value provided</i><br>
+  <i>No information provided</i><br>
 <br>
 <div><b>Debuggability</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -73,17 +73,17 @@ No
 <br>
 <br>
 <div><b>Flag name on about://flags</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
 <div><b>Finch feature name</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
 <div><b>Non-finch justification</b></div>
-  <i>No value provided</i><br>
+  <i>No information provided</i><br>
 <br>
 <div><b>Requires code in //chrome?</b></div>
 False<br>

--- a/pages/testdata/intentpreview_test/test_html_ot_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_ot_rendering.html
@@ -1,10 +1,10 @@
 <div><b>Contact emails</b></div><a href="mailto:user1@google.com">user1@google.com</a><br>
 <br>
-<div><b>Explainer</b></div><i>No value provided</i><br>
+<div><b>Explainer</b></div><i>No information provided</i><br>
 <br>
 
 <div><b>Specification</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -22,7 +22,7 @@ sum
 <br>
 <br>
 <div><b>TAG review</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -37,7 +37,7 @@ sum
 <br>
 <br>
 <div><b>Interoperability and Compatibility</b></div>
-  <i>No value provided</i>
+  <i>No information provided</i>
 <br>
 <br>
 <i>Gecko</i>: No signal<br>
@@ -54,18 +54,18 @@ sum
     such that it has potentially high risk for Android WebView-based
     applications?
   </p>
-  <i>No value provided</i>
+  <i>No information provided</i>
 
 </div> <!-- end risks --> <br>
 <br>
 <div><b>Goals for experimentation</b></div>
-  <i>No value provided</i><br>
+  <i>No information provided</i><br>
 <br>
 <div><b>Ongoing technical constraints</b></div>
-  <i>No value provided</i><br>
+  <i>No information provided</i><br>
 <br>
 <div><b>Debuggability</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -78,17 +78,17 @@ Yes
 WPT description, <a href="https://example.com/wpt" rel="noopener">https://example.com/wpt</a><br>
 <br>
 <div><b>Flag name on about://flags</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
 <div><b>Finch feature name</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
 <div><b>Non-finch justification</b></div>
-  <i>No value provided</i><br>
+  <i>No information provided</i><br>
 <br>
 <div><b>Requires code in //chrome?</b></div>
 False<br>

--- a/pages/testdata/intentpreview_test/test_html_prototype_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_prototype_rendering.html
@@ -1,10 +1,10 @@
 <div><b>Contact emails</b></div><a href="mailto:user1@google.com">user1@google.com</a><br>
 <br>
-<div><b>Explainer</b></div><i>No value provided</i><br>
+<div><b>Explainer</b></div><i>No information provided</i><br>
 <br>
 
 <div><b>Specification</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -22,7 +22,7 @@ sum
 <br>
 <br>
 <div><b>TAG review</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -37,7 +37,7 @@ sum
 <br>
 <br>
 <div><b>Interoperability and Compatibility</b></div>
-  <i>No value provided</i>
+  <i>No information provided</i>
 <br>
 <br>
 <i>Gecko</i>: No signal<br>
@@ -54,18 +54,18 @@ sum
     such that it has potentially high risk for Android WebView-based
     applications?
   </p>
-  <i>No value provided</i>
+  <i>No information provided</i>
 
 </div> <!-- end risks --> <br>
 <br>
 <div><b>Goals for experimentation</b></div>
-  <i>No value provided</i><br>
+  <i>No information provided</i><br>
 <br>
 <div><b>Ongoing technical constraints</b></div>
-  <i>No value provided</i><br>
+  <i>No information provided</i><br>
 <br>
 <div><b>Debuggability</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -78,17 +78,17 @@ Yes
 WPT description, <a href="https://example.com/wpt" rel="noopener">https://example.com/wpt</a><br>
 <br>
 <div><b>Flag name on about://flags</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
 <div><b>Finch feature name</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
 <div><b>Non-finch justification</b></div>
-  <i>No value provided</i><br>
+  <i>No information provided</i><br>
 <br>
 <div><b>Requires code in //chrome?</b></div>
 False<br>

--- a/pages/testdata/intentpreview_test/test_html_psa_ship_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_psa_ship_rendering.html
@@ -2,7 +2,7 @@
 <br>
 
 <div><b>Specification</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -25,7 +25,7 @@ sum
 <br>
 <br>
 <div><b>Interoperability and Compatibility</b></div>
-  <i>No value provided</i>
+  <i>No information provided</i>
 <br>
 <br>
 <i>Gecko</i>: No signal<br>
@@ -42,12 +42,12 @@ sum
     such that it has potentially high risk for Android WebView-based
     applications?
   </p>
-  <i>No value provided</i>
+  <i>No information provided</i>
 
 </div> <!-- end risks --> <br>
 <br>
 <div><b>Debuggability</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -60,17 +60,17 @@ No
 <br>
 <br>
 <div><b>Flag name on about://flags</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
 <div><b>Finch feature name</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
 <div><b>Non-finch justification</b></div>
-  <i>No value provided</i><br>
+  <i>No information provided</i><br>
 <br>
 <div><b>Rollout plan</b></div>
   Will ship enabled for all users<br>

--- a/pages/testdata/intentpreview_test/test_html_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_rendering.html
@@ -166,11 +166,11 @@ limitations under the License.
   <div class="email">
     <div><b>Contact emails</b></div><a href="mailto:user1@google.com">user1@google.com</a><br>
 <br>
-<div><b>Explainer</b></div><i>No value provided</i><br>
+<div><b>Explainer</b></div><i>No information provided</i><br>
 <br>
 
 <div><b>Specification</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -188,14 +188,14 @@ sum
 <br>
 <br>
 <div><b>Motivation</b></div>
-  <i>No value provided</i>
+  <i>No information provided</i>
 <br>
 <br>
 <div><b>Initial public proposal</b></div>
-  <i>No value provided</i><br>
+  <i>No information provided</i><br>
 <br>
 <div><b>TAG review</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -210,7 +210,7 @@ sum
 <br>
 <br>
 <div><b>Interoperability and Compatibility</b></div>
-  <i>No value provided</i>
+  <i>No information provided</i>
 <br>
 <br>
 <i>Gecko</i>: No signal<br>
@@ -227,12 +227,12 @@ sum
     such that it has potentially high risk for Android WebView-based
     applications?
   </p>
-  <i>No value provided</i>
+  <i>No information provided</i>
 
 </div> <!-- end risks --> <br>
 <br>
 <div><b>Debuggability</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>

--- a/pages/testdata/intentpreview_test/test_html_ship_rendering.html
+++ b/pages/testdata/intentpreview_test/test_html_ship_rendering.html
@@ -1,10 +1,10 @@
 <div><b>Contact emails</b></div><a href="mailto:user1@google.com">user1@google.com</a><br>
 <br>
-<div><b>Explainer</b></div><i>No value provided</i><br>
+<div><b>Explainer</b></div><i>No information provided</i><br>
 <br>
 
 <div><b>Specification</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -22,7 +22,7 @@ sum
 <br>
 <br>
 <div><b>TAG review</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -37,7 +37,7 @@ sum
 <br>
 <br>
 <div><b>Interoperability and Compatibility</b></div>
-  <i>No value provided</i>
+  <i>No information provided</i>
 <br>
 <br>
 <i>Gecko</i>: No signal<br>
@@ -54,18 +54,18 @@ sum
     such that it has potentially high risk for Android WebView-based
     applications?
   </p>
-  <i>No value provided</i>
+  <i>No information provided</i>
 
 </div> <!-- end risks --> <br>
 <br>
 <div><b>Goals for experimentation</b></div>
-  <i>No value provided</i><br>
+  <i>No information provided</i><br>
 <br>
 <div><b>Ongoing technical constraints</b></div>
-  <i>No value provided</i><br>
+  <i>No information provided</i><br>
 <br>
 <div><b>Debuggability</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
@@ -78,17 +78,17 @@ Yes
 WPT description, <a href="https://example.com/wpt" rel="noopener">https://example.com/wpt</a><br>
 <br>
 <div><b>Flag name on about://flags</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
 <div><b>Finch feature name</b></div>
-<i>No value provided</i>
+<i>No information provided</i>
 
 <br>
 <br>
 <div><b>Non-finch justification</b></div>
-  <i>No value provided</i><br>
+  <i>No information provided</i><br>
 <br>
 <div><b>Requires code in //chrome?</b></div>
 False<br>

--- a/templates/blink/intent_to_implement.html
+++ b/templates/blink/intent_to_implement.html
@@ -1,18 +1,18 @@
 {%- macro show_value(value) -%}
-  {{ value | default('<i>No value provided</i>', true) | safe }}
+  {{ value | default('<i>No information provided</i>', true) | safe }}
 {%- endmacro -%}
 
 {%- macro urlize_with_default(value) -%}
   {%- if value -%}
     {{ value | urlize | safe }}
   {%- else -%}
-    <i>No value provided</i>
+    <i>No information provided</i>
   {%- endif -%}
 {%- endmacro -%}
 
 <div><b>Contact emails</b></div>
 {%- if not feature.browsers.chrome.owners -%}
-  <i>No value provided</i>
+  <i>No information provided</i>
 {%- else -%}
   {%- for owner in feature.browsers.chrome.owners -%}
     <a href="mailto:{{owner}}">{{owner}}</a>{%- if not loop.last -%}, {% endif %}
@@ -24,7 +24,7 @@
 <br>
 <div><b>Explainer</b></div>
   {%- if not feature.explainer_links -%}
-    <i>No value provided</i>
+    <i>No information provided</i>
   {%- else -%}
     {%- for link in feature.explainer_links -%}
       {% if loop.index0 %}<br>{% endif %}<a href="{{link}}">{{link}}</a>
@@ -42,7 +42,7 @@
 <br>
 <div><b>Design docs</b></div>
   {%- if not feature.explainer_links -%}
-    <i>No value provided</i>
+    <i>No information provided</i>
   {%- endif -%}
   {%- for link in feature.resources.docs -%}
     <br><a href="{{link}}">{{link}}</a>
@@ -68,7 +68,7 @@
 {%- elif feature.web_feature -%}
   {{ show_value(feature.web_feature) }}
 {%- else -%}
-  <i>No value provided</i>
+  <i>No information provided</i>
 {%- endif %}
 
 {% if 'motivation' in sections_to_show -%}
@@ -297,7 +297,7 @@
 <br>
 <br>
 <div><b>Non-finch justification</b></div>
-  <i>No value provided</i>
+  <i>No information provided</i>
 {%- endif -%}
 {%- endif -%}
 


### PR DESCRIPTION
Fixes #4898 

Adds new macros to the Jinja template so that null or empty strings are not directly printed into the intent template.