### PR TITLE
Fix flaky Playwright test login by adding retry with reload

### DIFF
--- a/packages/playwright/tests/test_utils.js
+++ b/packages/playwright/tests/test_utils.js
@@ -170,7 +170,13 @@ export async function login(page) {
   } else {
     // On desktop, we can verify the account indicator is visible in the header.
     const accountIndicator = page.getByTestId('account-indicator');
-    await expect(accountIndicator).toBeVisible({timeout: 20000});
+    try {
+      await expect(accountIndicator).toBeVisible({timeout: 10000});
+    } catch {
+      console.log('Account indicator not found immediately. Reloading...');
+      await page.reload();
+      await expect(accountIndicator).toBeVisible({timeout: 10000});
+    }
   }
 }
 


### PR DESCRIPTION
## Overview
Fixes a flaky failure in Playwright tests where the `account-indicator` is not found visible after login, causing timeouts in `beforeEach` hooks.

## Root Cause / Motivation
The `login` function in `test_utils.js` waits for `domcontentloaded` after clicking the login button, but the `account-indicator` might not be rendered immediately if the async `getPermissions` call has not finished. This can lead to a race condition and test failures.

## Detailed Changelog
* **`packages/playwright/tests/test_utils.js`**: Added a retry mechanism with a page reload in the `login` function. If the `account-indicator` is not found visible within 10 seconds, the page is reloaded and it waits for another 10 seconds.
