### PR TITLE
Optimize memory and time complexity of search total order sorting

### DIFF
--- a/internals/search.py
+++ b/internals/search.py
@@ -360,13 +360,13 @@ def _resolve_promise_to_id_list(
 
 
 def _sort_by_total_order(
-    result_id_list: list[int], total_order_ids: list[int]
+    result_id_set: set[int], total_order_ids: list[int]
 ) -> list[int]:
     """Sort the result_ids according to their position in the total order.
 
     This extracts the matching IDs in their exact sorted sequence.
     """
-    result_id_set = set(result_id_list)
+    result_id_set = result_id_set.copy()
     sorted_id_list = []
 
     # Extract matching IDs in their exact sorted order.
@@ -620,14 +620,13 @@ def process_query(
                     len(unviewable_ids),
                 )
 
-    result_id_list = list(result_id_set)
-    total_count = len(result_id_list)
+    total_count = len(result_id_set)
 
     # 4. Finish getting the total sort order. Then, sort the IDs according
     # to their position in the complete sorted list.
     total_order_ids = _resolve_promise_to_id_list(total_order_promise)
     logging.info('sorting')
-    sorted_id_list = _sort_by_total_order(result_id_list, total_order_ids)
+    sorted_id_list = _sort_by_total_order(result_id_set, total_order_ids)
     logging.info('sorted %r result IDs', len(sorted_id_list))
 
     # 5. Paginate

--- a/internals/search.py
+++ b/internals/search.py
@@ -364,22 +364,28 @@ def _sort_by_total_order(
 ) -> list[int]:
     """Sort the result_ids according to their position in the total order.
 
-    If some result ID is not present in the total order, use the feature ID
-    value itself as the sorting value, which will effectively put those
-    features at the end of the list in order of creation.
+    This extracts the matching IDs in their exact sorted sequence.
     """
-    total_order_dict = {}
-    # For each feature entry ID in the total-order list, record the index of
-    # the first time that it occurs.  A feature could be in the list multiple
-    # times if it was produced via a join.  E.g., sorting by gate.requested_on
-    # would have total_order_ids items for every gate, not just one per feature.
-    for idx, f_id in enumerate(total_order_ids):
-        if f_id not in total_order_dict:
-            total_order_dict[f_id] = idx
+    result_id_set = set(result_id_list)
+    sorted_id_list = []
 
-    sorted_id_list = sorted(
-        result_id_list, key=lambda f_id: total_order_dict.get(f_id, f_id)
-    )
+    # Extract matching IDs in their exact sorted order.
+    # We iterate through the pre-sorted massive list exactly once.
+    for f_id in total_order_ids:
+        if f_id in result_id_set:
+            sorted_id_list.append(f_id)
+            # Remove from set to handle the case where total_order_ids
+            # contains duplicates (e.g. from a join on a repeated property).
+            result_id_set.remove(f_id)
+            if not result_id_set:
+                break
+    # Any remaining IDs that were in the result list but somehow NOT present
+    # in the total order are appended to the very end.
+    # We sort them by the feature ID value itself, which effectively puts
+    # those features at the end of the list in order of creation.
+    if result_id_set:
+        sorted_id_list.extend(sorted(list(result_id_set)))
+
     return sorted_id_list
 
 

--- a/internals/search_test.py
+++ b/internals/search_test.py
@@ -523,7 +523,7 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
 
     def test_sort_by_total_order__empty(self):
         """Sorting an empty list works."""
-        feature_ids = []
+        feature_ids = set()
         total_order_ids = []
         actual = search._sort_by_total_order(feature_ids, total_order_ids)
         self.assertEqual([], actual)
@@ -534,7 +534,7 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
 
     def test_sort_by_total_order__normal(self):
         """We can sort the results according to the total order."""
-        feature_ids = [10, 1, 9, 4]
+        feature_ids = {10, 1, 9, 4}
         total_order_ids = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
         actual = search._sort_by_total_order(feature_ids, total_order_ids)
         self.assertEqual([10, 9, 4, 1], actual)
@@ -543,7 +543,7 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
         """If the results include features not present in the total order,
         they are put at the end of the list in ID order.
         """  # noqa: D205
-        feature_ids = [999, 10, 998, 1, 9, 997, 4]
+        feature_ids = {999, 10, 998, 1, 9, 997, 4}
         total_order_ids = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
         actual = search._sort_by_total_order(feature_ids, total_order_ids)
         self.assertEqual([10, 9, 4, 1, 997, 998, 999], actual)
@@ -552,7 +552,7 @@ class SearchFunctionsTest(testing_config.CustomTestCase):
         """If the sort order is done via join, the total_order could have
         multiple copies of the same feature IDs.  We use the earliest.
         """  # noqa: D205
-        feature_ids = [10, 1, 9, 4]
+        feature_ids = {10, 1, 9, 4}
         total_order_ids = [
             10,
             9,


### PR DESCRIPTION
## Overview
Optimizes the `_sort_by_total_order` function in `internals/search.py` to reduce memory allocation overhead and improve time complexity during search queries.

## Root Cause / Motivation
The previous implementation allocated a large dictionary to map thousands of IDs to their indices on every search query, and then executed an `O(K log K)` sort on the results. Since the database already provides the total order as a correctly sorted sequence of IDs, this was mathematically suboptimal. By taking advantage of `O(1)` set membership lookups, we can simply stream the pre-sorted list and extract our matching items in `O(N)` time without allocating temporary dictionaries.

## Detailed Changelog
* **`internals/search.py`**: Rewrote `_sort_by_total_order` to convert the `result_id_list` into a set. It then iterates through the massive pre-sorted `total_order_ids` sequence exactly once, extracting matching items in their correct order. It appends any remaining unseen IDs to the very end to guarantee safe fallback behavior.