### PR TITLE
Cron description cannot cross lines

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -53,8 +53,7 @@ cron:
 - description: Generate a CSV of all stale features with upcoming shipping milestones.
   url: /cron/generate_stale_features
   schedule: every day 8:05
-- description: |
-    Generate CSVs for all features with upcoming shipping milestones and their missing criteria.
+- description: Generate CSVs for all features with upcoming shipping milestones and their missing criteria.
   url: /cron/generate_shipping_features
   schedule: every day 8:30
 - description: Reset the shipping milestones of features have not been verified after 4+ notifications.


### PR DESCRIPTION
We got an error when trying to deploy to staging.  Apparently GAE does not allow you to break lines there.