### PR TITLE
Fix stray logs during tests

### DIFF
--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from datetime import datetime
+import logging
 import testing_config  # Must be imported before the module under test.
 
 import flask
@@ -38,6 +39,7 @@ def _datetime_to_str(dt):
 class FeaturesAPITestDelete(testing_config.CustomTestCase):
 
   def setUp(self):
+    logging.disable(logging.CRITICAL)
     self.feature_1 = FeatureEntry(
         name='feature one', summary='sum', category=1,
         intent_stage=core_enums.INTENT_IMPLEMENT,
@@ -58,6 +60,7 @@ class FeaturesAPITestDelete(testing_config.CustomTestCase):
     self.random_user.put()
 
   def tearDown(self):
+    logging.disable(logging.NOTSET)
     cache_key = '%s|%s' % (
         FeatureEntry.DEFAULT_CACHE_KEY, self.feature_1.key.integer_id())
     for kind in [Activity, user_models.AppUser, FeatureEntry, Stage]:
@@ -148,6 +151,7 @@ class FeaturesAPITestDelete(testing_config.CustomTestCase):
 class FeaturesAPITest(testing_config.CustomTestCase):
 
   def setUp(self):
+    logging.disable(logging.CRITICAL)
     self.feature_1 = FeatureEntry(
         name='feature one', summary='sum Z', feature_type=0,
         owner_emails=['feature_owner@example.com'], category=1,
@@ -204,6 +208,7 @@ class FeaturesAPITest(testing_config.CustomTestCase):
     self.app_admin.put()
 
   def tearDown(self):
+    logging.disable(logging.NOTSET)
     for kind in [FeatureEntry, Gate, Stage, user_models.AppUser]:
       for entity in kind.query():
         entity.key.delete()

--- a/api/webdx_feature_api_test.py
+++ b/api/webdx_feature_api_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import testing_config
 from collections import OrderedDict
 
@@ -57,6 +58,7 @@ class WebFeatureIDsAPITest(testing_config.CustomTestCase):
 class WebdxFeatureAPITest(testing_config.CustomTestCase):
 
   def setUp(self):
+    logging.disable(logging.CRITICAL)
     self.webdx_observer = WebDXFeatureObserver(bucket_id=3, property_name='css')
     self.webdx_observer.put()
 
@@ -64,6 +66,7 @@ class WebdxFeatureAPITest(testing_config.CustomTestCase):
     self.request_path = '/api/v0/webdxfeatures'
 
   def tearDown(self):
+    logging.disable(logging.NOTSET)
     for entity in WebDXFeatureObserver.query():
       entity.key.delete()
 

--- a/framework/gemini_client_test.py
+++ b/framework/gemini_client_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import testing_config  # Must be imported before the module under test.
 
 import asyncio
@@ -26,6 +27,7 @@ class GeminiClientTest(testing_config.CustomTestCase):
 
   def setUp(self):
     """Set up shared mocks for all tests in this class."""
+    logging.disable(logging.CRITICAL)
     # Patch settings for all tests
     self.mock_settings = mock.patch('framework.gemini_client.settings').start()
 
@@ -51,6 +53,7 @@ class GeminiClientTest(testing_config.CustomTestCase):
     self.addCleanup(mock.patch.stopall)
 
   def tearDown(self):
+    logging.disable(logging.NOTSET)
     settings.GEMINI_API_KEY = self.original_gemini_api_key
 
   def test_init__success(self):

--- a/framework/secrets_test.py
+++ b/framework/secrets_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import testing_config  # Must be imported before the module under test.
 
 from unittest import mock
@@ -24,6 +25,7 @@ class SecretsFunctionsTest(testing_config.CustomTestCase):
   """Set of unit tests for accessing server-side secret values."""
 
   def setUp(self):
+    logging.disable(logging.CRITICAL)
     # Store original values to restore them after each test
     self.original_github_token = secrets.settings.GITHUB_TOKEN
     self.original_gemini_api_key = secrets.settings.GEMINI_API_KEY
@@ -39,6 +41,7 @@ class SecretsFunctionsTest(testing_config.CustomTestCase):
     secrets.settings.DEV_MODE = False
 
   def tearDown(self):
+    logging.disable(logging.NOTSET)
     # Restore original settings
     secrets.settings.GITHUB_TOKEN = self.original_github_token
     secrets.settings.GEMINI_API_KEY = self.original_gemini_api_key

--- a/internals/link_helpers_test.py
+++ b/internals/link_helpers_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import testing_config
 from unittest import mock
 from unittest import skip
@@ -31,6 +32,13 @@ from internals.link_helpers import (
 
 
 class LinkHelperTest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    logging.disable(logging.CRITICAL)
+
+  def tearDown(self):
+    logging.disable(logging.NOTSET)
+
   def test_specs_url(self):
     urls = [
       "https://w3c.github.io/presentation-api/",

--- a/internals/maintenance_scripts_test.py
+++ b/internals/maintenance_scripts_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import csv
+import logging
 import testing_config  # Must be imported before the module under test.
 from google.cloud import ndb
 
@@ -871,11 +872,13 @@ class BackfillGateDatesTest(testing_config.CustomTestCase):
 class FetchWebdxFeatureIdTest(testing_config.CustomTestCase):
 
    def setUp(self):
+     logging.disable(logging.CRITICAL)
      self.handler = maintenance_scripts.FetchWebdxFeatureId()
      self.webdx_features = WebdxFeatures(feature_ids = ['test1'])
      self.webdx_features.put()
 
    def tearDown(self):
+     logging.disable(logging.NOTSET)
      for entity in WebdxFeatures.query():
        entity.key.delete()
 

--- a/internals/ot_process_reminders_test.py
+++ b/internals/ot_process_reminders_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import testing_config  # Must be imported before the module under test.
 from unittest import mock
 
@@ -21,6 +22,7 @@ from internals.core_models import FeatureEntry, Stage
 
 class OTProcessRemindersTest(testing_config.CustomTestCase):
   def setUp(self):
+    logging.disable(logging.CRITICAL)
     self.feature_1 = FeatureEntry(
         feature_type=1, name='feature one', summary='sum', category=1)
     self.feature_1.put()
@@ -107,6 +109,7 @@ class OTProcessRemindersTest(testing_config.CustomTestCase):
     ]
 
   def tearDown(self):
+    logging.disable(logging.NOTSET)
     for kind in [FeatureEntry, Stage]:
       for entity in kind.query():
         entity.key.delete()


### PR DESCRIPTION
Several tests deliberately exercise error paths which cause the application to log errors and warnings. These logs bypass the unittest output buffer and pollute the console output during a successful test run.

This change uses `logging.disable(logging.CRITICAL)` in the `setUp` methods of affected tests to suppress these expected logs, and restores the logging level in `tearDown` using `logging.NOTSET`.

Fixes #5766