### PR TITLE
Add expectation for TypeScript error

### DIFF
--- a/client-src/elements/chromedash-textarea.ts
+++ b/client-src/elements/chromedash-textarea.ts
@@ -1,8 +1,9 @@
-import {TemplateResult, html, nothing} from 'lit';
+import {html, nothing} from 'lit';
 import SlTextarea from '@shoelace-style/shoelace/dist/components/textarea/textarea.js';
 import {customElement, property, state} from 'lit/decorators.js';
 import {autolink} from './utils.js';
 
+// @ts-expect-error ts(1238)
 @customElement('chromedash-textarea')
 export class ChromedashTextarea extends SlTextarea {
   @property({type: Boolean})


### PR DESCRIPTION
This is a fix for the issue that is blocking #5611

I originally thought that we would need to update the component to instead extend LitElement, but this also works as long as the behavior is what we expect it to.