### PR TITLE
Fix regex syntax needed by implied v flag.

### DIFF
--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -128,7 +128,7 @@ const DOMAIN_NAME_REGEX: string = String.raw`(([A-Za-z0-9\-]+\.)+[A-Za-z]{2,6})`
 const LOCALHOST_REGEX: string = String.raw`(localhost|127\.0\.0\.1)`;
 const DOMAIN_REGEX: string =
   '(' + DOMAIN_NAME_REGEX + '|' + LOCALHOST_REGEX + ')';
-const ALPHANUMERIC_REGEX = String.raw`[-_a-zA-Z0-9,]*`;
+const FINCH_NAMES_REGEX = String.raw`[\-_a-zA-Z0-9,]*`;
 
 const EMAIL_ADDRESS_REGEX: string = USER_REGEX + '@' + DOMAIN_NAME_REGEX;
 const GOOGLE_EMAIL_ADDRESS_REGEX: string = `${USER_REGEX}@google.com`;
@@ -2571,7 +2571,7 @@ export const ALL_FIELDS: Record<string, Field> = {
     attrs: {
       ...TEXT_FIELD_ATTRS,
       placeholder: 'e.g. "StorageBuckets"',
-      pattern: ALPHANUMERIC_REGEX,
+      pattern: FINCH_NAMES_REGEX,
     },
     required: false,
     label: 'Finch feature name',


### PR DESCRIPTION
The leading dash needs to be escaped because the `v` flag is implicitly added to the regex.
Also, this regex is no longer exactly alphanumeric, so I gave it a more specific name. 