### PR TITLE
Also filter the cached case.

### DIFF
--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -148,7 +148,9 @@ def get_features_in_release_notes(milestone: int):
   cached_features = rediscache.get(cache_key)
   if cached_features:
     logging.info('Returned cached features')
-    return filter_confidential_formatted(cached_features)
+    cached_features = filter_confidential_formatted(cached_features)
+    cached_features = filter_unpublished_formatted(cached_features)
+    return cached_features
 
   all_enterprise_feature_keys_future = FeatureEntry.query(
       FeatureEntry.deleted == False,


### PR DESCRIPTION
We cache the release notes query results before filtering, so we need to do personalized filtering after the cached results are retrieved, otherwise a lucky user could see results that don't have the additional filtering that I added today.