### PR TITLE
Fix review status checkmark rendering for security and privacy fields

### DIFF
--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -389,29 +389,43 @@ export class ChromedashFeatureDetail extends LitElement {
   }
 
   renderField(fieldDef, feStage) {
-    const [fieldId, fieldDisplayName, fieldType, deprecated, alwaysMarkdown] =
-      fieldDef;
-    const value = getFieldValueFromFeature(fieldId, feStage, this.feature);
-    const isDefined = isDefinedValue(value);
-    if (!isDefined && deprecated) {
-      return nothing;
-    }
-    const isMarkdown =
-      (this.feature.markdown_fields || []).includes(fieldId) || alwaysMarkdown;
+  const [fieldId, fieldDisplayName, fieldType, deprecated, alwaysMarkdown] =
+    fieldDef;
+  const value = getFieldValueFromFeature(fieldId, feStage, this.feature);
+  const isDefined = isDefinedValue(value);
 
-    const icon = isDefined
-      ? html`<sl-icon library="material" name="check_circle_20px"></sl-icon>`
-      : html`<sl-icon library="material" name="blank_20px"></sl-icon>`;
-
-    return html`
-      <dt id=${fieldId}>${icon} ${fieldDisplayName}</dt>
-      <dd>
-        ${isDefined
-          ? this.renderValue(fieldType, value, isMarkdown)
-          : html`<i>No information provided yet</i>`}
-      </dd>
-    `;
+  if (!isDefined && deprecated) {
+    return nothing;
   }
+
+  const isMarkdown =
+    (this.feature.markdown_fields || []).includes(fieldId) || alwaysMarkdown;
+
+  const isReviewStatusField =
+    fieldId === 'security_review_status' ||
+    fieldId === 'privacy_review_status';
+
+  const reviewIsComplete =
+    isReviewStatusField && typeof value === 'string' && value === 'Complete';
+
+  const showCheckmark = isReviewStatusField
+    ? reviewIsComplete
+    : isDefined;
+
+  const icon = showCheckmark
+    ? html`<sl-icon library="material" name="check_circle_20px"></sl-icon>`
+    : html`<sl-icon library="material" name="blank_20px"></sl-icon>`;
+
+  return html`
+    <dt id=${fieldId}>${icon} ${fieldDisplayName}</dt>
+    <dd>
+      ${isDefined
+        ? this.renderValue(fieldType, value, isMarkdown)
+        : html`<i>No information provided yet</i>`}
+    </dd>
+  `;
+}
+
 
   stageHasAnyFilledFields(fields, feStage) {
     return fields.some(fieldDef =>


### PR DESCRIPTION
**Summary**

For issue #5644
This PR fixes incorrect checkmark icon rendering for review status fields on the feature detail page.
Previously, the Security review and Privacy review fields displayed a checkmark as soon as the field was defined, even when the review was not complete. This change ensures that checkmarks are shown only when the review status is explicitly marked as “Complete.”

**Problem:**

On the feature detail page:

security_review_status

privacy_review_status

were treated like regular fields.
As a result, they showed a ✔️ icon whenever a value existed, which was misleading and inconsistent with how review completion is interpreted elsewhere in Chrome Status.

**Solution:**

Special-case security and privacy review fields.

Render a checkmark only when the value is exactly "Complete".

Preserve existing behavior for all other fields.

This keeps the UI accurate and avoids implying review completion prematurely.

**Implementation Details:**

Updated renderField() logic in chromedash-feature-detail.ts

Introduced explicit handling for review status fields

No backend changes

No behavioral changes to unrelated fields

Before

✔️ shown for security/privacy review fields even when incomplete

After

✔️ shown only when review status is “Complete”

Blank icon otherwise