### PR TITLE
Convert `metric.js` and `shared.js` to TypeScript

### DIFF
--- a/client-src/js-src/metric.ts
+++ b/client-src/js-src/metric.ts
@@ -14,13 +14,23 @@
  * limitations under the License.
  */
 
+declare global {
+  interface Window {
+    ga: (...args: unknown[]) => void;
+  }
+}
+
 export class Metric {
-  static get supportsPerfNow() {
-    return performance && performance.now;
+  name: string;
+  private _start?: number;
+  private _end?: number;
+
+  static get supportsPerfNow(): boolean {
+    return !!(performance && performance.now);
   }
 
-  static get supportsPerfMark() {
-    return performance && performance.mark;
+  static get supportsPerfMark(): boolean {
+    return !!(performance && performance.mark);
   }
 
   /**
@@ -28,8 +38,11 @@ export class Metric {
    * measurement made.
    * @readonly
    */
-  get duration() {
-    let duration = this._end - this._start;
+  get duration(): number {
+    let duration = -1;
+    if (this._start !== undefined && this._end !== undefined) {
+      duration = this._end - this._start;
+    }
 
     // Use User Timing API results if available, otherwise return
     // performance.now() fallback.
@@ -42,10 +55,10 @@ export class Metric {
       }
     }
 
-    return duration || -1;
+    return duration >= 0 ? duration : -1;
   }
 
-  constructor(name) {
+  constructor(name: string) {
     if (!name) {
       throw Error('Please provide a metric name');
     }
@@ -65,7 +78,7 @@ export class Metric {
    * Prints the metric's duration to the console.
    * @return {Metric} instance of this object.
    */
-  log() {
+  log(): Metric {
     console.info(this.name, this.duration, 'ms');
     return this;
   }
@@ -76,7 +89,7 @@ export class Metric {
    * @param {string=} name If provided, prints the stats of another metric.
    * @return {Metric} instance of this object.
    */
-  logAll(name = this.name) {
+  logAll(name = this.name): Metric {
     // Use User Timing API results if available, otherwise return
     // performance.now() fallback.
     if (Metric.supportsPerfNow) {
@@ -93,7 +106,7 @@ export class Metric {
    * Call to begin a measurement.
    * @return {Metric} instance of this object.
    */
-  start() {
+  start(): Metric {
     if (this._start) {
       console.warn('Recording already started.');
       return this;
@@ -113,7 +126,7 @@ export class Metric {
    * Call to end a measurement.
    * @return {Metric} instance of this object.
    */
-  end() {
+  end(): Metric {
     if (this._end) {
       console.warn('Recording already stopped.');
       return this;
@@ -142,11 +155,15 @@ export class Metric {
    *     optionally specify another value.
    * @return {Metric} instance of this object.
    */
-  sendToAnalytics(category, metric = this.name, duration = this.duration) {
+  sendToAnalytics(
+    category: string,
+    metric = this.name,
+    duration = this.duration
+  ): Metric {
     if (!window.ga) {
       console.warn('Google Analytics has not been loaded');
     } else if (duration >= 0) {
-      ga('send', 'timing', category, metric, duration);
+      window.ga('send', 'timing', category, metric, duration);
     }
     return this;
   }

--- a/client-src/js-src/shared.ts
+++ b/client-src/js-src/shared.ts
@@ -16,11 +16,17 @@
 
 'use strict';
 
+declare global {
+  interface Window {
+    dataLayer: unknown[];
+  }
+}
+
 // Google Analytics
 // Global site tag (gtag.js) - Google Analytics
 window.dataLayer = window.dataLayer || [];
-function gtag() {
-  dataLayer.push(arguments);
+function gtag(...args: unknown[]) {
+  window.dataLayer.push(args);
 }
 gtag('js', new Date());
 


### PR DESCRIPTION
## Overview
Converts `client-src/js-src/metric.js` and `client-src/js-src/shared.js` to TypeScript, adding types and resolving lint errors.

## Root Cause / Motivation
These files were plain JavaScript files. Converting them to TypeScript improves type safety and maintainability in the frontend code.

## Detailed Changelog
* **`client-src/js-src/metric.ts`**:
    *   Renamed from `metric.js`.
    *   Added type annotations to properties and methods.
    *   Extended `Window` interface to include `ga` to fix TypeScript error.
    *   **Behavior change**: `duration` getter now returns `0` instead of `-1` if calculated duration is exactly `0` (fixing what was likely a bug in the original code where `0 || -1` evaluated to `-1`).
* **`client-src/js-src/shared.ts`**:
    *   Renamed from `shared.js`.
    *   Extended `Window` interface to include `dataLayer`.
    *   **Potential behavior change**: Changed `gtag` to use rest parameters `...args: unknown[]` and push the array to `dataLayer`, instead of pushing the `arguments` object.
