### PR TITLE
Process origin trial creations transactionally to prevent race conditions

### DIFF
--- a/internals/core_enums.py
+++ b/internals/core_enums.py
@@ -654,6 +654,7 @@ OT_CREATION_FAILED = 3
 OT_ACTIVATION_FAILED = 4
 OT_CREATED = 5
 OT_ACTIVATED = 6
+OT_CREATION_PROCESSING = 7
 
 
 # Histogram IDs used for identifying origin trial use counters.

--- a/internals/maintenance_scripts.py
+++ b/internals/maintenance_scripts.py
@@ -704,6 +704,17 @@ class CreateOriginTrials(FlaskHandler):
                 '/tasks/email-ot-creation-processed', stage
             )
 
+    @ndb.transactional()
+    def _claim_stage_for_creation(self, stage_id: int) -> Stage | None:
+        """Transactionally claim a stage for creation processing."""
+        stage: Stage | None = Stage.get_by_id(stage_id)
+        if stage and stage.ot_setup_status == core_enums.OT_READY_FOR_CREATION:
+            stage.ot_setup_status = core_enums.OT_CREATION_PROCESSING
+            stage.ot_action_requested = False
+            stage.put()
+            return stage
+        return None
+
     def get_template_data(self, **kwargs) -> str:
         """Create any origin trials that are flagged for creation."""
         self.require_cron_header()
@@ -711,17 +722,23 @@ class CreateOriginTrials(FlaskHandler):
             return 'Automated OT creation process is not active.'
 
         # OT stages that are flagged to process a trial creation.
-        ot_stages: list[Stage] = Stage.query(
+        ot_stage_keys: list[ndb.Key] = Stage.query(
             Stage.ot_setup_status == core_enums.OT_READY_FOR_CREATION
-        ).fetch()
-        for stage in ot_stages:
-            stage.ot_action_requested = False
+        ).fetch(keys_only=True)
+
+        count = 0
+        for key in ot_stage_keys:
+            stage = self._claim_stage_for_creation(key.integer_id())
+            if not stage:
+                continue
+
             creation_success = self.handle_creation(stage)
             if creation_success:
                 self.prepare_for_activation(stage)
             stage.put()
+            count += 1
 
-        return f'{len(ot_stages)} trial creation request(s) processed.'
+        return f'{count} trial creation request(s) processed.'
 
 
 class ActivateOriginTrials(FlaskHandler):

--- a/internals/maintenance_scripts_test.py
+++ b/internals/maintenance_scripts_test.py
@@ -528,32 +528,37 @@ class CreateOriginTrialsTest(testing_config.CustomTestCase):
 
         result = self.handler.get_template_data()
         self.assertEqual('2 trial creation request(s) processed.', result)
+
+        # Reload stages from Datastore since the handler modifies them in a transaction
+        updated_stage_1 = Stage.get_by_id(self.ot_stage_1.key.integer_id())
+        updated_stage_2 = Stage.get_by_id(self.ot_stage_2.key.integer_id())
+
         # Check that different email notifications were sent.
         mock_enqueue_task.assert_has_calls(
             [
                 mock.call(
                     '/tasks/email-ot-activated',
-                    {'stage': converters.stage_to_json_dict(self.ot_stage_1)},
+                    {'stage': converters.stage_to_json_dict(updated_stage_1)},
                 ),
                 mock.call(
                     '/tasks/email-ot-creation-processed',
-                    {'stage': converters.stage_to_json_dict(self.ot_stage_2)},
+                    {'stage': converters.stage_to_json_dict(updated_stage_2)},
                 ),
             ],
             any_order=True,
         )
         # Activation was handled, so a delayed activation date should not be set.
-        self.assertIsNone(self.ot_stage_1.ot_activation_date)
+        self.assertIsNone(updated_stage_1.ot_activation_date)
         # OT 2 should have delayed activation date set.
-        self.assertEqual(date(2030, 1, 1), self.ot_stage_2.ot_activation_date)
+        self.assertEqual(date(2030, 1, 1), updated_stage_2.ot_activation_date)
         # Setup status should be verified.
         self.assertEqual(
-            self.ot_stage_1.ot_setup_status, core_enums.OT_ACTIVATED
+            updated_stage_1.ot_setup_status, core_enums.OT_ACTIVATED
         )
-        self.assertEqual(self.ot_stage_2.ot_setup_status, core_enums.OT_CREATED)
+        self.assertEqual(updated_stage_2.ot_setup_status, core_enums.OT_CREATED)
         # New origin trial ID should be associated with the stages.ss
-        self.assertIsNotNone(self.ot_stage_1.origin_trial_id)
-        self.assertIsNotNone(self.ot_stage_2.origin_trial_id)
+        self.assertIsNotNone(updated_stage_1.origin_trial_id)
+        self.assertIsNotNone(updated_stage_2.origin_trial_id)
         # OT 3 had no action request, so it should not have changed.
         self.assertIsNone(self.ot_stage_3.origin_trial_id)
 
@@ -590,20 +595,25 @@ class CreateOriginTrialsTest(testing_config.CustomTestCase):
 
         result = self.handler.get_template_data()
         self.assertEqual('2 trial creation request(s) processed.', result)
+
+        # Reload stages from Datastore
+        updated_stage_1 = Stage.get_by_id(self.ot_stage_1.key.integer_id())
+        updated_stage_2 = Stage.get_by_id(self.ot_stage_2.key.integer_id())
+
         # Failure notications should be sent to the OT support team.
         mock_enqueue_task.assert_has_calls(
             [
                 mock.call(
                     '/tasks/email-ot-creation-request-failed',
                     {
-                        'stage': converters.stage_to_json_dict(self.ot_stage_1),
+                        'stage': converters.stage_to_json_dict(updated_stage_1),
                         'error_text': '503, Unavailable',
                     },
                 ),
                 mock.call(
                     '/tasks/email-ot-creation-request-failed',
                     {
-                        'stage': converters.stage_to_json_dict(self.ot_stage_2),
+                        'stage': converters.stage_to_json_dict(updated_stage_2),
                         'error_text': '500, Problems happened after trial was created',
                     },
                 ),
@@ -618,20 +628,20 @@ class CreateOriginTrialsTest(testing_config.CustomTestCase):
             any_order=True,
         )
         # Creation wasn't handled, so activation dates shouldn't be set.
-        self.assertIsNone(self.ot_stage_1.ot_activation_date)
-        self.assertIsNone(self.ot_stage_2.ot_activation_date)
+        self.assertIsNone(updated_stage_1.ot_activation_date)
+        self.assertIsNone(updated_stage_2.ot_activation_date)
         # Setup status should be marked as "Failed".
         self.assertEqual(
-            self.ot_stage_1.ot_setup_status, core_enums.OT_CREATION_FAILED
+            updated_stage_1.ot_setup_status, core_enums.OT_CREATION_FAILED
         )
         self.assertEqual(
-            self.ot_stage_2.ot_setup_status, core_enums.OT_CREATION_FAILED
+            updated_stage_2.ot_setup_status, core_enums.OT_CREATION_FAILED
         )
         # No OT IDs should be added to stages that had no successful actions.
-        self.assertIsNone(self.ot_stage_1.origin_trial_id)
+        self.assertIsNone(updated_stage_1.origin_trial_id)
         self.assertIsNone(self.ot_stage_3.origin_trial_id)
         # OT stage 2 had an error, but a trial was successfully created.
-        self.assertEqual('1112223334', self.ot_stage_2.origin_trial_id)
+        self.assertEqual('1112223334', updated_stage_2.origin_trial_id)
 
     @mock.patch('framework.cloud_tasks_helpers.enqueue_task')
     @mock.patch('internals.maintenance_scripts.CreateOriginTrials._get_today')
@@ -669,34 +679,39 @@ class CreateOriginTrialsTest(testing_config.CustomTestCase):
 
         result = self.handler.get_template_data()
         self.assertEqual('2 trial creation request(s) processed.', result)
+
+        # Reload stages from Datastore
+        updated_stage_1 = Stage.get_by_id(self.ot_stage_1.key.integer_id())
+        updated_stage_2 = Stage.get_by_id(self.ot_stage_2.key.integer_id())
+
         # One trial activation should have failed, and one should be processed.
         mock_enqueue_task.assert_has_calls(
             [
                 mock.call(
                     '/tasks/email-ot-activation-failed',
-                    {'stage': converters.stage_to_json_dict(self.ot_stage_1)},
+                    {'stage': converters.stage_to_json_dict(updated_stage_1)},
                 ),
                 mock.call(
                     '/tasks/email-ot-creation-processed',
-                    {'stage': converters.stage_to_json_dict(self.ot_stage_2)},
+                    {'stage': converters.stage_to_json_dict(updated_stage_2)},
                 ),
             ],
             any_order=True,
         )
 
         # Activation failed, so an activation date should have been set.
-        self.assertEqual(self.ot_stage_1.ot_activation_date, date.today())
+        self.assertEqual(updated_stage_1.ot_activation_date, date.today())
         # OT 2 should have delayed activation date set.
-        self.assertEqual(date(2030, 1, 1), self.ot_stage_2.ot_activation_date)
+        self.assertEqual(date(2030, 1, 1), updated_stage_2.ot_activation_date)
         # OT 1 setup status should be verified, but activation failed.
         self.assertEqual(
-            self.ot_stage_1.ot_setup_status, core_enums.OT_ACTIVATION_FAILED
+            updated_stage_1.ot_setup_status, core_enums.OT_ACTIVATION_FAILED
         )
         # OT 2 should have been created but not yet activated.
-        self.assertEqual(self.ot_stage_2.ot_setup_status, core_enums.OT_CREATED)
+        self.assertEqual(updated_stage_2.ot_setup_status, core_enums.OT_CREATED)
         # New origin trial ID should be associated with the stages.
-        self.assertIsNotNone(self.ot_stage_1.origin_trial_id)
-        self.assertIsNotNone(self.ot_stage_2.origin_trial_id)
+        self.assertIsNotNone(updated_stage_1.origin_trial_id)
+        self.assertIsNotNone(updated_stage_2.origin_trial_id)
         # OT 3 had no action request, so it should not have changed.
         self.assertIsNone(self.ot_stage_3.origin_trial_id)
 


### PR DESCRIPTION
## Overview
This PR updates the `CreateOriginTrials` cron handler to process origin trial creation requests transactionally. This prevents potential race conditions where multiple runs of the cron job might attempt to create a trial for the same stage simultaneously.

## Root Cause / Motivation
Previously, `CreateOriginTrials` fetched stages with `OT_READY_FOR_CREATION` status and processed them without locking or transactional safety. If a run was slow or overlapping with another run, duplicate creation requests could be sent. This change introduces a transactional `_claim_stage_for_creation` method that marks the stage as `OT_CREATION_PROCESSING` immediately, ensuring only one run processes a given stage.

## Detailed Changelog
* **`internals/core_enums.py`**: Added `OT_CREATION_PROCESSING` state (value 7) to track stages currently being processed for creation.
* **`internals/maintenance_scripts.py`**:
    *   Added `_claim_stage_for_creation` method to transactionally update stage status from `OT_READY_FOR_CREATION` to `OT_CREATION_PROCESSING`.
    *   Updated `get_template_data` in `CreateOriginTrials` to use a keys-only query and fetch/claim stages one by one transactionally.
* **`internals/maintenance_scripts_test.py`**:
    *   Updated assertions in `CreateOriginTrialsTest` to reload stage entities from the datastore after calling `get_template_data`, as the handler now modifies them in a transaction.
