### PR TITLE
Manually upgrade prettier to 3.7.3.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "lodash.template": ">=4.5.0",
         "minimist": ">=1.2.8",
         "path-parse": ">=1.0.7",
-        "prettier": "^3.6.2",
+        "prettier": "^3.7.3",
         "regenerator-runtime": "^0.14.1",
         "rollup": "^4.53.3",
         "rollup-plugin-babel-minify": "^10.0.0",
@@ -12121,10 +12121,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.3.tgz",
+      "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "lodash.template": ">=4.5.0",
     "minimist": ">=1.2.8",
     "path-parse": ">=1.0.7",
-    "prettier": "^3.6.2",
+    "prettier": "^3.7.3",
     "regenerator-runtime": "^0.14.1",
     "rollup": "^4.53.3",
     "rollup-plugin-babel-minify": "^10.0.0",


### PR DESCRIPTION
This is just upgrading the version of `prettier` and running `npm install`.   I think that it accomplishes the goal of upgrading prettier without the unexpected `peer: true` changes that we saw in dependabot's PR #5734 .