### PR TITLE
Bypass Chromium code checks for WebGPU features

### DIFF
--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -55,6 +55,10 @@ class Criteria(str, Enum):
   CONTENT_FEATURE_NOT_ENABLED = 'content_feature_not_enabled'
   CHROMIUM_FEATURE_NOT_FOUND = 'chromium_feature_not_found'
 
+# Blink components that are hard to verify existence in the Chromium code.
+# We bypass the Chromium code checks here in order to avoid false positives.
+BLINK_COMPONENTS_SKIP_CHROMIUM_CHECKS = ['Blink>WebGPU']
+
 
 def filter_unlisted(feature_list: list[FeatureEntry]) -> list[FeatureEntry]:
   """Filters a FeatureEntry list to display only features the user should see."""
@@ -783,6 +787,12 @@ def validate_shipping_criteria(
   """Checks a feature against shipping requirements (Gates, Intents, Finch, Code)."""
   criteria_missing: list[Criteria] = []
 
+  # Skip the Chromium code checks if it is associated with any of the Blink
+  # components that are difficult to detect in the codebase.
+  skip_chromium_code_checks = bool(
+    set(BLINK_COMPONENTS_SKIP_CHROMIUM_CHECKS) & set(feature.blink_components)
+  )
+
   # Check Intent to Ship
   if not stage.intent_thread_url:
     criteria_missing.append(Criteria.INTENT_TO_SHIP_MISSING)
@@ -800,7 +810,7 @@ def validate_shipping_criteria(
     criteria_missing.append(Criteria.FINCH_NAME_MISSING)
 
   # Check Chromium Internal Status (if finch name is present)
-  if feature.finch_name:
+  if feature.finch_name and not skip_chromium_code_checks:
     criteria_missing.extend(validate_feature_in_chromium(
       feature.finch_name,
       enabled_features_json,

--- a/internals/feature_helpers_test.py
+++ b/internals/feature_helpers_test.py
@@ -1326,6 +1326,21 @@ class ShippingFeatureHelpersTest(testing_config.CustomTestCase):
     Gate(id=1010, feature_id=10, stage_id=110, gate_type=GATE_API_SHIP,
          state=Vote.APPROVED).put()
 
+    # Feature 11: Complete (skipped checks due to Blink Component).
+    self.feature_11 = FeatureEntry(
+        id=11, name='F11 WebGPU', summary='sum', category=1,
+        feature_type=FEATURE_TYPE_INCUBATE_ID,
+        finch_name='WebGPUFeature',
+        blink_components=['Blink>WebGPU'])
+    self.feature_11.put()
+    self.stage_11 = Stage(
+        id=111, feature_id=11, stage_type=160,
+        intent_thread_url='https://example.com/intent11',
+        milestones=MilestoneSet(desktop_first=self.milestone))
+    self.stage_11.put()
+    Gate(id=1011, feature_id=11, stage_id=111, gate_type=GATE_API_SHIP,
+         state=Vote.APPROVED).put()
+
   def tearDown(self):
     for kind in [FeatureEntry, Gate, Stage, Vote]:
       for entity in kind.query():
@@ -1404,11 +1419,18 @@ class ShippingFeatureHelpersTest(testing_config.CustomTestCase):
         MOCK_ENABLED_FEATURES_JSON, MOCK_CONTENT_FEATURES_CC)
     self.assertIn(feature_helpers.Criteria.API_OWNER_LGTMS_MISSING, result)
 
+    # Case 4: Skipped checks (Feature 11)
+    result = feature_helpers.validate_shipping_criteria(
+        self.feature_11, self.stage_11,
+        MOCK_ENABLED_FEATURES_JSON, MOCK_CONTENT_FEATURES_CC)
+    self.assertEqual(result, [])
+
   def test_aggregate_shipping_features(self):
     """Tests the full aggregation logic."""
     stages = [
         self.stage_1, self.stage_2, self.stage_3, self.stage_4,
-        self.stage_5, self.stage_7, self.stage_8, self.stage_9, self.stage_10
+        self.stage_5, self.stage_7, self.stage_8, self.stage_9, self.stage_10,
+        self.stage_11
     ]
 
     complete, incomplete = feature_helpers.aggregate_shipping_features(
@@ -1416,11 +1438,11 @@ class ShippingFeatureHelpersTest(testing_config.CustomTestCase):
         'http://localhost')
 
     # Verify Complete Features
-    self.assertEqual(len(complete), 3)
-    # IDs 1, 5, 8 are complete.
+    self.assertEqual(len(complete), 4)
+    # IDs 1, 5, 8, 11 are complete.
     complete_names = sorted([f['name'] for f in complete])
     self.assertEqual(complete_names,
-        ['F8 Enabled', 'Feature 1 (Complete)', 'Feature 5 (PSA)'])
+        ['F11 WebGPU', 'F8 Enabled', 'Feature 1 (Complete)', 'Feature 5 (PSA)'])
 
     # Verify Incomplete Features
     self.assertEqual(len(incomplete), 6)


### PR DESCRIPTION
WebGPU features are hard to verify in the Chromium code, as there seems to be no single source of truth. This change lets WebGPU features bypass the code checks in order to avoid false positives on features missing shipping criteria.