### PR TITLE
Fix bugs on releasenotes page

### DIFF
--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -54,10 +54,11 @@ export const IS_MOBILE = (() => {
  * where appropriate.
  */
 export function autolink(
-  s,
+  s: string | null | undefined,
   featureLinks: FeatureLink[] = [],
   isMarkdown: boolean = false
 ): TemplateResult[] {
+  s = s ?? '';
   if (isMarkdown) {
     const rendered: string = marked.parse(s) as string;
     const sanitized: string = DOMPurify.sanitize(rendered);


### PR DESCRIPTION
This PR fixes several bugs found while testing the enterprise release notes page:
* Summary markdown preview was previewing the last saved value rather than the value that the user typed.  The fix is to always render the textarea but sometimes make it visually hidden, then get its value for the preview.
* WP features that had enterprise impact but no rollout stage have a synthetic stage generated for display, but that synthetic stage was missing a rollout plan and details.  The fix is to provide default values of those fields.
* For a custom rollout plan, the rollout details were shown instead of the word "custom", but that is redundant with the display of the rollout details on the next line.  The fix is to show the phrase "Custom rollout" and leave the details for the next line.
* Some existing feature entries may have `undefined` as the rollout plan, in which case we display 'No plan specified` until the user  makes a choice.
* The sl-select for the rollout plan had no sl-options.  The fix was to add them.
* Markdown rendering failed when an undefined value was passed in.  Now we treat that as an empty string to avoid the error.