### PR TITLE
Record Activity records when filling in an OT extension request

### DIFF
--- a/api/stages_api.py
+++ b/api/stages_api.py
@@ -17,7 +17,7 @@
 
 from api import converters
 from framework import basehandlers, permissions, rediscache
-from internals import notifier_helpers, stage_helpers
+from internals import core_enums, notifier_helpers, stage_helpers
 from internals.core_models import FeatureEntry, Stage
 from internals.data_types import CHANGED_FIELDS_LIST_TYPE
 from internals.review_models import Gate
@@ -131,8 +131,21 @@ class StagesAPI(basehandlers.EntitiesAPIHandler):
         # Update specified fields.
         self.update_stage(stage, body, changed_fields)
 
+        ot_requested = False
+        for field, old_val, new_val in changed_fields:
+            if field == 'ot_action_requested' and new_val is True:
+                ot_requested = True
+                break
+
+        content = ''
+        if (
+            ot_requested
+            and stage.stage_type in core_enums.OT_EXTENSION_STAGE_TYPES
+        ):
+            content = 'Origin trial extension requested via form.'
+
         notifier_helpers.notify_subscribers_and_save_amendments(
-            feature, changed_fields, notify=True
+            feature, changed_fields, notify=True, content=content
         )
         # Remove all feature-related cache.
         rediscache.delete_keys_with_prefix(FeatureEntry.DEFAULT_CACHE_KEY)

--- a/api/stages_api_test.py
+++ b/api/stages_api_test.py
@@ -25,7 +25,7 @@ import testing_config  # Must be imported before the module under test.
 from api import stages_api
 from internals import core_enums
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
-from internals.review_models import Gate
+from internals.review_models import Activity, Gate
 from internals.user_models import AppUser
 
 test_app = flask.Flask(__name__)
@@ -826,6 +826,12 @@ class StagesAPITest(testing_config.CustomTestCase):
         # OT extension request should NOT send a notification.
         mock_send_ot_creation_notification.assert_not_called()
         self.assert_cache_was_flushed(mock_dkwp)
+
+        activities = Activity.get_activities(self.fe.key.integer_id())
+        self.assertEqual(len(activities), 1)
+        self.assertEqual(
+            activities[0].content, 'Origin trial extension requested via form.'
+        )
 
     @mock.patch('framework.rediscache.delete_keys_with_prefix')
     def test_patch__ot_request_googler(self, mock_dkwp):

--- a/internals/detect_intent.py
+++ b/internals/detect_intent.py
@@ -25,7 +25,7 @@ import settings
 from framework import basehandlers, permissions, users
 from internals import approval_defs, core_enums, notifier_helpers, slo
 from internals.core_models import FeatureEntry, Stage
-from internals.review_models import Gate, Vote
+from internals.review_models import Activity, Gate, Vote
 
 GATE_TYPES_REQUIRING_LGTMS = [
     approval_defs.PlanApproval.gate_type,
@@ -260,6 +260,19 @@ class IntentEmailHandler(basehandlers.FlaskHandler):
         self.set_intent_thread_url(stage, thread_url, subject)
         gate_id = gate.key.integer_id()  # In case it was found by gate_type.
         is_new_thread = detect_new_thread(gate)
+
+        if (
+            gate_info == approval_defs.ExtendExperimentApproval
+            and is_new_thread
+        ):
+            activity = Activity(
+                log_type=Activity.USER_CHANGE,
+                feature_id=feature.key.integer_id(),
+                author=from_addr,
+                content=f'Origin trial extension requested via email thread: {thread_url}',
+            )
+            activity.put()
+
         self.create_approvals(
             feature, stage, gate, gate_info, from_addr, body, is_new_thread
         )

--- a/internals/detect_intent_test.py
+++ b/internals/detect_intent_test.py
@@ -27,7 +27,7 @@ from internals import (
     stage_helpers,
 )
 from internals.core_models import FeatureEntry, Stage
-from internals.review_models import Gate, Vote
+from internals.review_models import Activity, Gate, Vote
 
 test_app = flask.Flask(__name__)
 
@@ -679,6 +679,16 @@ class IntentEmailHandlerTest(testing_config.CustomTestCase):
         )
         self.assertEqual(
             self.stages_dict[151][1].intent_thread_url, self.thread_url
+        )
+
+        activities = Activity.get_activities(self.feature_id)
+        self.assertTrue(
+            any(
+                a.content
+                and 'Origin trial extension requested via email thread'
+                in a.content
+                for a in activities
+            )
         )
 
     @mock.patch('logging.info')

--- a/internals/notifier_helpers.py
+++ b/internals/notifier_helpers.py
@@ -86,6 +86,7 @@ def notify_subscribers_and_save_amendments(
     changed_fields: CHANGED_FIELDS_LIST_TYPE,
     notify: bool = True,
     is_update: bool = True,
+    content: str = '',
 ) -> None:
     """Notify subscribers of changes to FeatureEntry and save amendments."""
     amendments = _get_changes_as_amendments(changed_fields)
@@ -97,7 +98,7 @@ def notify_subscribers_and_save_amendments(
             log_type=Activity.USER_CHANGE,
             feature_id=fe.key.integer_id(),
             author=email,
-            content='',
+            content=content,
         )
         activity.amendments = amendments
         activity.put()

--- a/internals/notifier_helpers_test.py
+++ b/internals/notifier_helpers_test.py
@@ -84,6 +84,19 @@ class ActivityTest(testing_config.CustomTestCase):
             self.assertEqual(str(old_val), act_1.amendments[i].old_value)
             self.assertEqual(str(new_val), act_1.amendments[i].new_value)
 
+    def test_activities_created__with_content(self):
+        """Test activities created with content."""
+        changed_fields: CHANGED_FIELDS_LIST_TYPE = [
+            ('name', 'feature a', 'feature Z')
+        ]
+        notifier_helpers.notify_subscribers_and_save_amendments(
+            self.feature_1, changed_fields, content='Test content'
+        )
+        feature_id = self.feature_1.key.integer_id()
+        activities = Activity.get_activities(feature_id)
+        self.assertEqual(len(activities), 1)
+        self.assertEqual(activities[0].content, 'Test content')
+
     def test_activities_created__no_changes(self):
         """No Activity should be logged if submitted with no changes."""
         changed_fields: CHANGED_FIELDS_LIST_TYPE = []


### PR DESCRIPTION
Resolves #4562

## Overview
This PR adds activity logging when an Origin Trial (OT) extension is requested, distinguishing between requests made via a form and those detected from email threads.

## Root Cause / Motivation
There was confusion about when and who started a request for an extension. We need to log these events to provide a clear audit trail in the "All comments & activity" section.

## Detailed Changelog
* **`internals/notifier_helpers.py`**: Added an optional `content` parameter to `notify_subscribers_and_save_amendments` to allow custom messages in activity logs.
* **`api/stages_api.py`**: Updated `do_patch` to log activity when `ot_action_requested` is set to `True` for an extension stage.
* **`internals/detect_intent.py`**: Updated `IntentEmailHandler` to log activity when an extension request is detected via email.
* **`internals/notifier_helpers_test.py`**: Added test for the new `content` parameter.
* **`api/stages_api_test.py`**: Added test for form-based request logging.
* **`internals/detect_intent_test.py`**: Added test for email-based request logging.
