### PR TITLE
Increase Gunicorn timeout for local dev

### DIFF
--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -11,7 +11,7 @@ export GAE_ENV='localdev'
 export DATASTORE_EMULATOR_HOST=${DATASTORE_EMULATOR_HOST:-'localhost:15606'}
 
 
-gunicorn --bind :7777 --workers 4 main:app
+gunicorn --bind :7777 --workers 4 main:app --timeout 120
 
 
 # TODO(jrobbins): Consider switching back to dev_appserver when


### PR DESCRIPTION
We were using the default 30 second timeouts here, which causes failures in WPT coverage evaluation pipeline. This increase to 2 minutes fixes this.