### PR TITLE
Use different description for deprecation motivation

### DIFF
--- a/client-src/elements/form-definition.ts
+++ b/client-src/elements/form-definition.ts
@@ -488,7 +488,7 @@ const DEPRECATION_PLAN_FIELDS: MetadataFields = {
   sections: [
     {
       name: 'Write up deprecation plan',
-      fields: ['motivation', 'spec_link'],
+      fields: ['deprecation_motivation', 'spec_link'],
     },
   ],
 };


### PR DESCRIPTION
While looking at field descriptions to hopefully clarify descriptions for deprecations, I noticed there's a field description we're not using ([deprecation_motivation](https://github.com/GoogleChrome/chromium-dashboard/blob/fdd187fa6d9337ddba2144257a48207e591b6906/client-src/elements/form-field-specs.ts#L704-L730)). Unfortunately, this just fell through the cracks, and the deprecation feature has been using [the typical motivation description](https://github.com/GoogleChrome/chromium-dashboard/blob/fdd187fa6d9337ddba2144257a48207e591b6906/client-src/elements/form-field-specs.ts#L676-L702) for a long time (to be fair, the wording on the typical motivation description sounds a little bit like it could pertain to deprecations).