### PR TITLE
Fix logging arguments in token count method

### DIFF
--- a/framework/gemini_client.py
+++ b/framework/gemini_client.py
@@ -83,9 +83,8 @@ class GeminiClient:
       contents=prompt
     )
     model_info = self.client.models.get(model=self.GEMINI_MODEL)
-    logging.info('Prompt token count:', response.total_tokens)
-    logging.info('Models context limit token count:',
-                 model_info.input_token_limit)
+    logging.info(f'Prompt token count: {response.total_tokens}')
+    logging.info(f'Model\'s context limit token count: {model_info.input_token_limit}')
     return response.total_tokens > model_info.input_token_limit
 
   @utils.retry(MAX_RETRIES, delay=RETRY_BACKOFF_SECONDS)


### PR DESCRIPTION
I was noticing some errors logged while testing out the pipeline "not all arguments converted during string formatting". I realized I had passed multiple arguments into `logging.info()` as if it were a print statement. 😬 This change fixes that.