### PR TITLE
Add descriptive text for each stackrank page.

### DIFF
--- a/client-src/elements/chromedash-stack-rank-page.ts
+++ b/client-src/elements/chromedash-stack-rank-page.ts
@@ -2,7 +2,11 @@ import {LitElement, css, html} from 'lit';
 import {property} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import './chromedash-stack-rank';
-import {showToastMessage, METRICS_TYPE_AND_VIEW_TO_SUBTITLE} from './utils';
+import {
+  showToastMessage,
+  METRICS_TYPE_AND_VIEW_TO_SUBTITLE,
+  METRICS_TYPE_AND_VIEW_TO_DESCRIPTION,
+} from './utils';
 
 export class ChromedashStackRankPage extends LitElement {
   static get styles() {
@@ -125,21 +129,17 @@ export class ChromedashStackRankPage extends LitElement {
   }
 
   renderDataPanel() {
+    const listDescription =
+      METRICS_TYPE_AND_VIEW_TO_DESCRIPTION[this.type + this.view];
     return html`
-      <h3>Data from last 24 hours</h3>
+      <h3>Recent usage data</h3>
       <p class="description">
-        The percentage numbers indicate the
+        ${listDescription} The percentage numbers indicate the
         <span id="highlighted-text"
           >percentage of Chrome page loads (across all channels and platforms)
           that use the ${this.type == 'css' ? 'property' : 'feature'} at least
           once</span
-        >. Data is collected via Chrome's
-        <a
-          href="https://cs.chromium.org/chromium/src/tools/metrics/histograms/enums.xml"
-          target="_blank"
-          rel="noopener"
-          >anonymous usage statistics</a
-        >.
+        >. Data is collected via Chrome's anonymous usage statistics.
       </p>
       <chromedash-stack-rank
         .type=${this.type}

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -770,6 +770,25 @@ export const METRICS_TYPE_AND_VIEW_TO_SUBTITLE = {
   webfeaturepopularity: 'Web features usage metrics > all features',
 };
 
+const USE_COUNTERS_LINK = html`<a
+  href="https://chromium.googlesource.com/chromium/src/+/HEAD/docs/use_counter_wiki.md"
+  target="_blank"
+  >UseCounters</a
+>`;
+
+export const METRICS_TYPE_AND_VIEW_TO_DESCRIPTION = {
+  csspopularity: html`This list shows ${USE_COUNTERS_LINK} for CSS properties
+  regardless of animiation.`,
+  cssanimated: html`This list shows ${USE_COUNTERS_LINK} for CSS properities in
+  combination with animation.`,
+  featurepopularity: html`This list shows ${USE_COUNTERS_LINK} for certain
+  Javascript and HTML features.`,
+  webfeaturepopularity: html`This list shows ${USE_COUNTERS_LINK} for
+    <a href="https://github.com/web-platform-dx/web-features" target="_blank"
+      >Web Features</a
+    >.`,
+};
+
 /**
  * A feature is outdated if it has shipped, and its
  * accurate_as_of is before its latest shipping date before today.


### PR DESCRIPTION
Fixes #6041.

Our stats pages don't offer much explanation of what is being shown.  This takes a small step toward correcting that by adding a one-sentence description and a link to the UseCounters documentation on chromium.org.  I have also removed the link to enums.xml because that is a huge file and the UseCounters page seems more helpful.