### PR TITLE
Submit buttons stay disabled after success

### DIFF
--- a/client-src/elements/chromedash-guide-editall-page.ts
+++ b/client-src/elements/chromedash-guide-editall-page.ts
@@ -65,6 +65,8 @@ export class ChromedashGuideEditallPage extends LitElement {
   @state()
   loading = true;
   @state()
+  submitting = false;
+  @state()
   previousStageTypeRendered = 0;
   @state()
   sameTypeRendered = 0;
@@ -116,6 +118,7 @@ export class ChromedashGuideEditallPage extends LitElement {
 
   handleFormSubmit(e, hiddenTokenField) {
     e.preventDefault();
+    this.submitting = true;
     const submitBody = formatFeatureChanges(this.fieldValues, this.featureId);
 
     // get the XSRF token and update it if it's expired before submission
@@ -129,6 +132,7 @@ export class ChromedashGuideEditallPage extends LitElement {
         window.location.href = this.getNextPage();
       })
       .catch(() => {
+        this.submitting = false;
         showToastMessage(
           'Some errors occurred. Please refresh the page or try again later.'
         );
@@ -485,7 +489,12 @@ export class ChromedashGuideEditallPage extends LitElement {
         ${this.renderAddStageButton()}
 
         <section class="final_buttons">
-          <input class="button" type="submit" value="Submit" />
+          <input
+            class="button"
+            type="submit"
+            value="Submit"
+            ?disabled=${this.submitting}
+          />
           <button
             id="cancel-button"
             type="reset"

--- a/client-src/elements/chromedash-guide-new-page.ts
+++ b/client-src/elements/chromedash-guide-new-page.ts
@@ -98,7 +98,6 @@ export class ChromedashGuideNewPage extends LitElement {
     window.csClient
       .createFeature(createBody)
       .then(resp => {
-        this.submitting = false;
         window.location.href = `/feature/${resp.feature_id}`;
       })
       .catch(() => {
@@ -282,8 +281,8 @@ export class ChromedashGuideNewPage extends LitElement {
           <input
             type="submit"
             class="primary"
-            ?disabled=${this.submitting}
             value=${submitLabel}
+            ?disabled=${this.submitting}
           />
         </form>
       </section>

--- a/client-src/elements/chromedash-guide-stage-page.ts
+++ b/client-src/elements/chromedash-guide-stage-page.ts
@@ -18,11 +18,7 @@ import {
   FORMS_BY_STAGE_TYPE,
   MetadataFields,
 } from './form-definition';
-import {
-  IMPLEMENTATION_STATUS,
-  OT_EXTENSION_STAGE_TYPES,
-  STAGE_SPECIFIC_FIELDS,
-} from './form-field-enums';
+import {STAGE_SPECIFIC_FIELDS} from './form-field-enums';
 import {ALL_FIELDS} from './form-field-specs';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {FORM_STYLES} from '../css/forms-css.js';
@@ -55,6 +51,8 @@ export class ChromedashGuideStagePage extends LitElement {
   featureFormFields!: MetadataFields;
   @state()
   loading = true;
+  @state()
+  submitting = false;
   @state()
   fieldValues: FieldInfo[] & {feature?: Feature} = [];
   @state()
@@ -152,6 +150,7 @@ export class ChromedashGuideStagePage extends LitElement {
       this.featureId,
       this.stageId
     );
+    this.submitting = true;
 
     // get the XSRF token and update it if it's expired before submission
     window.csClient
@@ -170,6 +169,7 @@ export class ChromedashGuideStagePage extends LitElement {
         }
       })
       .catch(() => {
+        this.submitting = false;
         showToastMessage(
           'Some errors occurred. Please refresh the page or try again later.'
         );
@@ -332,6 +332,7 @@ export class ChromedashGuideStagePage extends LitElement {
             class="button"
             type="submit"
             value="Submit"
+            ?disabled=${this.submitting}
           />
           <button
             id="cancel-button"

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -386,7 +386,6 @@ export class ChromedashOTCreationPage extends LitElement {
           this.submitting = false;
           this.requestUpdate();
         } else {
-          this.submitting = false;
           showToastMessage('Creation request submitted!');
           setTimeout(() => {
             window.location.href = `/feature/${this.featureId}`;
@@ -522,6 +521,7 @@ export class ChromedashOTCreationPage extends LitElement {
             class="button"
             type="submit"
             value="Submit"
+            ?disabled=${this.submitting}
           />
           <button
             id="cancel-button"


### PR DESCRIPTION
Fixes #5501 

This change ensures that the submit buttons in our forms are disabled during an asynchronous submission. 

Additionally, in all cases, we redirect immediately after a successful submit request. This means that there's no reason to re-enable the submit button after a success. This had the side effect of temporarily allowing the submit button to become active again for a short time before redirecting. This change removes that behavior.