### PR TITLE
Update spec mentors page Playwright tests

### DIFF
--- a/packages/playwright/tests/chromedash-report-spec-mentors-page_pwtest.js
+++ b/packages/playwright/tests/chromedash-report-spec-mentors-page_pwtest.js
@@ -1,62 +1,94 @@
 // @ts-check
-import {expect, test} from '@playwright/test';
-import {captureConsoleMessages} from './test_utils';
-
+import { expect, test } from '@playwright/test';
+import { captureConsoleMessages } from './test_utils';
 import spec_mentor_api_result from './spec_mentor_api_result.json';
 
-test.beforeEach(async ({page}, testInfo) => {
+// Define common mock data constants
+// The prefix ")]}'\n" is a standard Chromium XSSI defense.
+const API_PREFIX = ")]}'\n";
+const MOCK_BODY = API_PREFIX + JSON.stringify(spec_mentor_api_result);
+
+test.beforeEach(async ({ page }) => {
   captureConsoleMessages(page);
+
+  // Setup the route once for all tests.
+  // This ensures consistent behavior and reduces code duplication.
+  await page.route('/api/v0/spec_mentors?after=*', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: MOCK_BODY,
+    });
+  });
 });
 
-test('spec mentors report renders', async ({page}) => {
-  await page.route('/api/v0/spec_mentors?after=*', route => route.fulfill({
-    status: 200,
-    body: `)]}'\n${JSON.stringify(spec_mentor_api_result)}`,
-  }));
-
+test('spec mentors report renders', async ({ page }) => {
   await page.goto('/reports/spec_mentors');
 
-  // <details> elements have the 'group' role:
-  await expect.soft(page.getByRole('group').filter({hasText: /has mentored:/}))
-    .toHaveText([/expert@example.com/, /mentor@example.org/]);
+  await test.step('Verify Mentor groupings', async () => {
+    // Assert on the entire list of headers at once.
+    // This is cleaner than checking them individually.
+    await expect(page.getByRole('group').filter({ hasText: /has mentored:/ }))
+      .toHaveText([
+        /expert@example.com/,
+        /mentor@example.org/
+      ]);
+  });
 
-  const expertLink = page.locator('sl-details', {hasText: 'expert@example.com has mentored'})
-    .getByRole('link');
-  await expect.soft(expertLink).toHaveText("First feature");
-  await expect.soft(expertLink).toHaveAttribute("href", /\/feature\/9009/);
+  await test.step('Verify "Expert" mentor details', async () => {
+    // Scope locators to the specific panel to avoid accidental cross-talk
+    const expertPanel = page.locator('sl-details', { hasText: 'expert@example.com' });
+    const links = expertPanel.getByRole('link');
 
-  const mentorLinks = page.locator('sl-details', {hasText: "mentor@example.org has mentored"})
-    .getByRole('link');
-  await expect.soft(mentorLinks.nth(0)).toHaveText("Second feature");
-  await expect.soft(mentorLinks.nth(0)).toHaveAttribute("href", /\/feature\/9010/);
-  await expect.soft(mentorLinks.nth(1)).toHaveText("First feature");
-  await expect.soft(mentorLinks.nth(1)).toHaveAttribute("href", /\/feature\/9009/);
+    // Verify text and href link correctness
+    await expect(links).toHaveText(['First feature']);
+    await expect(links).toHaveAttribute('href', /\/feature\/9009/);
+  });
+
+  await test.step('Verify "Mentor" mentor details', async () => {
+    const mentorPanel = page.locator('sl-details', { hasText: 'mentor@example.org' });
+    const links = mentorPanel.getByRole('link');
+
+    // Verify order and content of multiple links simultaneously
+    // This replaces the brittle .nth(0) and .nth(1) calls
+    await expect(links).toHaveText(['Second feature', 'First feature']);
+
+    // Note: for attributes, we still check individually or use specific matchers,
+    // but scoping strictly to 'links' ensures we don't grab other elements.
+    await expect(links.first()).toHaveAttribute('href', /\/feature\/9010/);
+    await expect(links.last()).toHaveAttribute('href', /\/feature\/9009/);
+  });
 });
 
-test('after query param affects api request', async ({page}) => {
-  await page.route('/api/v0/spec_mentors?after=*', route => route.fulfill({
-    status: 200,
-    body: `)]}'\n${JSON.stringify(spec_mentor_api_result)}`,
-  }));
+test('after query param affects api request', async ({ page }) => {
+  const apiRequestPromise = page.waitForRequest(req =>
+    req.url().includes('/api/v0/spec_mentors') &&
+    req.url().endsWith('after=2023-04-05')
+  );
 
-  const apiRequest = page.waitForRequest(/\/api\/v0\/spec_mentors\?after=2023-04-05$/);
   await page.goto('/reports/spec_mentors?after=2023-04-05');
-  await apiRequest;
 
-  // Should be reflected in the form field.
+  // Wait for the specific request to fire
+  await apiRequestPromise;
+
+  // Verify UI reflection
   await expect(page.getByLabel('updated after')).toHaveValue('2023-04-05');
 });
 
-test('after form field affects api request and page url', async ({page}) => {
-  await page.route('/api/v0/spec_mentors?after=*', route => route.fulfill({
-    status: 200,
-    body: `)]}'\n${JSON.stringify(spec_mentor_api_result)}`,
-  }));
-
+test('after form field affects api request and page url', async ({ page }) => {
   await page.goto('/reports/spec_mentors');
 
-  const apiRequest = page.waitForRequest(/\/api\/v0\/spec_mentors\?after=2023-05-06$/);
+  const apiRequestPromise = page.waitForRequest(req =>
+    req.url().includes('/api/v0/spec_mentors') &&
+    req.url().includes('after=2023-05-06')
+  );
+
+  // Interaction
   await page.getByLabel('updated after').fill('2023-05-06');
-  await apiRequest;
-  await expect(page).toHaveURL('/reports/spec_mentors?after=2023-05-06')
+
+  // Wait for the network effect
+  await apiRequestPromise;
+
+  // Verify URL update
+  await expect(page).toHaveURL(/after=2023-05-06/);
 });


### PR DESCRIPTION
Daniel's summary:
We've been having consistent Playwright test issues for a long time. This is an attempt to use Gemini to evaluate our existing test suite and refactor the existing tests to follow best practices and eliminate potential flakiness. This may not resolve ALL flakiness, as some of our flakiness is caused by certain implementation choices in our UI that need to be refactored. However, this should reduce overall flakiness and reduce the time taken to run the Playwright tests.

Gemini's summary:
This change refactors existing Playwright test files and utilities to eliminate non-deterministic behavior ("flakiness") and align with modern Playwright best practices. The primary focus is removing hardcoded `delay()` calls in favor of Playwright's native auto-waiting assertions and state verification.

**Key Changes**

* **Removed Explicit Delays:** Replaced arbitrary `await delay(ms)` calls with specific, functional assertions (e.g., `await expect(locator).toBeVisible()`). This ensures tests progress exactly when the UI is ready, rather than waiting for a fixed amount of time.
* **Improved Synchronization:** Implemented robust waiting strategies for UI animations (e.g., dropdowns, accordions) and page navigation (`waitForURL`).
* **Refactored Interactions:** Updated interaction logic (click, hover, fill) to explicitly verify element stability before action, preventing errors where tests attempted to interact with elements that were animating or obscured.
* **Selector & Assertion Improvements:** Tightened selector specificity and replaced generic existence checks (like `.toHaveCount(0)`) with more readable and semantic assertions (like `.not.toBeVisible()`).
* **Utility Cleanup:** Refactored shared helpers (including `login` and `logout` flows) to remove brittle logic (such as mouse movements to reset state) and rely on cleaner event-driven checks.