### PR TITLE
Increase idle instances to 2.

### DIFF
--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -5,7 +5,7 @@ service: default
 instance_class: F4_1G
 
 automatic_scaling:
-  min_idle_instances: 1
+  min_idle_instances: 2
   max_pending_latency: 0.2s
 
 # Use a long HTTP cache expiration time for css and JS, but also

--- a/app.yaml
+++ b/app.yaml
@@ -5,7 +5,7 @@ service: default
 instance_class: F4_1G
 
 automatic_scaling:
-  min_idle_instances: 1
+  min_idle_instances: 2
   max_pending_latency: 0.2s
 
 # Use a long HTTP cache expiration time for css and JS, but also


### PR DESCRIPTION
This should avoid some latency spikes on staging that cause monitoring alerts.

I changed both prod and staging configurations to keep them consistent.  Also, this might help with occasional  slow responses on prod, even though such events are not triggering alerts.
