### PR TITLE
Add tag_review field to DevTrails stage for "Chrome catches up" features

### DIFF
--- a/client-src/elements/form-definition.ts
+++ b/client-src/elements/form-definition.ts
@@ -332,7 +332,8 @@ const FLAT_DEV_TRIAL_FIELDS: MetadataFields = {
 };
 
 const FAST_DEV_TRIAL_FIELDS: MetadataFields = structuredClone(
-  FLAT_DEV_TRIAL_FIELDS);
+  FLAT_DEV_TRIAL_FIELDS
+);
 FAST_DEV_TRIAL_FIELDS.sections[0].fields.push('tag_review');
 
 // TODO(jrobbins): UA support signals section


### PR DESCRIPTION
This should resolve #6005.

For new feature incubations, this field is part of the "Evaluate readiness to ship" stage, but "Chrome catches up" (FAST) features do not have that stage, so for those features, I added it to a copy of the devtrials form.