### PR TITLE
Cleanup: Fix typo and add basic type annotations in `chromedash-feature-detail.ts`

### DIFF
--- a/client-src/elements/chromedash-feature-detail.ts
+++ b/client-src/elements/chromedash-feature-detail.ts
@@ -221,7 +221,7 @@ export class ChromedashFeatureDetail extends LitElement {
     ];
   }
 
-  _fireEvent(eventName, detail) {
+  _fireEvent(eventName: string, detail: any) {
     const event = new CustomEvent(eventName, {
       bubbles: true,
       composed: true,
@@ -232,10 +232,10 @@ export class ChromedashFeatureDetail extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.intializeGateColumn();
+    this.initializeGateColumn();
   }
 
-  initializeExtensionDialog(rawQuery) {
+  initializeExtensionDialog(rawQuery: Record<string, string>) {
     if (!('initiateExtension' in rawQuery)) {
       return;
     }
@@ -270,7 +270,7 @@ export class ChromedashFeatureDetail extends LitElement {
     );
   }
 
-  intializeGateColumn() {
+  initializeGateColumn() {
     const rawQuery = parseRawQuery(window.location.search);
     if (!rawQuery.hasOwnProperty('gate')) {
       return;
@@ -324,7 +324,7 @@ export class ChromedashFeatureDetail extends LitElement {
     });
   }
 
-  handleAddXfnGates(feStage) {
+  handleAddXfnGates(feStage: StageDict) {
     const prompt =
       'Would you like to add gates for Privacy, Security, etc.? \n\n' +
       'This is needed if the API Owners ask you to add them, ' +
@@ -372,7 +372,7 @@ export class ChromedashFeatureDetail extends LitElement {
     `;
   }
 
-  renderText(value, isMarkdown: boolean = false): TemplateResult {
+  renderText(value: any, isMarkdown: boolean = false): TemplateResult {
     value = String(value);
     const markup: TemplateResult[] = autolink(
       value,
@@ -388,7 +388,7 @@ export class ChromedashFeatureDetail extends LitElement {
     return html`<span class="text">${markup}</span>`;
   }
 
-  renderUrl(value) {
+  renderUrl(value: string) {
     if (value.startsWith('http')) {
       return html`<chromedash-link
         href=${value}
@@ -399,7 +399,11 @@ export class ChromedashFeatureDetail extends LitElement {
     return this.renderText(value);
   }
 
-  renderValue(fieldType, value, isMarkdown: boolean): TemplateResult {
+  renderValue(
+    fieldType: string,
+    value: any,
+    isMarkdown: boolean
+  ): TemplateResult {
     if (fieldType == 'checkbox') {
       return this.renderText(value ? 'True' : 'False');
     } else if (fieldType == 'url') {
@@ -414,7 +418,7 @@ export class ChromedashFeatureDetail extends LitElement {
     return this.renderText(value, isMarkdown);
   }
 
-  renderField(fieldDef, feStage) {
+  renderField(fieldDef: any[], feStage: StageDict) {
     const [fieldId, fieldDisplayName, fieldType, deprecated, alwaysMarkdown] =
       fieldDef;
     const value = getFieldValueFromFeature(fieldId, feStage, this.feature);
@@ -439,7 +443,7 @@ export class ChromedashFeatureDetail extends LitElement {
     `;
   }
 
-  stageHasAnyFilledFields(fields, feStage) {
+  stageHasAnyFilledFields(fields: any[], feStage: StageDict) {
     return fields.some(fieldDef =>
       hasFieldValue(fieldDef[0], feStage, this.feature)
     );
@@ -447,7 +451,7 @@ export class ChromedashFeatureDetail extends LitElement {
 
   // Renders all fields for trial extension stages as a subsection of the
   // origin trial stage that the extension is associated with.
-  renderExtensionFields(extensionStages) {
+  renderExtensionFields(extensionStages: StageDict[]) {
     const extensionFields: TemplateResult[] = [];
     const fieldNames = flattenSections(FLAT_TRIAL_EXTENSION_FIELDS);
     const fields = makeDisplaySpecs(fieldNames);
@@ -467,7 +471,7 @@ export class ChromedashFeatureDetail extends LitElement {
     return extensionFields;
   }
 
-  renderSectionFields(fields, feStage) {
+  renderSectionFields(fields: any[], feStage: StageDict) {
     if (this.stageHasAnyFilledFields(fields, feStage)) {
       // Add the subsection of trial extension information if it is relevant.
       const extensionFields = feStage.extensions
@@ -484,11 +488,11 @@ export class ChromedashFeatureDetail extends LitElement {
   }
 
   renderSection(
-    summary,
-    content,
-    isActive = false,
-    defaultOpen = false,
-    isStage = true
+    summary: string,
+    content: TemplateResult,
+    isActive: boolean = false,
+    defaultOpen: boolean = false,
+    isStage: boolean = true
   ) {
     return html`
       <sl-details
@@ -503,7 +507,7 @@ export class ChromedashFeatureDetail extends LitElement {
     `;
   }
 
-  getStageForm(stageType) {
+  getStageForm(stageType: number) {
     return FORMS_BY_STAGE_TYPE[stageType] || null;
   }
 
@@ -529,7 +533,9 @@ export class ChromedashFeatureDetail extends LitElement {
 
     const content = html`
       <p class="description">${this.canEdit ? editButton : nothing}</p>
-      <section class="card">${this.renderSectionFields(fields, {})}</section>
+      <section class="card">
+        ${this.renderSectionFields(fields, {} as any)}
+      </section>
     `;
     return this.renderSection(
       'Metadata',
@@ -540,7 +546,7 @@ export class ChromedashFeatureDetail extends LitElement {
     );
   }
 
-  renderGateChip(feStage, gate) {
+  renderGateChip(feStage: StageDict, gate: GateDict) {
     return html`
       <chromedash-gate-chip
         .feature=${this.feature}
@@ -552,12 +558,12 @@ export class ChromedashFeatureDetail extends LitElement {
     `;
   }
 
-  hasActiveGates(feStage) {
+  hasActiveGates(feStage: StageDict) {
     const gatesForStage = this.gates.filter(g => g.stage_id == feStage.id);
     return gatesForStage.some(g => GATE_ACTIVE_REVIEW_STATES.includes(g.state));
   }
 
-  hasMixedGates(feStage) {
+  hasMixedGates(feStage: StageDict) {
     const gatesForStage = this.gates.filter(g => g.stage_id == feStage.id);
     return (
       gatesForStage.some(g => GATE_FINISHED_REVIEW_STATES.includes(g.state)) &&
@@ -565,7 +571,7 @@ export class ChromedashFeatureDetail extends LitElement {
     );
   }
 
-  renderGateChips(feStage) {
+  renderGateChips(feStage: StageDict) {
     const gatesForStage = this.gates.filter(g => {
       // Don't show API owner gate chips for shipping stages in PSA features.
       // TODO(DanielRyanSmith): This conditional can be removed once PSA
@@ -588,7 +594,7 @@ export class ChromedashFeatureDetail extends LitElement {
     return gatesForStage.map(g => this.renderGateChip(feStage, g));
   }
 
-  hasStageActions(stage, feStage) {
+  hasStageActions(stage: any, feStage: StageDict) {
     // TODO(DanielRyanSmith): This can be removed once PSA ship stages have
     // their API owners gate removed.
     if (
@@ -611,7 +617,7 @@ export class ChromedashFeatureDetail extends LitElement {
     return false;
   }
 
-  renderStageAction(action, stage, feStage) {
+  renderStageAction(action: any, stage: any, feStage: StageDict) {
     const label = action.name;
     const url = action.url
       .replace('{feature_id}', this.feature.id)
@@ -648,7 +654,7 @@ export class ChromedashFeatureDetail extends LitElement {
     `;
   }
 
-  renderStageActions(stage, feStage) {
+  renderStageActions(stage: any, feStage: StageDict) {
     if (!this.canEdit) {
       return nothing;
     }
@@ -657,7 +663,7 @@ export class ChromedashFeatureDetail extends LitElement {
     `;
   }
 
-  renderProcessStage(feStage) {
+  renderProcessStage(feStage: StageDict) {
     const stageForm = this.getStageForm(feStage.stage_type);
     const fieldNames = stageForm === null ? [] : flattenSections(stageForm);
     if (fieldNames === undefined || fieldNames.length == 0) return nothing;
@@ -722,7 +728,7 @@ export class ChromedashFeatureDetail extends LitElement {
     return this.renderSection(name, content, isActive, defaultOpen);
   }
 
-  renderEditButton(feStage, processStage) {
+  renderEditButton(feStage: StageDict, processStage: any) {
     if (!this.canEdit) {
       return nothing;
     }
@@ -734,7 +740,7 @@ export class ChromedashFeatureDetail extends LitElement {
     >`;
   }
 
-  renderFinalizeExtensionButton(extensionStage) {
+  renderFinalizeExtensionButton(extensionStage: StageDict) {
     return html` <sl-button
       size="small"
       variant="primary"
@@ -758,7 +764,7 @@ export class ChromedashFeatureDetail extends LitElement {
     </sl-tooltip>`;
   }
 
-  renderExtensionButton(feStage) {
+  renderExtensionButton(feStage: StageDict) {
     // Don't render an extension request button if this is not an OT stage,
     // or the user does not have access to submit an extension request,
     // or the OT stage has not been created in the OT Console yet.
@@ -815,7 +821,7 @@ export class ChromedashFeatureDetail extends LitElement {
     >`;
   }
 
-  renderOriginTrialButton(feStage) {
+  renderOriginTrialButton(feStage: StageDict) {
     // Don't render an origin trial button if this is not an OT stage.
     if (!STAGE_TYPES_ORIGIN_TRIAL.has(feStage.stage_type)) {
       return nothing;
@@ -884,7 +890,7 @@ export class ChromedashFeatureDetail extends LitElement {
     >`;
   }
 
-  renderRegistrantsDashboardButton(feStage) {
+  renderRegistrantsDashboardButton(feStage: StageDict) {
     // Registrants dashboard button is available on created OT stages,
     // only to Google/Chromium users with edit access to the feature.
     if (
@@ -911,7 +917,7 @@ export class ChromedashFeatureDetail extends LitElement {
     >`;
   }
 
-  offerAddXfnGates(feStage) {
+  offerAddXfnGates(feStage: StageDict) {
     const stageGates = this.gates.filter(g => g.stage_id == feStage.id);
     return feStage.stage_type == STAGE_PSA_SHIPPING && stageGates.length < 6;
   }
@@ -932,7 +938,7 @@ export class ChromedashFeatureDetail extends LitElement {
     `;
   }
 
-  renderStageMenu(feStage) {
+  renderStageMenu(feStage: StageDict) {
     const items: TemplateResult[] = [];
     if (this.offerAddXfnGates(feStage)) {
       items.push(html`

--- a/client-src/elements/chromedash-feature-detail_test.ts
+++ b/client-src/elements/chromedash-feature-detail_test.ts
@@ -24,11 +24,11 @@ import {
 } from './form-field-enums.js';
 
 describe('chromedash-feature-detail', () => {
-  const stageNoGates = {id: 1};
-  const stagePreparing = {id: 2};
-  const stageActive = {id: 3};
-  const stageMixed = {id: 4};
-  const stageResolved = {id: 5};
+  const stageNoGates = {id: 1} as any;
+  const stagePreparing = {id: 2} as any;
+  const stageActive = {id: 3} as any;
+  const stageMixed = {id: 4} as any;
+  const stageResolved = {id: 5} as any;
 
   const gates = [
     {stage_id: stagePreparing.id, state: GATE_PREPARING},


### PR DESCRIPTION
## Overview
This PR fixes a typo in a method name and adds basic TypeScript type annotations to `client-src/elements/chromedash-feature-detail.ts` to improve code quality and maintainability.

## Root Cause / Motivation
The file lacked explicit type annotations for many method parameters, leading to implicit `any` types and reducing the benefits of TypeScript. Additionally, a method was named `intializeGateColumn` instead of `initializeGateColumn`.

## Detailed Changelog
* **`client-src/elements/chromedash-feature-detail.ts`**:
    * Renamed `intializeGateColumn` to `initializeGateColumn` and updated its call site.
    * Added type annotations to parameters in various methods (e.g., `_fireEvent`, `renderText`, `renderUrl`, `renderProcessStage`).
    * Cast an empty object to `any` in `renderMetadataSection` to satisfy strict type checks.
* **`client-src/elements/chromedash-feature-detail_test.ts`**:
    * Cast mock stage objects to `any` to satisfy type checks in tests.
