### PR TITLE
Check for features in that are enabled by platform

### DIFF
--- a/api/shipping_features_api.py
+++ b/api/shipping_features_api.py
@@ -80,7 +80,15 @@ class ShippingFeaturesAPI(basehandlers.EntitiesAPIHandler):
       None)
     if feature_info:
       feature_found = True
-      if feature_info.get('status', None) != 'stable':
+      # The status of a feature can be represented as a string (meaning the same
+      # status for all platforms), or an object mapping the status of each
+      # platform individually.
+      if isinstance(feature_info.get('status', None), dict):
+        # If we're checking by platform, we just check if at least one platform
+        # is designated as stable.
+        if not any(s for s in feature_info['status'].values() if s == 'stable'):
+          criteria_missing.append(Criteria.RUNTIME_FEATURE_NOT_STABLE)
+      elif feature_info.get('status', None) != 'stable':
         criteria_missing.append(Criteria.RUNTIME_FEATURE_NOT_STABLE)
     else:
       # Search for the feature and determine if it is enabled.


### PR DESCRIPTION
This week, the endpoint for checking shipping criteria marked a feature as not enabled, but [it was actually enabled on most platforms](https://chromium-review.googlesource.com/c/chromium/src/+/6879487). There is a chance that features are represented this way. Previously, there was only one check to see if the status of the feature was a string with the value of "stable".

This change adds a check to see if the feature's status is represented as a dictionary, and then checks if any of those values in the dictionary are marked as "stable". This granularity is not perfect, but it will avoid false positives of features not enabled, when the features are actually enabled on certain platforms.