### PR TITLE
Add announced field to API responses.

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -22,7 +22,13 @@ from typing import Any, Optional, TypedDict
 from google.cloud import ndb  # type: ignore
 
 import settings
-from internals import approval_defs, core_enums, self_certify, slo
+from internals import (
+    approval_defs,
+    core_enums,
+    self_certify,
+    slo,
+    stage_helpers,
+)
 from internals.core_models import (
     FeatureEntry,
     MilestoneSet,
@@ -113,6 +119,7 @@ class StagePrepResponse(TypedDict):
     ship: Stage | None
     rollout: Stage | None
     all_stages: list[StageDict]
+    raw_stages: list[Stage]
 
 
 def _prep_stage_info(
@@ -143,6 +150,7 @@ def _prep_stage_info(
         'rollout': None,
         # Write a list of all stages associated with the feature.
         'all_stages': [],
+        'raw_stages': [],
     }
 
     # Keep track of trial stage indexes so that we can add trial extension
@@ -171,6 +179,7 @@ def _prep_stage_info(
         elif s.stage_type == rollout_type:
             stage_info['rollout'] = s
         stage_info['all_stages'].append(stage_dict)
+        stage_info['raw_stages'].append(s)
 
     for extension in extension_stages:
         # Trial extensions are kept as a list on the associated trial stage dict.
@@ -366,6 +375,12 @@ def feature_entry_to_json_verbose(
 
     # Get stage info, returning it to be more explicitly added.
     stage_info = _prep_stage_info(fe, prefetched_stages=prefetched_stages)
+    shipping_stage_type = core_enums.STAGE_TYPES_SHIPPING[fe.feature_type] or 0
+    ship_stages = [
+        s
+        for s in stage_info['raw_stages']
+        if s.stage_type == shipping_stage_type
+    ]
 
     new_crbug_url = _format_new_crbug_url(
         fe.blink_components, fe.bug_url, fe.impl_status_chrome, fe.owner_emails
@@ -512,6 +527,7 @@ def feature_entry_to_json_verbose(
                     'val': fe.impl_status_chrome,
                     'milestone_str': None,
                 },
+                'announced': stage_helpers.is_announced(ship_stages),
                 # TODO(danielrsmith): Find out if these are used and delete if not.
                 'desktop': _get_milestone_attr(
                     stage_info['ship'], 'desktop_first'
@@ -613,6 +629,11 @@ def feature_entry_to_json_basic(
     if not fe.key:
         return {}
 
+    shipping_stage_type = core_enums.STAGE_TYPES_SHIPPING[fe.feature_type] or 0
+    ship_stages = [
+        s for s in (stages or []) if s.stage_type == shipping_stage_type
+    ]
+
     d: dict[str, Any] = {
         'id': fe.key.integer_id(),
         'name': fe.name,
@@ -663,6 +684,7 @@ def feature_entry_to_json_basic(
                     ],
                     'val': fe.impl_status_chrome,
                 },
+                'announced': stage_helpers.is_announced(ship_stages),
             },
             'ff': {
                 'view': _compute_vendor_views(

--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -167,6 +167,7 @@ class FeatureConvertersTest(testing_config.CustomTestCase):
                     'prefixed': False,
                     'flag': False,
                     'status': {'text': 'Enabled by default', 'val': 5},
+                    'announced': False,
                 },
                 'ff': {
                     'view': {
@@ -256,6 +257,7 @@ class FeatureConvertersTest(testing_config.CustomTestCase):
                     'prefixed': False,
                     'flag': False,
                     'status': {'text': 'Enabled by default', 'val': 5},
+                    'announced': True,
                 },
                 'ff': {
                     'view': {
@@ -451,6 +453,7 @@ class FeatureConvertersTest(testing_config.CustomTestCase):
                         'text': 'Enabled by default',
                         'val': 5,
                     },
+                    'announced': True,
                 },
                 'ff': {
                     'view': {

--- a/api/stages_api.py
+++ b/api/stages_api.py
@@ -61,8 +61,11 @@ class StagesAPI(basehandlers.EntitiesAPIHandler):
         stage_dict = converters.stage_to_json_dict(stage)
         # Add extensions associated with the stage if they exist.
         extensions = stage_helpers.get_ot_stage_extensions(stage_dict['id'])
+        extensions_json = [
+            converters.stage_to_json_dict(es) for es in extensions
+        ]
         if extensions:
-            stage_dict['extensions'] = extensions
+            stage_dict['extensions'] = extensions_json
 
         return stage_dict
 

--- a/internals/data_types.py
+++ b/internals/data_types.py
@@ -157,6 +157,7 @@ class FeatureDictInnerChromeBrowserInfo(TypedDict):
     prefixed: bool | None
     flag: bool | None
     status: FeatureDictInnerBrowserStatus
+    announced: bool | None
 
     # Old representation of ship dates.
     # TODO(danielrsmith): find if needed and remove if unneeded.

--- a/internals/fetchchannels.py
+++ b/internals/fetchchannels.py
@@ -85,6 +85,20 @@ def get_omaha_data():
     return json.loads(omaha_data)
 
 
+def get_current_beta_milestone() -> int:
+    """Return the milestone number that is current on the beta channel."""
+    omaha_data = get_omaha_data()
+    beta_version = next(
+        (
+            v['version']
+            for v in omaha_data[0]['versions']
+            if v['channel'] == 'beta'
+        ),
+        '0.0',
+    )
+    return int(beta_version.split('.')[0])
+
+
 SCHEDULE_CACHE_TIME = 60 * 60  # 1 hour
 
 

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -253,16 +253,7 @@ def apply_subscription_rule_docs(
     """Every change to a post-beta feature notifies the docs team."""
     rule_results: dict[str, list[str]] = {}
     # Case A: name or summary changing while any milestone is post-beta.
-    omaha_data = fetchchannels.get_omaha_data()
-    beta_version = next(
-        (
-            v['version']
-            for v in omaha_data[0]['versions']
-            if v['channel'] == 'beta'
-        ),
-        '0.0',
-    )
-    current_beta_milestone = int(beta_version.split('.')[0])
+    current_beta_milestone = fetchchannels.get_current_beta_milestone()
     if 'name' in changed_field_names or 'summary' in changed_field_names:
         earliest_from_feature = stage_helpers.find_earliest_milestone(
             ship_stages

--- a/internals/stage_helpers.py
+++ b/internals/stage_helpers.py
@@ -21,7 +21,6 @@ from typing import TypedDict
 
 from google.cloud import ndb  # type: ignore
 
-from api import converters
 from framework import utils
 from internals import core_enums, fetchchannels
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
@@ -131,10 +130,11 @@ def get_feature_stage_ids_list(feature_id: int) -> list[dict[str, int]]:
 
 
 def get_ot_stage_extensions(ot_stage_id: int):
-    """Return a list of extension stages associated with a stage in JSON format"""  # noqa: D415
+    """Return a list of extension stages associated with a stage."""
     q = Stage.query(Stage.ot_stage_id == ot_stage_id)
-    extension_stages = [converters.stage_to_json_dict(stage) for stage in q]
-    return sorted(extension_stages, key=lambda s: s['created'])
+    extension_stages = q.fetch()
+    # extension_stages = [converters.stage_to_json_dict(stage) for stage in q]
+    return sorted(extension_stages, key=lambda s: s.created)
 
 
 def get_stage_info_for_templates(fe: FeatureEntry) -> StageTemplateInfo:
@@ -234,6 +234,16 @@ def get_stage_info_for_templates(fe: FeatureEntry) -> StageTemplateInfo:
     # a boolean value representing whether or not the estimated milestones
     # table will need to be rendered.
     return stage_info
+
+
+def is_announced(ship_stages: list[Stage]) -> bool:
+    """Return True if any milestone already went to the beta channel."""
+    current_beta_milestone = fetchchannels.get_current_beta_milestone()
+    earliest_from_feature = find_earliest_milestone(ship_stages)
+    return (
+        earliest_from_feature is not None
+        and earliest_from_feature <= current_beta_milestone
+    )
 
 
 LAST_MILESTONE_TO_YEAR: dict[int, int] = {


### PR DESCRIPTION
This implements a request from the docs team to add an `announced` boolean to our API responses for features.  The boolean should be true if any shipping stage has a milestone that is less than the milestone that is currently on the beta channel.

In this PR:
* Add the `announced` field to the JSON dict in converters.py.
* Implement a new `is_announced()` helper function.
* Refactor channel logic into fetchchannels.py and some JSON conversion logic out of feature_helpers.py to sort out our import dependencies.