### PR TITLE
Fix error when rendering screenshot_links

### DIFF
--- a/client-src/elements/chromedash-form-field.ts
+++ b/client-src/elements/chromedash-form-field.ts
@@ -537,7 +537,7 @@ export class ChromedashFormField extends LitElement {
 
     // If the field is used in ALL intents, render a special "All" tag.
     if (
-      ALL_INTENT_USAGE_BY_FEATURE_TYPE[featureType].isSubsetOf(intentTypesUsed)
+      ALL_INTENT_USAGE_BY_FEATURE_TYPE[featureType]?.isSubsetOf(intentTypesUsed)
     ) {
       return [
         html`<span


### PR DESCRIPTION
This fixes a bug reported by the enterprise team just now. 
When editing the metadata for an enterprise feature, there is supposed to be a screenshot_links field, however it does not show up due to an error on the console:

Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'isSubsetOf')
    at ChromedashFormField.renderUsageIcons (chromedash-form-field.js:442:59)
    at ChromedashFormField.render (chromedash-form-field.js:486:26)
    ...

The root cause is that ALL_INTENT_USAGE_BY_FEATURE_TYPE does not have an entry for enterprise features.  And, since those features don't use intents, it makes sense that there would be no entry in that object.  So, the code that accesses it just needs to take that into account.

