### PR TITLE
Refactor shipping features logic to be reusable

### DIFF
--- a/api/shipping_features_api_test.py
+++ b/api/shipping_features_api_test.py
@@ -13,60 +13,19 @@
 # limitations under the License.
 
 import flask
-import json5
 import werkzeug.exceptions
 from unittest import mock
 
 import testing_config
 from api import shipping_features_api
 from internals import core_enums
-from internals.core_models import FeatureEntry, Stage, MilestoneSet
-from internals.review_models import Gate, Vote
+from internals.core_models import Stage, MilestoneSet
 
 test_app = flask.Flask(__name__)
 
-# Mock data representing the content of Chromium source files.
-MOCK_ENABLED_FEATURES_JSON5 = """
-{
-  "data": [
-    // For feature_1: A complete feature that is stable.
-    { "name": "featureOneFinch", "status": "stable" },
-    // For feature_7: An incomplete feature that is not stable.
-    { "name": "feature7-unstable", "status": "experimental" },
-
-    // Status is a dict, and at least one platform is "stable".
-    {
-      "name": "FeatureDictStable",
-      "status": {
-        "Mac": "experimental",
-        "Win": "stable",
-        "Linux": "dev"
-      }
-    },
-    // Status is a dict, but no platform is "stable".
-    {
-      "name": "FeatureDictUnstable",
-      "status": {
-        "Mac": "experimental",
-        "Win": "experimental",
-        "Linux": "experimental"
-      }
-    }
-  ]
-}
-"""
-
-MOCK_CONTENT_FEATURES_CC = """
-// Some C++ code here...
-// For feature_8: A complete feature, enabled by default.
-BASE_FEATURE(kFeature8Enabled,
-             // Some rogue comment.
-             base::FEATURE_ENABLED_BY_DEFAULT);
-// More C++ code...
-// For feature_9: An incomplete feature, disabled by default.
-BASE_FEATURE(kFeature9Disabled, base::FEATURE_DISABLED_BY_DEFAULT);
-// Even more C++ code...
-"""
+# Minimal mock data to ensure json5.loads works in the handler.
+MOCK_ENABLED_FEATURES_JSON5 = '{ \"data\": [] }'
+MOCK_CONTENT_FEATURES_CC = 'BASE_FEATURE...'
 
 
 class ShippingFeaturesAPITest(testing_config.CustomTestCase):
@@ -75,221 +34,42 @@ class ShippingFeaturesAPITest(testing_config.CustomTestCase):
     self.handler = shipping_features_api.ShippingFeaturesAPI()
     self.milestone = 120
 
-    # Feature 1: Complete - Should be in `complete_features`.
-    # Finch name 'featureOneFinch' is in MOCK_ENABLED_FEATURES_JSON5 as "stable".
-    self.feature_1 = FeatureEntry(
-        id=1, name='Feature 1 (Complete)', summary='sum', category=1,
-        feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID,
-        finch_name='featureOneFinch', owner_emails=['owner@example.com'],
-        bug_url='https://example.com/bug1',
-        launch_bug_url='https://example.com/launch1')
-    self.feature_1.put()
-    stage_1 = Stage(
-        id=101, feature_id=1, stage_type=160,  # Shipping stage
-        intent_thread_url='https://example.com/intent1',
+    # Stages 1 & 2: Matches Milestone 120 (Various platforms)
+    self.stage_1 = Stage(id=101, feature_id=1, stage_type=160,
         milestones=MilestoneSet(desktop_first=self.milestone))
-    stage_1.put()
-    Gate(id=1001, feature_id=1, stage_id=101, gate_type=core_enums.GATE_API_SHIP,
-         state=Vote.APPROVED).put()
+    self.stage_1.put()
 
-    # Feature 2: Incomplete (Missing LGTM) - Should be in `incomplete_features`.
-    self.feature_2 = FeatureEntry(
-        id=2, name='Feature 2 (No LGTM)', summary='sum', category=1,
-        feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID,
-        finch_name='feature2-finch')
-    self.feature_2.put()
-    stage_2 = Stage(
-        id=102, feature_id=2, stage_type=160,
-        intent_thread_url='https://example.com/intent2',
+    self.stage_2 = Stage(id=102, feature_id=2, stage_type=160,
         milestones=MilestoneSet(android_first=self.milestone))
-    stage_2.put()
-    Gate(id=1002, feature_id=2, stage_id=102, gate_type=core_enums.GATE_API_SHIP,
-         state=Vote.NA).put()  # Not approved
+    self.stage_2.put()
 
-    # Feature 3: Incomplete (Missing Intent to Ship).
-    self.feature_3 = FeatureEntry(
-        id=3, name='Feature 3 (No I2S)', summary='sum', category=1,
-        feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID,
-        finch_name='feature3-finch')
-    self.feature_3.put()
-    stage_3 = Stage(
-        id=103, feature_id=3, stage_type=160,
-        intent_thread_url=None,  # Missing intent
-        milestones=MilestoneSet(webview_first=self.milestone))
-    stage_3.put()
-    Gate(id=1003, feature_id=3, stage_id=103, gate_type=core_enums.GATE_API_SHIP,
-         state=Vote.APPROVED).put()
-    Gate(id=1010, feature_id=3, stage_id=103,
-         gate_type=core_enums.GATE_DEBUGGABILITY_SHIP, # Not an API owners gate.
-         state=Vote.APPROVED).put()
+    # Stage 3: Wrong Milestone (Should be ignored)
+    self.stage_3 = Stage(id=106, feature_id=6, stage_type=160,
+        milestones=MilestoneSet(desktop_first=self.milestone + 1))
+    self.stage_3.put()
 
-    # Feature 4: Incomplete (Missing Finch name and justification).
-    self.feature_4 = FeatureEntry(
-        id=4, name='Feature 4 (No Finch)', summary='sum', category=1,
-        feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID,
-        finch_name=None, non_finch_justification=None)  # Both missing
-    self.feature_4.put()
-    stage_4 = Stage(
-        id=104, feature_id=4, stage_type=160,
-        intent_thread_url='https://example.com/intent4',
+    # Stage 4: Wrong Stage Type (Dev trial, should be ignored)
+    self.stage_4 = Stage(id=107, feature_id=7, stage_type=110,
         milestones=MilestoneSet(desktop_first=self.milestone))
-    stage_4.put()
-    Gate(id=1004, feature_id=4, stage_id=104, gate_type=core_enums.GATE_API_SHIP,
-         state=Vote.APPROVED).put()
-
-    # Feature 5: Complete (PSA/Code Change) - Bypasses checks.
-    self.feature_5 = FeatureEntry(
-        id=5, name='Feature 5 (PSA)', summary='sum', category=1,
-        feature_type=core_enums.FEATURE_TYPE_CODE_CHANGE_ID) # PSA type
-    self.feature_5.put()
-    stage_5 = Stage(
-        id=105, feature_id=5, stage_type=360,
-        milestones=MilestoneSet(desktop_first=self.milestone))
-    stage_5.put()
-
-    # Feature 6: Wrong Milestone - Should be excluded entirely.
-    self.feature_6 = FeatureEntry(
-        id=6, name='Feature 6 (Wrong Mstone)', summary='sum', category=1,
-        feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID,
-        finch_name='feature6-finch')
-    self.feature_6.put()
-    stage_6 = Stage(
-        id=106, feature_id=6, stage_type=160,
-        intent_thread_url='https://example.com/intent6',
-        milestones=MilestoneSet(desktop_first=self.milestone + 1))  # Future mstone
-    stage_6.put()
-    Gate(id=1006, feature_id=6, stage_id=106, gate_type=core_enums.GATE_API_SHIP,
-         state=Vote.APPROVED).put()
-
-    # Feature 7: Incomplete (Not stable in runtime_enabled_features.json5).
-    self.feature_7 = FeatureEntry(
-        id=7, name='F7 Unstable', summary='sum', category=1,
-        feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID,
-        finch_name='feature7-unstable')
-    self.feature_7.put()
-    stage_7 = Stage(
-        id=107, feature_id=7, stage_type=160,
-        intent_thread_url='https://example.com/intent7',
-        milestones=MilestoneSet(desktop_first=self.milestone))
-    stage_7.put()
-    Gate(id=1007, feature_id=7, stage_id=107, gate_type=core_enums.GATE_API_SHIP,
-         state=Vote.APPROVED).put()
-
-    # Feature 8: Complete (Enabled in content_features.cc).
-    self.feature_8 = FeatureEntry(
-        id=8, name='F8 Enabled', summary='sum', category=1,
-        feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID,
-        finch_name='Feature8Enabled')
-    self.feature_8.put()
-    stage_8 = Stage(
-        id=108, feature_id=8, stage_type=160,
-        intent_thread_url='https://example.com/intent8',
-        milestones=MilestoneSet(desktop_first=self.milestone))
-    stage_8.put()
-    Gate(id=1008, feature_id=8, stage_id=108, gate_type=core_enums.GATE_API_SHIP,
-         state=Vote.APPROVED).put()
-
-    # Feature 9: Incomplete (Disabled in content_features.cc).
-    self.feature_9 = FeatureEntry(
-        id=9, name='F9 Disabled', summary='sum', category=1,
-        feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID,
-        finch_name='Feature9Disabled')
-    self.feature_9.put()
-    stage_9 = Stage(
-        id=109, feature_id=9, stage_type=160,
-        intent_thread_url='https://example.com/intent9',
-        milestones=MilestoneSet(desktop_first=self.milestone))
-    stage_9.put()
-    Gate(id=1009, feature_id=9, stage_id=109, gate_type=core_enums.GATE_API_SHIP,
-         state=Vote.APPROVED).put()
-
-    # Feature 10: Incomplete (Not found in Chromium files).
-    self.feature_10 = FeatureEntry(
-        id=10, name='F10 Not Found', summary='sum', category=1,
-        feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID,
-        finch_name='non-existent-feature')
-    self.feature_10.put()
-    stage_10 = Stage(
-        id=110, feature_id=10, stage_type=160,
-        intent_thread_url='https://example.com/intent10',
-        milestones=MilestoneSet(desktop_first=self.milestone))
-    stage_10.put()
-    Gate(id=1010, feature_id=10, stage_id=110, gate_type=core_enums.GATE_API_SHIP,
-         state=Vote.APPROVED).put()
-
-
-    # Stage for a feature that doesn't exist - Should be logged and ignored.
-    self.stage_deleted_feature = Stage(
-        id=999, feature_id=999, stage_type=160,
-        milestones=MilestoneSet(desktop_first=self.milestone))
-    self.stage_deleted_feature.put()
+    self.stage_4.put()
 
   def tearDown(self):
-    for kind in [FeatureEntry, Stage, Gate]:
-      for entity in kind.query():
-        entity.key.delete()
+    for entity in Stage.query():
+      entity.key.delete()
 
   def test_get_shipping_stages__success(self):
     """Should retrieve only stages with the correct milestone and type."""
     shipping_stages = self.handler._get_shipping_stages(self.milestone)
-    # 10 stages are in the target milestone (stages for features 1-5, 7-10,
-    # and the deleted feature 999).
-    self.assertEqual(len(shipping_stages), 10)
 
-    feature_ids = {s.feature_id for s in shipping_stages}
-    expected_ids = {1, 2, 3, 4, 5, 7, 8, 9, 10, 999}
-    self.assertEqual(feature_ids, expected_ids)
+    # Should match stage_1 and stage_2 only.
+    self.assertEqual(len(shipping_stages), 2)
+    stage_ids = {s.key.integer_id() for s in shipping_stages}
+    self.assertEqual(stage_ids, {101, 102})
 
-  def test_validate_feature_in_chromium__all_cases(self):
-    """Tests the validation logic against mock Chromium file content."""
-    handler = shipping_features_api.ShippingFeaturesAPI()
-    enabled_features_json = json5.loads(MOCK_ENABLED_FEATURES_JSON5)
-    content_features_file = MOCK_CONTENT_FEATURES_CC
-
-    # Case 1: Found in JSON and stable -> No missing criteria.
-    result = handler._validate_feature_in_chromium(
-        'featureOneFinch', enabled_features_json, content_features_file)
-    self.assertEqual(result, [])
-
-    # Case 2: Found in JSON but not stable.
-    result = handler._validate_feature_in_chromium(
-        'feature7-unstable', enabled_features_json, content_features_file)
-    self.assertEqual(result,
-        [shipping_features_api.Criteria.RUNTIME_FEATURE_NOT_STABLE])
-
-    # Case 3: Found in .cc file and enabled.
-    result = handler._validate_feature_in_chromium(
-        'Feature8Enabled', enabled_features_json, content_features_file)
-    self.assertEqual(result, [])
-
-    # Case 4: Found in .cc file but disabled.
-    result = handler._validate_feature_in_chromium(
-        'Feature9Disabled', enabled_features_json, content_features_file)
-    self.assertEqual(result,
-        [shipping_features_api.Criteria.CONTENT_FEATURE_NOT_ENABLED])
-
-    # Case 5: Not found in either file.
-    result = handler._validate_feature_in_chromium(
-        'not-a-real-feature', enabled_features_json, content_features_file)
-    self.assertEqual(result,
-        [shipping_features_api.Criteria.CHROMIUM_FEATURE_NOT_FOUND])
-
-    # Found in JSON, status is dict, one platform is "stable".
-    result = handler._validate_feature_in_chromium(
-        'FeatureDictStable', enabled_features_json, content_features_file)
-    self.assertEqual(result, [])
-
-    # Found in JSON, status is dict, no platforms are "stable".
-    result = handler._validate_feature_in_chromium(
-        'FeatureDictUnstable', enabled_features_json, content_features_file)
-    self.assertEqual(result,
-        [shipping_features_api.Criteria.RUNTIME_FEATURE_NOT_STABLE])
-
-
-  @mock.patch('logging.warning')
+  @mock.patch('internals.feature_helpers.aggregate_shipping_features')
   @mock.patch('api.shipping_features_api.utils.get_chromium_file')
-  def test_do_get__success(self, mock_get_chromium_file, mock_logging):
-    """Correctly categorizes features into complete and incomplete lists."""
+  def test_do_get__success(self, mock_get_chromium_file, mock_aggregate):
+    """Handler should fetch files and delegate logic to the helper function."""
     def mock_get_file(url):
       if url == core_enums.ENABLED_FEATURES_FILE_URL:
         return MOCK_ENABLED_FEATURES_JSON5
@@ -298,85 +78,41 @@ class ShippingFeaturesAPITest(testing_config.CustomTestCase):
       return ''
     mock_get_chromium_file.side_effect = mock_get_file
 
+    # Define the expected return from the helper
+    mock_response_data = {
+        'complete_features': [{'name': 'Feature 1'}],
+        'incomplete_features': []
+    }
+    mock_aggregate.return_value = (
+        mock_response_data['complete_features'],
+        mock_response_data['incomplete_features']
+    )
+
     with test_app.test_request_context(
         f'/api/v0/features/shipping?mstone={self.milestone}'):
       response = self.handler.do_get(mstone=self.milestone)
 
-    # Verify Complete Features
-    complete_features = response['complete_features']
-    self.assertEqual(len(complete_features), 3)
-    # feature_1 is complete.
-    # feature_5 is a PSA that bypasses checks.
-    # feature_8 is enabled in the mock .cc file.
+    self.assertEqual(response, mock_response_data)
 
-    # Check that the right features are present by checking their URLs
-    complete_urls = {f['chromestatus_url'] for f in complete_features}
-    expected_complete_urls = {
-        'http://localhost/feature/1',
-        'http://localhost/feature/5',
-        'http://localhost/feature/8'
-    }
-    self.assertEqual(complete_urls, expected_complete_urls)
+    # Ensure the helper was called with the stages found in DB and the files fetched
+    mock_aggregate.assert_called_once()
+    call_args = mock_aggregate.call_args[0]
 
-    # Spot-check the data structure of a complete feature (Feature 1)
-    feature_1_info = next(
-        f for f in complete_features if f['name'] == self.feature_1.name)
-    self.assertIsNotNone(feature_1_info)
-    self.assertEqual(feature_1_info['tracking_bug_url'], 'https://example.com/bug1')
-    self.assertEqual(feature_1_info['launch_bug_url'], 'https://example.com/launch1')
-    self.assertEqual(feature_1_info['finch_name'], 'featureOneFinch')
-    self.assertEqual(feature_1_info['owner_emails'], ['owner@example.com'])
-    self.assertEqual(feature_1_info['intent_to_ship'], 'https://example.com/intent1')
+    # List of stages (Order matches query result)
+    passed_stages = call_args[0]
+    passed_stage_ids = sorted([s.key.integer_id() for s in passed_stages])
+    self.assertEqual(passed_stage_ids, [101, 102])
 
-    # Verify Incomplete Features
-    incomplete_features = response['incomplete_features']
-    self.assertEqual(len(incomplete_features), 6)
+    self.assertEqual(call_args[1], {'data': []})
 
-    # Create a map of {feature_name: [reasons]} for easier assertion
-    incomplete_map = {
-        f_info['name']: reasons
-        for f_info, reasons in incomplete_features
-    }
+    self.assertEqual(call_args[2], MOCK_CONTENT_FEATURES_CC)
 
-    # Spot-check the data structure of an incomplete feature (Feature 2)
-    self.assertIn(self.feature_2.name, incomplete_map)
-    feature_2_tuple = next(
-        t for t in incomplete_features if t[0]['name'] == self.feature_2.name)
-    feature_2_info = feature_2_tuple[0]
-    self.assertEqual(feature_2_info['chromestatus_url'], 'http://localhost/feature/2')
-    self.assertEqual(feature_2_info['finch_name'], 'feature2-finch')
-    self.assertEqual(feature_2_info['intent_to_ship'], 'https://example.com/intent2')
-
-    # Check the reasons for incompleteness for all 6 features
-    # Feature 2: Missing LGTM
-    self.assertEqual(incomplete_map[self.feature_2.name],
-                     ['lgtms', 'chromium_feature_not_found'])
-    # Feature 3: Missing Intent to Ship
-    self.assertIn(self.feature_3.name, incomplete_map)
-    self.assertEqual(incomplete_map[self.feature_3.name],
-                     ['i2s', 'chromium_feature_not_found'])
-    # Feature 4: Missing Finch name
-    self.assertIn(self.feature_4.name, incomplete_map)
-    self.assertEqual(incomplete_map[self.feature_4.name], ['finch_name'])
-    # Feature 7: Not stable in JSON
-    self.assertIn(self.feature_7.name, incomplete_map)
-    self.assertEqual(
-        incomplete_map[self.feature_7.name], ['runtime_feature_not_stable'])
-    # Feature 9: Not enabled in .cc file
-    self.assertIn(self.feature_9.name, incomplete_map)
-    self.assertEqual(
-        incomplete_map[self.feature_9.name], ['content_feature_not_enabled'])
-    # Feature 10: Not found in Chromium files
-    self.assertIn(self.feature_10.name, incomplete_map)
-    self.assertEqual(
-        incomplete_map[self.feature_10.name], ['chromium_feature_not_found'])
-
-    # Verify that the missing feature was logged
-    mock_logging.assert_called_once_with('Feature 999 not found.')
+    # URL root (constructed from request context)
+    self.assertEqual(call_args[3], 'http://localhost')
 
   def test_do_get__no_features_found(self):
-    """API returns empty lists when no features match the milestone."""
-    unmatched_milestone = 99
+    """API returns empty lists immediately if no features match the milestone."""
+    unmatched_milestone = 999
     with test_app.test_request_context(
         f'/api/v0/features/shipping?mstone={unmatched_milestone}'):
       response = self.handler.do_get(mstone=unmatched_milestone)

--- a/internals/feature_helpers_test.py
+++ b/internals/feature_helpers_test.py
@@ -25,6 +25,48 @@ from internals.core_models import FeatureEntry, MilestoneSet, Stage
 from internals.review_models import Gate, Vote
 
 
+
+MOCK_ENABLED_FEATURES_JSON = {
+  "data": [
+    # For feature_1: A complete feature that is stable.
+    { "name": "featureOneFinch", "status": "stable" },
+    # For feature_7: An incomplete feature that is not stable.
+    { "name": "feature7-unstable", "status": "experimental" },
+
+    # Status is a dict, and at least one platform is "stable".
+    {
+      "name": "FeatureDictStable",
+      "status": {
+        "Mac": "experimental",
+        "Win": "stable",
+        "Linux": "dev"
+      }
+    },
+    # Status is a dict, but no platform is "stable".
+    {
+      "name": "FeatureDictUnstable",
+      "status": {
+        "Mac": "experimental",
+        "Win": "experimental",
+        "Linux": "experimental"
+      }
+    }
+  ]
+}
+
+MOCK_CONTENT_FEATURES_CC = """
+// Some C++ code here...
+// For feature_8: A complete feature, enabled by default.
+BASE_FEATURE(kFeature8Enabled,
+             // Some rogue comment.
+             base::FEATURE_ENABLED_BY_DEFAULT);
+// More C++ code...
+// For feature_9: An incomplete feature, disabled by default.
+BASE_FEATURE(kFeature9Disabled, base::FEATURE_DISABLED_BY_DEFAULT);
+// Even more C++ code...
+"""
+
+
 class FeatureHelpersTest(testing_config.CustomTestCase):
 
   def setUp(self):
@@ -1097,3 +1139,246 @@ class FeatureHelpersFilteringTest(testing_config.CustomTestCase):
     self.assertEqual(2, len(actual))
     self.assertCountEqual(
         ['Unlisted viewable', 'Unlisted hidden'], self._get_names(actual))
+
+
+class ShippingFeatureHelpersTest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.milestone = 120
+
+    # Feature 1: Complete.
+    self.feature_1 = FeatureEntry(
+        id=1, name='Feature 1 (Complete)', summary='sum', category=1,
+        feature_type=FEATURE_TYPE_INCUBATE_ID,
+        finch_name='featureOneFinch', owner_emails=['owner@example.com'],
+        bug_url='https://example.com/bug1',
+        launch_bug_url='https://example.com/launch1')
+    self.feature_1.put()
+    self.stage_1 = Stage(
+        id=101, feature_id=1, stage_type=160,
+        intent_thread_url='https://example.com/intent1',
+        milestones=MilestoneSet(desktop_first=self.milestone))
+    self.stage_1.put()
+    Gate(id=1001, feature_id=1, stage_id=101, gate_type=GATE_API_SHIP,
+         state=Vote.APPROVED).put()
+
+    # Feature 2: Incomplete (Missing LGTM).
+    self.feature_2 = FeatureEntry(
+        id=2, name='Feature 2 (No LGTM)', summary='sum', category=1,
+        feature_type=FEATURE_TYPE_INCUBATE_ID,
+        finch_name='feature2-finch')
+    self.feature_2.put()
+    self.stage_2 = Stage(
+        id=102, feature_id=2, stage_type=160,
+        intent_thread_url='https://example.com/intent2',
+        milestones=MilestoneSet(android_first=self.milestone))
+    self.stage_2.put()
+    Gate(id=1002, feature_id=2, stage_id=102, gate_type=GATE_API_SHIP,
+         state=Vote.NA).put()
+
+    # Feature 3: Incomplete (Missing Intent to Ship).
+    self.feature_3 = FeatureEntry(
+        id=3, name='Feature 3 (No I2S)', summary='sum', category=1,
+        feature_type=FEATURE_TYPE_INCUBATE_ID,
+        finch_name='feature3-finch')
+    self.feature_3.put()
+    self.stage_3 = Stage(
+        id=103, feature_id=3, stage_type=160,
+        intent_thread_url=None,
+        milestones=MilestoneSet(webview_first=self.milestone))
+    self.stage_3.put()
+    Gate(id=1003, feature_id=3, stage_id=103, gate_type=GATE_API_SHIP,
+         state=Vote.APPROVED).put()
+
+    # Feature 4: Incomplete (Missing Finch name and justification).
+    self.feature_4 = FeatureEntry(
+        id=4, name='Feature 4 (No Finch)', summary='sum', category=1,
+        feature_type=FEATURE_TYPE_INCUBATE_ID,
+        finch_name=None, non_finch_justification=None)
+    self.feature_4.put()
+    self.stage_4 = Stage(
+        id=104, feature_id=4, stage_type=160,
+        intent_thread_url='https://example.com/intent4',
+        milestones=MilestoneSet(desktop_first=self.milestone))
+    self.stage_4.put()
+    Gate(id=1004, feature_id=4, stage_id=104, gate_type=GATE_API_SHIP,
+         state=Vote.APPROVED).put()
+
+    # Feature 5: Complete (PSA/Code Change) - Bypasses checks.
+    self.feature_5 = FeatureEntry(
+        id=5, name='Feature 5 (PSA)', summary='sum', category=1,
+        feature_type=FEATURE_TYPE_CODE_CHANGE_ID)
+    self.feature_5.put()
+    self.stage_5 = Stage(
+        id=105, feature_id=5, stage_type=360,
+        milestones=MilestoneSet(desktop_first=self.milestone))
+    self.stage_5.put()
+
+    # Feature 7: Incomplete (Not stable in JSON).
+    self.feature_7 = FeatureEntry(
+        id=7, name='F7 Unstable', summary='sum', category=1,
+        feature_type=FEATURE_TYPE_INCUBATE_ID,
+        finch_name='feature7-unstable')
+    self.feature_7.put()
+    self.stage_7 = Stage(
+        id=107, feature_id=7, stage_type=160,
+        intent_thread_url='https://example.com/intent7',
+        milestones=MilestoneSet(desktop_first=self.milestone))
+    self.stage_7.put()
+    Gate(id=1007, feature_id=7, stage_id=107, gate_type=GATE_API_SHIP,
+         state=Vote.APPROVED).put()
+
+    # Feature 8: Complete (Enabled in content_features.cc).
+    self.feature_8 = FeatureEntry(
+        id=8, name='F8 Enabled', summary='sum', category=1,
+        feature_type=FEATURE_TYPE_INCUBATE_ID,
+        finch_name='Feature8Enabled')
+    self.feature_8.put()
+    self.stage_8 = Stage(
+        id=108, feature_id=8, stage_type=160,
+        intent_thread_url='https://example.com/intent8',
+        milestones=MilestoneSet(desktop_first=self.milestone))
+    self.stage_8.put()
+    Gate(id=1008, feature_id=8, stage_id=108, gate_type=GATE_API_SHIP,
+         state=Vote.APPROVED).put()
+
+    # Feature 9: Incomplete (Disabled in content_features.cc).
+    self.feature_9 = FeatureEntry(
+        id=9, name='F9 Disabled', summary='sum', category=1,
+        feature_type=FEATURE_TYPE_INCUBATE_ID,
+        finch_name='Feature9Disabled')
+    self.feature_9.put()
+    self.stage_9 = Stage(
+        id=109, feature_id=9, stage_type=160,
+        intent_thread_url='https://example.com/intent9',
+        milestones=MilestoneSet(desktop_first=self.milestone))
+    self.stage_9.put()
+    Gate(id=1009, feature_id=9, stage_id=109, gate_type=GATE_API_SHIP,
+         state=Vote.APPROVED).put()
+
+    # Feature 10: Incomplete (Not found in Chromium files).
+    self.feature_10 = FeatureEntry(
+        id=10, name='F10 Not Found', summary='sum', category=1,
+        feature_type=FEATURE_TYPE_INCUBATE_ID,
+        finch_name='non-existent-feature')
+    self.feature_10.put()
+    self.stage_10 = Stage(
+        id=110, feature_id=10, stage_type=160,
+        intent_thread_url='https://example.com/intent10',
+        milestones=MilestoneSet(desktop_first=self.milestone))
+    self.stage_10.put()
+    Gate(id=1010, feature_id=10, stage_id=110, gate_type=GATE_API_SHIP,
+         state=Vote.APPROVED).put()
+
+  def tearDown(self):
+    for kind in [FeatureEntry, Gate, Stage, Vote]:
+      for entity in kind.query():
+        entity.key.delete()
+
+  def test_validate_feature_in_chromium(self):
+    """Tests parsing logic for JSON and C++ mock data."""
+    # Case 1: Found in JSON and stable -> No missing criteria.
+    result = feature_helpers.validate_feature_in_chromium(
+        'featureOneFinch', MOCK_ENABLED_FEATURES_JSON, MOCK_CONTENT_FEATURES_CC)
+    self.assertEqual(result, [])
+
+    # Case 2: Found in JSON but not stable.
+    result = feature_helpers.validate_feature_in_chromium(
+        'feature7-unstable', MOCK_ENABLED_FEATURES_JSON, MOCK_CONTENT_FEATURES_CC)
+    self.assertEqual(result,
+        [feature_helpers.Criteria.RUNTIME_FEATURE_NOT_STABLE])
+
+    # Case 3: Found in .cc file and enabled.
+    result = feature_helpers.validate_feature_in_chromium(
+        'Feature8Enabled', MOCK_ENABLED_FEATURES_JSON, MOCK_CONTENT_FEATURES_CC)
+    self.assertEqual(result, [])
+
+    # Case 4: Found in .cc file but disabled.
+    result = feature_helpers.validate_feature_in_chromium(
+        'Feature9Disabled', MOCK_ENABLED_FEATURES_JSON, MOCK_CONTENT_FEATURES_CC)
+    self.assertEqual(result,
+        [feature_helpers.Criteria.CONTENT_FEATURE_NOT_ENABLED])
+
+    # Case 5: Not found in either file.
+    result = feature_helpers.validate_feature_in_chromium(
+        'not-a-real-feature', MOCK_ENABLED_FEATURES_JSON, MOCK_CONTENT_FEATURES_CC)
+    self.assertEqual(result,
+        [feature_helpers.Criteria.CHROMIUM_FEATURE_NOT_FOUND])
+
+    # Case 6: Found in JSON, status is dict, one platform is "stable".
+    result = feature_helpers.validate_feature_in_chromium(
+        'FeatureDictStable', MOCK_ENABLED_FEATURES_JSON, MOCK_CONTENT_FEATURES_CC)
+    self.assertEqual(result, [])
+
+    # Case 7: Found in JSON, status is dict, no platforms are "stable".
+    result = feature_helpers.validate_feature_in_chromium(
+        'FeatureDictUnstable', MOCK_ENABLED_FEATURES_JSON, MOCK_CONTENT_FEATURES_CC)
+    self.assertEqual(result,
+        [feature_helpers.Criteria.RUNTIME_FEATURE_NOT_STABLE])
+
+  def test_build_feature_info(self):
+    """Verifies that the feature info dict is constructed correctly."""
+    info = feature_helpers.build_feature_info(
+        self.feature_1, self.stage_1, 'http://localhost')
+
+    self.assertEqual(info['name'], 'Feature 1 (Complete)')
+    self.assertEqual(info['chromestatus_url'], 'http://localhost/feature/1')
+    self.assertEqual(info['tracking_bug_url'], 'https://example.com/bug1')
+    self.assertEqual(info['intent_to_ship'], 'https://example.com/intent1')
+    self.assertEqual(info['owner_emails'], ['owner@example.com'])
+
+  def test_validate_shipping_criteria(self):
+    """Tests specific validation logic for Gates and Intents."""
+    # Case 1: Success (Complete Feature 1)
+    result = feature_helpers.validate_shipping_criteria(
+        self.feature_1, self.stage_1,
+        MOCK_ENABLED_FEATURES_JSON, MOCK_CONTENT_FEATURES_CC)
+    self.assertEqual(result, [])
+
+    # Case 2: Missing Intent
+    result = feature_helpers.validate_shipping_criteria(
+        self.feature_3, self.stage_3,
+        MOCK_ENABLED_FEATURES_JSON, MOCK_CONTENT_FEATURES_CC)
+    # Feature 3 also has 'feature3-finch' which is not in the mock files.
+    self.assertIn(feature_helpers.Criteria.INTENT_TO_SHIP_MISSING, result)
+
+    # Case 3: Missing LGTM
+    result = feature_helpers.validate_shipping_criteria(
+        self.feature_2, self.stage_2,
+        MOCK_ENABLED_FEATURES_JSON, MOCK_CONTENT_FEATURES_CC)
+    self.assertIn(feature_helpers.Criteria.API_OWNER_LGTMS_MISSING, result)
+
+  def test_aggregate_shipping_features(self):
+    """Tests the full aggregation logic."""
+    stages = [
+        self.stage_1, self.stage_2, self.stage_3, self.stage_4,
+        self.stage_5, self.stage_7, self.stage_8, self.stage_9, self.stage_10
+    ]
+
+    complete, incomplete = feature_helpers.aggregate_shipping_features(
+        stages, MOCK_ENABLED_FEATURES_JSON, MOCK_CONTENT_FEATURES_CC,
+        'http://localhost')
+
+    # Verify Complete Features
+    self.assertEqual(len(complete), 3)
+    # IDs 1, 5, 8 are complete.
+    complete_names = sorted([f['name'] for f in complete])
+    self.assertEqual(complete_names,
+        ['F8 Enabled', 'Feature 1 (Complete)', 'Feature 5 (PSA)'])
+
+    # Verify Incomplete Features
+    self.assertEqual(len(incomplete), 6)
+    # Map name -> missing criteria list
+    incomplete_map = {item[0]['name']: item[1] for item in incomplete}
+
+    # Feature 2: Missing LGTM + Not in Chromium
+    self.assertIn('Feature 2 (No LGTM)', incomplete_map)
+    self.assertIn('lgtms', incomplete_map['Feature 2 (No LGTM)'])
+
+    # Feature 7: Unstable in JSON
+    self.assertIn('F7 Unstable', incomplete_map)
+    self.assertEqual(incomplete_map['F7 Unstable'], ['runtime_feature_not_stable'])
+
+    # Feature 9: Disabled in CC
+    self.assertIn('F9 Disabled', incomplete_map)
+    self.assertEqual(incomplete_map['F9 Disabled'], ['content_feature_not_enabled'])


### PR DESCRIPTION
This PR refactors the logic of checking for shipping features and their missing fields to pull it out of `shipping_features_api.py` and moves it to `feature_helpers.py` to allow the logic to be reusable.

This is so that we can use the logic to generate data for display in an internal dashboard (similar to the stale features data).