### PR TITLE
Fix actionable Ruff violations and document infeasible rules

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -546,9 +546,6 @@ def feature_entry_to_json_verbose(
                 },
             },
         },
-        'enterprise_feature_categories': fe.enterprise_feature_categories or [],  # noqa: F601
-        'enterprise_product_category': fe.enterprise_product_category
-        or ENTERPRISE_PRODUCT_CATEGORY_CHROME_BROWSER_UPDATE,  # noqa: E501, F405, F601
         'standards': {
             'spec': fe.spec_link,
             'maturity': {

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -175,7 +175,6 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
             feature.first_enterprise_notification_milestone = int(
                 feature_changes['first_enterprise_notification_milestone']
             )
-            has_updated = True
         elif needs_default_first_notification_milestone(
             new_fields=feature_changes
         ):

--- a/framework/users.py
+++ b/framework/users.py
@@ -139,18 +139,32 @@ class User(object):
         else:
             return hash((self.__email, self.__auth_domain))
 
-    def __cmp__(self, other):
+    def __eq__(self, other):
         if not isinstance(other, User):
             return NotImplemented
         if self.__federated_identity:
-            return cmp(
-                (self.__federated_identity, self.__auth_domain),  # noqa: F821
-                (other.__federated_identity, other.__auth_domain),
+            return (self.__federated_identity, self.__auth_domain) == (
+                other.__federated_identity,
+                other.__auth_domain,
             )
         else:
-            return cmp(
-                (self.__email, self.__auth_domain),  # noqa: F821
-                (other.__email, other.__auth_domain),
+            return (self.__email, self.__auth_domain) == (
+                other.__email,
+                other.__auth_domain,
+            )
+
+    def __lt__(self, other):
+        if not isinstance(other, User):
+            return NotImplemented
+        if self.__federated_identity:
+            return (self.__federated_identity, self.__auth_domain) < (
+                other.__federated_identity,
+                other.__auth_domain,
+            )
+        else:
+            return (self.__email, self.__auth_domain) < (
+                other.__email,
+                other.__auth_domain,
             )
 
     def get_current_user(self):

--- a/internals/attachments.py
+++ b/internals/attachments.py
@@ -63,7 +63,7 @@ SUPPORTED_MIME_TYPES = RESIZABLE_MIME_TYPES + ['text/plain']
 def store_attachment(
     feature_id: int, content: bytes, mime_type: str
 ) -> Attachment:
-    """ "Store some data for an attachment.  Return its URI."""
+    """Store some data for an attachment.  Return its URI."""
     check_attachment_size(content)
     check_attachment_type(mime_type)
     logging.info('Storing attachment with %r bytes', len(content))

--- a/internals/enterprise_helpers.py
+++ b/internals/enterprise_helpers.py
@@ -85,11 +85,11 @@ def needs_default_first_notification_milestone(
 
 def is_update_first_notification_milestone(
     feature: FeatureEntry, new_fields: dict
-) -> bool:  # noqa: D417, E501
+) -> bool:  # noqa: E501
     """Returns whether the milestone can be used to update first_enterprise_notification_milestone.
 
     Args:
-      existing_feature: FeatureEntry feature that needs to be updated.
+      feature: FeatureEntry feature that needs to be updated.
       new_fields: dict Fields that will be used to update or create the feature.
     """  # noqa: E501
     milestone = new_fields.get('first_enterprise_notification_milestone')

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 import settings
 from api import converters
 from framework import cloud_tasks_helpers, users
-from internals import approval_defs, core_enums, core_models
+from internals import approval_defs, core_enums
 from internals.core_models import Stage
 from internals.data_types import CHANGED_FIELDS_LIST_TYPE
 from internals.review_models import Activity, Amendment, Gate, Vote
@@ -149,16 +149,10 @@ def notify_subscribers_of_vote_changes(
     fe: 'FeatureEntry', gate: Gate, email: str, new_state: int, old_state: int
 ) -> None:
     """Notify subscribers of a vote change and save amendments."""
-    stage = core_models.Stage.get_by_id(gate.stage_id)
-    stage_enum = core_enums.INTENT_STAGES_BY_STAGE_TYPE.get(
-        stage.stage_type, core_enums.INTENT_NONE
-    )
-    stage_name = core_enums.INTENT_STAGES[stage_enum]
     state_name = Vote.VOTE_VALUES[new_state]
     old_state_name = Vote.VOTE_VALUES.get(old_state, str(old_state))
 
     appr_def = approval_defs.APPROVAL_FIELDS_BY_ID[gate.gate_type]
-    gate_name = appr_def.name
 
     amendment = Amendment(
         field_name='review_status',

--- a/internals/notifier_helpers_test.py
+++ b/internals/notifier_helpers_test.py
@@ -105,10 +105,6 @@ class ActivityTest(testing_config.CustomTestCase):
         notifier_helpers.notify_subscribers_of_vote_changes(
             self.feature_1, self.gate_1, 'abc@example.com', Vote.DENIED, Vote.NA
         )
-        expected_content = (
-            'abc@example.com set review status for stage'  # noqa: F841
-            ': Start prototyping, gate: Intent to Prototype to denied.'
-        )
         feature_id = self.feature_1.key.integer_id()
         activities = Activity.get_activities(feature_id)
         self.assertEqual(len(activities), 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,31 @@ docstring-code-format = true
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "D"]
-ignore = ["D100", "D101", "D102", "D103", "D104", "D105", "D106", "D107", "D203", "D213", "E501", "F403", "F405", "E712", "F841", "F601", "F821", "D210", "D417"] # Ignore missing docstrings temporarily, conflicting rules, and unfixable legacy errors.
+ignore = [
+    # Infeasible: Legacy codebase lacks hundreds of module/class/function docstrings; writing them all at once is infeasible.
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+
+    # Infeasible: Conflicts with Ruff's default Google style docstring rules (D211, D212).
+    "D203",
+    "D213",
+
+    # Infeasible: Legacy codebase has many long strings/comments; fixing all manually is infeasible.
+    "E501",
+
+    # Infeasible: Legacy tests heavily rely on wildcard imports (e.g., from internals.core_enums import *).
+    "F403",
+    "F405",
+
+    # Infeasible: Google Cloud NDB ORM overloads equality operators (== True/False) for query construction.
+    "E712",
+]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
Resolves #6177 (Follow-up)

## Overview
This PR is a stacked change that addresses the remaining actionable Ruff linting violations that were previously ignored. It also reformats the `pyproject.toml` ignore list to clearly document why the remaining unfixable legacy rules must be kept ignored.

## Root Cause / Motivation
In the previous PR, several Ruff rules were blanket-ignored to establish a clean CI baseline. Many of these rules were actionable and have now been fixed (e.g., duplicate dictionary keys, deprecated `__cmp__` usage, unused variables). For rules that are infeasible to fix in a single PR (like missing docstrings or NDB ORM equality overloads), we document the exact reason for ignoring them directly in the configuration file to prevent future confusion.

## Detailed Changelog
* **`pyproject.toml`**: Reformatted the Ruff `ignore` list to have one rule per line, grouped with comments explaining why they are infeasible to fix currently (e.g., NDB ORM overloading `== False`, legacy wildcard imports). Removed `F601`, `F821`, `D210`, `D417`, and `F841` from the ignore list.
* **`api/converters.py`**: Fixed `F601` by removing duplicated dictionary keys (`enterprise_feature_categories` and `enterprise_product_category`).
* **`api/features_api.py`**: Fixed `F841` by removing an unused local variable (`has_updated`).
* **`framework/users.py`**: Fixed `F821` by replacing the deprecated Python 2 `__cmp__` method with modern `__eq__` and `__lt__` methods.
* **`internals/attachments.py`**: Fixed `D210` by removing leading whitespaces in the docstring.
* **`internals/enterprise_helpers.py`**: Fixed `D417` by correcting the documented argument name to match the function signature.
* **`internals/notifier_helpers.py`**: Fixed `F841` by removing unused local variables (`stage`, `stage_enum`, `stage_name`, and `gate_name`).
* **`internals/notifier_helpers_test.py`**: Fixed `F841` by removing an unused local variable (`expected_content`).
