### PR TITLE
Use defensive coding when converting Amendment to OpenAPI.

### DIFF
--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -36,8 +36,8 @@ from internals.review_models import Activity, Amendment, Gate
 def amendment_to_OAM(amendment: Amendment) -> AmendmentModel:
   return AmendmentModel(
       field_name = amendment.field_name,
-      old_value = amendment.old_value.strip('[]'),
-      new_value = amendment.new_value.strip('[]'),
+      old_value = (amendment.old_value or '').strip('[]'),
+      new_value = (amendment.new_value or '').strip('[]'),
   )
 
 

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -34,6 +34,25 @@ NOW = datetime.datetime.now()
 
 class CommentsConvertersTest(testing_config.CustomTestCase):
 
+  def test_amendment_to_OAM__normal(self):
+    """We can convert a NDB Amendment to a Open API Amendment."""
+    amend = Amendment(
+        field_name='summary',
+        old_value='old',
+        new_value='[new,fresh]')
+    oam = comments_api.amendment_to_OAM(amend)
+    self.assertEqual(oam.field_name, 'summary')
+    self.assertEqual(oam.old_value, 'old')
+    self.assertEqual(oam.new_value, 'new,fresh')
+
+  def test_amendment_to_OAM__null(self):
+    """We can convert, even if some field was specified."""
+    amend = Amendment(field_name='summary', old_value='old')
+    oam = comments_api.amendment_to_OAM(amend)
+    self.assertEqual(oam.field_name, 'summary')
+    self.assertEqual(oam.old_value, 'old')
+    self.assertEqual(oam.new_value, '')
+
   def test_amendment_to_json_dict(self):
     amnd = Amendment(
         field_name='summary', old_value='foo', new_value='bar')


### PR DESCRIPTION
This should address an error seen on staging just now.
Somehow we got an Amendment object stored in NDB that had a `null` for the new_value, so we can't assume it is a string.