### PR TITLE
Fix typo in `GeminiClient.prompt_exceeds_input_token_limit`

### DIFF
--- a/framework/gemini_client.py
+++ b/framework/gemini_client.py
@@ -82,7 +82,7 @@ class GeminiClient:
       model=GeminiClient.GEMINI_MODEL,
       contents=prompt
     )
-    model_info = self.client.get(model=self.GEMINI_MODEL)
+    model_info = self.client.models.get(model=self.GEMINI_MODEL)
     logging.info('Prompt token count:', response.total_tokens)
     logging.info('Models context limit token count:',
                  model_info.input_token_limit)

--- a/framework/gemini_client_test.py
+++ b/framework/gemini_client_test.py
@@ -122,10 +122,10 @@ class GeminiClientTest(testing_config.CustomTestCase):
     mock_count_response.total_tokens = current_tokens
     self.mock_client_instance.models.count_tokens.return_value = mock_count_response
 
-    # Configure the mock response for client.get (to fetch model info)
+    # Configure the mock response for client.models.get (to fetch model info)
     mock_model_info = mock.MagicMock()
     mock_model_info.input_token_limit = token_limit
-    self.mock_client_instance.get.return_value = mock_model_info
+    self.mock_client_instance.models.get.return_value = mock_model_info
 
     client = gemini_client.GeminiClient()
     result = client.prompt_exceeds_input_token_limit(prompt)
@@ -140,7 +140,7 @@ class GeminiClientTest(testing_config.CustomTestCase):
     )
 
     # Verify the get model info API call
-    self.mock_client_instance.get.assert_called_once_with(
+    self.mock_client_instance.models.get.assert_called_once_with(
         model=client.GEMINI_MODEL
     )
 


### PR DESCRIPTION
The model info was referenced incorrectly.