### PR TITLE
Fix annual shipping features nav links breaking Playwright tests

### DIFF
--- a/packages/playwright/tests/test_utils.js
+++ b/packages/playwright/tests/test_utils.js
@@ -126,6 +126,7 @@ export function acceptAlertDialogs(page) {
  * @param {import("playwright-core").Page} page
  */
 export async function login(page) {
+  await setupFakeNow(page);
   page.exposeFunction('isPlaywright', () => {});
 
   // Always reset to the roadmap page.
@@ -382,4 +383,43 @@ export async function expectScreenshot(page, name, options, hoverElement) {
   }
   await page.waitForTimeout(250 + 100); // Some shoelace animations take 250ms.
   await expect(page).toHaveScreenshot(`${name}.png`, options);
+}
+
+/**
+ * Fakes the current date in the page.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} [fakeNowDateString]
+ */
+export async function setupFakeNow(
+  page,
+  fakeNowDateString = 'Jan 1 2026 00:00:00'
+) {
+  // Get fakeNow from UTC to extract the timeZone offset used in the test
+  const fakeNowFromUTC = new Date(fakeNowDateString);
+  const offset = fakeNowFromUTC.getTimezoneOffset();
+  const offsetSign = offset < 0 ? '-' : '+';
+  const offsetHours = `${Math.abs(Math.floor(offset / 60))}`.padStart(2, '0');
+  const offsetMinutes = `${Math.abs(offset % 60)}`.padStart(2, '0');
+  const offsetText = `${offsetSign}${offsetHours}:${offsetMinutes}`;
+
+  // Get fakeNow from the test timeZone
+  const fakeNow = new Date(`${fakeNowDateString}Z${offsetText}`).valueOf();
+
+  // Update the Date accordingly in your test pages
+  await page.addInitScript(`{
+    // Extend Date constructor to default to fakeNow
+    Date = class extends Date {
+      constructor(...args) {
+        if (args.length === 0) {
+          super(${fakeNow});
+        } else {
+          super(...args);
+        }
+      }
+    }
+    // Override Date.now() to start from fakeNow
+    const __DateNowOffset = ${fakeNow} - Date.now();
+    const __DateNow = Date.now;
+    Date.now = () => __DateNow() + __DateNowOffset;
+  }`);
 }


### PR DESCRIPTION
Resolves #4490

## Overview
Fakes the current date in Playwright tests to prevent date-based UI changes in the navigation drawer from breaking screenshot tests.

## Root Cause / Motivation
Date-based logic in `chromedash-drawer.ts` changes navigation links twice a year (e.g., adding a link for the next year after September 1st). This adds a row to the menu and shifts layout, breaking visual regression tests. By faking the date to a fixed point (Jan 1, 2026), we stabilize the UI for tests.

## Detailed Changelog
* **`packages/playwright/tests/test_utils.js`**: Added `setupFakeNow` function to override `Date` constructor and `Date.now()` in the browser context using `page.addInitScript`. Called this function in `login` to apply it by default.
