### PR TITLE
Change description of OT UseCounter field for OT creation

### DIFF
--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -1548,20 +1548,24 @@ export const ALL_FIELDS: Record<string, Field> = {
       placeholder: 'e.g. "kWebFeature"',
       pattern: String.raw`k\S*`,
     },
-    label: 'WebFeature UseCounter name',
+    label: 'UseCounter name',
     help_text: html` For measuring usage, this must be a single named value from
-      the WebFeature enum, e.g. kWorkerStart. The use counter must be landed in
-      either
+      the WebFeature, WebDXFeature, or CSSSampleId enum, e.g. kWorkerStart. The
+      use counter must be landed in either
       <a
         target="_blank"
         href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/use_counter/metrics/web_feature.mojom"
         >web_feature.mojom</a
-      >
-      or
+      >,
       <a
         target="_blank"
         href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/use_counter/metrics/webdx_feature.mojom"
         >webdx_feature.mojom</a
+      >, or
+      <a
+        target="_blank"
+        href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/use_counter/metrics/css_property_id.mojom"
+        >css_property_id.mojom</a
       >. Not required for deprecation trials.`,
   },
 


### PR DESCRIPTION
Leftover part of #4702 

This field can now accept 3 different use counter types, but it still has the old description. It should be clear to users because they have to specify where the use counter is located in a separate field, but this will remove ambiguity.