### PR TITLE
Make WPT report timestamps are in UTC timezone

### DIFF
--- a/client-src/elements/chromedash-wpt-eval-page.ts
+++ b/client-src/elements/chromedash-wpt-eval-page.ts
@@ -363,7 +363,9 @@ export class ChromedashWPTEvalPage extends LitElement {
       return;
     }
 
-    const completedAt = parseRawTimestamp(this.feature?.ai_test_eval_status_timestamp);
+    const completedAt = parseRawTimestamp(
+      this.feature?.ai_test_eval_status_timestamp
+    );
 
     if (completedAt) {
       const now = Date.now();
@@ -577,7 +579,9 @@ export class ChromedashWPTEvalPage extends LitElement {
       status === AITestEvaluationStatus.IN_PROGRESS &&
       this.feature.ai_test_eval_status_timestamp
     ) {
-      const startedAt = parseRawTimestamp(this.feature.ai_test_eval_status_timestamp);
+      const startedAt = parseRawTimestamp(
+        this.feature.ai_test_eval_status_timestamp
+      );
 
       if (startedAt) {
         const now = Date.now();

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -1077,13 +1077,14 @@ export function getFeatureOutdatedBanner(
   return null;
 }
 
-
 /**
  * Parses a timestamp string from the server.
  * If the string is "naive" (has no timezone offset or Z), it appends 'Z'
  * to force the browser to interpret it as UTC.
  */
-export function parseRawTimestamp(timestamp: string | undefined | null): number | null {
+export function parseRawTimestamp(
+  timestamp: string | undefined | null
+): number | null {
   if (!timestamp) {
     return null;
   }

--- a/client-src/elements/utils_test.ts
+++ b/client-src/elements/utils_test.ts
@@ -7,7 +7,7 @@ import {
   getDisabledHelpText,
   getFeatureOutdatedBanner,
   isVerifiedWithinGracePeriod,
-  parseRawTimestamp
+  parseRawTimestamp,
 } from './utils';
 import {assert} from '@open-wc/testing';
 import {OT_SETUP_STATUS_OPTIONS} from './form-field-enums';
@@ -1017,7 +1017,6 @@ describe('isVerifiedWithinGracePeriod', () => {
     });
   });
 });
-
 
 describe('parseRawTimestamp', () => {
   it('returns null for null, undefined, or empty inputs', () => {


### PR DESCRIPTION
This should fix #5898

I originally tried to add timezone-aware timestamps saved in datastore, but that is not supported. Instead, assume that the naive date strings coming from datastore are UTC time.