### PR TITLE
Add WPT URL normalization for .any.js tests

### DIFF
--- a/framework/utils.py
+++ b/framework/utils.py
@@ -197,6 +197,30 @@ def _get_github_headers(token: str | None = None) -> dict[str, str]:
   return headers
 
 
+def reformat_wpt_fyi_url(url: str) -> str:
+  """
+  Normalizes a WPT URL by converting multi-global test variants back to their
+  source ".any.js" file.
+
+  If the URL does not contain ".any.", it is returned unchanged.
+
+  See documentation: https://web-platform-tests.org/writing-tests/testharness.html#tests-for-other-or-multiple-globals-any-js
+
+  Args:
+    url: The full wpt.fyi URL (e.g., '.../test.any.worker.html').
+
+  Returns:
+    The URL normalized to the source file (e.g., '.../test.any.js').
+  """
+  substring = ".any."
+  if substring in url:
+    # Find the index where ".any." ends
+    end_index = url.find('.any.') + len(substring)
+    # Slice the string up to that point and add "js"
+    return url[:end_index] + "js"
+  return url
+
+
 def _parse_wpt_fyi_url(url: str) -> str:
   """
   Parses a wpt.fyi URL to map it to a GitHub repo path.
@@ -209,6 +233,7 @@ def _parse_wpt_fyi_url(url: str) -> str:
   Expected URL format:
   [http|https]://wpt.fyi/results/<path>...
   """
+  url = reformat_wpt_fyi_url(url)
   parsed_url = urlparse(url)
 
   if parsed_url.netloc != 'wpt.fyi':

--- a/framework/utils_test.py
+++ b/framework/utils_test.py
@@ -240,6 +240,37 @@ class UtilsFunctionTests(unittest.TestCase):
         actual = utils.extract_wpt_fyi_results_urls(input_str)
         self.assertEqual(expected, actual)
 
+  def test_reformat_wpt_fyi_url(self):
+    """Ensure .any.js variant URLs are correctly reformatted to their source."""
+    # Case: Standard URL that should not change.
+    self.assertEqual(
+      'https://wpt.fyi/results/dom/nodes/Element-firstElementChild.html',
+      utils.reformat_wpt_fyi_url(
+        'https://wpt.fyi/results/dom/nodes/Element-firstElementChild.html'))
+
+    # Case: A standard .any.html file.
+    self.assertEqual(
+      'https://wpt.fyi/results/dpub-aam/doc-afterword.any.js',
+      utils.reformat_wpt_fyi_url(
+        'https://wpt.fyi/results/dpub-aam/doc-afterword.any.html'))
+
+    # Case: A worker variant of an .any.js test.
+    self.assertEqual(
+      'https://wpt.fyi/results/content-security-policy/reporting/report-only-in-worker.any.js',
+      utils.reformat_wpt_fyi_url(
+        'https://wpt.fyi/results/content-security-policy/reporting/report-only-in-worker.any.worker.html'))
+
+    # Case: A sharedworker variant.
+    self.assertEqual(
+      'https://wpt.fyi/results/fs/FileSystemFileHandle-sync-access-handle-lock-modes.any.js',
+      utils.reformat_wpt_fyi_url(
+        'https://wpt.fyi/results/fs/FileSystemFileHandle-sync-access-handle-lock-modes.any.sharedworker.html'))
+
+    # Case: Edge case to ensure it strictly matches '.any.' and not just '.any'.
+    self.assertEqual(
+      'https://wpt.fyi/results/foo/bar.anything.html',
+      utils.reformat_wpt_fyi_url('https://wpt.fyi/results/foo/bar.anything.html'))
+
 
 class UtilsGitHubTests(unittest.TestCase):
   """Tests for the GitHub fetching utility functions."""


### PR DESCRIPTION
This PR introduces a helper function to normalize [multi-global variant URLs](https://web-platform-tests.org/writing-tests/testharness.html#tests-for-other-or-multiple-globals-any-js) in WPT. This ensures we're targeting the address of the actual test file, rather than a generated name that does not map to any file in WPT.