### PR TITLE
Update docs to explain the unified prompt for WPT coverage reports

### DIFF
--- a/docs/wpt-coverage-evaluation.md
+++ b/docs/wpt-coverage-evaluation.md
@@ -102,7 +102,7 @@ The system is tuned to balance App Engine limits against LLM generation time.
 These constants are defined in `framework/gemini_client.py`.
 
 ### Gemini Model
-* **Model:** `gemini-3.0-pro-preview` (Hardcoded as `GEMINI_MODEL`).
+* **Model:** `gemini-3-pro-preview` (Hardcoded as `GEMINI_MODEL`).
 
 ### Timeout Strategy
 To prevent "Task Deadline Exceeded" errors in Cloud Tasks, the system uses a


### PR DESCRIPTION
This change updates the documentation to include the description of the single-prompt flow for WPT coverage evaluation. Also, updates the model version referenced to Gemini 3.