### PR TITLE
Loosen the rule for accepting NA_VERIFIED votes.

### DIFF
--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -134,10 +134,13 @@ class VotesAPI(basehandlers.APIHandler):
 
   def check_voting_rules(self, gate, new_state):
     """Abort the request if the user casts a vote that we cannot accept."""
-    if (new_state == Vote.NA_VERIFIED and
-        gate.state not in [Vote.NA_SELF, Vote.NA_VERIFIED]):
-      self.abort(
-          400, msg='User may not verify when gate was not self-certified')
+    if new_state == Vote.NA_VERIFIED:
+      existing_na_votes = Vote.get_votes(
+          feature_id=gate.feature_id, gate_id=gate.key.integer_id(),
+          states=[Vote.NA_SELF, Vote.NA_VERIFIED])
+      if not existing_na_votes:
+        self.abort(
+            400, msg='User may not verify when gate has no self-certifications')
 
 
 class GatesAPI(basehandlers.APIHandler):

--- a/api/reviews_api_test.py
+++ b/api/reviews_api_test.py
@@ -342,6 +342,25 @@ class VotesAPITest(testing_config.CustomTestCase):
         self.feature_1, self.gate_1, 'owner1@example.com',
         Vote.NA_SELF, Vote.NO_RESPONSE)
 
+  def test_check_voting_rules__not_verification(self):
+    """We allow anything that is not NA_VERIFIED."""
+    self.handler.check_voting_rules(self.gate_1, Vote.NO_RESPONSE)
+    self.handler.check_voting_rules(self.gate_1, Vote.NA_SELF)
+    self.handler.check_voting_rules(self.gate_1, Vote.APPROVED)
+    self.handler.check_voting_rules(self.gate_1, Vote.REVIEW_REQUESTED)
+    self.handler.check_voting_rules(self.gate_1, Vote.DENIED)
+    self.handler.check_voting_rules(self.gate_1, Vote.NEEDS_WORK)
+
+  def test_check_voting_rules__verification(self):
+    """A NA_VERIFIED is only accepted if there was a NA_SELF."""
+    self.vote_1_1.put()
+    with self.assertRaises(werkzeug.exceptions.BadRequest):
+      self.handler.check_voting_rules(self.gate_1, Vote.NA_VERIFIED)
+
+    self.vote_1_1.state = Vote.NA_SELF
+    self.vote_1_1.put()
+    self.handler.check_voting_rules(self.gate_1, Vote.NA_VERIFIED)
+
 
 class GatesAPITest(testing_config.CustomTestCase):
 


### PR DESCRIPTION
This should resolve #5721.

The `check_voting_rules()` method is not responsible for permission checking, it only checks that a NA_VERIFIED vote can only be made in response to a NA_SELF vote.  In the most common case, the feature owner votes NA_SELF and a reviewer might later vote NA_VERIFIED.  Also, multiple reviewers can verify the same gate.

Issue #5721 pointed out that people don't always follow the expected usage flow.  In the case where a reviewer initiated the review by voting NEEDS_WORK, then the feature owner self-certified, the reviewer could not verify because their own NEEDS_WORK would block the NA_VERIFIED.   The fix is to simply look for any existing NA_SELF (or NA_VERIFIED) vote, rather than looking at the overall gate state, which takes more rules into account.

This looser rule is OK because it only controls storing the requested vote, not determining the resulting gate state.  For example, if two reviewers both voted NEEDS_WORK, then the feature owner self-certified, and one reviewer changed their vote to NA_VERIFIED, then that vote would be accepted, but the overall gate state would remain NEEDS_WORK because of the second reviewer's vote.