### PR TITLE
Add script to check and enforce Apache 2.0 license headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ dev-ot-key:
 do-tests:
 	. cs-env/bin/activate && curl -X POST 'http://localhost:15606/reset' && \
 	if command -v pytest >/dev/null 2>&1; then \
-		pytest -n auto -q *_test.py api/*_test.py internals/*_test.py framework/*_test.py pages/*_test.py; \
+		pytest -n auto -q *_test.py api/*_test.py internals/*_test.py framework/*_test.py pages/*_test.py scripts/*_test.py; \
 	else \
 		python3.13 -m unittest discover -p '*_test.py' -b; \
 	fi
@@ -73,7 +73,7 @@ stop: pwtests-shutdown
 
 test:
 	($(MAKE) start-emulator > /dev/null 2>&1 &)
-	
+
 	curl --retry 10 --retry-all-errors --retry-delay 1 http://localhost:15606/
 	$(MAKE) do-tests; status=$$?; $(MAKE) stop-emulator; exit $$status
 
@@ -107,6 +107,12 @@ view-coverage:
 mypy:
 	. cs-env/bin/activate && mypy --ignore-missing-imports --exclude cs-env/ --exclude appengine_config.py --exclude gen/py/webstatus_openapi/build/ --exclude gen/py/webstatus_openapi/setup.py --exclude gen/py/webstatus_openapi/test/ --exclude gen/py/chromestatus_openapi/build/ --exclude gen/py/chromestatus_openapi/chromestatus_openapi/test --exclude appengine_config.py --no-namespace-packages --disable-error-code "annotation-unchecked" .
 
+check-license:
+	. cs-env/bin/activate && python3 scripts/check_license.py
+
+check-license-fix:
+	. cs-env/bin/activate && python3 scripts/check_license.py --fix
+
 lint-frontend:
 	npx prettier client-src/js-src client-src/elements client-src/elements packages/playwright/tests --check
 	npx eslint "client-src/js-src/**/*.{js,ts}" "packages/playwright/tests/*.{js,ts}"
@@ -116,6 +122,7 @@ lint-frontend:
 lint-backend:
 	$(MAKE) pylint
 	. cs-env/bin/activate && ruff format --check .
+	$(MAKE) check-license
 
 lint: lint-frontend lint-backend
 
@@ -125,6 +132,7 @@ lint-fix-frontend:
 
 lint-fix-backend:
 	$(MAKE) format
+	$(MAKE) check-license-fix
 
 lint-fix: lint-fix-frontend lint-fix-backend
 

--- a/client-src/components.js
+++ b/client-src/components.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /** This is the entry file for rollup. It bundles all the web components:
     shoelace components and our own components */
 

--- a/client-src/css/_layout-css.js
+++ b/client-src/css/_layout-css.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { css } from "lit";
 
 export const LAYOUT_CSS = css`

--- a/client-src/css/_reset-css.js
+++ b/client-src/css/_reset-css.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {css} from 'lit';
 
 export const RESET = css`

--- a/client-src/css/_vars-css.js
+++ b/client-src/css/_vars-css.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {css} from 'lit';
 
 export const VARS = css`

--- a/client-src/css/elements/chromedash-roadmap-milestone-card-css.js
+++ b/client-src/css/elements/chromedash-roadmap-milestone-card-css.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {css} from 'lit';
 import {SHARED_STYLES} from '../shared-css.js';
 

--- a/client-src/css/forms-css.js
+++ b/client-src/css/forms-css.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {css} from 'lit';
 import {VARS} from './_vars-css.js';
 

--- a/client-src/css/shared-css.js
+++ b/client-src/css/shared-css.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {css} from 'lit';
 import {VARS} from './_vars-css.js';
 import {RESET} from './_reset-css.js';

--- a/client-src/elements/autolink.ts
+++ b/client-src/elements/autolink.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // This is an implementation of autolinking pulled from Monorail and repurposed
 // for use with text entries in WebStatus. Use this directly via './utils.js'
 // See: https://chromium.googlesource.com/infra/infra/+/refs/heads/main/appengine/monorail/static_src/autolink.js

--- a/client-src/elements/chromeash-stale-features-page_test.ts
+++ b/client-src/elements/chromeash-stale-features-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {fixture, html, assert, elementUpdated} from '@open-wc/testing';
 import sinon from 'sinon';
 import {ChromedashStaleFeaturesPage} from './chromedash-stale-features-page.js';

--- a/client-src/elements/chromedash-activity-log.ts
+++ b/client-src/elements/chromedash-activity-log.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {property, state} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-activity-log_test.ts
+++ b/client-src/elements/chromedash-activity-log_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {

--- a/client-src/elements/chromedash-activity-page.ts
+++ b/client-src/elements/chromedash-activity-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {css, html, LitElement, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {createRef, ref, Ref} from 'lit/directives/ref.js';

--- a/client-src/elements/chromedash-activity-page_test.ts
+++ b/client-src/elements/chromedash-activity-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert, fixture} from '@open-wc/testing';
 import {html} from 'lit';
 import {ChromedashActivityPage} from './chromedash-activity-page.js';

--- a/client-src/elements/chromedash-add-stage-dialog.ts
+++ b/client-src/elements/chromedash-add-stage-dialog.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, TemplateResult, css, html} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {CREATEABLE_STAGES, FORMS_BY_STAGE_TYPE} from './form-definition.js';

--- a/client-src/elements/chromedash-admin-blink-component-listing.ts
+++ b/client-src/elements/chromedash-admin-blink-component-listing.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html, css, LitElement, TemplateResult} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {VARS} from '../css/_vars-css.js';

--- a/client-src/elements/chromedash-admin-blink-component-listing_test.ts
+++ b/client-src/elements/chromedash-admin-blink-component-listing_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {ChromedashAdminBlinkComponentListing} from './chromedash-admin-blink-component-listing.js';
 import {html} from 'lit';
 import {assert, expect, fixture, oneEvent} from '@open-wc/testing';

--- a/client-src/elements/chromedash-admin-blink-page.ts
+++ b/client-src/elements/chromedash-admin-blink-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {showToastMessage} from './utils.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-admin-blink-page_test.ts
+++ b/client-src/elements/chromedash-admin-blink-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import './chromedash-toast.js';
 import {html} from 'lit';
 import {ChromedashAdminBlinkPage} from './chromedash-admin-blink-page.js';

--- a/client-src/elements/chromedash-admin-feature-links-page.ts
+++ b/client-src/elements/chromedash-admin-feature-links-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {showToastMessage} from './utils.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-all-features-page.ts
+++ b/client-src/elements/chromedash-all-features-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {showToastMessage} from './utils.js';
 import './chromedash-feature-table.js';

--- a/client-src/elements/chromedash-all-features-page_test.ts
+++ b/client-src/elements/chromedash-all-features-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashAllFeaturesPage} from './chromedash-all-features-page.js';

--- a/client-src/elements/chromedash-app.ts
+++ b/client-src/elements/chromedash-app.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {styleMap} from 'lit-html/directives/style-map.js';
 import {customElement, property, state} from 'lit/decorators.js';

--- a/client-src/elements/chromedash-attachments.ts
+++ b/client-src/elements/chromedash-attachments.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {createRef, ref, Ref} from 'lit/directives/ref.js';

--- a/client-src/elements/chromedash-attachments_test.ts
+++ b/client-src/elements/chromedash-attachments_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashAttachments} from './chromedash-attachments.js';

--- a/client-src/elements/chromedash-banner.ts
+++ b/client-src/elements/chromedash-banner.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {customElement, property} from 'lit/decorators.js';

--- a/client-src/elements/chromedash-bulk-edit-page.ts
+++ b/client-src/elements/chromedash-bulk-edit-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {customElement, state} from 'lit/decorators.js';
 import {FORM_STYLES} from '../css/forms-css.js';

--- a/client-src/elements/chromedash-bulk-edit-page_test.ts
+++ b/client-src/elements/chromedash-bulk-edit-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert, fixture} from '@open-wc/testing';
 import {html} from 'lit';
 import {ChromedashBulkEditPage} from './chromedash-bulk-edit-page.js';

--- a/client-src/elements/chromedash-callout.ts
+++ b/client-src/elements/chromedash-callout.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {customElement, property, state} from 'lit/decorators.js';

--- a/client-src/elements/chromedash-continuity-id-dialog.ts
+++ b/client-src/elements/chromedash-continuity-id-dialog.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {customElement, property, state, query} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-continuity-id-dialog_test.ts
+++ b/client-src/elements/chromedash-continuity-id-dialog_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {fixture, assert, expect} from '@open-wc/testing';
 import sinon from 'sinon';

--- a/client-src/elements/chromedash-drawer.ts
+++ b/client-src/elements/chromedash-drawer.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {SlDrawer} from '@shoelace-style/shoelace';
 import {LitElement, TemplateResult, css, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';

--- a/client-src/elements/chromedash-drawer_test.ts
+++ b/client-src/elements/chromedash-drawer_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashDrawer} from './chromedash-drawer.js';

--- a/client-src/elements/chromedash-enterprise-page.ts
+++ b/client-src/elements/chromedash-enterprise-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {ChromedashAllFeaturesPage} from './chromedash-all-features-page.js';
 import {customElement} from 'lit/decorators.js';

--- a/client-src/elements/chromedash-enterprise-page_test.ts
+++ b/client-src/elements/chromedash-enterprise-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashEnterprisePage} from './chromedash-enterprise-page.js';

--- a/client-src/elements/chromedash-enterprise-release-notes-page.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {css, html, LitElement, TemplateResult, nothing} from 'lit';
 import {customElement, state, property} from 'lit/decorators.js';
 import {ifDefined} from 'lit/directives/if-defined.js';

--- a/client-src/elements/chromedash-enterprise-release-notes-page_test.ts
+++ b/client-src/elements/chromedash-enterprise-release-notes-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture, nextFrame} from '@open-wc/testing';
 import {SlButton} from '@shoelace-style/shoelace';

--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, TemplateResult, css, html, nothing} from 'lit';
 import {openAddStageDialog} from './chromedash-add-stage-dialog.js';
 import {

--- a/client-src/elements/chromedash-feature-detail_test.ts
+++ b/client-src/elements/chromedash-feature-detail_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert, fixture} from '@open-wc/testing';
 import {html} from 'lit';
 import {ChromedashFeatureDetail} from './chromedash-feature-detail.js';

--- a/client-src/elements/chromedash-feature-filter.ts
+++ b/client-src/elements/chromedash-feature-filter.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {createRef, Ref, ref} from 'lit/directives/ref.js';

--- a/client-src/elements/chromedash-feature-highlights.ts
+++ b/client-src/elements/chromedash-feature-highlights.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-feature-page.ts
+++ b/client-src/elements/chromedash-feature-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, TemplateResult, css, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {ifDefined} from 'lit/directives/if-defined.js';

--- a/client-src/elements/chromedash-feature-page_test.ts
+++ b/client-src/elements/chromedash-feature-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert, fixture} from '@open-wc/testing';
 import {html} from 'lit';
 import sinon from 'sinon';

--- a/client-src/elements/chromedash-feature-row.ts
+++ b/client-src/elements/chromedash-feature-row.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-feature-table.ts
+++ b/client-src/elements/chromedash-feature-table.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {ifDefined} from 'lit/directives/if-defined.js';

--- a/client-src/elements/chromedash-footer.ts
+++ b/client-src/elements/chromedash-footer.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {customElement} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-footer_test.ts
+++ b/client-src/elements/chromedash-footer_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashFooter} from './chromedash-footer.js';

--- a/client-src/elements/chromedash-form-field.ts
+++ b/client-src/elements/chromedash-form-field.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {SlDetails, SlIconButton, SlInput} from '@shoelace-style/shoelace';
 import {LitElement, TemplateResult, css, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';

--- a/client-src/elements/chromedash-form-field_test.ts
+++ b/client-src/elements/chromedash-form-field_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert, fixture} from '@open-wc/testing';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
 import {html, render} from 'lit';

--- a/client-src/elements/chromedash-form-table.ts
+++ b/client-src/elements/chromedash-form-table.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 

--- a/client-src/elements/chromedash-form-table_test.ts
+++ b/client-src/elements/chromedash-form-table_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert, fixture} from '@open-wc/testing';
 import {html} from 'lit';
 import {ChromedashFormTable} from './chromedash-form-table.js';

--- a/client-src/elements/chromedash-gantt.ts
+++ b/client-src/elements/chromedash-gantt.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, TemplateResult, css, html, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-gantt_test.ts
+++ b/client-src/elements/chromedash-gantt_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert, fixture} from '@open-wc/testing';
 import {html} from 'lit';
 import {ChromedashGantt} from './chromedash-gantt.js';

--- a/client-src/elements/chromedash-gate-chip.ts
+++ b/client-src/elements/chromedash-gate-chip.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {updateURLParams} from './utils.js';

--- a/client-src/elements/chromedash-gate-column.ts
+++ b/client-src/elements/chromedash-gate-column.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, TemplateResult, css, html, nothing} from 'lit';
 import {createRef, ref} from 'lit/directives/ref.js';
 import './chromedash-activity-log.js';

--- a/client-src/elements/chromedash-gate-column_test.ts
+++ b/client-src/elements/chromedash-gate-column_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashGateColumn} from './chromedash-gate-column.js';

--- a/client-src/elements/chromedash-guide-editall-page.ts
+++ b/client-src/elements/chromedash-guide-editall-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, TemplateResult, css, html, nothing} from 'lit';
 import {ref} from 'lit/directives/ref.js';
 import {repeat} from 'lit/directives/repeat.js';

--- a/client-src/elements/chromedash-guide-editall-page_test.ts
+++ b/client-src/elements/chromedash-guide-editall-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert, fixture} from '@open-wc/testing';
 import {html} from 'lit';
 import sinon from 'sinon';

--- a/client-src/elements/chromedash-guide-metadata-page.ts
+++ b/client-src/elements/chromedash-guide-metadata-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {ref} from 'lit/directives/ref.js';
 import {

--- a/client-src/elements/chromedash-guide-new-page.ts
+++ b/client-src/elements/chromedash-guide-new-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {ref} from 'lit/directives/ref.js';
 import './chromedash-form-table.js';

--- a/client-src/elements/chromedash-guide-new-page_test.ts
+++ b/client-src/elements/chromedash-guide-new-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashGuideNewPage} from './chromedash-guide-new-page.js';

--- a/client-src/elements/chromedash-guide-stage-page.ts
+++ b/client-src/elements/chromedash-guide-stage-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, TemplateResult, css, html, nothing} from 'lit';
 import {ref} from 'lit/directives/ref.js';
 import {

--- a/client-src/elements/chromedash-guide-stage-page_test.ts
+++ b/client-src/elements/chromedash-guide-stage-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashGuideStagePage} from './chromedash-guide-stage-page.js';

--- a/client-src/elements/chromedash-guide-verify-accuracy-page.ts
+++ b/client-src/elements/chromedash-guide-verify-accuracy-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {ref} from 'lit/directives/ref.js';
 import {

--- a/client-src/elements/chromedash-guide-verify-accuracy-page_test.ts
+++ b/client-src/elements/chromedash-guide-verify-accuracy-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashGuideVerifyAccuracyPage} from './chromedash-guide-verify-accuracy-page.js';

--- a/client-src/elements/chromedash-header.ts
+++ b/client-src/elements/chromedash-header.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, html, css, nothing} from 'lit';
 import {showToastMessage, IS_MOBILE, redirectToCurrentPage} from './utils.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-header_test.ts
+++ b/client-src/elements/chromedash-header_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashHeader} from './chromedash-header.js';

--- a/client-src/elements/chromedash-intent-content.ts
+++ b/client-src/elements/chromedash-intent-content.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-intent-preview-page.ts
+++ b/client-src/elements/chromedash-intent-preview-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {showToastMessage} from './utils.js';

--- a/client-src/elements/chromedash-intent-template_test.ts
+++ b/client-src/elements/chromedash-intent-template_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashIntentContent} from './chromedash-intent-content.js';

--- a/client-src/elements/chromedash-link.ts
+++ b/client-src/elements/chromedash-link.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // @ts-check
 
 import {SlBadge} from '@shoelace-style/shoelace';

--- a/client-src/elements/chromedash-link_test.ts
+++ b/client-src/elements/chromedash-link_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {expect, fixture} from '@open-wc/testing';
 import {html} from 'lit';
 import './chromedash-link.js';

--- a/client-src/elements/chromedash-login-required-page.ts
+++ b/client-src/elements/chromedash-login-required-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, html} from 'lit';
 import {customElement} from 'lit/decorators.js';
 

--- a/client-src/elements/chromedash-metadata.ts
+++ b/client-src/elements/chromedash-metadata.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {ifDefined} from 'lit/directives/if-defined.js';

--- a/client-src/elements/chromedash-na-rationale-dialog.ts
+++ b/client-src/elements/chromedash-na-rationale-dialog.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {ref, createRef} from 'lit/directives/ref.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-ot-creation-page.ts
+++ b/client-src/elements/chromedash-ot-creation-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, TemplateResult, css, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {ref} from 'lit/directives/ref.js';

--- a/client-src/elements/chromedash-ot-extension-page.ts
+++ b/client-src/elements/chromedash-ot-extension-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {property, state} from 'lit/decorators.js';
 import {ref} from 'lit/directives/ref.js';

--- a/client-src/elements/chromedash-ot-prereqs-dialog.ts
+++ b/client-src/elements/chromedash-ot-prereqs-dialog.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {showToastMessage} from './utils.js';

--- a/client-src/elements/chromedash-post-intent-dialog.ts
+++ b/client-src/elements/chromedash-post-intent-dialog.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {ref} from 'lit/directives/ref.js';

--- a/client-src/elements/chromedash-preflight-dialog.ts
+++ b/client-src/elements/chromedash-preflight-dialog.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import './chromedash-callout.js';
 import {

--- a/client-src/elements/chromedash-preflight-dialog_test.ts
+++ b/client-src/elements/chromedash-preflight-dialog_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert} from '@open-wc/testing';
 import {Feature, StageDict} from '../js-src/cs-client.js';
 import {VOTE_OPTIONS} from './form-field-enums.js';

--- a/client-src/elements/chromedash-prevote-dialog.ts
+++ b/client-src/elements/chromedash-prevote-dialog.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {findPendingGates} from './chromedash-preflight-dialog.js';

--- a/client-src/elements/chromedash-prevote-dialog_test.ts
+++ b/client-src/elements/chromedash-prevote-dialog_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert} from '@open-wc/testing';
 import {Feature, StageDict} from '../js-src/cs-client.js';
 import {GATE_TYPES, VOTE_OPTIONS} from './form-field-enums.js';

--- a/client-src/elements/chromedash-report-external-reviews-dispatch-page.ts
+++ b/client-src/elements/chromedash-report-external-reviews-dispatch-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // @ts-check
 import {LitElement, html} from 'lit';
 import {customElement} from 'lit/decorators.js';

--- a/client-src/elements/chromedash-report-external-reviews-page.ts
+++ b/client-src/elements/chromedash-report-external-reviews-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // @ts-check
 import {Task} from '@lit/task';
 import '@shoelace-style/shoelace';

--- a/client-src/elements/chromedash-report-feature-latency-page.ts
+++ b/client-src/elements/chromedash-report-feature-latency-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // @ts-check
 import {Task} from '@lit/task';
 import '@shoelace-style/shoelace';

--- a/client-src/elements/chromedash-report-review-latency-page.ts
+++ b/client-src/elements/chromedash-report-review-latency-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // @ts-check
 import {Task} from '@lit/task';
 import {LitElement, css, html} from 'lit';

--- a/client-src/elements/chromedash-report-spec-mentor.ts
+++ b/client-src/elements/chromedash-report-spec-mentor.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // @ts-check
 import {SpecMentor} from 'chromestatus-openapi';
 import {LitElement, css, html} from 'lit';

--- a/client-src/elements/chromedash-report-spec-mentors-page.ts
+++ b/client-src/elements/chromedash-report-spec-mentors-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // @ts-check
 import {Task} from '@lit/task';
 import '@shoelace-style/shoelace';

--- a/client-src/elements/chromedash-review-status-icon.ts
+++ b/client-src/elements/chromedash-review-status-icon.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {customElement, property, state} from 'lit/decorators.js';

--- a/client-src/elements/chromedash-review-status-icon_test.ts
+++ b/client-src/elements/chromedash-review-status-icon_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashReviewStatusIcon} from './chromedash-review-status-icon.js';

--- a/client-src/elements/chromedash-roadmap-help-dialog.ts
+++ b/client-src/elements/chromedash-roadmap-help-dialog.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {customElement} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-roadmap-milestone-card.ts
+++ b/client-src/elements/chromedash-roadmap-milestone-card.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {SlPopup} from '@shoelace-style/shoelace';
 import {LitElement, TemplateResult, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';

--- a/client-src/elements/chromedash-roadmap-milestone-card_test.ts
+++ b/client-src/elements/chromedash-roadmap-milestone-card_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert, fixture} from '@open-wc/testing';
 import {html} from 'lit';
 import {ReleaseInfo, Feature} from '../js-src/cs-client.js';

--- a/client-src/elements/chromedash-roadmap-page.ts
+++ b/client-src/elements/chromedash-roadmap-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {createRef, ref} from 'lit/directives/ref.js';

--- a/client-src/elements/chromedash-roadmap-page_test.ts
+++ b/client-src/elements/chromedash-roadmap-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert, fixture} from '@open-wc/testing';
 import {html} from 'lit';
 import sinon from 'sinon';

--- a/client-src/elements/chromedash-roadmap.ts
+++ b/client-src/elements/chromedash-roadmap.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {repeat} from 'lit/directives/repeat.js';

--- a/client-src/elements/chromedash-search-help-dialog.ts
+++ b/client-src/elements/chromedash-search-help-dialog.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {customElement} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-secondary-survey-dialog.ts
+++ b/client-src/elements/chromedash-secondary-survey-dialog.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {SlRadioGroup, SlTextarea} from '@shoelace-style/shoelace';

--- a/client-src/elements/chromedash-secondary-survey-dialog_test.ts
+++ b/client-src/elements/chromedash-secondary-survey-dialog_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {fixture, assert, expect, elementUpdated} from '@open-wc/testing';
 import {SlTextarea} from '@shoelace-style/shoelace';

--- a/client-src/elements/chromedash-self-certify-dialog.ts
+++ b/client-src/elements/chromedash-self-certify-dialog.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {customElement, property} from 'lit/decorators.js';

--- a/client-src/elements/chromedash-settings-page.ts
+++ b/client-src/elements/chromedash-settings-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {customElement, state} from 'lit/decorators.js';
 import {FORM_STYLES} from '../css/forms-css.js';

--- a/client-src/elements/chromedash-settings-page_test.ts
+++ b/client-src/elements/chromedash-settings-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashSettingsPage} from './chromedash-settings-page.js';

--- a/client-src/elements/chromedash-stack-rank-page.ts
+++ b/client-src/elements/chromedash-stack-rank-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {property} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-stack-rank-page_test.ts
+++ b/client-src/elements/chromedash-stack-rank-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {ChromedashStackRankPage} from './chromedash-stack-rank-page.js';

--- a/client-src/elements/chromedash-stack-rank.ts
+++ b/client-src/elements/chromedash-stack-rank.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-stale-features-page.ts
+++ b/client-src/elements/chromedash-stale-features-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {showToastMessage} from './utils.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-survey-questions.ts
+++ b/client-src/elements/chromedash-survey-questions.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, TemplateResult, css, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-survey-questions_test.ts
+++ b/client-src/elements/chromedash-survey-questions_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import {assert, fixture} from '@open-wc/testing';
 import {SlCheckbox} from '@shoelace-style/shoelace';

--- a/client-src/elements/chromedash-textarea.ts
+++ b/client-src/elements/chromedash-textarea.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {TemplateResult, html, nothing} from 'lit';
 import SlTextarea from '@shoelace-style/shoelace/dist/components/textarea/textarea.js';
 import {customElement, property, state} from 'lit/decorators.js';

--- a/client-src/elements/chromedash-textarea_test.ts
+++ b/client-src/elements/chromedash-textarea_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import SlCheckbox from '@shoelace-style/shoelace/dist/components/checkbox/checkbox.js';
 import {assert, fixture} from '@open-wc/testing';

--- a/client-src/elements/chromedash-timeline-page.ts
+++ b/client-src/elements/chromedash-timeline-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import './chromedash-timeline.js';

--- a/client-src/elements/chromedash-timeline-page_test.ts
+++ b/client-src/elements/chromedash-timeline-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert, fixture} from '@open-wc/testing';
 import {html} from 'lit';
 import sinon from 'sinon';

--- a/client-src/elements/chromedash-timeline.ts
+++ b/client-src/elements/chromedash-timeline.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {showToastMessage} from './utils.js';

--- a/client-src/elements/chromedash-toast.ts
+++ b/client-src/elements/chromedash-toast.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {customElement, state, property} from 'lit/decorators.js';

--- a/client-src/elements/chromedash-typeahead.ts
+++ b/client-src/elements/chromedash-typeahead.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   SlInput,
   SlDropdown,

--- a/client-src/elements/chromedash-typeahead_test.ts
+++ b/client-src/elements/chromedash-typeahead_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert, fixture} from '@open-wc/testing';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import {

--- a/client-src/elements/chromedash-userlist.ts
+++ b/client-src/elements/chromedash-userlist.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html, nothing} from 'lit';
 import {customElement, state} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/chromedash-vendor-views.ts
+++ b/client-src/elements/chromedash-vendor-views.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // @ts-check
 
 import {LitElement, html} from 'lit';

--- a/client-src/elements/chromedash-vendor-views_test.ts
+++ b/client-src/elements/chromedash-vendor-views_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {expect, fixture} from '@open-wc/testing';
 import {html} from 'lit';
 import './chromedash-vendor-views.js';

--- a/client-src/elements/chromedash-wpt-eval-button.ts
+++ b/client-src/elements/chromedash-wpt-eval-button.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, html, css} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';

--- a/client-src/elements/chromedash-wpt-eval-button_test.ts
+++ b/client-src/elements/chromedash-wpt-eval-button_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html, fixture, expect} from '@open-wc/testing';
 import './chromedash-wpt-eval-button.js';
 import {ChromedashWPTEvalButton} from './chromedash-wpt-eval-button.js';

--- a/client-src/elements/chromedash-wpt-eval-page.ts
+++ b/client-src/elements/chromedash-wpt-eval-page.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, TemplateResult, css, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';

--- a/client-src/elements/chromedash-wpt-eval-page_test.ts
+++ b/client-src/elements/chromedash-wpt-eval-page_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html, fixture, expect, nextFrame} from '@open-wc/testing';
 import sinon from 'sinon';
 import './chromedash-wpt-eval-page.js';

--- a/client-src/elements/chromedash-x-meter.ts
+++ b/client-src/elements/chromedash-x-meter.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {LitElement, css, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';

--- a/client-src/elements/external-reviewers.ts
+++ b/client-src/elements/external-reviewers.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // @ts-check
 
 /** Represents an external organization that reviews Chromium changes. Currently the W3C TAG,

--- a/client-src/elements/form-definition.ts
+++ b/client-src/elements/form-definition.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html, TemplateResult} from 'lit';
 import {Feature, StageDict} from '../js-src/cs-client.js';
 import * as enums from './form-field-enums.js';

--- a/client-src/elements/form-field-enums.ts
+++ b/client-src/elements/form-field-enums.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html, type HTMLTemplateResult} from 'lit';
 
 // The following objects define the list of options for select fields.

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html, TemplateResult} from 'lit';
 import {Feature, StageDict} from '../js-src/cs-client.js';
 import {FormattedFeature} from './form-definition.js';

--- a/client-src/elements/gate-details.ts
+++ b/client-src/elements/gate-details.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html, TemplateResult} from 'lit';
 import * as enums from './form-field-enums.js';
 

--- a/client-src/elements/queriable-fields.ts
+++ b/client-src/elements/queriable-fields.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Constants that are used by the search help dialog.
 // And will be used by autocomplete in the future.
 

--- a/client-src/elements/utils.ts
+++ b/client-src/elements/utils.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // This file contains helper functions for our elements.
 
 import {html, nothing, TemplateResult} from 'lit';

--- a/client-src/elements/utils_test.ts
+++ b/client-src/elements/utils_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {html} from 'lit';
 import sinon from 'sinon';
 import {

--- a/client-src/js-src/openapi-client_test.js
+++ b/client-src/js-src/openapi-client_test.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {assert, expect} from '@open-wc/testing';
 import sinon from 'sinon';
 import {ChromeStatusClient} from './cs-client';

--- a/client-src/js-src/types.d.ts
+++ b/client-src/js-src/types.d.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {DefaultApiInterface} from 'chromestatus-openapi';
 import {ChromeStatusClient} from './chrome-status-client';
 

--- a/framework/users.py
+++ b/framework/users.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """User authentication and representation.
 
 Provides the User class for representing authenticated users and functions

--- a/scripts/check_license.py
+++ b/scripts/check_license.py
@@ -1,0 +1,155 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import datetime
+import argparse
+
+YEAR = datetime.datetime.now().year
+
+PY_LICENSE = f"""# Copyright {YEAR} Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+JS_LICENSE = f"""/**
+ * Copyright {YEAR} Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
+HTML_LICENSE = f"""<!--
+Copyright {YEAR} Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+"""
+
+DIRECTORIES = ['api', 'client-src', 'internals', 'pages', 'framework', 'scripts']
+EXTENSIONS = {
+    '.py': PY_LICENSE,
+    '.js': JS_LICENSE,
+    '.ts': JS_LICENSE,
+    '.html': HTML_LICENSE
+}
+
+# Directories or files to explicitly ignore if necessary
+IGNORE_DIRS = ['node_modules', 'venv', 'cs-env', 'testdata', 'gen']
+
+def check_license(fix=False, directories=DIRECTORIES, exit_on_fail=True):
+    missing_license = []
+
+    for directory in directories:
+        if not os.path.exists(directory):
+            continue
+        for root, dirs, files in os.walk(directory):
+            # Modify dirs in-place to avoid traversing ignored directories
+            dirs[:] = [d for d in dirs if d not in IGNORE_DIRS]
+
+            for file in files:
+                ext = os.path.splitext(file)[1]
+                if ext in EXTENSIONS:
+                    filepath = os.path.join(root, file)
+                    try:
+                        with open(filepath, 'r', encoding='utf-8') as f:
+                            content = f.read()
+                        
+                        if 'Licensed under the Apache License, Version 2.0' not in content:
+                            missing_license.append(filepath)
+                    except Exception as e:
+                        print(f"Error reading {filepath}: {e}")
+
+    if not fix:
+        if missing_license:
+            print("The following files are missing the Apache license:")
+            for f in missing_license:
+                print(f"  {f}")
+            print("\nRun `make lint-fix` (or script with --fix) to add them.")
+            if exit_on_fail:
+                sys.exit(1)
+        else:
+            print("All files have the Apache license.")
+            if exit_on_fail:
+                sys.exit(0)
+    else:
+        if missing_license:
+            for filepath in missing_license:
+                ext = os.path.splitext(filepath)[1]
+                template = EXTENSIONS[ext]
+                
+                try:
+                    with open(filepath, 'r', encoding='utf-8') as f:
+                        content = f.read()
+                    
+                    # Special handling for python scripts that might have a shebang or encoding comment
+                    if ext == '.py' and content.startswith('#'):
+                        lines = content.splitlines(keepends=True)
+                        insert_idx = 0
+                        for i, line in enumerate(lines):
+                            if line.startswith('#!') or line.startswith('# -*-'):
+                                insert_idx = i + 1
+                            else:
+                                break
+                        new_content = "".join(lines[:insert_idx]) + template + "\n" + "".join(lines[insert_idx:])
+                    else:
+                        new_content = template + "\n" + content
+                    
+                    with open(filepath, 'w', encoding='utf-8') as f:
+                        f.write(new_content)
+                except Exception as e:
+                    print(f"Error processing {filepath}: {e}")
+
+            print(f"Added license to {len(missing_license)} files.")
+        else:
+            print("All files already have the Apache license.")
+            
+    return missing_license
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Check or fix missing Apache license headers.")
+    parser.add_argument('--fix', action='store_true', help='Fix missing licenses')
+    args = parser.parse_args()
+    check_license(fix=args.fix)

--- a/scripts/check_license.py
+++ b/scripts/check_license.py
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Checks and enforces Apache 2.0 license headers across project files.
+
+This script scans specified directories for Python, JavaScript, TypeScript,
+and HTML files. It verifies that each file contains the Apache 2.0 license
+header. It can also automatically inject missing headers using the `--fix` flag.
+"""
+
+import argparse
+import datetime
 import os
 import sys
-import datetime
-import argparse
 
 YEAR = datetime.datetime.now().year
 
@@ -68,18 +75,37 @@ limitations under the License.
 -->
 """
 
-DIRECTORIES = ['api', 'client-src', 'internals', 'pages', 'framework', 'scripts']
+DIRECTORIES = [
+    'api',
+    'client-src',
+    'internals',
+    'pages',
+    'framework',
+    'scripts',
+]
 EXTENSIONS = {
     '.py': PY_LICENSE,
     '.js': JS_LICENSE,
     '.ts': JS_LICENSE,
-    '.html': HTML_LICENSE
+    '.html': HTML_LICENSE,
 }
 
 # Directories or files to explicitly ignore if necessary
 IGNORE_DIRS = ['node_modules', 'venv', 'cs-env', 'testdata', 'gen']
 
+
 def check_license(fix=False, directories=DIRECTORIES, exit_on_fail=True):
+    """Checks for and optionally fixes missing license headers in files.
+
+    Args:
+        fix: If True, injects the license header into files missing it.
+        directories: A list of directory paths to scan.
+        exit_on_fail: If True, calls sys.exit() with status code 1 when missing
+            licenses are found (and not fixed). Useful for CI/CD pipelines.
+
+    Returns:
+        A list of file paths that are missing the license header.
+    """
     missing_license = []
 
     for directory in directories:
@@ -96,22 +122,25 @@ def check_license(fix=False, directories=DIRECTORIES, exit_on_fail=True):
                     try:
                         with open(filepath, 'r', encoding='utf-8') as f:
                             content = f.read()
-                        
-                        if 'Licensed under the Apache License, Version 2.0' not in content:
+
+                        if (
+                            'Licensed under the Apache License, Version 2.0'
+                            not in content
+                        ):
                             missing_license.append(filepath)
                     except Exception as e:
-                        print(f"Error reading {filepath}: {e}")
+                        print(f'Error reading {filepath}: {e}')
 
     if not fix:
         if missing_license:
-            print("The following files are missing the Apache license:")
+            print('The following files are missing the Apache license:')
             for f in missing_license:
-                print(f"  {f}")
-            print("\nRun `make lint-fix` (or script with --fix) to add them.")
+                print(f'  {f}')
+            print('\nRun `make lint-fix` (or script with --fix) to add them.')
             if exit_on_fail:
                 sys.exit(1)
         else:
-            print("All files have the Apache license.")
+            print('All files have the Apache license.')
             if exit_on_fail:
                 sys.exit(0)
     else:
@@ -119,37 +148,49 @@ def check_license(fix=False, directories=DIRECTORIES, exit_on_fail=True):
             for filepath in missing_license:
                 ext = os.path.splitext(filepath)[1]
                 template = EXTENSIONS[ext]
-                
+
                 try:
                     with open(filepath, 'r', encoding='utf-8') as f:
                         content = f.read()
-                    
+
                     # Special handling for python scripts that might have a shebang or encoding comment
                     if ext == '.py' and content.startswith('#'):
                         lines = content.splitlines(keepends=True)
                         insert_idx = 0
                         for i, line in enumerate(lines):
-                            if line.startswith('#!') or line.startswith('# -*-'):
+                            if line.startswith('#!') or line.startswith(
+                                '# -*-'
+                            ):
                                 insert_idx = i + 1
                             else:
                                 break
-                        new_content = "".join(lines[:insert_idx]) + template + "\n" + "".join(lines[insert_idx:])
+                        new_content = (
+                            ''.join(lines[:insert_idx])
+                            + template
+                            + '\n'
+                            + ''.join(lines[insert_idx:])
+                        )
                     else:
-                        new_content = template + "\n" + content
-                    
+                        new_content = template + '\n' + content
+
                     with open(filepath, 'w', encoding='utf-8') as f:
                         f.write(new_content)
                 except Exception as e:
-                    print(f"Error processing {filepath}: {e}")
+                    print(f'Error processing {filepath}: {e}')
 
-            print(f"Added license to {len(missing_license)} files.")
+            print(f'Added license to {len(missing_license)} files.')
         else:
-            print("All files already have the Apache license.")
-            
+            print('All files already have the Apache license.')
+
     return missing_license
 
+
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Check or fix missing Apache license headers.")
-    parser.add_argument('--fix', action='store_true', help='Fix missing licenses')
+    parser = argparse.ArgumentParser(
+        description='Check or fix missing Apache license headers.'
+    )
+    parser.add_argument(
+        '--fix', action='store_true', help='Fix missing licenses'
+    )
     args = parser.parse_args()
     check_license(fix=args.fix)

--- a/scripts/check_license.py
+++ b/scripts/check_license.py
@@ -119,17 +119,14 @@ def check_license(fix=False, directories=DIRECTORIES, exit_on_fail=True):
                 ext = os.path.splitext(file)[1]
                 if ext in EXTENSIONS:
                     filepath = os.path.join(root, file)
-                    try:
-                        with open(filepath, 'r', encoding='utf-8') as f:
-                            content = f.read()
+                    with open(filepath, 'r', encoding='utf-8') as f:
+                        content = f.read()
 
-                        if (
-                            'Licensed under the Apache License, Version 2.0'
-                            not in content
-                        ):
-                            missing_license.append(filepath)
-                    except Exception as e:
-                        print(f'Error reading {filepath}: {e}')
+                    if (
+                        'Licensed under the Apache License, Version 2.0'
+                        not in content
+                    ):
+                        missing_license.append(filepath)
 
     if not fix:
         if missing_license:
@@ -149,34 +146,27 @@ def check_license(fix=False, directories=DIRECTORIES, exit_on_fail=True):
                 ext = os.path.splitext(filepath)[1]
                 template = EXTENSIONS[ext]
 
-                try:
-                    with open(filepath, 'r', encoding='utf-8') as f:
-                        content = f.read()
+                with open(filepath, 'r', encoding='utf-8') as f:
+                    content = f.read()
 
-                    # Special handling for python scripts that might have a shebang or encoding comment
-                    if ext == '.py' and content.startswith('#'):
-                        lines = content.splitlines(keepends=True)
-                        insert_idx = 0
-                        for i, line in enumerate(lines):
-                            if line.startswith('#!') or line.startswith(
-                                '# -*-'
-                            ):
-                                insert_idx = i + 1
-                            else:
-                                break
-                        new_content = (
-                            ''.join(lines[:insert_idx])
-                            + template
-                            + '\n'
-                            + ''.join(lines[insert_idx:])
-                        )
+                # Special handling for scripts that might have a shebang or encoding comment
+                lines = content.splitlines(keepends=True)
+                insert_idx = 0
+                for i, line in enumerate(lines):
+                    if line.startswith('#!') or line.startswith('# -*-'):
+                        insert_idx = i + 1
                     else:
-                        new_content = template + '\n' + content
+                        break
 
-                    with open(filepath, 'w', encoding='utf-8') as f:
-                        f.write(new_content)
-                except Exception as e:
-                    print(f'Error processing {filepath}: {e}')
+                new_content = (
+                    ''.join(lines[:insert_idx])
+                    + template
+                    + '\n'
+                    + ''.join(lines[insert_idx:])
+                )
+
+                with open(filepath, 'w', encoding='utf-8') as f:
+                    f.write(new_content)
 
             print(f'Added license to {len(missing_license)} files.')
         else:

--- a/scripts/check_license_test.py
+++ b/scripts/check_license_test.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+import tempfile
+import shutil
+from scripts.check_license import check_license, PY_LICENSE, JS_LICENSE, HTML_LICENSE
+
+class CheckLicenseTest(unittest.TestCase):
+
+    def setUp(self):
+        # Create a temporary directory
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        # Remove the directory after the test
+        shutil.rmtree(self.test_dir)
+
+    def test_all_files_have_licenses(self):
+        # Create valid python and JS files
+        py_file = os.path.join(self.test_dir, 'valid.py')
+        js_file = os.path.join(self.test_dir, 'valid.js')
+
+        with open(py_file, 'w', encoding='utf-8') as f:
+            f.write(PY_LICENSE + "\nprint('hello world')")
+            
+        with open(js_file, 'w', encoding='utf-8') as f:
+            f.write(JS_LICENSE + "\nconsole.log('hello');")
+            
+        missing = check_license(fix=False, directories=[self.test_dir], exit_on_fail=False)
+        self.assertEqual(len(missing), 0)
+
+    def test_missing_licenses_detected(self):
+        # Create invalid files
+        py_file = os.path.join(self.test_dir, 'invalid.py')
+        ts_file = os.path.join(self.test_dir, 'invalid.ts')
+
+        with open(py_file, 'w', encoding='utf-8') as f:
+            f.write("print('no license here')")
+            
+        with open(ts_file, 'w', encoding='utf-8') as f:
+            f.write("const x: number = 5;")
+            
+        missing = check_license(fix=False, directories=[self.test_dir], exit_on_fail=False)
+        self.assertEqual(len(missing), 2)
+        self.assertIn(py_file, missing)
+        self.assertIn(ts_file, missing)
+
+    def test_fix_adds_license(self):
+        # Create an invalid py file
+        py_file = os.path.join(self.test_dir, 'to_fix.py')
+        with open(py_file, 'w', encoding='utf-8') as f:
+            f.write("def do_something():\n    pass")
+
+        # Run with fix=True
+        missing = check_license(fix=True, directories=[self.test_dir], exit_on_fail=False)
+        
+        # It should have returned the list of files it detected as missing
+        self.assertEqual(len(missing), 1)
+        
+        # Verify the file was actually fixed
+        with open(py_file, 'r', encoding='utf-8') as f:
+            content = f.read()
+            
+        self.assertIn('Licensed under the Apache License, Version 2.0', content)
+        self.assertIn('def do_something():', content)
+
+    def test_fix_respects_shebang(self):
+        py_file = os.path.join(self.test_dir, 'script.py')
+        with open(py_file, 'w', encoding='utf-8') as f:
+            f.write("#!/usr/bin/env python\n# -*- coding: utf-8 -*-\nprint('start')")
+
+        check_license(fix=True, directories=[self.test_dir], exit_on_fail=False)
+        
+        with open(py_file, 'r', encoding='utf-8') as f:
+            lines = f.readlines()
+            
+        # The first two lines should still be the shebang and encoding
+        self.assertTrue(lines[0].startswith('#!'))
+        self.assertTrue(lines[1].startswith('# -*-'))
+        # The license should be injected immediately after
+        self.assertIn('Copyright', lines[2])
+
+    def test_ignores_specified_directories(self):
+        # Create an ignored node_modules directory
+        ignored_dir = os.path.join(self.test_dir, 'node_modules')
+        os.makedirs(ignored_dir)
+        
+        js_file = os.path.join(ignored_dir, 'invalid.js')
+        with open(js_file, 'w', encoding='utf-8') as f:
+            f.write("console.log('ignored');")
+
+        # It shouldn't detect this missing license because it's in node_modules
+        missing = check_license(fix=False, directories=[self.test_dir], exit_on_fail=False)
+        self.assertEqual(len(missing), 0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/check_license_test.py
+++ b/scripts/check_license_test.py
@@ -116,6 +116,20 @@ class CheckLicenseTest(unittest.TestCase):
         # The license should be injected immediately after
         self.assertIn('Copyright', lines[2])
 
+    def test_fix_respects_shebang_js(self):
+        """Verifies that licenses are injected after JS shebangs."""
+        js_file = os.path.join(self.test_dir, 'script.js')
+        with open(js_file, 'w', encoding='utf-8') as f:
+            f.write("#!/usr/bin/env node\nconsole.log('start');")
+
+        check_license(fix=True, directories=[self.test_dir], exit_on_fail=False)
+
+        with open(js_file, 'r', encoding='utf-8') as f:
+            lines = f.readlines()
+
+        self.assertTrue(lines[0].startswith('#!'))
+        self.assertIn('Copyright', ''.join(lines[1:]))
+
     def test_ignores_specified_directories(self):
         """Verifies that files in explicitly ignored directories are not checked."""
         # Create an ignored node_modules directory

--- a/scripts/check_license_test.py
+++ b/scripts/check_license_test.py
@@ -12,81 +12,104 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Unit tests for the check_license script."""
+
 import os
-import unittest
-import tempfile
 import shutil
-from scripts.check_license import check_license, PY_LICENSE, JS_LICENSE, HTML_LICENSE
+import tempfile
+import unittest
+
+from scripts.check_license import (
+    JS_LICENSE,
+    PY_LICENSE,
+    check_license,
+)
+
 
 class CheckLicenseTest(unittest.TestCase):
+    """Test suite for the license checking and fixing script."""
 
     def setUp(self):
+        """Creates a temporary directory for testing."""
         # Create a temporary directory
         self.test_dir = tempfile.mkdtemp()
 
     def tearDown(self):
+        """Removes the temporary directory after each test."""
         # Remove the directory after the test
         shutil.rmtree(self.test_dir)
 
     def test_all_files_have_licenses(self):
+        """Verifies that no missing licenses are reported when all files have them."""
         # Create valid python and JS files
         py_file = os.path.join(self.test_dir, 'valid.py')
         js_file = os.path.join(self.test_dir, 'valid.js')
 
         with open(py_file, 'w', encoding='utf-8') as f:
             f.write(PY_LICENSE + "\nprint('hello world')")
-            
+
         with open(js_file, 'w', encoding='utf-8') as f:
             f.write(JS_LICENSE + "\nconsole.log('hello');")
-            
-        missing = check_license(fix=False, directories=[self.test_dir], exit_on_fail=False)
+
+        missing = check_license(
+            fix=False, directories=[self.test_dir], exit_on_fail=False
+        )
         self.assertEqual(len(missing), 0)
 
     def test_missing_licenses_detected(self):
+        """Verifies that files missing licenses are correctly detected."""
         # Create invalid files
         py_file = os.path.join(self.test_dir, 'invalid.py')
         ts_file = os.path.join(self.test_dir, 'invalid.ts')
 
         with open(py_file, 'w', encoding='utf-8') as f:
             f.write("print('no license here')")
-            
+
         with open(ts_file, 'w', encoding='utf-8') as f:
-            f.write("const x: number = 5;")
-            
-        missing = check_license(fix=False, directories=[self.test_dir], exit_on_fail=False)
+            f.write('const x: number = 5;')
+
+        missing = check_license(
+            fix=False, directories=[self.test_dir], exit_on_fail=False
+        )
         self.assertEqual(len(missing), 2)
         self.assertIn(py_file, missing)
         self.assertIn(ts_file, missing)
 
     def test_fix_adds_license(self):
+        """Verifies that the --fix flag successfully injects missing licenses."""
         # Create an invalid py file
         py_file = os.path.join(self.test_dir, 'to_fix.py')
         with open(py_file, 'w', encoding='utf-8') as f:
-            f.write("def do_something():\n    pass")
+            f.write('def do_something():\n    pass')
 
         # Run with fix=True
-        missing = check_license(fix=True, directories=[self.test_dir], exit_on_fail=False)
-        
+        missing = check_license(
+            fix=True, directories=[self.test_dir], exit_on_fail=False
+        )
+
         # It should have returned the list of files it detected as missing
         self.assertEqual(len(missing), 1)
-        
+
         # Verify the file was actually fixed
         with open(py_file, 'r', encoding='utf-8') as f:
             content = f.read()
-            
+
         self.assertIn('Licensed under the Apache License, Version 2.0', content)
         self.assertIn('def do_something():', content)
 
     def test_fix_respects_shebang(self):
+        """Verifies that licenses are injected after python shebangs and encoding headers."""
         py_file = os.path.join(self.test_dir, 'script.py')
         with open(py_file, 'w', encoding='utf-8') as f:
-            f.write("#!/usr/bin/env python\n# -*- coding: utf-8 -*-\nprint('start')")
+            f.write(
+                "#!/usr/bin/env python\n# -*- coding: utf-8 -*-\nprint('start')"
+            )
 
         check_license(fix=True, directories=[self.test_dir], exit_on_fail=False)
-        
+
         with open(py_file, 'r', encoding='utf-8') as f:
             lines = f.readlines()
-            
+
         # The first two lines should still be the shebang and encoding
         self.assertTrue(lines[0].startswith('#!'))
         self.assertTrue(lines[1].startswith('# -*-'))
@@ -94,17 +117,21 @@ class CheckLicenseTest(unittest.TestCase):
         self.assertIn('Copyright', lines[2])
 
     def test_ignores_specified_directories(self):
+        """Verifies that files in explicitly ignored directories are not checked."""
         # Create an ignored node_modules directory
         ignored_dir = os.path.join(self.test_dir, 'node_modules')
         os.makedirs(ignored_dir)
-        
+
         js_file = os.path.join(ignored_dir, 'invalid.js')
         with open(js_file, 'w', encoding='utf-8') as f:
             f.write("console.log('ignored');")
 
         # It shouldn't detect this missing license because it's in node_modules
-        missing = check_license(fix=False, directories=[self.test_dir], exit_on_fail=False)
+        missing = check_license(
+            fix=False, directories=[self.test_dir], exit_on_fail=False
+        )
         self.assertEqual(len(missing), 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/fix_data.py
+++ b/scripts/fix_data.py
@@ -1,7 +1,18 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
 #
-# Copyright 2017 Google Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """When new UMA data is collected without a corresponding histogram in
 the db, the entry is saved with a property_name === 'ERROR'. The


### PR DESCRIPTION
Resolves #6185

## Overview
Adds a custom Python script to automatically check and apply Apache 2.0 license headers across the project's Python, JS, TS, and HTML files. Integrates this check into the existing `make lint` and `make lint-fix` workflows.

## Root Cause / Motivation
Ensuring all major files contain the required Apache 2.0 open-source license can be tedious to manage manually. Since we want to avoid introducing external dependencies like the Go-based `addlicense` tool to our Python/Node.js stack, a custom, zero-dependency Python checker script provides a lightweight and fully integrated way to enforce license compliance directly within our native `lint` commands.

## Detailed Changelog
* **`scripts/check_license.py`**: Added a standalone python script that scans for missing Apache 2.0 license headers and features a `--fix` argument to automatically apply missing headers cleanly (handling edge cases like python shebangs and encoding comments).
* **`scripts/check_license_test.py`**: Added an exhaustive unit test suite for the license checking script, validating detection, fixing, and ignore directory logic.
* **`Makefile`**: 
  - Wired `python3 scripts/check_license.py` into the `check-license` and `lint` targets.
  - Wired `python3 scripts/check_license.py --fix` into the `check-license-fix` and `lint-fix` targets.
  - Wired `scripts/*_test.py` into the pytest execution list for the `make test` target.
* **Various source files** (*138 files*): Applied the Apache 2.0 license to the top of all missing files within `client-src/`, `scripts/`, `framework/`, and others using the newly generated checking tool.