### PR TITLE
Implement gate phase-in logic and add unit tests

### DIFF
--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -519,6 +519,13 @@ STAGES_AND_GATES_BY_FEATURE_TYPE: dict[int, list[tuple[int, list[int]]]] = {
     FEATURE_TYPE_ENTERPRISE_ID: [(STAGE_ENT_ROLLOUT, [])],
 }
 
+# These gates are are not added to stages with any milestones before
+# the phase-in milestone.
+GATE_PHASE_IN: dict[int, int] = {
+    GATE_ADOPTION_SHIP: 150,
+    GATE_ADOPTION_PLAN: 150,
+}
+
 # Plan stage types for every feature type that has plan.
 STAGE_TYPES_PLAN: dict[int, Optional[int]] = {
     FEATURE_TYPE_INCUBATE_ID: None,

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -96,16 +96,23 @@ class WriteMissingGates(FlaskHandler):
         new_gates: list[Gate] = []
         needed_gates = self.GATE_RULES[fe.feature_type][stage.stage_type]
         for needed_gate_type in needed_gates:
-            if not any(
+            if any(
                 eg for eg in existing_gates if eg.gate_type == needed_gate_type
             ):
-                gate = Gate(
-                    feature_id=stage.feature_id,
-                    stage_id=stage.key.integer_id(),
-                    gate_type=needed_gate_type,
-                    state=Gate.PREPARING,
-                )
-                new_gates.append(gate)
+                continue
+            earliest = stage_helpers.find_earliest_milestone([stage])
+            phase_in_starting = core_enums.GATE_PHASE_IN.get(
+                needed_gate_type, 0
+            )
+            if earliest and earliest < phase_in_starting:
+                continue
+            gate = Gate(
+                feature_id=stage.feature_id,
+                stage_id=stage.key.integer_id(),
+                gate_type=needed_gate_type,
+                state=Gate.PREPARING,
+            )
+            new_gates.append(gate)
         return new_gates
 
     def get_template_data(self, **kwargs) -> str:

--- a/internals/maintenance_scripts_test.py
+++ b/internals/maintenance_scripts_test.py
@@ -127,6 +127,78 @@ class EvaluateGateStatusTest(testing_config.CustomTestCase):
         self.assertEqual(revised_gate_1.state, Vote.APPROVED)
 
 
+class WriteMissingGatesTest(testing_config.CustomTestCase):
+    """Tests for the WriteMissingGates handler."""
+
+    def setUp(self):
+        """Set up the test environment."""
+        self.handler = maintenance_scripts.WriteMissingGates()
+        self.fe = FeatureEntry(
+            name='feature one', summary='sum', category=1,
+            feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID)
+        self.fe.put()
+        self.stage = Stage(
+            feature_id=self.fe.key.integer_id(),
+            stage_type=core_enums.STAGE_BLINK_SHIPPING)
+        self.stage.put()
+
+    def tearDown(self):
+        """Clean up the test environment."""
+        self.fe.key.delete()
+        self.stage.key.delete()
+
+    def test_make_needed_gates__no_fe(self):
+        """It handles a stage with no feature entry."""
+        actual = self.handler.make_needed_gates(None, self.stage, [])
+        self.assertEqual([], actual)
+
+    def test_make_needed_gates__bad_fe_type(self):
+        """It handles a feature with an invalid feature type."""
+        self.fe.feature_type = 999
+        actual = self.handler.make_needed_gates(self.fe, self.stage, [])
+        self.assertEqual([], actual)
+
+    def test_make_needed_gates__bad_stage_type(self):
+        """It handles a stage with an invalid stage type."""
+        self.stage.stage_type = 999
+        actual = self.handler.make_needed_gates(self.fe, self.stage, [])
+        self.assertEqual([], actual)
+
+    def test_make_needed_gates__already_exists(self):
+        """It skips gates that already exist."""
+        existing_gate = Gate(
+            feature_id=self.fe.key.integer_id(),
+            stage_id=self.stage.key.integer_id(),
+            gate_type=core_enums.GATE_API_SHIP)
+        actual = self.handler.make_needed_gates(
+            self.fe, self.stage, [existing_gate])
+        gate_types = [g.gate_type for g in actual]
+        self.assertNotIn(core_enums.GATE_API_SHIP, gate_types)
+
+    def test_make_needed_gates__phase_in_skipped(self):
+        """It skips phased-in gates if the milestone is too early."""
+        self.stage.milestones = MilestoneSet(desktop_first=149)
+        # GATE_ADOPTION_SHIP phase-in is 150.
+        actual = self.handler.make_needed_gates(self.fe, self.stage, [])
+        gate_types = [g.gate_type for g in actual]
+        self.assertNotIn(core_enums.GATE_ADOPTION_SHIP, gate_types)
+
+    def test_make_needed_gates__phase_in_not_skipped(self):
+        """It creates phased-in gates if the milestone is late enough."""
+        self.stage.milestones = MilestoneSet(desktop_first=150)
+        # GATE_ADOPTION_SHIP phase-in is 150.
+        actual = self.handler.make_needed_gates(self.fe, self.stage, [])
+        gate_types = [g.gate_type for g in actual]
+        self.assertIn(core_enums.GATE_ADOPTION_SHIP, gate_types)
+
+    def test_make_needed_gates__no_milestone(self):
+        """It creates phased-in gates if there is no milestone."""
+        self.stage.milestones = None
+        actual = self.handler.make_needed_gates(self.fe, self.stage, [])
+        gate_types = [g.gate_type for g in actual]
+        self.assertIn(core_enums.GATE_ADOPTION_SHIP, gate_types)
+
+
 class AssociateOTsTest(testing_config.CustomTestCase):
     """Tests for the AssociateOTs handler."""
 

--- a/internals/maintenance_scripts_test.py
+++ b/internals/maintenance_scripts_test.py
@@ -134,12 +134,16 @@ class WriteMissingGatesTest(testing_config.CustomTestCase):
         """Set up the test environment."""
         self.handler = maintenance_scripts.WriteMissingGates()
         self.fe = FeatureEntry(
-            name='feature one', summary='sum', category=1,
-            feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID)
+            name='feature one',
+            summary='sum',
+            category=1,
+            feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID,
+        )
         self.fe.put()
         self.stage = Stage(
             feature_id=self.fe.key.integer_id(),
-            stage_type=core_enums.STAGE_BLINK_SHIPPING)
+            stage_type=core_enums.STAGE_BLINK_SHIPPING,
+        )
         self.stage.put()
 
     def tearDown(self):
@@ -169,9 +173,11 @@ class WriteMissingGatesTest(testing_config.CustomTestCase):
         existing_gate = Gate(
             feature_id=self.fe.key.integer_id(),
             stage_id=self.stage.key.integer_id(),
-            gate_type=core_enums.GATE_API_SHIP)
+            gate_type=core_enums.GATE_API_SHIP,
+        )
         actual = self.handler.make_needed_gates(
-            self.fe, self.stage, [existing_gate])
+            self.fe, self.stage, [existing_gate]
+        )
         gate_types = [g.gate_type for g in actual]
         self.assertNotIn(core_enums.GATE_API_SHIP, gate_types)
 


### PR DESCRIPTION
This is part of rolling out the new Adoption gate.  We will backfill this gate only onto feature entries that ship in m150 or later, or that have no relevant milestones specifeid.  This PR implements a phase-in mechanism for gates based on feature milestones and adds unit tests to verify the behavior.