### PR TITLE
Annotate directory WPT URLs in prerequisites list

### DIFF
--- a/client-src/elements/chromedash-wpt-eval-page.ts
+++ b/client-src/elements/chromedash-wpt-eval-page.ts
@@ -478,6 +478,7 @@ export class ChromedashWPTEvalPage extends LitElement {
       </div>
     `;
   }
+
   /**
    * Renders pre-formatted text within a div, applying `prettier-ignore`
    * to prevent unwanted whitespace from being introduced by Prettier's
@@ -494,6 +495,7 @@ export class ChromedashWPTEvalPage extends LitElement {
     // prettier-ignore
     return html`<div class="url-list prewrap">${content}</div>`;
   }
+
   /**
    * Returns true if a WPT results URL represents a directory rather than a test file.
    */

--- a/client-src/elements/chromedash-wpt-eval-page_test.ts
+++ b/client-src/elements/chromedash-wpt-eval-page_test.ts
@@ -34,6 +34,7 @@ describe('chromedash-wpt-eval-page', () => {
   afterEach(() => {
     sinon.restore();
   });
+
   it('renders the basic page structure', async () => {
     csClientStub.getFeature.resolves(mockFeatureV1);
     const el = await fixture<ChromedashWPTEvalPage>(
@@ -187,6 +188,7 @@ describe('chromedash-wpt-eval-page', () => {
       ).to.not.exist;
       expect(fileItem!.textContent).to.not.contain('(all tests in directory)');
     });
+
     it('shows Name/Summary as success, but other checks as danger when optional data is missing', async () => {
       // Feature has name/summary (default mock), but missing spec and wpt_descr
       csClientStub.getFeature.resolves({
@@ -223,6 +225,7 @@ describe('chromedash-wpt-eval-page', () => {
       expect(dataContainers[1].textContent).to.contain(mockFeatureV1.summary);
     });
   });
+
   describe('Action Section & Generation Flow', () => {
     it('disables generate button if prerequisites are not met', async () => {
       csClientStub.getFeature.resolves({
@@ -514,6 +517,7 @@ describe('chromedash-wpt-eval-page', () => {
       expect(message).to.exist;
       expect(message!.textContent).to.contain('Available in');
     });
+
     it('enables button if last run was COMPLETE > 30 mins ago', async () => {
       const thirtyFiveMinutesAgo = new Date(
         Date.now() - 35 * 60 * 1000


### PR DESCRIPTION
Fixing #5910 
**Summary**

This PR improves the Prerequisites Checklist on the WPT evaluation page by distinguishing between directory-level and file-level WPT result URLs.

Directory URLs are now annotated to clarify that they represent all tests in that directory, while individual test file URLs remain unannotated.

**What’s changed**

Annotates directory WPT URLs with a subtle note:
(all tests in directory)
Ensures individual test file URLs are not annotated
Adds unit tests covering both directory and file URL cases
Introduces a small helper to determine directory vs file URLs in a defensive way (query/hash safe)

**Why**

WPT descriptions often mix directory URLs and individual test files.
Without annotation, it’s unclear whether coverage applies to a single test or an entire directory.
This change makes the scope of coverage explicit and reduces confusion for reviewers and feature owners.

**Testing**

Added unit tests asserting:
Directory URLs are annotated
File URLs are not annotated
Tests run via @web/test-runner and pass locally

**Note on screenshots / images**

I attempted to attach a screenshot via the web test runner’s Playwright integration.
However, in this setup the Playwright page object is not consistently available, so the screenshot file is not reliably generated.

**As a result:**

The PR relies on DOM-based assertions instead of image snapshots
No image files are attached in this PR

This approach keeps the tests stable and aligns with existing testing patterns in the repo.