### PR TITLE
fix: maintenance_scripts_test

### DIFF
--- a/internals/fetchchannels.py
+++ b/internals/fetchchannels.py
@@ -87,9 +87,9 @@ def fetch_chrome_release_info(version):
         result_json = json.loads(result.content)
         if 'mstones' in result_json:
           data = result_json['mstones'][0]
-          del data['owners']
-          del data['feature_freeze']
-          del data['ldaps']
+          data.pop('owners', None)
+          data.pop('feature_freeze', None)
+          data.pop('ldaps', None)
           rediscache.set(key, data, time=SCHEDULE_CACHE_TIME)
       except ValueError:
         pass  # Handled by next statement

--- a/internals/maintenance_scripts_test.py
+++ b/internals/maintenance_scripts_test.py
@@ -756,12 +756,15 @@ class BackfillShippingYearTest(testing_config.CustomTestCase):
     actual = self.handler.calc_all_shipping_years()
     self.assertEqual({}, actual)
 
+  @mock.patch('internals.fetchchannels.fetch_chrome_release_info')
   @mock.patch('internals.stage_helpers.get_all_shipping_stages_with_milestones')
-  def test_calc_all_shipping_years__some(self, mock_gasswm: mock.MagicMock):
+  def test_calc_all_shipping_years__some(
+      self, mock_gasswm: mock.MagicMock, mock_fcri: mock.MagicMock):
     """We can calculate a dict of earliest milestones for a set of stages."""
     mock_gasswm.return_value = [
         self.stage_1_1, self.stage_2_1, self.stage_2_2, self.stage_3_1,
         self.stage_4_1]
+    mock_fcri.return_value = {'final_beta': '2030-01-01T00:00:00'}
     actual = self.handler.calc_all_shipping_years()
     expected = {22222: 2023, 33333: 2024, 44444: 2030}
     self.assertEqual(expected, actual)


### PR DESCRIPTION
1. Improved Data Handling in fetchchannels.py
In the [internals/fetchchannels.py](https://www.google.com/search?q=%5Bhttps://github.com/GoogleChrome/chromium-dashboard/pull/6082/changes%23diff-f6484918f7d97607ea0be38676008587be6965109b068770c061757833502859%5D(https://github.com/GoogleChrome/chromium-dashboard/pull/6082/changes%23diff-f6484918f7d97607ea0be38676008587be6965109b068770c061757833502859)) file, the method for removing keys from the release information dictionary was updated:

Change: Replaced del data['key'] with data.pop('key', None).

Reason: Using .pop(key, None) prevents the application from raising a KeyError if the keys (owners, feature_freeze, or ldaps) are missing from the API response, making the data processing more resilient.

2. Test Fix in maintenance_scripts_test.py
In the [internals/maintenance_scripts_test.py](https://www.google.com/search?q=%5Bhttps://github.com/GoogleChrome/chromium-dashboard/pull/6082/changes%23diff-e90696c6463569726619be982a1762002302300958172901306c9a3587b64952%5D(https://github.com/GoogleChrome/chromium-dashboard/pull/6082/changes%23diff-e90696c6463569726619be982a1762002302300958172901306c9a3587b64952)) file, the test_calc_all_shipping_years__some test case was updated to handle external dependencies:

Change: Added a mock for internals.fetchchannels.fetch_chrome_release_info.

Reason: The test now explicitly mocks the release info return value ({'final_beta': '2030-01-01T00:00:00'}), ensuring the test is deterministic and does not rely on actual network calls or external data state.