### PR TITLE
Remove the alphanumeric finch flag restriction

### DIFF
--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -128,6 +128,7 @@ const DOMAIN_NAME_REGEX: string = String.raw`(([A-Za-z0-9\-]+\.)+[A-Za-z]{2,6})`
 const LOCALHOST_REGEX: string = String.raw`(localhost|127\.0\.0\.1)`;
 const DOMAIN_REGEX: string =
   '(' + DOMAIN_NAME_REGEX + '|' + LOCALHOST_REGEX + ')';
+const ALPHANUMERIC_REGEX = String.raw`[-_a-zA-Z0-9,]*`;
 
 const EMAIL_ADDRESS_REGEX: string = USER_REGEX + '@' + DOMAIN_NAME_REGEX;
 const GOOGLE_EMAIL_ADDRESS_REGEX: string = `${USER_REGEX}@google.com`;
@@ -2570,6 +2571,7 @@ export const ALL_FIELDS: Record<string, Field> = {
     attrs: {
       ...TEXT_FIELD_ATTRS,
       placeholder: 'e.g. "StorageBuckets"',
+      pattern: ALPHANUMERIC_REGEX,
     },
     required: false,
     label: 'Finch feature name',


### PR DESCRIPTION
Fixes #5636

This was a restriction I added to the field to enforce the naming requirement of typical Finch flags. However, it seems that the field has been used pretty loosely, and I've now seen multiple scenarios where users want to provide multiple Finch flags for a single feature. This will give us a difficult time detecting features landed in Chromium code, but it's best to open this field back up to what it was, and then figure out the next steps later on how to make the field more definitive in its required inputs.