### PR TITLE
Fix web test warnings related to Lit lifecycle and layout

### DIFF
--- a/client-src/elements/chromedash-form-field.ts
+++ b/client-src/elements/chromedash-form-field.ts
@@ -15,7 +15,14 @@
  */
 
 import {SlDetails, SlIconButton, SlInput} from '@shoelace-style/shoelace';
-import {LitElement, TemplateResult, css, html, nothing} from 'lit';
+import {
+  LitElement,
+  TemplateResult,
+  css,
+  html,
+  nothing,
+  PropertyValues,
+} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {ref} from 'lit/directives/ref.js';
 
@@ -192,8 +199,14 @@ export class ChromedashFormField extends LitElement {
       });
   }
 
+  willUpdate(changedProperties: PropertyValues) {
+    super.willUpdate(changedProperties);
+    if (!this.hasUpdated) {
+      this.initialValue = JSON.parse(JSON.stringify(this.value));
+    }
+  }
+
   firstUpdated() {
-    this.initialValue = JSON.parse(JSON.stringify(this.value));
     // We need to wait until the entire page is rendered, so later dependents
     // are available to do the semantic check.
     if (document.readyState === 'loading') {
@@ -201,7 +214,7 @@ export class ChromedashFormField extends LitElement {
         this.doSemanticCheck();
       });
     } else {
-      this.doSemanticCheck();
+      setTimeout(() => this.doSemanticCheck(), 0);
     }
   }
 

--- a/client-src/elements/chromedash-roadmap-page.ts
+++ b/client-src/elements/chromedash-roadmap-page.ts
@@ -77,11 +77,14 @@ export class ChromedashRoadmapPage extends LitElement {
   }
 
   firstUpdated() {
-    this.handleResize();
+    requestAnimationFrame(() => {
+      this.handleResize();
+    });
   }
 
   handleResize() {
-    const containerWidth = this.sectionRef.value!.offsetWidth;
+    if (!this.sectionRef.value) return;
+    const containerWidth = this.sectionRef.value.offsetWidth;
     const margin = 16;
 
     let numColumns = 3;

--- a/client-src/elements/chromedash-roadmap.ts
+++ b/client-src/elements/chromedash-roadmap.ts
@@ -198,8 +198,11 @@ export class ChromedashRoadmap extends LitElement {
 
       this.fetchNextBatch(channels['beta'].version, true);
       this.fetchPreviousBatch(channels['stable'].version);
-      this.lastMilestoneVisible =
-        channels[this.shownChannelNames[this.numColumns - 1]].version;
+      const colIndex = this.numColumns > 0 ? this.numColumns - 1 : 0;
+      const channelName = this.shownChannelNames[colIndex];
+      if (channelName && channels[channelName]) {
+        this.lastMilestoneVisible = channels[channelName].version;
+      }
     });
   }
 

--- a/client-src/elements/chromedash-wpt-eval-page.ts
+++ b/client-src/elements/chromedash-wpt-eval-page.ts
@@ -357,7 +357,7 @@ export class ChromedashWPTEvalPage extends LitElement {
     }
   }
 
-  updated(changedProperties: Map<string | symbol, unknown>) {
+  willUpdate(changedProperties: Map<string | symbol, unknown>) {
     if (changedProperties.has('feature') && this.feature) {
       const currentReport = this.feature.ai_test_eval_report || null;
 

--- a/client-src/elements/chromedash-wpt-eval-page_test.ts
+++ b/client-src/elements/chromedash-wpt-eval-page_test.ts
@@ -609,7 +609,6 @@ describe('chromedash-wpt-eval-page', () => {
       checkbox.checked = true;
       checkbox.dispatchEvent(new Event('sl-change'));
       await el.updateComplete;
-      await new Promise(resolve => setTimeout(resolve, 0));
 
       const button = el.shadowRoot!.querySelector(
         '.generate-button'


### PR DESCRIPTION
## Overview
This PR addresses various warnings in web tests by improving the timing of state updates and layout measurements in several Lit components.

This removes all of the warnings from the web tests stating: `Element X scheduled an update (generally because a property was set) after an update completed, causing a new update to be scheduled.`

## Root Cause / Motivation
Warnings were likely caused by:
1. Updating state in lifecycle methods like `updated` that can trigger extra render cycles.
2. Measuring layout (`offsetWidth`) before the DOM was fully ready or stable.
3. Potential null pointer access during initialization.

## Detailed Changelog
* **`client-src/elements/chromedash-form-field.ts`**: Moved `initialValue` setup to `willUpdate` and delayed `doSemanticCheck` to avoid synchronous updates during the first render.
* **`client-src/elements/chromedash-roadmap-page.ts`**: Deferred `handleResize` to `requestAnimationFrame` and added a guard for `sectionRef.value`.
* **`client-src/elements/chromedash-roadmap.ts`**: Added defensive checks for `numColumns` and channel existence.
* **`client-src/elements/chromedash-wpt-eval-page.ts`**: Changed `updated` to `willUpdate` to safely update state based on property changes before rendering.
* **`client-src/elements/chromedash-wpt-eval-page_test.ts`**: Removed an unnecessary `setTimeout` wait in the test.
