### PR TITLE
Notify release notes reviewers after a flag reset.

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -31,7 +31,7 @@ from internals.core_enums import *
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
 from internals.data_types import CHANGED_FIELDS_LIST_TYPE
 from internals import feature_links
-from internals import notifier_helpers
+from internals import notifier, notifier_helpers
 from internals.review_models import Gate, Activity
 from internals.data_types import VerboseFeatureDict
 from internals import feature_helpers
@@ -324,12 +324,17 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
       changed_fields: CHANGED_FIELDS_LIST_TYPE) -> None:
     if permissions.can_review_release_notes(self.get_current_user()):
       return
+    notify_reviewers = False
     if feature.is_releasenotes_content_reviewed:
       feature.is_releasenotes_content_reviewed = False
       changed_fields.append(('is_releasenotes_content_reviewed', True, False))
+      notify_reviewers = True
     if feature.is_releasenotes_publish_ready:
       feature.is_releasenotes_publish_ready = False
       changed_fields.append(('is_releasenotes_publish_ready', True, False))
+      notify_reviewers = True
+    if notify_reviewers:
+      notifier.notify_releasenotes_reviewers(feature)
 
   def _patch_update_special_fields(
       self,

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -1334,3 +1334,30 @@ class ResetShippingMilestonesEmailHandler(basehandlers.FlaskHandler):
       'reply_to': None,
       'html': body,
     }
+
+
+RELEASENOTES_NOTIFY_ADDRS = [
+    'cbe-tpgms@google.com',
+    'siobhankeating@google.com',
+    ]
+RESET_RELEASENOTES_TEMPLATE_PATH = 'reset-releasenotes-flags-email.html'
+
+
+def notify_releasenotes_reviewers(fe: FeatureEntry) -> None:
+  """Notify releasenotes reviewers that a feature's flags were reset."""
+  subject = 'Review flags reset on %s' % fe.name
+  site_url = settings.SITE_URL
+  feature_id = fe.key.integer_id()
+  body_data = {
+      'feature_url': f'{site_url}feature/{feature_id}',
+      'APP_TITLE': settings.APP_TITLE,
+      'feature': converters.feature_entry_to_json_verbose(fe),
+      'releasenotes_url': f'{site_url}enterprise/releasenotes',
+  }
+  html = render_template(RESET_RELEASENOTES_TEMPLATE_PATH, **body_data)
+  email_task = {
+      'to': RELEASENOTES_NOTIFY_ADDRS,
+      'subject': subject,
+      'html': html,
+      }
+  send_emails([email_task])

--- a/templates/reset-releasenotes-flags-email.html
+++ b/templates/reset-releasenotes-flags-email.html
@@ -1,0 +1,40 @@
+{% import 'email-styles.html' as styles %}
+<div style="{{styles.body}}">
+<div style="{{styles.branding}}">{{APP_TITLE}}</div>
+
+<div style="{{styles.content}} {{styles.content_alert}}">
+
+<section id="details" style="{{styles.section}}">
+  <h3>What happened</h3>
+  <p>
+    The release notes review checkboxes for the ChromeStatus feature
+    "<a href="{{feature_url}}">{{feature.name}}</a>"
+    have been reset.
+  </p>
+
+  <h3>Reason for this change</h3>
+  <p>
+    This action was taken because someone edited the feature name, summary,
+    or milestones after its release notes review checkboxes were checked.
+  </p>
+</section>
+
+<section id="why-triggered" style="{{styles.section}}">
+  <h3>Next steps</h3>
+  <p>
+    Please review the changes and click the review checkboxes again:
+  </p>
+  <div style="display:flex">
+    <div style="{{styles.button_div}}">
+      <a href="{{feature_url}}/activity" style="{{styles.button_a}}"
+         >Feature activity</a>
+    </div>
+    <div style="{{styles.button_div}}">
+      <a href="{{releasenotes_url}}" style="{{styles.button_a}}"
+         >Current release notes</a>
+    </div>
+  </div>
+</section>
+
+</div>
+</div>


### PR DESCRIPTION
This should resolve item 3 of b/444431984.

Basically, there was already logic to reset the release notes review flags when a non-reviewer edited the milestones, name, or summary. This PR adds an email notification so that reviewers will know to go and re-review.