### PR TITLE
Set timestamp when submitting a new report request

### DIFF
--- a/client-src/elements/chromedash-wpt-eval-page.ts
+++ b/client-src/elements/chromedash-wpt-eval-page.ts
@@ -432,6 +432,7 @@ export class ChromedashWPTEvalPage extends LitElement {
       this.feature = {
         ...this.feature,
         ai_test_eval_run_status: AITestEvaluationStatus.IN_PROGRESS,
+        ai_test_eval_status_timestamp: new Date().toString(),
       };
       this.completedInThisSession = false; // Reset if user tries to regenerate.
       this.managePolling();


### PR DESCRIPTION
This change updates the UI logic to reset the `ai_test_eval_status_timestamp` to the current time when submitting a report generation request. Without this change, the button briefly displays as "Process timed out. Try again." after submitting a report generation request if the previous timestamp was 1 hour+ old.