### PR TITLE
Automate traffic migration and issue closing in deploy-production script

### DIFF
--- a/util/deployment/create-deployment-issue
+++ b/util/deployment/create-deployment-issue
@@ -78,7 +78,7 @@ echo "---"
 echo "Press enter to create the issue, or Ctrl+C to cancel."
 read -r
 
-if ( ! gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "release" -R "$REPO"); then
+if ( ! gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "release" --assignee "@me" -R "$REPO"); then
   echo "GitHub issue creation failed."
   exit 1
 fi

--- a/util/deployment/deploy-production
+++ b/util/deployment/deploy-production
@@ -39,7 +39,7 @@ LATEST_VERSION=$(gcloud app --project="$APP_NAME" versions list --sort-by=~last_
 
 echo -e "\nDeployment complete. Validating..."
 echo "Visit $VERSION_URL to confirm that everything works."
-read -p "Wait a few minutes, then press 'y' to redirect traffic to version $LATEST_VERSION for all services. (y/n) " -n 1 -r
+read -p "Press 'y' to redirect traffic to version $LATEST_VERSION for all services. (y/n) " -n 1 -r
 echo
 
 if [[ $REPLY =~ ^[Yy]$ ]]; then

--- a/util/deployment/deploy-production
+++ b/util/deployment/deploy-production
@@ -33,8 +33,34 @@ export NOTIFIER_YAML="notifier.yaml"
 
 "$DIR/deploy-env"
 
-echo "Remember to migrate the traffic to the latest version after validating it."
-echo "- 'default' service: https://console.cloud.google.com/appengine/versions?serviceId=default&project=cr-status"
-echo "- 'notifier' service https://console.cloud.google.com/appengine/versions?serviceId=notifier&project=cr-status"
-echo "Remember to close the GitHub release issue."
-echo "https://github.com/GoogleChrome/chromium-dashboard/issues?q=is%3Aissue+label%3Arelease+is%3Aopen"
+SERVICES="default notifier"
+VERSION_URL=$(gcloud app --project="$APP_NAME" versions list --sort-by=~last_deployed_time --filter='service=default' --limit=1 --format=json | jq -r '.[] | .version.versionUrl')
+LATEST_VERSION=$(gcloud app --project="$APP_NAME" versions list --sort-by=~last_deployed_time --filter='service=default' --limit=1 --format=json | jq -r '.[] | .id')
+
+echo -e "\nDeployment complete. Validating..."
+echo "Visit $VERSION_URL to confirm that everything works."
+read -p "Wait a few minutes, then press 'y' to redirect traffic to version $LATEST_VERSION for all services. (y/n) " -n 1 -r
+echo
+
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  for SERVICE in $SERVICES
+  do
+    gcloud app --project="$APP_NAME" services set-traffic $SERVICE --splits $LATEST_VERSION=1 --quiet
+  done
+  echo "Traffic migrated."
+else
+  echo "Traffic migration skipped. Don't forget to migrate traffic manually:"
+  echo "- 'default' service: https://console.cloud.google.com/appengine/versions?serviceId=default&project=$APP_NAME"
+  echo "- 'notifier' service: https://console.cloud.google.com/appengine/versions?serviceId=notifier&project=$APP_NAME"
+fi
+
+# Update and close deployment bug.
+REPO="GoogleChrome/chromium-dashboard"
+LAST_DEPLOYMENT_ISSUE=$(gh issue list --state open --label "release" --repo "$REPO" --limit 1 --json number --jq '.[] | .number')
+
+if [ -n "$LAST_DEPLOYMENT_ISSUE" ]; then
+  gh issue close "$LAST_DEPLOYMENT_ISSUE" -c "Deployment is now complete." -R "$REPO"
+  echo "Closed GitHub release issue #$LAST_DEPLOYMENT_ISSUE."
+else
+  echo "Could not find an open release issue to close."
+fi


### PR DESCRIPTION
## Overview
Automates the post-deployment steps of migrating traffic to the latest versions of the 'default' and 'notifier' services, and automatically closes the associated GitHub release issue.

## Root Cause / Motivation
Previously, the deployment script outputted instructions for the user to manually handle traffic migration and closing the generated release issue in GitHub. By automating these final manual steps within the script, we streamline the deployment workflow, reduce friction, and avoid forgotten cleanup steps.

## Detailed Changelog
* **`util/deployment/deploy-production`**: 
  - Added logic to fetch the latest deployed version and its URL using `gcloud app versions list`.
  - Replaced trailing echo messages with an interactive prompt asking the user if they want to automatically migrate 100% of the traffic to the new version for the `default` and `notifier` services.
  - Implemented the `gh issue close` command to automatically find and close the open 'release' issue for the repository once the deployment and validation are complete.