### PR TITLE
Supress dev mode warnings while testing

### DIFF
--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -1,3 +1,7 @@
+const filteredLogs = [
+  'Lit is in dev mode',
+];
+
 export default {
   files: 'build/**/*_test.{js,ts}',
   concurrentBrowsers: 1,
@@ -5,12 +9,12 @@ export default {
   nodeResolve: true,
   browserStartTimeout: 60000,
   filterBrowserLogs(log) {
-      // Suppress the "Lit is in dev mode" warning
-      if (log.args.some((arg) => typeof arg === 'string' && arg.includes('Lit is in dev mode'))) {
+    for (const arg of log.args) {
+      if (typeof arg === 'string' && filteredLogs.some(l => arg.includes(l))) {
         return false;
       }
+    }
 
-      // Allow all other logs to pass through
-      return true;
-    },
+    return true;
+  },
 };


### PR DESCRIPTION
In our webtest logs, we get spammed with this warning:

```
Lit is in dev mode. Not recommended for production! See https://lit.dev/msg/dev-mode for more information.
```

This change suppresses those warnings so our logs are less busy with non-actionable info.