### PR TITLE
Avoid a keyerror when logging after a bounce avoidance.

### DIFF
--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -139,7 +139,8 @@ class AbstractReminderHandler(basehandlers.FlaskHandler):
     # Add an alphabetical list of unique recipients to the return message.
     if len(email_tasks):
       recipients = '\n'.join(
-          sorted(list(set([task['to'] for task in email_tasks]))))
+          sorted(list(set([task['to'] for task in email_tasks
+                           if task.get('to')]))))
       recipients_str = f'\nRecipients:\n{recipients}'
     message =  f'{len(email_tasks)} email(s) sent or logged.{recipients_str}'
     logging.info(message)


### PR DESCRIPTION
This is a follow-up to #5788.  In that PR, I implemented logic that can clear out the `to` field of an email task if all the listed addresses have bounced in the past.  That unfortunately led to a KeyError when we logged successfully processing a batch of emails.  The error was seen in prod, but since it happens after the emails are sent, it only affects our logs rather than users.

In this PR:
* Only log the email tasks that have some value for the `to` field after bounce avoidance.
