### PR TITLE
Fix issue 5663: Add intent_to_deprecate_url to deprecation plan

### DIFF
--- a/client-src/elements/form-definition.ts
+++ b/client-src/elements/form-definition.ts
@@ -517,7 +517,12 @@ const DEPRECATION_PLAN_FIELDS: MetadataFields = {
   sections: [
     {
       name: 'Write up deprecation plan',
-      fields: ['deprecation_motivation', 'explainer_links', 'spec_link'],
+      fields: [
+        'deprecation_motivation',
+        'explainer_links',
+        'spec_link',
+        'intent_to_deprecate_url',
+      ],
     },
   ],
 };

--- a/client-src/elements/form-field-enums.ts
+++ b/client-src/elements/form-field-enums.ts
@@ -570,6 +570,7 @@ export const STAGE_FIELD_NAME_MAPPING: Record<string, string> = {
   intent_to_ship_url: 'intent_thread_url',
   intent_to_experiment_url: 'intent_thread_url',
   intent_to_extend_experiment_url: 'intent_thread_url',
+  intent_to_deprecate_url: 'intent_thread_url',
   ot_creation__intent_to_experiment_url: 'intent_thread_url',
   ot_extension__intent_to_extend_experiment_url: 'intent_thread_url',
   r4dt_url: 'intent_thread_url',

--- a/client-src/elements/form-field-specs.ts
+++ b/client-src/elements/form-field-specs.ts
@@ -970,6 +970,16 @@ export const ALL_FIELDS: Record<string, Field> = {
     thread, link to it here.`,
   },
 
+  intent_to_deprecate_url: {
+    type: 'input',
+    attrs: URL_FIELD_ATTRS,
+    required: false,
+    label: 'Intent to Deprecate and Remove link',
+    usage: ALL_INTENT_USAGE_BY_FEATURE_TYPE,
+    help_text: html` After you have started the "Intent to Deprecate and Remove"
+    discussion thread, link to it here.`,
+  },
+
   doc_links: {
     type: 'textarea',
     attrs: MULTI_URL_FIELD_ATTRS,

--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -610,6 +610,7 @@ STAGE_TYPES_BY_FIELD_MAPPING: dict[str, dict[int, Optional[int]]] = {
     'experiment_extension_reason': STAGE_TYPES_EXTEND_ORIGIN_TRIAL,
     'origin_trial_feedback_url': STAGE_TYPES_ORIGIN_TRIAL,
     'intent_to_implement_url': STAGE_TYPES_PROTOTYPE,
+    'intent_to_deprecate_url': STAGE_TYPES_PLAN,
     'announcement_url': STAGE_TYPES_DEV_TRIAL,
     'intent_to_ship_url': STAGE_TYPES_SHIPPING,
     'intent_to_experiment_url': STAGE_TYPES_ORIGIN_TRIAL,

--- a/internals/search_queries.py
+++ b/internals/search_queries.py
@@ -366,6 +366,7 @@ STAGE_QUERIABLE_FIELDS: dict[str, Property] = {
     'experiment_goals': Stage.experiment_goals,
     'experiment_risks': Stage.experiment_risks,
     'finch_url': Stage.finch_url,
+    'intent_to_deprecate_url': Stage.intent_thread_url,
     'intent_to_experiment_url': Stage.intent_thread_url,
     'intent_to_extend_experiment_url': Stage.intent_thread_url,
     'intent_to_implement_url': Stage.intent_thread_url,
@@ -400,6 +401,7 @@ STAGE_TYPES_BY_QUERY_FIELD: dict[str, dict[int, Optional[int]]] = {
     'experiment_goals': core_enums.STAGE_TYPES_ORIGIN_TRIAL,
     'experiment_risks': core_enums.STAGE_TYPES_ORIGIN_TRIAL,
     'finch_url': core_enums.STAGE_TYPES_SHIPPING,
+    'intent_to_deprecate_url': core_enums.STAGE_TYPES_PLAN,
     'intent_to_experiment_url': core_enums.STAGE_TYPES_ORIGIN_TRIAL,
     'intent_to_extend_experiment_url': core_enums.STAGE_TYPES_EXTEND_ORIGIN_TRIAL,  # noqa: E501
     'intent_to_implement_url': core_enums.STAGE_TYPES_PROTOTYPE,


### PR DESCRIPTION
Resolves #5663

## Overview
Adds the `intent_to_deprecate_url` field to the frontend forms for deprecation plans and maps it to the `intent_thread_url` field in the backend so it functions like other intent fields.

## Root Cause / Motivation
Currently, "Intent to Deprecate and Remove" threads are mapped correctly if the thread detection regex passes, but there was no field in the UI for users to manually input the intent thread URL for a deprecation plan. Adding the field and mapping it to the underlying `intent_thread_url` resolves this. 

## Detailed Changelog
* **`client-src/elements/form-definition.ts`**: Added `intent_to_deprecate_url` to the `DEPRECATION_PLAN_FIELDS` form definition.
* **`client-src/elements/form-field-specs.ts`**: Added display properties and help text for the new `intent_to_deprecate_url` field.
* **`client-src/elements/form-field-enums.ts`**: Mapped `intent_to_deprecate_url` to `intent_thread_url`.
* **`internals/core_enums.py`**: Added `intent_to_deprecate_url` to `STAGE_TYPES_BY_FIELD_MAPPING` associated with `STAGE_TYPES_PLAN`.
* **`internals/search_queries.py`**: Added `intent_to_deprecate_url` mapping in `STAGE_QUERIABLE_FIELDS` and `STAGE_TYPES_BY_QUERY_FIELD`.