### PR TITLE
Add logic for retries to Gemini API requests [1/4]

### DIFF
--- a/framework/gemini_client.py
+++ b/framework/gemini_client.py
@@ -18,6 +18,7 @@ import time
 from google import genai
 from google.genai import types
 
+from framework import utils
 import settings
 
 
@@ -58,6 +59,7 @@ class GeminiClient:
     if hasattr(self, 'client') and self.client:
       self.client.close()
 
+  @utils.retry(MAX_RETRIES, delay=RETRY_BACKOFF_SECONDS)
   def get_response(self, prompt: str) -> str:
     """Sends a prompt to the Gemini model and returns the text response.
 
@@ -73,47 +75,27 @@ class GeminiClient:
     logging.info('--- Sending Prompt to Gemini --- \n'
                  f'{prompt}\n'
                  '---------------------------------')
-    last_exception = None
 
-    for attempt in range(1, GeminiClient.MAX_RETRIES + 1):
-      try:
-        if attempt > 1:
-          logging.info(f'Starting attempt {attempt}/{GeminiClient.MAX_RETRIES}...')
+    response = self.client.models.generate_content(
+      model=GeminiClient.GEMINI_MODEL,
+      contents=prompt,
+      config=types.GenerateContentConfig(
+        # timeout is passed to the config using milliseconds.
+        http_options=types.HttpOptions(timeout=GeminiClient.API_TIMEOUT_SECONDS * 1000)
+      )
+    )
 
-        response = self.client.models.generate_content(
-          model=GeminiClient.GEMINI_MODEL,
-          contents=prompt,
-          config=types.GenerateContentConfig(
-            # timeout is passed to the config using milliseconds.
-            http_options=types.HttpOptions(timeout=GeminiClient.API_TIMEOUT_SECONDS * 1000)
-          )
-        )
+    if not response.text:
+      raise RuntimeError('No text response received from the API.')
 
-        if not response.text:
-          raise RuntimeError('No text response received from the API.')
+    # Check for the specific failure sentinel in the response.
+    # Using lstrip().upper() for robustness against minor formatting variations.
+    if response.text.lstrip().upper().startswith("RESPONSE FAILED"):
+      # Log the specific failure reason returned by the model
+      logging.warning(f'Model returned failure sentinel: {response.text}')
+      raise RuntimeError(f'Model reported failure: {response.text}')
 
-        # Check for the specific failure sentinel in the response.
-        # Using lstrip().upper() for robustness against minor formatting variations.
-        if response.text.lstrip().upper().startswith("RESPONSE FAILED"):
-          # Log the specific failure reason returned by the model
-          logging.warning(f'Model returned failure sentinel on attempt {attempt}: {response.text}')
-          raise RuntimeError(f'Model reported failure: {response.text}')
-
-        return response.text
-
-      except Exception as e:
-        last_exception = e
-        logging.error(f'Attempt {attempt}/{GeminiClient.MAX_RETRIES} failed: {e}')
-
-        if attempt < GeminiClient.MAX_RETRIES:
-          sleep_time = GeminiClient.RETRY_BACKOFF_SECONDS * attempt
-          logging.info(f'Waiting {sleep_time}s before retry...')
-          time.sleep(sleep_time)
-
-    # If loop finishes without returning, raise the last error encountered.
-    raise RuntimeError(
-      f'Failed to get valid response after {GeminiClient.MAX_RETRIES} attempts'
-    ) from last_exception
+    return response.text
 
   async def get_response_async(self, prompt: str) -> str:
     """Asynchronously sends a prompt to the Gemini model.


### PR DESCRIPTION
This change updates the GeminiClient logic to allow 3 tries for both "hard" and "soft" failures.

- If the Gemini API fails to send a response, we will retry the request after a short wait (2 seconds).
- If the Gemini API sends a response but the response denotes a failure, then we will also retry.

The logic for soft failures is prepended to all of our prompts:
```
### **Critical Error Handling Rule**

**Before all other instructions, apply this rule:** If the provided `SPECIFICATION_DOCUMENT` content is empty, nonsensical, or clearly not a valid specification (e.g., an HTML 'Not Found' page, boilerplate text), your **entire** response must be *only* the following string, followed by a brief explanation:
`RESPONSE FAILED: <short explanation of the issue>`

**Examples:**
* `RESPONSE FAILED: Provided specification document was empty.`
* `RESPONSE FAILED: Content is an HTML '404 Not Found' page, not a specification.`
* `RESPONSE FAILED: Content does not appear to be a valid specification document.`
```

This now updates the maximum wait time for async requests to 9 minutes, to allow the maximum (3 minute timeout * 3 tries).