### PR TITLE
Fix icon library name.

### DIFF
--- a/client-src/elements/chromedash-stack-rank.ts
+++ b/client-src/elements/chromedash-stack-rank.ts
@@ -275,7 +275,11 @@ class ChromedashStackRank extends LitElement {
                 href="#${item.property_name}"
                 @click=${this.scrollToPosition}
               >
-                <sl-icon class="hash-link" library="material" name="link"></sl-icon>
+                <sl-icon
+                  class="hash-link"
+                  library="material"
+                  name="link"
+                ></sl-icon>
                 <p>${item.property_name}</p>
               </a>
             </div>


### PR DESCRIPTION
This fixes a small error introduced in #5551.  I changed from iron-icon to sl-icon, but for the link icon we are using one that is part of the material design icon library, and this reference to it was lacking the library name.  