### PR TITLE
Add more enterprise release notes reviewers.

### DIFF
--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -144,6 +144,11 @@ def can_edit_any_feature(user: User) -> bool:
 RELEASE_NOTE_REVIEWERS = [
     'elmirakalali@google.com',
     'siobhankeating@google.com',
+    'mhoste@google.com',
+    'kimreardon@google.com',
+    'aaudi@google.com',
+    'crushworth@google.com',
+    'atarrant@google.com',
     'jrobbins@google.com']
 
 def can_review_release_notes(user: User) -> bool:


### PR DESCRIPTION
This should address comment 10 on b/446217660.  Basically, the enterprise team just wants more release notes reviewers.  This list has some overlap with their review gate reviewers, but it is not the same list.