### PR TITLE
Update address to notify of releasenotes flag resets.

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -1333,7 +1333,7 @@ class ResetShippingMilestonesEmailHandler(basehandlers.FlaskHandler):
 
 
 RELEASENOTES_NOTIFY_ADDRS = [
-    'cbe-tpgms@google.com',
+    core_enums.CBE_ESCLATION_EMAIL,
     'siobhankeating@google.com',
     ]
 RESET_RELEASENOTES_TEMPLATE_PATH = 'reset-releasenotes-flags-email.html'


### PR DESCRIPTION
The enterprise team would prefer to use this email address.