### PR TITLE
Remove unnecessary icons on roadmap page

### DIFF
--- a/client-src/elements/chromedash-roadmap-milestone-card.ts
+++ b/client-src/elements/chromedash-roadmap-milestone-card.ts
@@ -323,18 +323,6 @@ export class ChromedashRoadmapMilestoneCard extends LitElement {
                 </span>
               `
             : nothing}
-          ${ORIGIN_TRIAL.includes(shippingType)
-            ? html`
-                <span class="tooltip" title="Origin Trial">
-                  <sl-icon
-                    library="material"
-                    name="extension"
-                    class="experimental"
-                    data-tooltip
-                  ></sl-icon>
-                </span>
-              `
-            : nothing}
           ${DEPRECATION_TRIAL.includes(shippingType)
             ? html`
                 <span class="tooltip" title="Deprecation Trial">
@@ -353,17 +341,6 @@ export class ChromedashRoadmapMilestoneCard extends LitElement {
                   <sl-icon
                     name="x-circle-fill"
                     class="remove"
-                    data-tooltip
-                  ></sl-icon>
-                </span>
-              `
-            : nothing}
-          ${DEPRECATED_STATUS.includes(shippingType)
-            ? html`
-                <span class="tooltip" title="Deprecated">
-                  <sl-icon
-                    name="exclamation-triangle-fill"
-                    class="deprecated"
                     data-tooltip
                   ></sl-icon>
                 </span>


### PR DESCRIPTION
I realized after looking at the roadmap page that there are two redundant icons that populate the milestone cards, specifically for deprecations and origin trials (the triangle exclamation sign and the puzzle piece).

<img width="591" height="1158" alt="Screenshot 2026-01-06 11 59 05 AM" src="https://github.com/user-attachments/assets/3d5b9dc7-86ec-4d7b-85a9-467613de8fb3" />

<img width="590" height="358" alt="Screenshot 2026-01-06 12 02 01 PM" src="https://github.com/user-attachments/assets/4982391f-a708-4061-ac88-90ae531ff40e" />


Both the deprecation and origin trial feature are already in their own section, so their entire section contains these icons for each feature. The page is already a little busy, so this can be removed to make it more clear what information is actually relevant