### PR TITLE
Redirect unauthenticated and unauthorized users from restricted SPA pages

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -766,44 +766,65 @@ class SPAHandler(FlaskHandler):
 
 def get_spa_template_data(handler_obj, defaults):
   """Check permissions then let spa.html do its thing."""
+  # Determine if this route requires a signed-in user.
+  requires_signin = (
+      defaults.get('require_signin') or
+      defaults.get('require_create_feature') or
+      defaults.get('require_edit_feature') or
+      defaults.get('require_admin_site') or
+      defaults.get('is_enterprise_page')
+  )
+
   # Check if the page requires user to sign in
-  if defaults.get('require_signin') and not handler_obj.get_current_user():
+  if requires_signin and not handler_obj.get_current_user():
     common_data = handler_obj.get_common_data()
     if 'loginStatus=False' in common_data['current_path']:
       return {}
     return flask.redirect(settings.LOGIN_PAGE_URL), handler_obj.get_headers()
 
-  # Check if the page requires create feature permission
-  if defaults.get('require_create_feature'):
-    redirect_resp = permissions.validate_feature_create_permission(handler_obj)
-    if redirect_resp:
-      return redirect_resp
+  try:
+    # Check if the page requires create feature permission
+    if defaults.get('require_create_feature'):
+      redirect_resp = permissions.validate_feature_create_permission(handler_obj)
+      if redirect_resp:
+        return redirect_resp
 
-  # Validate the user has edit permissions and redirect if needed.
-  if defaults.get('require_edit_feature'):
-    feature_id = defaults.get('feature_id')
-    if not feature_id:
-      handler_obj.abort(500, msg='Cannot get feature ID from the URL')
-    redirect_resp = permissions.validate_feature_edit_permission(
-        handler_obj, feature_id)
-    if redirect_resp:
-      return redirect_resp
+    # Validate the user has edit permissions and redirect if needed.
+    if defaults.get('require_edit_feature'):
+      feature_id = defaults.get('feature_id')
+      if not feature_id:
+        handler_obj.abort(500, msg='Cannot get feature ID from the URL')
+      redirect_resp = permissions.validate_feature_edit_permission(
+          handler_obj, feature_id)
+      if redirect_resp:
+        return redirect_resp
 
-  # Validate the user has admin permissions and redirect if needed.
-  if defaults.get('require_admin_site'):
-    user = handler_obj.get_current_user()
-    # Should have already done the require_signin check.
-    # If for reason, we don't let's treat it as the main 403 case.
-    if not user or not permissions.can_admin_site(user):
-      handler_obj.abort(403, msg='Cannot perform admin actions')
+    # Validate the user has admin permissions and redirect if needed.
+    if defaults.get('require_admin_site'):
+      user = handler_obj.get_current_user()
+      # Should have already done the require_signin check.
+      # If for reason, we don't let's treat it as the main 403 case.
+      if not user or not permissions.can_admin_site(user):
+        handler_obj.abort(403, msg='Cannot perform admin actions')
 
-  # Validate the user has a google or chromium account and redirect if needed.
-  if defaults.get('is_enterprise_page'):
-    user = handler_obj.get_current_user()
-    # Should have already done the require_signin check.
-    # If for reason, we don't let's treat it as the main 403 case.
-    if not user or not permissions.is_google_or_chromium_account(user):
-      handler_obj.abort(403, msg='You cannot access this page')
+    # Validate the user has a google or chromium account and redirect if needed.
+    if defaults.get('is_enterprise_page'):
+      user = handler_obj.get_current_user()
+      # Should have already done the require_signin check.
+      # If for reason, we don't let's treat it as the main 403 case.
+      if not user or not permissions.is_google_or_chromium_account(user):
+        handler_obj.abort(403, msg='You cannot access this page')
+
+  except werkzeug.exceptions.Forbidden:
+    # If the user is logged in but lacks permission, redirect them to a safe page
+    # instead of showing a generic white 403 error page.
+    if defaults.get('require_edit_feature') and defaults.get('feature_id'):
+      try:
+        safe_feature_id = int(defaults.get('feature_id'))
+        return flask.redirect(f"/feature/{safe_feature_id}?error=403"), handler_obj.get_headers()
+      except (ValueError, TypeError):
+        pass
+    return flask.redirect('/features?error=403'), handler_obj.get_headers()
 
   return {} # no handler_data needed to be returned
 

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -1279,7 +1279,7 @@ class GetSPATemplateDataTests(testing_config.CustomTestCase):
     testing_config.sign_out()
     with test_app.test_request_context('/must_have_create'):
       defaults = {'require_create_feature': True}
-      actual_redirect = basehandlers.get_spa_template_data(
+      actual_redirect, actual_headers = basehandlers.get_spa_template_data(
           self.handler, defaults)
 
     self.assertEqual(302, actual_redirect.status_code)
@@ -1291,9 +1291,11 @@ class GetSPATemplateDataTests(testing_config.CustomTestCase):
     testing_config.sign_in('user@example.com', 111)
     with test_app.test_request_context('/must_have_create'):
       defaults = {'require_create_feature': True}
-      with self.assertRaises(werkzeug.exceptions.Forbidden):
-        basehandlers.get_spa_template_data(
-            self.handler, defaults)
+      actual_redirect, actual_headers = basehandlers.get_spa_template_data(
+          self.handler, defaults)
+
+    self.assertEqual(302, actual_redirect.status_code)
+    self.assertEqual('/features?error=403', actual_redirect.headers['location'])
 
   def test_get_spa_template_data__create_perm_ok(self):
     """This page requires permission to create, and user has it."""
@@ -1324,7 +1326,7 @@ class GetSPATemplateDataTests(testing_config.CustomTestCase):
       defaults = {
           'require_edit_feature': True,
           'feature_id': self.fe_1.key.integer_id()}
-      actual_redirect = basehandlers.get_spa_template_data(
+      actual_redirect, actual_headers = basehandlers.get_spa_template_data(
           self.handler, defaults)
 
     self.assertEqual(302, actual_redirect.status_code)
@@ -1338,8 +1340,11 @@ class GetSPATemplateDataTests(testing_config.CustomTestCase):
       defaults = {
           'require_edit_feature': True,
           'feature_id': self.fe_1.key.integer_id()}
-      with self.assertRaises(werkzeug.exceptions.Forbidden):
-        basehandlers.get_spa_template_data(self.handler, defaults)
+      actual_redirect, actual_headers = basehandlers.get_spa_template_data(
+          self.handler, defaults)
+
+    self.assertEqual(302, actual_redirect.status_code)
+    self.assertEqual(f"/feature/{self.fe_1.key.integer_id()}?error=403", actual_redirect.headers['location'])
 
   def test_get_spa_template_data__edit_perm_ok(self):
     """This page requires editing a feature, and user has it."""
@@ -1357,16 +1362,23 @@ class GetSPATemplateDataTests(testing_config.CustomTestCase):
     testing_config.sign_out()
     with test_app.test_request_context('/must_have_admin'):
       defaults = {'require_admin_site': True}
-      with self.assertRaises(werkzeug.exceptions.Forbidden):
-        basehandlers.get_spa_template_data(self.handler, defaults)
+      actual_redirect, actual_headers = basehandlers.get_spa_template_data(
+          self.handler, defaults)
+
+    self.assertEqual(302, actual_redirect.status_code)
+    self.assertEqual(
+        settings.LOGIN_PAGE_URL, actual_redirect.headers['location'])
 
   def test_get_spa_template_data__admin_perm_no_permission(self):
     """This page requires admin perms, but user lacks it."""
     testing_config.sign_in('user@example.com', 111)
     with test_app.test_request_context('/must_have_admin'):
       defaults = {'require_admin_site': True}
-      with self.assertRaises(werkzeug.exceptions.Forbidden):
-        basehandlers.get_spa_template_data(self.handler, defaults)
+      actual_redirect, actual_headers = basehandlers.get_spa_template_data(
+          self.handler, defaults)
+
+    self.assertEqual(302, actual_redirect.status_code)
+    self.assertEqual('/features?error=403', actual_redirect.headers['location'])
 
   def test_get_spa_template_data__admin_perm_ok(self):
     """This page requires admin perms, and user has it."""

--- a/pages/testdata/users_test/test_html_rendering.html
+++ b/pages/testdata/users_test/test_html_rendering.html
@@ -56,6 +56,16 @@ limitations under the License.
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.get("loginStatus") == 'False') {
       alert('Please log in.');
+      window.location.replace('/');
+    } else {
+      if (urlParams.get("error") == '403') {
+        alert('You do not have permission to access that page. You may need to sign in with an authorized account.');
+      }
+      if (urlParams.has("error")) {
+        urlParams.delete("error");
+        const newSearch = urlParams.toString() ? '?' + urlParams.toString() : '';
+        window.history.replaceState({}, document.title, window.location.pathname + newSearch + window.location.hash);
+      }
     }
   </script>
   <script type="module" nonce="fake nonce">

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -54,6 +54,16 @@ limitations under the License.
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.get("loginStatus") == 'False') {
       alert('Please log in.');
+      window.location.replace('/');
+    } else {
+      if (urlParams.get("error") == '403') {
+        alert('You do not have permission to access that page. You may need to sign in with an authorized account.');
+      }
+      if (urlParams.has("error")) {
+        urlParams.delete("error");
+        const newSearch = urlParams.toString() ? '?' + urlParams.toString() : '';
+        window.history.replaceState({}, document.title, window.location.pathname + newSearch + window.location.hash);
+      }
     }
   </script>
   <script type="module" nonce="{{nonce}}">

--- a/templates/spa.html
+++ b/templates/spa.html
@@ -54,6 +54,16 @@ limitations under the License.
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.get("loginStatus") == 'False') {
       alert('Please log in.');
+      window.location.replace('/');
+    } else {
+      if (urlParams.get("error") == '403') {
+        alert('You do not have permission to access that page. You may need to sign in with an authorized account.');
+      }
+      if (urlParams.has("error")) {
+        urlParams.delete("error");
+        const newSearch = urlParams.toString() ? '?' + urlParams.toString() : '';
+        window.history.replaceState({}, document.title, window.location.pathname + newSearch + window.location.hash);
+      }
     }
   </script>
   <script type="module" nonce="{{nonce}}">


### PR DESCRIPTION
Resolves #6055

## Overview
When users attempt to access restricted SPA pages while unauthenticated or unauthorized, they are now gracefully redirected to the login screen or a safe fallback page with an alert, rather than encountering a generic 403 Forbidden error page.

## Root Cause / Motivation
Previously, SPA routes that specified permission requirements like `require_edit_feature` or `require_create_feature` in `main.py` did not explicitly enforce a `require_signin` check if it wasn't defined alongside them. Unauthenticated users were redirected initially, but on the subsequent request, the permission check failed because they were still unauthenticated, causing the server to abort with a generic `403` error. Even when logged in, if a user lacked the necessary permissions for a page, the server would also throw a `403`, bypassing the SPA and rendering a blank white error page without context.

## Detailed Changelog
* **`framework/basehandlers.py`**:
  * Updated `get_spa_template_data` to ensure any route with a permission requirement (e.g., `require_create_feature`, `require_edit_feature`) acts as if `require_signin` is `True`. This correctly intercepts unauthenticated users and returns early so the SPA can render the login prompt.
  * Added a `try...except werkzeug.exceptions.Forbidden` block to catch permission failures for logged-in users. Instead of a hard 403 abort, it redirects them to the read-only feature details page (`/feature/{feature_id}?error=403`) or the features list (`/features?error=403`) depending on the context.
* **`templates/spa.html` & `templates/_base.html`**:
  * Added logic to the initial script block to check for the `error=403` URL parameter. If present, it displays an alert advising the user that they do not have permission and may need to sign in with an authorized account.
* **`framework/basehandlers_test.py` & `pages/testdata/users_test/test_html_rendering.html`**:
  * Updated tests to anticipate the new redirect tuples and fallback routes (`/features?error=403`) instead of the previous `werkzeug.exceptions.Forbidden` assertions. Updated HTML rendering snapshots to include the new JS logic.
