### PR TITLE
Track system and user events with Activity `log_type` (#6163)

### DIFF
--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -115,6 +115,7 @@ class CommentsAPI(basehandlers.APIHandler):
                 self.abort(403, msg='User is not allowed to comment')
 
             comment_activity = Activity(
+                log_type=Activity.USER_COMMENT,
                 feature_id=feature_id,
                 gate_id=gate_id,
                 author=user.email(),

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -81,6 +81,7 @@ class CommentsConvertersTest(testing_config.CustomTestCase):
         )
         created = datetime.datetime(2022, 10, 28, 0, 0, 0)
         act = Activity(
+            log_type=Activity.USER_COMMENT,
             id=1,
             feature_id=123,
             gate_id=456,
@@ -131,6 +132,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
         )
 
         self.act_1_1 = Activity(
+            log_type=Activity.USER_COMMENT,
             feature_id=self.feature_id,
             gate_id=self.gate_1_id,
             author='owner1@example.com',
@@ -164,6 +166,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
         testing_config.sign_in('user7@example.com', 123567890)
 
         legacy_comment = Activity(
+            log_type=Activity.USER_COMMENT,
             feature_id=self.feature_id,
             author='owner1@example.com',
             created=NOW,
@@ -185,6 +188,7 @@ class CommentsAPITest(testing_config.CustomTestCase):
         self.act_1_1.put()
 
         random_activity = Activity(
+            log_type=Activity.USER_COMMENT,
             feature_id=self.feature_id,
             gate_id=99,
             author='owner1@example.com',

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -589,6 +589,7 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
         user = users.get_current_user()
         email = user.email() if user else None
         activity = Activity(
+            log_type=Activity.USER_COMMENT,
             feature_id=feature_id,
             author=email,
             content=f'Feature "{feature.name}" was archived.',

--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -109,6 +109,7 @@ class VotesAPI(basehandlers.APIHandler):
                     new_value=', '.join(new_assignees),
                 )
                 activity = Activity(
+                    log_type=Activity.USER_CHANGE,
                     feature_id=fe.key.integer_id(),
                     gate_id=gate_id,
                     author=user.email(),

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -1542,6 +1542,7 @@ class ResetStaleShippingMilestones(FlaskHandler):
             for s in stages:
                 # Create an activity that shows all the shipping milestones have been set to null.
                 activity = Activity(
+                    log_type=Activity.MILESTONE_RESET,
                     feature_id=f.key.integer_id(),
                     amendments=[],
                     content='Shipping/Rollout milestones were unset due to failure to verify accuracy.',
@@ -1603,6 +1604,7 @@ class DeleteWPTCoverageReport(FlaskHandler):
             # because the `ai_test_eval_report` field is not indexed.
             if feature.ai_test_eval_report:
                 activity = Activity(
+                    log_type=Activity.SYSTEM_CHANGE,
                     feature_id=feature.key.integer_id(),
                     content=(
                         f'WPT coverage report was deleted due to {self.RETENTION_DAYS}-day '

--- a/internals/maintenance_scripts_test.py
+++ b/internals/maintenance_scripts_test.py
@@ -1296,6 +1296,7 @@ class GenerateReviewActivityFileTest(testing_config.CustomTestCase):
         self.gate_2.put()
 
         self.activity_1 = Activity(
+            log_type=Activity.USER_COMMENT,
             feature_id=1,
             gate_id=11,
             author='user1@example.com',
@@ -1306,6 +1307,7 @@ class GenerateReviewActivityFileTest(testing_config.CustomTestCase):
         self.activity_1.put()
 
         self.activity_2 = Activity(
+            log_type=Activity.USER_CHANGE,
             feature_id=1,
             gate_id=11,
             created=datetime(2020, 1, 2, 9),
@@ -1322,6 +1324,7 @@ class GenerateReviewActivityFileTest(testing_config.CustomTestCase):
         self.activity_2.put()
 
         self.activity_3 = Activity(
+            log_type=Activity.USER_COMMENT,
             feature_id=1,
             gate_id=11,
             author='user2@example.com',
@@ -1332,6 +1335,7 @@ class GenerateReviewActivityFileTest(testing_config.CustomTestCase):
         self.activity_3.put()
 
         self.activity_4 = Activity(
+            log_type=Activity.USER_CHANGE,
             feature_id=1,
             gate_id=11,
             created=datetime(2020, 1, 4, 12),
@@ -1349,6 +1353,7 @@ class GenerateReviewActivityFileTest(testing_config.CustomTestCase):
 
         # Deleted comment.
         self.activity_5 = Activity(
+            log_type=Activity.USER_COMMENT,
             feature_id=1,
             gate_id=11,
             author='user2@example.com',
@@ -1360,6 +1365,7 @@ class GenerateReviewActivityFileTest(testing_config.CustomTestCase):
         self.activity_5.put()
 
         self.activity_6 = Activity(
+            log_type=Activity.USER_CHANGE,
             feature_id=1,
             gate_id=11,
             created=datetime(2020, 1, 6, 12),
@@ -1377,6 +1383,7 @@ class GenerateReviewActivityFileTest(testing_config.CustomTestCase):
 
         # Comment with no gate ID.
         self.activity_7 = Activity(
+            log_type=Activity.USER_COMMENT,
             feature_id=2,
             gate_id=None,
             author='user3@example.com',
@@ -1387,6 +1394,7 @@ class GenerateReviewActivityFileTest(testing_config.CustomTestCase):
         self.activity_7.put()
 
         self.activity_8 = Activity(
+            log_type=Activity.USER_CHANGE,
             feature_id=2,
             gate_id=12,
             author='user3@example.com',
@@ -1403,6 +1411,7 @@ class GenerateReviewActivityFileTest(testing_config.CustomTestCase):
         self.activity_8.put()
 
         self.activity_9 = Activity(
+            log_type=Activity.USER_CHANGE,
             feature_id=2,
             gate_id=12,
             author='user4@example.com',
@@ -1419,6 +1428,7 @@ class GenerateReviewActivityFileTest(testing_config.CustomTestCase):
         self.activity_9.put()
 
         self.activity_10 = Activity(
+            log_type=Activity.USER_COMMENT,
             feature_id=2,
             gate_id=12,
             author='user3@example.com',
@@ -1430,6 +1440,7 @@ class GenerateReviewActivityFileTest(testing_config.CustomTestCase):
 
         # Activity whose gate doesn't exist.
         self.activity_11 = Activity(
+            log_type=Activity.USER_COMMENT,
             feature_id=2,
             gate_id=13,
             author='user4@example.com',

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -92,7 +92,10 @@ def notify_subscribers_and_save_amendments(
         user = users.get_current_user()
         email = user.email() if user else None
         activity = Activity(
-            feature_id=fe.key.integer_id(), author=email, content=''
+            log_type=Activity.USER_CHANGE,
+            feature_id=fe.key.integer_id(),
+            author=email,
+            content='',
         )
         activity.amendments = amendments
         activity.put()
@@ -124,6 +127,7 @@ def notify_approvers_of_reviews(
     )
     gate_id = gate.key.integer_id()
     activity = Activity(
+        log_type=Activity.USER_CHANGE,
         feature_id=fe.key.integer_id(),
         gate_id=gate_id,
         author=email,
@@ -167,6 +171,7 @@ def notify_subscribers_of_vote_changes(
     )
     gate_id = gate.key.integer_id()
     activity = Activity(
+        log_type=Activity.USER_CHANGE,
         feature_id=fe.key.integer_id(),
         gate_id=gate_id,
         author=email,
@@ -226,6 +231,7 @@ def notify_assignees(
     )
     gate_id = gate.key.integer_id()
     activity = Activity(
+        log_type=Activity.USER_CHANGE,
         feature_id=fe.key.integer_id(),
         gate_id=gate_id,
         author=triggering_user_email,

--- a/internals/review_models.py
+++ b/internals/review_models.py
@@ -265,10 +265,17 @@ class Amendment(ndb.Model):
 class Activity(ndb.Model):
     """An activity log entry (comment + amendments) on a gate or feature."""
 
+    # Log types
+    USER_CHANGE = 1
+    MILESTONE_RESET = 2
+    USER_COMMENT = 3
+    SYSTEM_CHANGE = 4
+
     feature_id = ndb.IntegerProperty(required=True)
     gate_id = (
         ndb.IntegerProperty()
     )  # The gate commented on, or general comment.
+    log_type = ndb.IntegerProperty()
     created = ndb.DateTimeProperty(auto_now_add=True)
     author = ndb.StringProperty()
     content = ndb.TextProperty()

--- a/internals/review_models_test.py
+++ b/internals/review_models_test.py
@@ -31,6 +31,7 @@ class ActivityTest(testing_config.CustomTestCase):
         self.feature_1.put()
         self.feature_1_id = self.feature_1.key.integer_id()
         self.act_1_1 = Activity(
+            log_type=Activity.USER_COMMENT,
             feature_id=self.feature_1_id,
             gate_id=1,
             author='one@example.com',
@@ -38,6 +39,7 @@ class ActivityTest(testing_config.CustomTestCase):
         )
         self.act_1_1.put()
         self.act_1_2 = Activity(
+            log_type=Activity.USER_COMMENT,
             feature_id=self.feature_1_id,
             gate_id=2,
             author='one@example.com',
@@ -45,6 +47,7 @@ class ActivityTest(testing_config.CustomTestCase):
         )
         self.act_1_2.put()
         self.act_1_3 = Activity(
+            log_type=Activity.USER_COMMENT,
             feature_id=self.feature_1_id,
             author='one@example.com',
             content='random',


### PR DESCRIPTION
Resolves #6163

## Overview
Adds an indexed `log_type` property to the `Activity` model to track system and user events, making events like milestone resets and comments easily queryable.

## Root Cause / Motivation
Previously, tracking system-level events (like a feature's shipping milestones being reset due to unverified data, or WPT reports being deleted) relied on parsing the unindexed `content` text field of the `Activity` model. This approach was brittle and slow. By introducing an indexed `log_type` property with specific enums (`USER_CHANGE`, `MILESTONE_RESET`, `USER_COMMENT`, `SYSTEM_CHANGE`), we can programmatically query for these specific events efficiently without losing their visibility in the standard feature history log.

## Detailed Changelog
* **`internals/review_models.py`**: Added `log_type` property to the `Activity` model and defined enums (`USER_CHANGE = 1`, `MILESTONE_RESET = 2`, `USER_COMMENT = 3`, `SYSTEM_CHANGE = 4`).
* **`internals/maintenance_scripts.py`**: Updated `ResetStaleShippingMilestones` to set `log_type=Activity.MILESTONE_RESET` and `DeleteWPTCoverageReport` to set `log_type=Activity.SYSTEM_CHANGE`.
* **`api/comments_api.py`**: Updated user comment creation to set `log_type=Activity.USER_COMMENT`.
* **`api/features_api.py`, `api/reviews_api.py`, `internals/notifier_helpers.py`**: Updated activity instantiations for system modifications triggered by users to set `log_type=Activity.USER_CHANGE`.
* **`api/comments_api_test.py`, `internals/review_models_test.py`, `internals/maintenance_scripts_test.py`**: Updated test instantiations of `Activity` to include `log_type=Activity.USER_COMMENT` to ensure backwards compatibility and passing tests.