### PR TITLE
Update editorconfig to default to 4-space indentations in Python

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ insert_final_newline = true
 ; Python
 [*.py]
 indent_style = space
-indent_size = 2
+indent_size = 4
 
 ; YAML
 [*.{yaml,yml}]


### PR DESCRIPTION
This will make it so IDEs like VSCode will default to 4-space indentation for this project.