### PR TITLE
Fix Insecure Direct Object Reference (IDOR) vulnerabilities in backend APIs

### DIFF
--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -133,6 +133,11 @@ class CommentsAPI(basehandlers.APIHandler):
             gate = Gate.get_by_id(gate_id)
             if not gate:
                 self.abort(404, msg='Gate not found; notifications abort.')
+            if gate.feature_id != feature_id:
+                self.abort(
+                    403,
+                    msg=f'Gate {gate_id} does not belong to Feature {feature_id}',
+                )
             notifier_helpers.notify_subscribers_of_new_comments(
                 feature, gate, user.email(), comment_content
             )

--- a/api/comments_api_test.py
+++ b/api/comments_api_test.py
@@ -254,6 +254,22 @@ class CommentsAPITest(testing_config.CustomTestCase):
             with self.assertRaises(werkzeug.exceptions.NotFound):
                 self.handler.do_post(feature_id=12345, gate_id=self.gate_1_id)
 
+    def test_post__mismatched_gate_feature(self):
+        """Handler rejects requests where gate_id does not belong to feature_id."""
+        bad_path = f'/api/v0/features/{self.feature_id}/approvals/1/comments'
+        gate2 = Gate(
+            feature_id=999, stage_id=1, gate_type=1, state=Gate.PREPARING
+        )
+        gate2.put()
+        testing_config.sign_in('owner1@example.com', 123567890)
+        with test_app.test_request_context(
+            bad_path, json={'comment': 'test', 'postToThreadType': 1}
+        ):
+            with self.assertRaises(werkzeug.exceptions.Forbidden):
+                self.handler.do_post(
+                    feature_id=self.feature_id, gate_id=gate2.key.integer_id()
+                )
+
     def test_patch__forbidden(self):
         """Handler rejects requests from users who can't edit the given comment."""
         self.act_1_1.put()

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -276,6 +276,7 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
 
     def _patch_update_stages(
         self,
+        feature_id: int,
         stage_changes_list: list[dict[str, Any]],
         changed_fields: CHANGED_FIELDS_LIST_TYPE,
     ) -> tuple[list[Stage], bool]:
@@ -293,6 +294,11 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
             stage = Stage.get_by_id(id)
             if not stage:
                 self.abort(400, msg=f'Stage not found for ID {id}')
+            if stage.feature_id != feature_id:
+                self.abort(
+                    403,
+                    msg=f'Stage {id} does not belong to Feature {feature_id}',
+                )
 
             # Update stage fields.
             for field, field_type in api_specs.STAGE_FIELD_DATA_TYPES:
@@ -546,7 +552,9 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
         changed_fields: CHANGED_FIELDS_LIST_TYPE = []
         stage_ids = [s['id'] for s in body['stages'] if 'id' in s]
         updated_stages, ship_milestones_were_updated = (
-            self._patch_update_stages(body['stages'], changed_fields)
+            self._patch_update_stages(
+                feature_id, body['stages'], changed_fields
+            )
         )
         # Reset outstanding notifications if the user updated any ship/rollout milestones.
         if ship_milestones_were_updated:

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -674,6 +674,30 @@ class FeaturesAPITest(testing_config.CustomTestCase):
         self.assertIsNotNone(self.feature_1.updated)
         self.assertEqual(self.feature_1.updater_email, 'admin@example.com')
 
+    def test_patch__mismatched_stage_feature(self):
+        """PATCH request fails if stage ID belongs to another feature."""
+        testing_config.sign_in('admin@example.com', 123567890)
+        stage2 = Stage(feature_id=999, stage_type=150)
+        stage2.put()
+        request_body = {
+            'feature_changes': {
+                'id': self.feature_1_id,
+            },
+            'stages': [
+                {
+                    'id': stage2.key.integer_id(),
+                    'intent_thread_url': {
+                        'form_field_name': 'shipped_milestone',
+                        'value': 'bad_url',
+                    },
+                },
+            ],
+        }
+        request_path = f'{self.request_path}/update'
+        with test_app.test_request_context(request_path, json=request_body):
+            with self.assertRaises(werkzeug.exceptions.Forbidden):
+                self.handler.do_patch()
+
     def test_patch__stage_changes(self):
         """Valid PATCH updates stage entities."""
         # Signed-in user with permissions.

--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -323,6 +323,11 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
         ot_stage: Stage | None = Stage.get_by_id(ot_stage_id)
         if ot_stage is None:
             self.abort(404, msg=f'Stage {ot_stage_id} not found')
+        if ot_stage.feature_id != feature_id:
+            self.abort(
+                403,
+                msg=f'Stage {ot_stage_id} does not belong to Feature {feature_id}',
+            )
 
         # Check that user has permission to edit the feature associated
         # with the origin trial, or has a @google or @chromium account.

--- a/api/origin_trials_api_test.py
+++ b/api/origin_trials_api_test.py
@@ -893,6 +893,18 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
                     self.feature_1_id, self.ot_stage_1, self.extension_stage_1
                 )
 
+    def test_post__mismatched_stage_feature(self):
+        """Handler rejects requests where stage_id does not belong to feature_id."""
+        testing_config.sign_in('feature_owner@google.com', 1234567890)
+        stage2 = Stage(feature_id=999, stage_type=150)
+        stage2.put()
+        with test_app.test_request_context(self.request_path, json={}):
+            with self.assertRaises(werkzeug.exceptions.Forbidden):
+                self.handler.do_post(
+                    feature_id=self.feature_1_id,
+                    stage_id=stage2.key.integer_id(),
+                )
+
     @mock.patch('api.origin_trials_api.OriginTrialsAPI._validate_creation_args')
     @mock.patch('api.origin_trials_api.get_chromium_files_for_validation')
     def test_post__valid(self, mock_get_chromium_files, mock_validate_func):


### PR DESCRIPTION
## Overview
Fixes IDOR vulnerabilities in `FeaturesAPI`, `CommentsAPI`, and `OriginTrialsAPI` where API endpoints did not verify if the targeted child entities (e.g., stages, gates) belonged to the requested feature.

## Root Cause / Motivation
During a security review, it was discovered that multiple endpoints allowed users to modify or interact with entities associated with features they did not own, provided they had edit access to at least one feature and knew the ID of the target entity. This could lead to unauthorized modifications of stages and gates or spoofed notifications. The patches enforce a strict object ownership check, verifying that the child object's `feature_id` matches the parent `feature_id` specified in the request. 

## Detailed Changelog
* **`api/features_api.py`**: Added `feature_id` parameter to `_patch_update_stages` and enforced `stage.feature_id == feature_id` when modifying stages via PATCH.
* **`api/comments_api.py`**: Enforced `gate.feature_id == feature_id` when posting comments to a specific gate.
* **`api/origin_trials_api.py`**: Enforced `ot_stage.feature_id == feature_id` when creating an origin trial on a stage.
* **`api/features_api_test.py`**: Added `test_patch__mismatched_stage_feature` to verify the IDOR mitigation.
* **`api/comments_api_test.py`**: Added `test_post__mismatched_gate_feature` to verify the IDOR mitigation.
* **`api/origin_trials_api_test.py`**: Added `test_post__mismatched_stage_feature` to verify the IDOR mitigation.