### PR TITLE
Do not allow confidential features to generate WPT coverage reports (UI)

### DIFF
--- a/client-src/elements/chromedash-wpt-eval-page.ts
+++ b/client-src/elements/chromedash-wpt-eval-page.ts
@@ -691,12 +691,22 @@ export class ChromedashWPTEvalPage extends LitElement {
           variant="${this.feature.ai_test_eval_report ? 'danger' : 'primary'}"
           size="large"
           class="generate-button"
-          ?disabled=${!this.isRequirementsFulfilled || isCooldownActive}
+          ?disabled=${!this.isRequirementsFulfilled ||
+          isCooldownActive ||
+          this.feature.confidential}
           @click=${this.handleGenerateClick}
         >
           ${buttonLabel}
         </sl-button>
 
+        ${this.feature.confidential
+          ? html`
+              <div class="help-text">
+                This feature is set to "confidential". The feature's information
+                cannot be sent to Gemini for evaluation.
+              </div>
+            `
+          : nothing}
         ${isHanging
           ? html`
               <div class="help-text">
@@ -705,7 +715,7 @@ export class ChromedashWPTEvalPage extends LitElement {
               </div>
             `
           : nothing}
-        ${isCooldownActive
+        ${isCooldownActive && !this.feature.confidential
           ? html`
               <div class="cooldown-message">
                 <sl-icon name="hourglass-split"></sl-icon>


### PR DESCRIPTION
Part of #5939

This restricts WPT coverage report generation to non-confidential features. Checks to avoid this in the API will come in a subsequent PR.

<img width="832" height="191" alt="Screenshot 2026-01-27 9 51 54 AM" src="https://github.com/user-attachments/assets/7d221599-10c7-4c8a-9855-6e8688d32de9" />
