### PR TITLE
Frontend logic cleanups and duplicate test removal

### DIFF
--- a/client-src/elements/chromedash-bulk-edit-page.ts
+++ b/client-src/elements/chromedash-bulk-edit-page.ts
@@ -77,10 +77,8 @@ export class ChromedashBulkEditPage extends LitElement {
     if (match) {
       return Number(match.groups?.id);
     }
-    try {
-      return Number(url);
-    } catch {}
-    return 0;
+    const num = Number(url);
+    return isNaN(num) ? 0 : num;
   }
 
   isFeatureIdHeader(header: string, index: number) {

--- a/client-src/elements/chromedash-link_test.ts
+++ b/client-src/elements/chromedash-link_test.ts
@@ -99,51 +99,6 @@ it('shows content as label when requested', async () => {
   );
 });
 
-it('shows content as label when requested', async () => {
-  const yesterday = new Date(Date.now() - DAY);
-  const featureLinks = [
-    {
-      url: 'https://github.com/GoogleChrome/chromium-dashboard/issues/3007',
-      type: 'github_issue',
-      information: {
-        url: 'https://api.github.com/repos/GoogleChrome/chromium-dashboard/issues/3007',
-        state: 'open',
-        created_at: yesterday.toISOString(),
-      },
-    },
-  ];
-
-  const elWithLabel = await fixture(
-    html`<chromedash-link
-      showContentAsLabel
-      href="https://github.com/GoogleChrome/chromium-dashboard/issues/3007"
-      .featureLinks=${featureLinks}
-      >Content</chromedash-link
-    >`
-  );
-  expect(elWithLabel).shadowDom.to.equal(
-    `<slot>...</slot>:
-     <a href="https://github.com/GoogleChrome/chromium-dashboard/issues/3007"
-        rel="noopener noreferrer"
-        target="_blank">...</a>`,
-    {ignoreChildren: ['slot', 'a']}
-  );
-
-  const elWithoutLabel = await fixture(
-    html`<chromedash-link
-      href="https://github.com/GoogleChrome/chromium-dashboard/issues/3007"
-      .featureLinks=${featureLinks}
-      >Content</chromedash-link
-    >`
-  );
-  expect(elWithoutLabel).shadowDom.to.equal(
-    `<a href="https://github.com/GoogleChrome/chromium-dashboard/issues/3007"
-        rel="noopener noreferrer"
-        target="_blank">...</a>`,
-    {ignoreChildren: ['slot', 'a']}
-  );
-});
-
 describe('Github issue links', () => {
   // Get the 'information' object by running
   // `curl -L https://api.github.com/repos/OWNER/REPO/issues/ISSUE_NUMBER`

--- a/client-src/elements/form-definition.ts
+++ b/client-src/elements/form-definition.ts
@@ -151,12 +151,12 @@ export function formatFeatureForEdit(feature: Feature): FormattedFeature {
     other_views_notes: feature.browsers.other.view?.notes,
   };
 
-  COMMA_SEPARATED_FIELDS.map(field => {
+  COMMA_SEPARATED_FIELDS.forEach(field => {
     if (formattedFeature[field])
       formattedFeature[field] = formattedFeature[field].join(', ');
   });
 
-  LINE_SEPARATED_FIELDS.map(field => {
+  LINE_SEPARATED_FIELDS.forEach(field => {
     if (formattedFeature[field])
       formattedFeature[field] = formattedFeature[field].join('\r\n');
   });


### PR DESCRIPTION
## Overview
This PR addresses several code health issues in the frontend, including removing a duplicate test block, fixing an ineffective try-catch, and using `forEach` instead of `map` for side effects.

## Root Cause / Motivation
These are minor cleanups to improve code quality, remove redundant code, and fix a logical flaw in CSV parsing fallback.

## Detailed Changelog
* **`client-src/elements/chromedash-link_test.ts`**: Removed a duplicate test block for "shows content as label when requested" (Lines 102-145).
* **`client-src/elements/chromedash-bulk-edit-page.ts`**: Fixed `parseChromestatusIdFromURL` to use `isNaN` instead of an ineffective try-catch block.
* **`client-src/elements/form-definition.ts`**: Changed `map` to `forEach` for iterations that only perform side effects.
