### PR TITLE
Fix Chromium file mapping for WebDXFeatures

### DIFF
--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -39,7 +39,7 @@ CHROMIUM_USE_COUNTER_FILES_MAP = {
   BlinkHistogramID.web_feature: {
       'name': 'webfeature_file', 'url': core_enums.WEBFEATURE_FILE_URL},
   BlinkHistogramID.webdx_feature: {
-      'name': 'webdxfeature_file', 'url': core_enums.WEBFEATURE_FILE_URL},
+      'name': 'webdxfeature_file', 'url': core_enums.WEBDXFEATURE_FILE_URL},
   BlinkHistogramID.css_property_id: {
       'name': 'css_property_id_file', 'url': core_enums.CSS_PROPERTY_ID_FILE_URL},
 }


### PR DESCRIPTION
Unfortunately, the OT creation form was using the wrong file contents to check for WebDXFeature use counters due to a minor typo.

This was brought to our attention in a support request, and I went ahead and landed a tainted version on prod to make sure the user could submit the form properly.