### PR TITLE
Optimize API query performance by avoiding full keys-only Datastore fetch on empty queries

### DIFF
--- a/internals/search.py
+++ b/internals/search.py
@@ -582,13 +582,22 @@ def process_query(
     # 3a. Process user query: negation, AND, and OR.
     feature_id_future_ops = process_negation_operations(feature_id_future_ops)
     query_clauses = process_and_operations(feature_id_future_ops)
-    result_id_set = process_or_operations(query_clauses)
-    logging.info('got %r result IDs w/o permissions', len(result_id_set))
 
-    # 3b. Process all permission ops, then interesect to apply permisisons.
+    # 3b. Process all permission ops.
     permission_clauses = process_and_operations(permissions_future_ops)
-    permission_ids = process_or_operations(permission_clauses)
-    result_id_set.intersection_update(permission_ids)
+
+    # Apply permissions without unnecessarily fetching all keys
+    if not query_clauses and not permission_clauses:
+        result_id_set = fetch_all_feature_ids_set()
+    elif not query_clauses:
+        result_id_set = process_or_operations(permission_clauses)
+    elif not permission_clauses:
+        result_id_set = process_or_operations(query_clauses)
+    else:
+        result_id_set = process_or_operations(query_clauses)
+        permission_ids = process_or_operations(permission_clauses)
+        result_id_set.intersection_update(permission_ids)
+
     logging.info('got %r result IDs with permissions', len(result_id_set))
 
     # 3c. Filter out confidential features that the user cannot view.

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -897,6 +897,26 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
         self.assertEqual(1, len(actual))
         self.assertEqual(actual[0]['name'], 'feature 1')
 
+    @mock.patch('internals.search.fetch_all_feature_ids_set')
+    def test_process_query__empty_query_optimization(self, mock_fetch_all):
+        """We do not fetch all feature IDs when the user query is empty."""
+        actual, tc = search.process_query('')
+        mock_fetch_all.assert_not_called()
+
+        # Conversely, if a query consists only of a negation term, it must fetch
+        # all IDs initially so it has a complete set to subtract the matches from.
+        mock_fetch_all.reset_mock()
+        mock_fetch_all.return_value = set(
+            [
+                self.featureentry_1.key.integer_id(),
+                self.featureentry_2.key.integer_id(),
+                self.featureentry_3.key.integer_id(),
+                self.featureentry_4.key.integer_id(),
+            ]
+        )
+        actual, tc = search.process_query('-owner:me')
+        mock_fetch_all.assert_called_once()
+
     @mock.patch('logging.warning')
     def test_process_query__bad(self, mock_warn):
         """Query terms that are not valid, give warnings."""


### PR DESCRIPTION
Resolves #6317

## Overview
Optimizes the search API query pipeline to bypass fetching all Datastore feature keys when the user query is empty.

## Root Cause / Motivation
When a user visits the main dashboard page without a search query, `process_and_operations` returned an empty list of user query clauses. Because the list was empty, `process_or_operations` fell back to `fetch_all_feature_ids_set()`, triggering a keys-only Datastore fetch of every single feature in the database. This set was then intersected with the permissions set, which is redundant since intersecting "all features" with "permitted features" just yields the permitted features. Avoiding this global fetch drastically reduces Datastore read operations and CPU cycle overhead on default views.

## Detailed Changelog
* **`internals/search.py`**: Refactored `process_query` to check if `query_clauses` and `permission_clauses` are empty before combining them, entirely skipping the fallback call to `fetch_all_feature_ids_set` for empty searches.
* **`internals/search_test.py`**: Added `test_process_query__empty_query_optimization` to explicitly verify that `fetch_all_feature_ids_set` is not called when an empty string is provided, ensuring regression coverage.