### PR TITLE
Optimize `get_current_beta_milestone` with request-scoped caching

### DIFF
--- a/internals/fetchchannels.py
+++ b/internals/fetchchannels.py
@@ -18,6 +18,7 @@
 import json
 import logging
 
+import flask
 import requests
 
 # Note: this file cannot import core_models because it would be circular.
@@ -87,6 +88,9 @@ def get_omaha_data():
 
 def get_current_beta_milestone() -> int:
     """Return the milestone number that is current on the beta channel."""
+    if flask.has_app_context() and hasattr(flask.g, 'current_beta_milestone'):
+        return flask.g.current_beta_milestone
+
     omaha_data = get_omaha_data()
     beta_version = next(
         (
@@ -96,7 +100,12 @@ def get_current_beta_milestone() -> int:
         ),
         '0.0',
     )
-    return int(beta_version.split('.')[0])
+    milestone = int(beta_version.split('.')[0])
+
+    if flask.has_app_context():
+        flask.g.current_beta_milestone = milestone
+
+    return milestone
 
 
 SCHEDULE_CACHE_TIME = 60 * 60  # 1 hour


### PR DESCRIPTION
## Overview
Optimizes `get_current_beta_milestone` by implementing request-scoped caching using `flask.g` to mitigate an N+1 performance bottleneck.

## Root Cause / Motivation
Previously, `get_current_beta_milestone()` triggered redundant network requests to Redis (`rediscache.get`) and repeated JSON parsing for every single feature processed within the API response loop. When fetching hundreds of features (e.g., loading the main dashboard via `/api/v0/features`), this N+1 issue incurred massive overhead. 

Using `@functools.lru_cache` was initially considered but is not viable for App Engine, as it caches the milestone indefinitely within the long-lived process. This would lead to stale data that ignores the underlying 24-hour Redis TTL. Request-scoped caching (`flask.g`) perfectly resolves the repeated redundant calls during the loop while ensuring the data is discarded at the end of the HTTP request, keeping the application up-to-date.

## Detailed Changelog
* **`internals/fetchchannels.py`**: Added `flask` import and modified `get_current_beta_milestone()` to store and retrieve the calculated beta milestone from `flask.g` (if within an app context). This ensures the Redis lookup and JSON parsing only occur once per HTTP request.