### PR TITLE
Refactor: Improve Playwright and Dev Container DX

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,25 +1,25 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/python-3/.devcontainer/base.Dockerfile
+# Copyright 2025 Google LLC
 
-# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
-# Update 'VARIANT' to pick a version of Python: 3, 3.10, 3.9, 3.8, 3.7, 3.6
-# Append -bullseye or -buster to pin to an OS version.
-# Use -bullseye variants on local arm64/Apple Silicon.
-ARG VARIANT="3.13-bookworm"
-FROM mcr.microsoft.com/devcontainers/python:${VARIANT} as ide
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 
-# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="18"
-RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM mcr.microsoft.com/devcontainers/base:bookworm as ide
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && sudo apt-get install -y \
-       # openapi-generator-cli dependencies
-       openjdk-17-jre \
-       # Convenience tools
        bash-completion
 
 # Install gcloud
-ENV CLOUD_SDK_VERSION=497.0.0
+ENV CLOUD_SDK_VERSION=542.0.0
 # Install gcloud similarly to how it is done in cloud-sdk-docker
 # https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/debian_component_based/Dockerfile
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
@@ -30,6 +30,6 @@ RUN echo -n "beta" > /tmp/additional_components
 RUN /google-cloud-sdk/install.sh --usage-reporting=false \
     --additional-components `cat /tmp/additional_components` && rm -rf /google-cloud-sdk/.install/.backup
 
-RUN su vscode -c "echo 'PATH=${PATH}:/google-cloud-sdk/bin' >> ~/.bashrc"
+USER vscode
 
-RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g gulp-cli" 2>&1
+RUN echo 'PATH=${PATH}:/google-cloud-sdk/bin' >> ~/.bashrc

--- a/.devcontainer/db-docker-compose.yml
+++ b/.devcontainer/db-docker-compose.yml
@@ -1,17 +1,18 @@
 services:
   db:
-    image: google/cloud-sdk:402.0.0-emulators
+    image: google/cloud-sdk:542.0.0-emulators
     restart: unless-stopped
     command: sh -c "gcloud beta emulators datastore start --project=cr-status-staging --host-port 0.0.0.0:$${DB_PORT} --no-store-on-disk --use-firestore-in-datastore-mode"
     environment:
       DB_PORT: 15606
+    ports:
+      - "15606:15606"
 
   dsadmin:
-    image: ghcr.io/remko/dsadmin:v0.18.1
+    image: ghcr.io/remko/dsadmin:v0.21.0
     entrypoint: /ko-app/dsadmin -port 8888
     depends_on:
       - db
-    network_mode: service:db
     environment:
       DATASTORE_PROJECT_ID: cr-status-staging
       DATASTORE_EMULATOR_HOST: "db:15606"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,12 +2,9 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/python-3
 {
 	"name": "Chromium Dashboard",
-	"dockerComposeFile": [
-		"docker-compose.yml",
-		"db-docker-compose.yml"
-	],
-	"service": "ide",
-	"workspaceFolder": "/workspace",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 
 	// Configure tool-specific properties.
 	"customizations": {
@@ -16,7 +13,7 @@
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
 				"mypy-type-checker.args": ["--ignore-missing-imports --exclude cs-env/ --exclude gen/ --exclude appengine_config.py --disable-error-code \"annotation-unchecked\""],
-				"python.defaultInterpreterPath": "/workspace/cs-env/bin/python",
+				"python.defaultInterpreterPath": "/workspaces/chromium-dashboard/cs-env/bin/python",
 				"python.languageServer": "Jedi",
 				"python.testing.pytestEnabled": false,
 				"python.testing.unittestArgs": [
@@ -59,30 +56,44 @@
 				"esbenp.prettier-vscode",
 				"ms-python.mypy-type-checker",
 				"ms-python.python",
-				"EditorConfig.EditorConfig"
+				"EditorConfig.EditorConfig",
+				"Google.gemini-cli-vscode-ide-companion"
 			]
 		}
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
-		// datastore emulator
-		15606,
 		// datastore emulator viewer
 		8888
 	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "npm run clean-setup",
+	"postCreateCommand": "npm install -g gulp-cli && npm run clean-setup",
 	// 'postStartCommand' runs each time the devcontainer is started.
-	"postStartCommand": "npm run setup && npx playwright install --with-deps",
-
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode",
-
+	"postStartCommand": "docker-compose -f .devcontainer/db-docker-compose.yml down && docker-compose -f .devcontainer/db-docker-compose.yml up -d && npm run setup && npx playwright install --with-deps",
+	// Use 'postAttachCommand' to run commands after the container is created and attached.
+	"postAttachCommand": "./.devcontainer/post_attach.sh",
 	"features": {
 		// https://github.com/devcontainers/features/tree/main/src/docker-in-docker
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
-		"ghcr.io/devcontainers/features/github-cli:1": {}
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers/features/java:1": {
+			// Only pick LTS versions from
+			// https://www.oracle.com/java/technologies/java-se-support-roadmap.html
+			// Match the version on Cloudtops
+			"version": "25"
+		},
+		"ghcr.io/devcontainers/features/node:1": {
+			// Match the version on Cloudtops
+			"version": "20"
+		},
+		"ghcr.io/devcontainers/features/python:1": {
+			// Match the version on Cloudtops
+			"version": "3.13"
+		}
+	},
+	"remoteEnv": {
+		"GEMINI_API_KEY": "${localEnv:GEMINI_API_KEY}"
 	}
 }

--- a/.devcontainer/post_attach.sh
+++ b/.devcontainer/post_attach.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Setup Gemini & MCP Servers
+# https://developers.google.com/gemini-code-assist/docs/use-agentic-chat-pair-programmer#configure-mcp-servers
+npm install -g @google/gemini-cli
+GEMINI_CONFIG='{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    }
+  }
+}'
+# Check if the user is authenticated to GitHub.
+# If so, append the mcpServers section with the Github MCP server.
+# If not, print out a warning message.
+if gh auth status &>/dev/null; then
+  echo "GitHub CLI authenticated. Adding GitHub MCP server to Gemini config."
+  GH_TOKEN=$(gh auth token)
+  GEMINI_CONFIG=$(echo "$GEMINI_CONFIG" | jq --arg token "$GH_TOKEN" '.mcpServers.github = {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-github"],
+    "env": {
+      "GITHUB_PERSONAL_ACCESS_TOKEN": $token
+    }
+  }')
+else
+  echo "WARNING: GitHub CLI not authenticated. GitHub MCP server will not be configured."
+  echo "To configure the GitHub MCP Server, use 'gh auth login' and then reload (not rebuild) the devcontainer."
+  echo "In the Command Palette, run: Developer: Reload Window"
+fi
+
+mkdir -p "$HOME/.gemini"
+echo "$GEMINI_CONFIG" > "$HOME/.gemini/settings.json"
+
+# Configure Gemini API Key if available
+if [ -n "$GEMINI_API_KEY" ]; then
+  echo "GEMINI_API_KEY found."
+else
+  echo "WARNING: GEMINI_API_KEY environment variable not set."
+  echo "You may need to configure an API key manually to use certain Gemini features."
+fi
+
+
+echo "Note: After starting the Gemini CLI for the first time, it may present you with some errors."
+echo "In that case, it will tell you to open a new terminal and start the Gemini CLI again."

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ tsconfig.tsbuildinfo
 
 # build output
 build/
+
+# Temporary
+packages/playwright/playwright.config.ts

--- a/package.json
+++ b/package.json
@@ -50,13 +50,13 @@
     "openapi-frontend": "rm -rf gen/js/chromestatus-openapi && openapi-generator-cli generate  --reserved-words-mappings field=field -i openapi/api.yaml -g typescript-fetch  -o gen/js/chromestatus-openapi --config openapi/js-config.yaml && npm install",
     "openapi-backend": ". cs-env/bin/activate; rm -rf gen/py/chromestatus_openapi && openapi-generator-cli generate  --reserved-words-mappings field=field -i openapi/api.yaml -g python-flask  -o gen/py/chromestatus_openapi --additional-properties=packageName=chromestatus_openapi && pip install -r requirements.txt",
     "openapi-validate": "openapi-generator-cli validate -i openapi/api.yaml",
-    "pwtests": "npm run pwtests-shutdown; ./packages/playwright/run.sh bash -c \"./wait-for-app.sh && npx playwright test\"",
-    "pwtests-update": "npm run pwtests-shutdown; ./packages/playwright/run.sh bash -c \"./wait-for-app.sh && npx playwright test --update-snapshots $npm_config_filename \"",
-    "pwtests-report": "npm run pwtests-shutdown; ./packages/playwright/run.sh bash -c \"./wait-for-app.sh && npx playwright show-report\"",
-    "pwtests-ui": "npm run pwtests-shutdown; ./packages/playwright/run.sh bash -c \"./wait-for-app.sh && npx playwright test --ui --ui-port=8123\"",
-    "pwtests-shell": "./packages/playwright/run.sh bash",
-    "pwtests-debug": "./packages/playwright/run.sh debug",
-    "pwtests-shutdown": "./packages/playwright/run.sh down"
+    "pwtests": "npm run pwtests-shutdown; ./scripts/playwright.sh bash -c \"./wait-for-app.sh && npx playwright test\"",
+    "pwtests-update": "npm run pwtests-shutdown; ./scripts/playwright.sh bash -c \"./wait-for-app.sh && npx playwright test --update-snapshots $npm_config_filename \"",
+    "pwtests-report": "npm run pwtests-shutdown; ./scripts/playwright.sh bash -c \"./wait-for-app.sh && npx playwright show-report\"",
+    "pwtests-ui": "npm run pwtests-shutdown; ./scripts/playwright.sh bash -c \"./wait-for-app.sh && npx playwright test --ui --ui-port=8123\"",
+    "pwtests-shell": "./scripts/playwright.sh bash",
+    "pwtests-debug": "./scripts/playwright.sh debug",
+    "pwtests-shutdown": "./scripts/playwright.sh down"
   },
   "repository": {
     "type": "git",

--- a/packages/playwright/Dockerfile
+++ b/packages/playwright/Dockerfile
@@ -26,4 +26,9 @@ ARG PLAYWRIGHT_VERSION
 RUN npm install @playwright/test@${PLAYWRIGHT_VERSION}
 
 # Copy the root directory. Subdirectories are mounted in docker-compose.yml.
-COPY --chown=pwuser:pwuser wait-for-app.sh playwright.config.cjs /work/
+COPY --chown=pwuser:pwuser wait-for-app.sh playwright.config.ts /work/
+
+# The playwright.config.ts file is copied from the repository root, where it is
+# needed for VS Code integration. Inside the container, the test directory is
+# the root, so we update the path.
+RUN sed -i "s|testDir: 'packages/playwright/tests'|testDir: '.'|" /work/playwright.config.ts

--- a/packages/playwright/tests/test_utils.js
+++ b/packages/playwright/tests/test_utils.js
@@ -1,6 +1,5 @@
 // @ts-check
 import { expect } from '@playwright/test';
-import { Page } from "playwright-core";
 
 
 /**
@@ -14,12 +13,12 @@ export async function delay(ms) {
 /**
  * Call this, say in your test.beforeEach() method, to capture all
  * console messages and copy them to the playwright console.
- * @param {Page} page
+ * @param {import("playwright-core").Page} page
  */
 export function captureConsoleMessages(page) {
   page.on('console', async msg => {
     // ignore warnings for now.  There are tons of them.
-    if (msg.type() === 'warn') {
+    if (msg.type() === 'warning') {
       return;
     }
 
@@ -37,7 +36,7 @@ export function captureConsoleMessages(page) {
         // Sometimes this fails with something like:
         //  "Protocol error (Runtime.callFunctionOn): Target closed."
         argString = (await arg.jsonValue()).toString();
-      } catch (e) {
+      } catch {
         argString = arg.toString();
       }
       // Simplify tons of "SameSite" warnings.
@@ -53,7 +52,7 @@ export function captureConsoleMessages(page) {
 }
 
 /**
- * @param {Page} page
+ * @param {import("playwright-core").Page} page
  */
 export function capturePageEvents(page) {
   // page.on('open', async () => {
@@ -88,7 +87,7 @@ export function capturePageEvents(page) {
 }
 
 /**
- * @param {Page} page
+ * @param {import("playwright-core").Page} page
  */
 export async function decodeCookies(page) {
   const cookies = await page.context().cookies();
@@ -98,7 +97,7 @@ export async function decodeCookies(page) {
 }
 
 /**
- * @param {Page} page
+ * @param {import("playwright-core").Page} page
  */
 export async function isMobile(page) {
   const viewportSize = page.viewportSize();
@@ -152,7 +151,7 @@ export function acceptAlertDialogs(page) {
 let loginTimeout = 20000;
 
 /**
- * @param {Page} page
+ * @param {import("playwright-core").Page} page
  */
 export async function login(page) {
 
@@ -213,7 +212,7 @@ export async function login(page) {
 }
 
 /**
- * @param {Page} page
+ * @param {import("playwright-core").Page} page
  */
 export async function logout(page) {
   // Attempt to sign out after running each test.
@@ -263,7 +262,7 @@ export async function logout(page) {
 
 /**
  * From top-level page, after logging in, go to the New Feature page.
- * @param {Page} page
+ * @param {import('@playwright/test').Page} page
  */
 export async function gotoNewFeaturePage(page) {
   // console.log('navigate to create feature page');
@@ -293,7 +292,7 @@ export async function gotoNewFeaturePage(page) {
 /**
  * Enters a blink component on the page.
  *
- * @param {Page} page - The page object representing the web page.
+ * @param {import("playwright-core").Page} page - The page object representing the web page.
  * @return {Promise<void>} A promise that resolves once the blink component is entered.
  */
 export async function enterBlinkComponent(page) {
@@ -312,7 +311,7 @@ export async function enterBlinkComponent(page) {
 /**
  * Enters a web feature id on the page.
  *
- * @param {Page} page - The page object representing the web page.
+ * @param {import("playwright-core").Page} page - The page object representing the web page.
  * @return {Promise<void>} A promise that resolves once the web feature id is entered.
  */
 export async function enterWebFeatureId(page) {
@@ -369,6 +368,10 @@ export async function createNewFeature(page) {
   await delay(1500);
 }
 
+/**
+ * Navigates to new features list page.
+ * @param {import("playwright-core").Page} page
+ */
 export async function gotoNewFeatureList(page) {
   await page.goto('/newfeatures');
   await page.locator('chromedash-feature-pagination');

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,18 +1,12 @@
-// @ts-check
-const { defineConfig, devices } = require('@playwright/test');
+import {defineConfig, devices} from '@playwright/test';
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
 
 /**
  * @see https://playwright.dev/docs/test-configuration
  */
-module.exports = defineConfig({
+export default defineConfig({
   // Directory where the tests are located. "." for top-level directory.
-  testDir: '.',
+  testDir: 'packages/playwright/tests',
   // Glob patterns or regular expressions that match test files.
   testMatch: '*/*_pwtest.js',
   snapshotPathTemplate: '{testDir}/{testFileDir}/__screenshots__/{testFileName}/{testName}/{arg}-{projectName}-{platform}{ext}',

--- a/scripts/playwright.sh
+++ b/scripts/playwright.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT_DIR="${SCRIPT_DIR}/../"
+PLAYWRIGHT_DIR="${REPO_ROOT_DIR}/packages/playwright"
 
 export USERID=$(id -u)
 export GROUPID=$(id -g)
-export PLAYWRIGHT_VERSION=$(bash -c "${SCRIPT_DIR}/get-npm-package-version.sh ./package.json '@playwright/test'")
+export PLAYWRIGHT_VERSION=$(bash -c "${PLAYWRIGHT_DIR}/get-npm-package-version.sh ./package.json '@playwright/test'")
+
+# playwright.config.ts needs to be in the root of the repository so that vscode will pick up automatically.
+# In the meantime for the pwtests container, we copy a version over
+cp ${REPO_ROOT_DIR}/playwright.config.ts ${PLAYWRIGHT_DIR}/playwright.config.ts
 
 set -e
 
-export COMPOSE_FILES_FLAG="-f ${SCRIPT_DIR}/docker-compose.yml
-    -f  ${SCRIPT_DIR}/../../.devcontainer/db-docker-compose.yml"
+export COMPOSE_FILES_FLAG="-f ${PLAYWRIGHT_DIR}/docker-compose.yml
+    -f  ${REPO_ROOT_DIR}/.devcontainer/db-docker-compose.yml"
 echo $COMPOSE_FILES_FLAG
 build() {
    docker compose \


### PR DESCRIPTION
This commit introduces several changes to improve the developer experience, particularly for those using VS Code and dev containers.

The Gemini CLI was also configured in the dev container. Something carried over from webstatus.dev

The `playwright.config.ts` file has been moved to the repository root. This allows VS Code's Playwright extension to automatically discover and run tests through its UI, which works for developers both locally and inside a dev container.

To support this, the Playwright Dockerfile now copies the root config and patches the `testDir` path to match the container's file structure. The `.devcontainer/Dockerfile` was also updated to leverage built-in dev container features for installing tools like python and java, rather than using manual installation steps. A minor code quality improvement was made in `test_utils.js` to use JSDoc type annotations as suggested by the IDE.

This change enables the following next steps for our testing workflow:

- **One-off Screenshot Regeneration:** Developers can now regenerate screenshots for a single test directly from the VS Code UI, avoiding the need to run the full `pwtests-update` script.

- **CI Parity for Dev Container Users:** We use containers in GitHub CI to guarantee a consistent browser environment, as recommended by Playwright. By aligning the dev container to use the same base image as CI in the future, developers can run tests within VS Code and get results that perfectly mirror the CI environment. This simplifies debugging CI-specific failures in a local, IDE-integrated workflow.

**NOTE** These changes enhance the developer experience WITHOUT making dev containers a requirement; existing workflows for all developers remain unaffected.