### PR TITLE
Add browser-side feature file to Finch name description

### DIFF
--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -128,6 +128,7 @@ const DOMAIN_NAME_REGEX: string = String.raw`(([A-Za-z0-9\-]+\.)+[A-Za-z]{2,6})`
 const LOCALHOST_REGEX: string = String.raw`(localhost|127\.0\.0\.1)`;
 const DOMAIN_REGEX: string =
   '(' + DOMAIN_NAME_REGEX + '|' + LOCALHOST_REGEX + ')';
+const ALPHANUMERIC_REGEX = String.raw`[a-zA-Z0-9]*`;
 
 const EMAIL_ADDRESS_REGEX: string = USER_REGEX + '@' + DOMAIN_NAME_REGEX;
 const GOOGLE_EMAIL_ADDRESS_REGEX: string = `${USER_REGEX}@google.com`;
@@ -2570,7 +2571,7 @@ export const ALL_FIELDS: Record<string, Field> = {
     attrs: {
       ...TEXT_FIELD_ATTRS,
       placeholder: 'e.g. "StorageBuckets"',
-      pattern: String.raw`[a-zA-Z0-9]*`,
+      pattern: ALPHANUMERIC_REGEX,
     },
     required: false,
     label: 'Finch feature name',


### PR DESCRIPTION
Related to #5517

Not all Finch features are referenced in runtime_enabled_features.json5 - browser content features are instead referenced in another file. This change updates our description to clarify that.

Additionally, this field is more strict, and requires only alphanumeric characters.

