### PR TITLE
Backend performance and scalability improvements

### DIFF
--- a/api/feature_latency_api.py
+++ b/api/feature_latency_api.py
@@ -23,6 +23,7 @@ from chromestatus_openapi.models.feature_link import FeatureLink
 
 from api import channels_api
 from framework import basehandlers, permissions
+from framework.utils import chunk_list
 from internals import core_enums, stage_helpers
 from internals.core_models import FeatureEntry, Stage
 
@@ -112,20 +113,22 @@ class FeatureLatencyAPI(basehandlers.APIHandler):
         logging.info('feature_ids %r', feature_ids)
         if not feature_ids:
             return {}
-        stage_query = Stage.query()
-        stage_query = stage_query.filter(Stage.feature_id.IN(feature_ids))
-        stage_query = stage_query.filter(
-            Stage.stage_type.IN(
-                [
-                    core_enums.STAGE_BLINK_SHIPPING,
-                    core_enums.STAGE_PSA_SHIPPING,
-                    core_enums.STAGE_FAST_SHIPPING,
-                    core_enums.STAGE_DEP_SHIPPING,
-                    core_enums.STAGE_ENT_ROLLOUT,
-                ]
+        stages = []
+        for chunk in chunk_list(list(feature_ids), 30):
+            stage_query = Stage.query()
+            stage_query = stage_query.filter(Stage.feature_id.IN(chunk))
+            stage_query = stage_query.filter(
+                Stage.stage_type.IN(
+                    [
+                        core_enums.STAGE_BLINK_SHIPPING,
+                        core_enums.STAGE_PSA_SHIPPING,
+                        core_enums.STAGE_FAST_SHIPPING,
+                        core_enums.STAGE_DEP_SHIPPING,
+                        core_enums.STAGE_ENT_ROLLOUT,
+                    ]
+                )
             )
-        )
-        stages = stage_query.fetch(None)
+            stages.extend(stage_query.fetch(None))
         stages = [s for s in stages if not s.archived]
         if not stages:
             return {}

--- a/api/feature_latency_api.py
+++ b/api/feature_latency_api.py
@@ -113,7 +113,7 @@ class FeatureLatencyAPI(basehandlers.APIHandler):
         logging.info('feature_ids %r', feature_ids)
         if not feature_ids:
             return {}
-        stages = []
+        futures = []
         for chunk in chunk_list(list(feature_ids), 30):
             stage_query = Stage.query()
             stage_query = stage_query.filter(Stage.feature_id.IN(chunk))
@@ -128,7 +128,11 @@ class FeatureLatencyAPI(basehandlers.APIHandler):
                     ]
                 )
             )
-            stages.extend(stage_query.fetch(None))
+            futures.append(stage_query.fetch_async(None))
+
+        stages = []
+        for f in futures:
+            stages.extend(f.get_result())
         stages = [s for s in stages if not s.archived]
         if not stages:
             return {}

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -250,18 +250,23 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
         # Obtain a list of stages and gates for the given feature type.
         stages_gates = core_enums.STAGES_AND_GATES_BY_FEATURE_TYPE[feature_type]
 
-        for stage_type, gate_types in stages_gates:
-            # Don't create a trial extension stage pre-emptively.
-            if (
-                stage_type
-                == core_enums.STAGE_TYPES_EXTEND_ORIGIN_TRIAL[feature_type]
-            ):
-                continue
+        # Filter out trial extension stages.
+        filtered_stages_gates = [
+            (st, gt)
+            for st, gt in stages_gates
+            if st != core_enums.STAGE_TYPES_EXTEND_ORIGIN_TRIAL[feature_type]
+        ]
 
-            stage = Stage(feature_id=feature_id, stage_type=stage_type)
-            stage.put()
-            new_gates: list[Gate] = []
-            # Stages can have zero or more gates.
+        # Create and put all stages in bulk to avoid N+1 puts.
+        stages = [
+            Stage(feature_id=feature_id, stage_type=st)
+            for st, _ in filtered_stages_gates
+        ]
+        ndb.put_multi(stages)
+
+        new_gates: list[Gate] = []
+        # Create gates referencing the saved stages.
+        for stage, (_, gate_types) in zip(stages, filtered_stages_gates):
             for gate_type in gate_types:
                 gate = Gate(
                     feature_id=feature_id,
@@ -271,8 +276,8 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
                 )
                 new_gates.append(gate)
 
-            if new_gates:
-                ndb.put_multi(new_gates)
+        if new_gates:
+            ndb.put_multi(new_gates)
 
     def _patch_update_stages(
         self,

--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -297,9 +297,13 @@ class PendingGatesAPI(basehandlers.APIHandler):
             return GetGateResponse.from_dict({'gates': []}).to_dict()
 
         # 2. Fetch all the gates on those stages.
-        gates: list[Gate] = []
+        futures = []
         for chunk in chunk_list(list(stage_ids), 30):
-            gates.extend(Gate.query(Gate.stage_id.IN(chunk)).fetch())
+            futures.append(Gate.query(Gate.stage_id.IN(chunk)).fetch_async())
+
+        gates: list[Gate] = []
+        for f in futures:
+            gates.extend(f.get_result())
 
         # 3. Convert to dicts and add possible assignees.
         dicts = [converters.gate_value_to_json_dict(g) for g in gates]

--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -32,6 +32,7 @@ from google.cloud.ndb.tasklets import Future  # for type checking only
 from api import converters
 from framework import basehandlers, permissions
 from framework.users import User
+from framework.utils import chunk_list
 from internals import approval_defs, core_enums, notifier_helpers, self_certify
 from internals.core_models import FeatureEntry, Stage
 from internals.review_models import Activity, Amendment, Gate, Vote
@@ -296,7 +297,9 @@ class PendingGatesAPI(basehandlers.APIHandler):
             return GetGateResponse.from_dict({'gates': []}).to_dict()
 
         # 2. Fetch all the gates on those stages.
-        gates: list[Gate] = Gate.query(Gate.stage_id.IN(stage_ids)).fetch()
+        gates: list[Gate] = []
+        for chunk in chunk_list(list(stage_ids), 30):
+            gates.extend(Gate.query(Gate.stage_id.IN(chunk)).fetch())
 
         # 3. Convert to dicts and add possible assignees.
         dicts = [converters.gate_value_to_json_dict(g) for g in gates]

--- a/framework/utils.py
+++ b/framework/utils.py
@@ -202,6 +202,12 @@ def dedupe(list_with_duplicates):
     return list(dict.fromkeys(list_with_duplicates))
 
 
+def chunk_list(lst, n):
+    """Yield successive n-sized chunks from lst."""
+    for i in range(0, len(lst), n):
+        yield lst[i : i + n]
+
+
 def get_chromium_milestone_info(milestone: int) -> dict:
     """Fetches the Chromium milestone schedule info for a given milestone."""
     if settings.UNIT_TEST_MODE or settings.PLAYWRIGHT_MODE:

--- a/internals/ot_process_reminders.py
+++ b/internals/ot_process_reminders.py
@@ -22,6 +22,7 @@ from typing import Any
 import requests
 
 from framework import cloud_tasks_helpers, origin_trials_client
+from framework.utils import chunk_list
 from internals.core_models import Stage
 
 RELEASE_DATA_URL = (
@@ -34,14 +35,14 @@ release_cache: dict[str | int, dict[str, str]] = {}
 trials = None
 
 
-def build_trial_data(trial_data: dict[str, Any]) -> dict[str, Any] | None:
+def build_trial_data(
+    trial_data: dict[str, Any], stage_map: dict[str, Stage]
+) -> dict[str, Any] | None:
     """Find corresponding OT stage and assemble necessary info for reminders."""
     logging.info(f'Building trial data for {trial_data.get("id")}')
-    trial_stage: Stage | None = Stage.query(
-        Stage.origin_trial_id == trial_data['id']
-    ).get()
+    trial_stage = stage_map.get(trial_data['id'])
     if trial_stage is None:
-        logging.exception(f'No stage found for trial {trial_data["id"]}')
+        logging.warning(f'No stage found for trial {trial_data["id"]}')
         return None
     contact_list = trial_stage.ot_emails.copy()
     contact_list.append(trial_stage.ot_owner_email)
@@ -76,24 +77,38 @@ def get_trials(
     starting_trials = []
     ending_trials = []
 
+    # First pass: identify matching trials and collect IDs
+    matching_trials = []
+    matching_trial_ids = []
     for trial in trials_list:
+        start_milestone = int(trial['start_milestone'])
+        end_milestone = int(trial['end_milestone'])
+        if start_milestone == release or end_milestone == release:
+            matching_trials.append(trial)
+            matching_trial_ids.append(trial['id'])
+
+    # Bulk fetch stages
+    stages = []
+    for chunk in chunk_list(matching_trial_ids, 30):
+        stages.extend(Stage.query(Stage.origin_trial_id.IN(chunk)).fetch())
+    stage_map = {s.origin_trial_id: s for s in stages}
+
+    for trial in matching_trials:
         start_milestone = int(trial['start_milestone'])
         end_milestone = int(trial['end_milestone'])
 
         matches_start = start_milestone == release
         matches_end = end_milestone == release
-        trial_info = None
 
-        if matches_start or matches_end:
-            trial_info = build_trial_data(trial)
-            if not trial_info:
-                continue
+        trial_info = build_trial_data(trial, stage_map)
+        if not trial_info:
+            continue
 
-            if matches_start:
-                starting_trials.append(trial_info)
+        if matches_start:
+            starting_trials.append(trial_info)
 
-            if matches_end:
-                ending_trials.append(trial_info)
+        if matches_end:
+            ending_trials.append(trial_info)
 
     return starting_trials, ending_trials
 

--- a/internals/ot_process_reminders.py
+++ b/internals/ot_process_reminders.py
@@ -88,9 +88,15 @@ def get_trials(
             matching_trial_ids.append(trial['id'])
 
     # Bulk fetch stages
-    stages = []
+    futures = []
     for chunk in chunk_list(matching_trial_ids, 30):
-        stages.extend(Stage.query(Stage.origin_trial_id.IN(chunk)).fetch())
+        futures.append(
+            Stage.query(Stage.origin_trial_id.IN(chunk)).fetch_async()
+        )
+
+    stages = []
+    for f in futures:
+        stages.extend(f.get_result())
     stage_map = {s.origin_trial_id: s for s in stages}
 
     for trial in matching_trials:

--- a/internals/ot_process_reminders_test.py
+++ b/internals/ot_process_reminders_test.py
@@ -150,14 +150,18 @@ class OTProcessRemindersTest(testing_config.CustomTestCase):
                 ],
             },
         ]
+        stage_map = {
+            self.stage_1.origin_trial_id: self.stage_1,
+            self.stage_2.origin_trial_id: self.stage_2,
+        }
         formatted_1 = ot_process_reminders.build_trial_data(
-            self.mock_get_trials_list_return_value[0]
+            self.mock_get_trials_list_return_value[0], stage_map
         )
         formatted_2 = ot_process_reminders.build_trial_data(
-            self.mock_get_trials_list_return_value[1]
+            self.mock_get_trials_list_return_value[1], stage_map
         )
         formatted_3 = ot_process_reminders.build_trial_data(
-            self.mock_get_trials_list_return_value[2]
+            self.mock_get_trials_list_return_value[2], stage_map
         )
         # 3rd trial does not have associated stage, so should return as None.
         self.assertIsNone(formatted_3)

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -24,7 +24,7 @@ from google.cloud import ndb  # type: ignore
 
 import settings
 from framework import basehandlers
-from framework.utils import get_current_milestone_info
+from framework.utils import chunk_list, get_current_milestone_info
 from internals import (
     approval_defs,
     core_enums,
@@ -33,7 +33,7 @@ from internals import (
     slo,
     stage_helpers,
 )
-from internals.core_models import FeatureEntry, MilestoneSet
+from internals.core_models import FeatureEntry, MilestoneSet, Stage
 from internals.review_models import Gate
 from internals.user_models import UserPref
 
@@ -204,14 +204,25 @@ class AbstractReminderHandler(basehandlers.FlaskHandler):
         min_mstone = int(current_milestone_info['mstone'])
         max_mstone = min_mstone + self.FUTURE_MILESTONES_TO_CONSIDER
 
+        feature_ids = [f.key.integer_id() for f in features]
+        stages = []
+        for chunk in chunk_list(feature_ids, 30):
+            stages.extend(Stage.query(Stage.feature_id.IN(chunk)).fetch())
+
+        stages_by_fid: defaultdict[int, defaultdict[int, list[Stage]]] = (
+            defaultdict(lambda: defaultdict(list))
+        )
+        for s in stages:
+            stages_by_fid[s.feature_id][s.stage_type].append(s)
+
         result = []
         for feature in features:
-            stages = stage_helpers.get_feature_stages(feature.key.integer_id())
+            feature_stages = stages_by_fid[feature.key.integer_id()]
             min_milestone = None
             for field in self.MILESTONE_FIELDS:
                 # Get fields that are relevant to the milestones field specified
                 # (e.g. 'shipped_milestone' implies shipping stages)
-                relevant_stages = stages.get(
+                relevant_stages = feature_stages.get(
                     core_enums.STAGE_TYPES_BY_FIELD_MAPPING[field][
                         feature.feature_type
                     ]
@@ -486,10 +497,11 @@ class SLOOverdueHandler(basehandlers.FlaskHandler):
                 long_overdue_resolve.append(g)
                 relevant_feature_ids.add(g.feature_id)
 
-        relevant_features = {
-            fe_id: FeatureEntry.get_by_id(fe_id)
-            for fe_id in relevant_feature_ids
-        }
+        feature_keys = [
+            ndb.Key(FeatureEntry, fe_id) for fe_id in relevant_feature_ids
+        ]
+        features = ndb.get_multi(feature_keys)
+        relevant_features = {fe.key.integer_id(): fe for fe in features if fe}
         return (
             newly_overdue_initial_response,
             long_overdue_initial_response,

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -205,9 +205,15 @@ class AbstractReminderHandler(basehandlers.FlaskHandler):
         max_mstone = min_mstone + self.FUTURE_MILESTONES_TO_CONSIDER
 
         feature_ids = [f.key.integer_id() for f in features]
-        stages = []
+        futures = []
         for chunk in chunk_list(feature_ids, 30):
-            stages.extend(Stage.query(Stage.feature_id.IN(chunk)).fetch())
+            futures.append(
+                Stage.query(Stage.feature_id.IN(chunk)).fetch_async()
+            )
+
+        stages = []
+        for f in futures:
+            stages.extend(f.get_result())
 
         stages_by_fid: defaultdict[int, defaultdict[int, list[Stage]]] = (
             defaultdict(lambda: defaultdict(list))

--- a/internals/search.py
+++ b/internals/search.py
@@ -756,13 +756,6 @@ def process_and_operations(feature_id_future_ops):
 
 def fetch_all_feature_ids_set():
     """Fetch all FeatureEntry ids."""
-    feature_ids_set = set()
-    cursor = None
-    while True:
-        keys, cursor, more = FeatureEntry.query().fetch_page(
-            1000, keys_only=True, start_cursor=cursor
-        )
-        feature_ids_set.update(key.integer_id() for key in keys)
-        if not more or not cursor:
-            break
+    all_feature_keys = FeatureEntry.query().fetch(keys_only=True)
+    feature_ids_set = set(key.integer_id() for key in all_feature_keys)
     return feature_ids_set

--- a/internals/search.py
+++ b/internals/search.py
@@ -756,6 +756,13 @@ def process_and_operations(feature_id_future_ops):
 
 def fetch_all_feature_ids_set():
     """Fetch all FeatureEntry ids."""
-    all_feature_keys = FeatureEntry.query().fetch(keys_only=True)
-    feature_ids_set = set(key.integer_id() for key in all_feature_keys)
+    feature_ids_set = set()
+    cursor = None
+    while True:
+        keys, cursor, more = FeatureEntry.query().fetch_page(
+            1000, keys_only=True, start_cursor=cursor
+        )
+        feature_ids_set.update(key.integer_id() for key in keys)
+        if not more or not cursor:
+            break
     return feature_ids_set

--- a/internals/search_fulltext.py
+++ b/internals/search_fulltext.py
@@ -229,13 +229,38 @@ class ReindexAllFeatures(FlaskHandler):
         """Updates the fulltext index for all features."""
         self.require_cron_header()
 
-        all_feature_entries = FeatureEntry.query().fetch()
-        all_feature_words = FeatureWords.query().fetch()
-        updated_fw_list = batch_index_features(
-            all_feature_entries, all_feature_words
-        )
-        ndb.put_multi(updated_fw_list)
-        msg = f'Added or updated {len(updated_fw_list)} FeatureWords'
+        from framework.utils import chunk_list
+
+        count = 0
+        cursor = None
+        while True:
+            feature_entries, cursor, more = FeatureEntry.query().fetch_page(
+                100, start_cursor=cursor
+            )
+            if not feature_entries:
+                break
+
+            feature_ids = [fe.key.integer_id() for fe in feature_entries]
+
+            # Fetch existing FeatureWords for these features, respecting IN limit.
+            existing_fw_list = []
+            for chunk in chunk_list(feature_ids, 30):
+                existing_fw_list.extend(
+                    FeatureWords.query(
+                        FeatureWords.feature_id.IN(chunk)
+                    ).fetch()
+                )
+
+            updated_fw_list = batch_index_features(
+                feature_entries, existing_fw_list
+            )
+            ndb.put_multi(updated_fw_list)
+            count += len(updated_fw_list)
+
+            if not more or not cursor:
+                break
+
+        msg = f'Added or updated {count} FeatureWords'
         logging.info(msg)
         return msg
 

--- a/internals/search_fulltext.py
+++ b/internals/search_fulltext.py
@@ -243,13 +243,17 @@ class ReindexAllFeatures(FlaskHandler):
             feature_ids = [fe.key.integer_id() for fe in feature_entries]
 
             # Fetch existing FeatureWords for these features, respecting IN limit.
-            existing_fw_list = []
+            futures = []
             for chunk in chunk_list(feature_ids, 30):
-                existing_fw_list.extend(
+                futures.append(
                     FeatureWords.query(
                         FeatureWords.feature_id.IN(chunk)
-                    ).fetch()
+                    ).fetch_async()
                 )
+
+            existing_fw_list = []
+            for f in futures:
+                existing_fw_list.extend(f.get_result())
 
             updated_fw_list = batch_index_features(
                 feature_entries, existing_fw_list

--- a/internals/user_models.py
+++ b/internals/user_models.py
@@ -96,9 +96,9 @@ class UserPref(ndb.Model):
             new_prefs = [
                 UserPref(email=e) for e in chunk_emails if e not in found_set
             ]
-            for np in new_prefs:
-                np.put()
-                result.append(np)
+            if new_prefs:
+                ndb.put_multi(new_prefs)
+                result.extend(new_prefs)
 
         return result
 


### PR DESCRIPTION
## Overview
This PR addresses several performance bottlenecks and scalability risks in the backend. It fixes N+1 queries, adds batch operations, respects NDB query limits, and optimizes chunked NDB queries by utilizing asynchronous fetches to reduce sequential network latency.

## Root Cause / Motivation
The codebase had several patterns that would not scale well with a large number of features or users, such as queries inside loops and fetching all entities at once.

## Detailed Changelog
* **`framework/utils.py`**: Added `chunk_list` utility function.
* **`api/features_api.py`**: Batched `stage.put()` calls in `_write_stages_and_gates_for_feature`.
* **`api/feature_latency_api.py`**: Used `chunk_list` to avoid NDB `IN` query limit for `feature_ids`, and optimized with `fetch_async()` for concurrent execution.
* **`api/reviews_api.py`**: Used `chunk_list` to avoid NDB `IN` query limit for `stage_ids`, and optimized with `fetch_async()` for concurrent execution.
* **`internals/ot_process_reminders.py`**: Fixed N+1 query in `get_trials` by bulk fetching stages, and optimized chunked queries with `fetch_async()`.
* **`internals/reminders.py`**: Fixed N+1 query in `filter_by_milestones`, optimized chunked queries with `fetch_async()`, and used `get_multi` in `get_overdue_gates_and_features`. Added `Stage` import.
* **`internals/user_models.py`**: Batched `UserPref` puts in `get_prefs_for_emails`.
* **`internals/search_fulltext.py`**: Used pagination and cursors in `ReindexAllFeatures` to avoid memory issues, and optimized with `fetch_async()` for chunked queries.
* **`internals/ot_process_reminders_test.py`**: Updated test to pass `stage_map` to `build_trial_data`.