### PR TITLE
feat: display the accurate_as_of date for enterprise release notes.

### DIFF
--- a/client-src/elements/chromedash-enterprise-release-notes-page.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page.ts
@@ -732,7 +732,9 @@ export class ChromedashEnterpriseReleaseNotesPage extends LitElement {
         >
           ${renderRelativeDate(f.updated.when)}
         </a>
-        by ${f.updated.by}
+        by ${f.updated.by} -
+        <b>Accurate as of:</b>
+        ${f.accurate_as_of ? f.accurate_as_of.split(' ')[0] : 'Unknown'}
         <b>></b>
       </p>
     `;

--- a/client-src/elements/chromedash-enterprise-release-notes-page_test.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page_test.ts
@@ -210,6 +210,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
             when: '2000-03-04 22:33:44',
             by: 'updater6',
           },
+          accurate_as_of: '2026-03-20 18:00:00',
           screenshot_links: [],
         },
         {
@@ -530,7 +531,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
         assert.equal(
           '< To remove - Feature details - ' +
             'Owners: owner - Editors: editor1, editor2 - Enterprise impact: Medium - First notice: n_milestone_feat_6 - ' +
-            'Last updated: ( ) by updater6 >',
+          'Last updated: ( ) by updater6 - Accurate as of: 2026-03-20 >',
           normalizedTextContent(features[0].querySelector('.toremove')));
         assert.equal(
           'feature 6 summary',
@@ -568,7 +569,7 @@ describe('chromedash-enterprise-release-notes-page', () => {
         assert.equal(
           '< To remove - Feature details - ' +
             'Owners: owner - Editors: editor1, editor2 - Enterprise impact: Medium - First notice: n_milestone_feat_8 - ' +
-            'Last updated: by updater8 >',
+          'Last updated: by updater8 - Accurate as of: Unknown >',
           normalizedTextContent(features[0].querySelector('.toremove')));
         assert.equal(
           'future premium feature summary',


### PR DESCRIPTION
This is a change requested by the Enterprise team.  They would like the accurate_as_of date to for each feature to be visible on the release notes page.  That date is already available a string in the JSON response that populates that page.