### PR TITLE
Never exclude deprecations from release notes.

### DIFF
--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -98,9 +98,17 @@ def get_future_results(async_features: Future | None) -> list[FeatureEntry]:
 
 def _filter_out_wp_features_lacking_enterprise_approval(
     features: list[FeatureEntry]) -> list[FeatureEntry]:
-  """Take out any WP features that did not yet earn enterprise approval."""
+  """Take out any WP features that did not yet earn enterprise approval.
+  But, leave in any deprecation-type features.
+  """
+  FEATURE_TYPES_TO_FILTER = [
+      FEATURE_TYPE_INCUBATE_ID,
+      FEATURE_TYPE_EXISTING_ID,
+      FEATURE_TYPE_CODE_CHANGE_ID,
+      # Not enterprise- or deprecation-type features.
+  ]
   wp_feature_ids = {fe.key.integer_id() for fe in features
-                    if fe.feature_type != FEATURE_TYPE_ENTERPRISE_ID}
+                    if fe.feature_type in FEATURE_TYPES_TO_FILTER}
   approved_enterprise_gates: list[Gate] = []
   if wp_feature_ids:
     approved_enterprise_gates = Gate.query(

--- a/internals/feature_helpers_test.py
+++ b/internals/feature_helpers_test.py
@@ -31,25 +31,26 @@ class FeatureHelpersTest(testing_config.CustomTestCase):
     self.feature_2 = FeatureEntry(
         name='feature b', summary='sum',
         owner_emails=['feature_owner@example.com'], category=1,
-        updated=datetime(2020, 4, 1), feature_type=1, impl_status_chrome=1)
+        updated=datetime(2020, 4, 1), feature_type=FEATURE_TYPE_EXISTING_ID,
+        impl_status_chrome=1)
     self.feature_2.put()
 
     self.feature_1 = FeatureEntry(
         name='feature a', summary='sum', impl_status_chrome=3,
         owner_emails=['feature_owner@example.com'], category=1,
-        updated=datetime(2020, 3, 1), feature_type=0)
+        updated=datetime(2020, 3, 1), feature_type=FEATURE_TYPE_INCUBATE_ID)
     self.feature_1.put()
 
     self.feature_3 = FeatureEntry(
         name='feature c', summary='sum', category=1, impl_status_chrome=2,
         owner_emails=['feature_owner@example.com'],
-        updated=datetime(2020, 1, 1), feature_type=2)
+        updated=datetime(2020, 1, 1), feature_type=FEATURE_TYPE_CODE_CHANGE_ID)
     self.feature_3.put()
 
     self.feature_4 = FeatureEntry(
         name='feature d', summary='sum', category=1, impl_status_chrome=2,
         owner_emails=['feature_owner@example.com'],
-        updated=datetime(2020, 2, 1), feature_type=3)
+        updated=datetime(2020, 2, 1), feature_type=FEATURE_TYPE_DEPRECATION_ID)
     self.feature_4.put()
 
     fe_1_stage_types = [110, 120, 130, 140, 150, 151, 160]
@@ -485,7 +486,8 @@ class FeatureHelpersTest(testing_config.CustomTestCase):
     self.g4.put()
 
     features = feature_helpers.get_features_in_release_notes(milestone=1)
-    self.assertEqual(0, len(features))
+    # feature_4 is a deprecation, so it is always included.
+    self.assertEqual(['feature d'], [f['name'] for f in features])
     rediscache.delete(cache_key)
 
   def test_get_in_milestone__non_enterprise_features(self):


### PR DESCRIPTION
This should resolve the recent comment on b/454934046.  A previous change excluded any WP features from the enterprise release notes unless they had an approved Enterprise shipping gate.  With this change, deprecations are no longer excluded, so they will appear in the release notes regardless of review gate status.