### PR TITLE
Optimize link validation using HEAD requests and narrow exception handling

### DIFF
--- a/internals/link_helpers.py
+++ b/internals/link_helpers.py
@@ -363,7 +363,15 @@ class Link:
         200 (OK), it sets the `is_error` flag to True and stores the HTTP error code. This method is
         used to determine if the URL is accessible and valid.
         """  # noqa: D205, E501
-        res = requests.get(self.url, allow_redirects=True, timeout=TIMEOUT)
+        try:
+            res = requests.head(self.url, allow_redirects=True, timeout=TIMEOUT)
+            if res.status_code != 200:
+                res = requests.get(
+                    self.url, allow_redirects=True, timeout=TIMEOUT
+                )
+        except requests.RequestException:
+            res = requests.get(self.url, allow_redirects=True, timeout=TIMEOUT)
+
         if res.status_code != 200:
             self.is_error = True
             self.http_error_code = res.status_code
@@ -408,7 +416,7 @@ class Link:
                 self.information = self._parse_html_head()
             elif self.type == LINK_TYPE_WEB:
                 self.information = None
-        except Exception as e:
+        except (requests.RequestException, HTTPError, ValueError) as e:
             logging.error(f'Error parsing {self.type} {self.url}: {e}')
             self.error = e
             self.is_error = True

--- a/internals/link_helpers_test.py
+++ b/internals/link_helpers_test.py
@@ -124,8 +124,12 @@ class LinkHelperTest(testing_config.CustomTestCase):
                 self.assertTrue(valid_url(url))
 
     @mock.patch('requests.get')
-    def test_mock_not_found_url(self, mock_requests_get):
+    @mock.patch('requests.head')
+    def test_mock_not_found_url(self, mock_requests_head, mock_requests_get):
         """Test mock not found url."""
+        mock_requests_head.return_value = testing_config.Blank(
+            status_code=404, content=''
+        )
         mock_requests_get.return_value = testing_config.Blank(
             status_code=404, content=''
         )
@@ -135,6 +139,41 @@ class LinkHelperTest(testing_config.CustomTestCase):
         self.assertEqual(link.type, LINK_TYPE_WEB)
         self.assertEqual(link.is_error, True)
         self.assertEqual(link.http_error_code, 404)
+
+    @mock.patch('requests.get')
+    @mock.patch('requests.head')
+    def test_validate_url_uses_head_success(
+        self, mock_requests_head, mock_requests_get
+    ):
+        """Test that _validate_url uses HEAD and succeeds."""
+        mock_requests_head.return_value = testing_config.Blank(
+            status_code=200, content=''
+        )
+
+        link = Link('https://www.google.com/')
+        link.parse()
+        self.assertTrue(mock_requests_head.called)
+        self.assertFalse(mock_requests_get.called)
+        self.assertFalse(link.is_error)
+
+    @mock.patch('requests.get')
+    @mock.patch('requests.head')
+    def test_validate_url_falls_back_to_get(
+        self, mock_requests_head, mock_requests_get
+    ):
+        """Test that _validate_url falls back to GET on non-200 HEAD."""
+        mock_requests_head.return_value = testing_config.Blank(
+            status_code=405, content=''
+        )
+        mock_requests_get.return_value = testing_config.Blank(
+            status_code=200, content=''
+        )
+
+        link = Link('https://www.google.com/')
+        link.parse()
+        self.assertTrue(mock_requests_head.called)
+        self.assertTrue(mock_requests_get.called)
+        self.assertFalse(link.is_error)
 
     def test_extract_urls_from_value(self):
         """Test extract urls from value."""


### PR DESCRIPTION
## Overview
This PR optimizes the link validation process by attempting a `HEAD` request before falling back to a `GET` request, and narrows the exception handling to avoid masking unrelated errors.

## Root Cause / Motivation
Currently, link validation uses `requests.get` which downloads the entire content of the page. This is inefficient when we only need to check if the link is valid (returns 200). Using `HEAD` requests first will save bandwidth and time. Additionally, catching a generic `Exception` is a bad practice as it can hide bugs.

## Detailed Changelog
* **`internals/link_helpers.py`**:
    *   Modified `Link._validate_url` to try `requests.head` first, falling back to `requests.get` if the status is not 200 or if an exception occurs.
    *   Narrowed exception handling in `Link.parse` from `Exception` to `(requests.RequestException, HTTPError, ValueError)`.
* **`internals/link_helpers_test.py`**:
    *   Updated `test_mock_not_found_url` to mock both `HEAD` and `GET` requests.
    *   Added `test_validate_url_uses_head_success` to verify `HEAD` is used when successful.
    *   Added `test_validate_url_falls_back_to_get` to verify fallback to `GET` on failure.
