### PR TITLE
Make settings link be keyboard navigable.

### DIFF
--- a/client-src/elements/chromedash-header.ts
+++ b/client-src/elements/chromedash-header.ts
@@ -244,6 +244,10 @@ export class ChromedashHeader extends LitElement {
       });
   }
 
+  gotoSettings() {
+    window.location.href = '/settings';
+  }
+
   signOut() {
     window.csClient.signOut().then(() => {
       window.location.reload();
@@ -297,9 +301,9 @@ export class ChromedashHeader extends LitElement {
                 ${this.user.email}
               </sl-button>
               <sl-menu>
-                <a href="/settings">
-                  <sl-menu-item>Settings</sl-menu-item>
-                </a>
+                <sl-menu-item @click=${this.gotoSettings}>
+                  Settings
+                </sl-menu-item>
                 <sl-menu-item
                   id="sign-out-link"
                   data-testid="sign-out-link"


### PR DESCRIPTION
Gemini suggested using`<a><sl-menu-item>Settings</sl-menu-item></a>`, but it turns out that that is not keyboard navigable.  I also tried `<sl-menu-item><a>Settings</a></sl-menu-item>` and that could be selected via the keyboard, but the link could not be followed using the keyboard.  So, we are back to `@click`.