### PR TITLE
Still send emails to bounced addresses

### DIFF
--- a/framework/sendemail.py
+++ b/framework/sendemail.py
@@ -165,6 +165,10 @@ def receive(bounce_message):
   message.check_initialized()
   if settings.SEND_EMAIL:
     message.send()
+  logging.info('Full parsed original message that was sent: %r',
+               bounce_message.original)
+  logging.info('Full parsed notification of the bounce: %r',
+               bounce_message.notification)
 
 
 def _extract_addrs(header_value):

--- a/framework/sendemail_test.py
+++ b/framework/sendemail_test.py
@@ -170,7 +170,8 @@ class BouncedEmailHandlerTest(testing_config.CustomTestCase):
         original={'to': 'starrer_3@example.com',
                   'from': 'sender',
                   'subject': 'subject',
-                  'text': 'body'})
+                  'text': 'body'},
+        notification={'some': 'more details'})
 
     sendemail.receive(bounce_message)
 
@@ -197,7 +198,8 @@ class BouncedEmailHandlerTest(testing_config.CustomTestCase):
         original={'to': 'starrer_4@example.com',
                   'from': 'sender',
                   'subject': 'subject',
-                  'text': 'body'})
+                  'text': 'body'},
+        notification={'some': 'more details'})
 
     sendemail.receive(bounce_message)
 

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -1202,6 +1202,9 @@ def get_thread_id(stage: Stage):
   return thread_id
 
 
+# TODO(jrobbins): Find a robust way to avoid repeatedly sending emails
+# to invalid email addresses, even if valid addresses sometimes bounce.
+# This function is currently unused.
 def find_bounced_emails(email_tasks):
   """Look up all user prefs and make a set of the emails that bounced."""
   emails = []
@@ -1222,7 +1225,7 @@ def find_bounced_emails(email_tasks):
 def send_emails(email_tasks):
   """Process a list of email tasks (send or log)."""
   logging.info('Processing %d email tasks', len(email_tasks))
-  bounced_emails = find_bounced_emails(email_tasks)
+  bounced_emails = []  # See TODO for find_bounced_emails().
   for task in email_tasks:
     to = task.get('to') or []
     if isinstance(to, str):

--- a/internals/reminders_test.py
+++ b/internals/reminders_test.py
@@ -566,7 +566,9 @@ class SLOOverdueHandlerTest(testing_config.CustomTestCase):
 
     expected_message = ('2 email(s) sent or logged.\n'
                         'Recipients:\n'
-                        'a_assignee@example.com')
+                        'a_assignee@example.com\n'
+                         # Note: Bounce avoidance logic is disabled
+                        'b_assignee@example.com')
     expected = {'message': expected_message}
     self.assertEqual(actual, expected)
 


### PR DESCRIPTION
This should resolve #5853.

In #5788 I stopped sending email notifications to addresses that had previously bounced, but that was a mistake because a lot of addresses have temporary failures.  So, this reverts the logic to avoid sending.  We still detect bounces, mark bouncing users, log that, and send escalation emails, but we just won't avoid sending new emails.