### PR TITLE
Update to use Gemini 3.1

### DIFF
--- a/docs/wpt-coverage-evaluation.md
+++ b/docs/wpt-coverage-evaluation.md
@@ -102,7 +102,7 @@ The system is tuned to balance App Engine limits against LLM generation time.
 These constants are defined in `framework/gemini_client.py`.
 
 ### Gemini Model
-* **Model:** `gemini-3-pro-preview` (Hardcoded as `GEMINI_MODEL`).
+* **Model:** `gemini-3.1-pro-preview` (Hardcoded as `GEMINI_MODEL`).
 
 ### Timeout Strategy
 To prevent "Task Deadline Exceeded" errors in Cloud Tasks, the system uses a

--- a/framework/gemini_client.py
+++ b/framework/gemini_client.py
@@ -30,7 +30,7 @@ class GeminiClient:
   handling API key configuration and simplifying content generation requests.
   """
 
-  GEMINI_MODEL = 'gemini-3-pro-preview'
+  GEMINI_MODEL = 'gemini-3.1-pro-preview'
 
   # Retry configuration.
   MAX_RETRIES = 3


### PR DESCRIPTION
Gemini 3.0 will be discontinued from the Gemini API on March 9th.