### PR TITLE
Improve robustness of SLO reminder generation.

### DIFF
--- a/internals/approval_defs.py
+++ b/internals/approval_defs.py
@@ -45,7 +45,6 @@ ENTERPRISE_APPROVERS = [
     'mhoste@google.com',
     'angelaweber@google.com',
     'davidayad@google.com',
-    'omole@google.com',
     'nsamarakkody@google.com',
     'pastarmovj@google.com',
     'aaudi@google.com',

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -352,7 +352,8 @@ class SLOOverdueHandler(basehandlers.FlaskHandler):
     # Add an alphabetical list of unique recipients to the return message.
     if len(email_tasks):
       recipients = '\n'.join(
-          sorted(list(set([task['to'] for task in email_tasks]))))
+          sorted(list(set([task['to'] for task in email_tasks
+                           if 'to' in task]))))
       recipients_str = f'\nRecipients:\n{recipients}'
     message =  f'{len(email_tasks)} email(s) sent or logged.{recipients_str}'
     logging.info(message)

--- a/internals/reminders_test.py
+++ b/internals/reminders_test.py
@@ -513,7 +513,7 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
     with test_app.app_context():
       actual = self.handler.get_template_data()
 
-    expected_message = (f'11 email(s) sent or logged.\n'
+    expected_message = (f'10 email(s) sent or logged.\n'
                         'Recipients:\n'
                         'aaudi@google.com\n'
                         'angelaweber@google.com\n'
@@ -524,7 +524,6 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
                         'kimreardon@google.com\n'
                         'mhoste@google.com\n'
                         'nsamarakkody@google.com\n'
-                        'omole@google.com\n'
                         'pastarmovj@google.com'
                         )
     expected = {'message': expected_message}
@@ -551,6 +550,27 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
     self.assertEqual(actual, expected)
 
   @mock.patch('internals.slo.now_utc')
+  def test_get_template_data__one_due_assigned_bounced(self, mock_now_utc):
+    """One gate is due, but one reviewer has bounced email."""
+    self.gate_1.state = Vote.REVIEW_REQUESTED
+    self.gate_1.assignee_emails = [
+        'b_assignee@example.com', 'a_assignee@example.com']
+    self.gate_1.requested_on = self.request_date
+    self.gate_1.put()
+    mock_now_utc.return_value = self.day_6
+    user_pref = UserPref(email='b_assignee@example.com', bounced=True)
+    user_pref.put()
+
+    with test_app.app_context():
+      actual = self.handler.get_template_data()
+
+    expected_message = ('2 email(s) sent or logged.\n'
+                        'Recipients:\n'
+                        'a_assignee@example.com')
+    expected = {'message': expected_message}
+    self.assertEqual(actual, expected)
+
+  @mock.patch('internals.slo.now_utc')
   def test_get_template_data__initial_overdue_unassigned(self, mock_now_utc):
     """Overdue for initial response. Notify all reviewers."""
     self.gate_1.state = Vote.REVIEW_REQUESTED
@@ -561,7 +581,7 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
     with test_app.app_context():
       actual = self.handler.get_template_data()
 
-    expected_message = (f'11 email(s) sent or logged.\n'
+    expected_message = (f'10 email(s) sent or logged.\n'
                         'Recipients:\n'
                         'aaudi@google.com\n'
                         'angelaweber@google.com\n'
@@ -572,7 +592,6 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
                         'kimreardon@google.com\n'
                         'mhoste@google.com\n'
                         'nsamarakkody@google.com\n'
-                        'omole@google.com\n'
                         'pastarmovj@google.com')
     expected = {'message': expected_message}
     self.assertEqual(actual, expected)
@@ -590,7 +609,7 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
     with test_app.app_context():
       actual = self.handler.get_template_data()
 
-    expected_message = ('12 email(s) sent or logged.\n'
+    expected_message = ('11 email(s) sent or logged.\n'
                         'Recipients:\n'
                         'a_assignee@example.com\n'
                         'aaudi@google.com\n'
@@ -602,7 +621,6 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
                         'kimreardon@google.com\n'
                         'mhoste@google.com\n'
                         'nsamarakkody@google.com\n'
-                        'omole@google.com\n'
                         'pastarmovj@google.com')
     expected = {'message': expected_message}
     self.assertEqual(actual, expected)
@@ -618,7 +636,7 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
     with test_app.app_context():
       actual = self.handler.get_template_data()
 
-    expected_message = ('11 email(s) sent or logged.\n'
+    expected_message = ('10 email(s) sent or logged.\n'
                         'Recipients:\n'
                         'aaudi@google.com\n'
                         'angelaweber@google.com\n'
@@ -629,7 +647,6 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
                         'kimreardon@google.com\n'
                         'mhoste@google.com\n'
                         'nsamarakkody@google.com\n'
-                        'omole@google.com\n'
                         'pastarmovj@google.com')
     expected = {'message': expected_message}
     self.assertEqual(actual, expected)
@@ -646,7 +663,7 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
     with test_app.app_context():
       actual = self.handler.get_template_data()
 
-    expected_message = ('11 email(s) sent or logged.\n'
+    expected_message = ('10 email(s) sent or logged.\n'
                         'Recipients:\n'
                         'aaudi@google.com\n'
                         'angelaweber@google.com\n'
@@ -657,7 +674,6 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
                         'kimreardon@google.com\n'
                         'mhoste@google.com\n'
                         'nsamarakkody@google.com\n'
-                        'omole@google.com\n'
                         'pastarmovj@google.com')
     expected = {'message': expected_message}
     self.assertEqual(actual, expected)
@@ -719,7 +735,7 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
         {self.feature_1.key.integer_id(): self.feature_1},
         True, True)
 
-    self.assertEqual(13, len(actual))
+    self.assertEqual(12, len(actual))
     task = actual[0]
     self.assertEqual('a_assignee@example.com', task['to'])
     self.assertEqual('ESCALATED: Review due for: feature one', task['subject'])
@@ -757,7 +773,7 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
         {self.feature_1.key.integer_id(): self.feature_1},
         True, False)
 
-    self.assertEqual(13, len(actual))
+    self.assertEqual(12, len(actual))
     task = actual[0]
     self.assertEqual('a_assignee@example.com', task['to'])
     self.assertEqual('ESCALATED: Review due for: feature one', task['subject'])


### PR DESCRIPTION
This addresses an error that we saw in prod this morning.  Basically, we were logging the email addresses of email recipients, but a recent change to handling accounts that had bounced emails meant that sometimes the email task might not have a `to` field.

In particular, there was an obsolete reviewer listed on one of the gates and emails to them had bounced.  So, I removed them.