### PR TITLE
Refactor: Extract `write_gates_and_stages_for_feature` to `processes.py`

### DIFF
--- a/internals/processes.py
+++ b/internals/processes.py
@@ -18,7 +18,9 @@
 from dataclasses import asdict, dataclass
 
 from internals import approval_defs, core_enums
+from internals.core_models import Stage
 from internals.metrics_models import WebDXFeatureObserver
+from internals.review_models import Gate
 
 
 @dataclass
@@ -1006,3 +1008,31 @@ PROGRESS_DETECTORS = {
         ].enterprise_policies
     ),
 }
+
+
+def write_gates_and_stages_for_feature(
+    feature_id: int, feature_type: int
+) -> None:
+    """Write each Stage and Gate entity for the given feature."""
+    # Obtain a list of stages and gates for the given feature type.
+    stages_gates = core_enums.STAGES_AND_GATES_BY_FEATURE_TYPE[feature_type]
+
+    for stage_type, gate_types in stages_gates:
+        # Don't create a trial extension stage pre-emptively.
+        if (
+            stage_type
+            == core_enums.STAGE_TYPES_EXTEND_ORIGIN_TRIAL[feature_type]
+        ):
+            continue
+
+        stage = Stage(feature_id=feature_id, stage_type=stage_type)
+        stage.put()
+        # Stages can have zero or more gates.
+        for gate_type in gate_types:
+            gate = Gate(
+                feature_id=feature_id,
+                stage_id=stage.key.integer_id(),
+                gate_type=gate_type,
+                state=Gate.PREPARING,
+            )
+            gate.put()

--- a/internals/processes_test.py
+++ b/internals/processes_test.py
@@ -413,3 +413,37 @@ class ProgressDetectorsTest(testing_config.CustomTestCase):
         self.assertFalse(detector(self.feature_1, self.stages_dict))
         self.stages_dict[1061][0].enterprise_policies = ['Policy1', 'Policy2']
         self.assertTrue(detector(self.feature_1, self.stages_dict))
+
+
+class WriteGatesAndStagesForFeatureTest(testing_config.CustomTestCase):
+    """Tests for write_gates_and_stages_for_feature."""
+
+    def tearDown(self):
+        """Clean up the test environment."""
+        from internals.review_models import Gate
+
+        kinds = [core_models.FeatureEntry, core_models.Stage, Gate]
+        for kind in kinds:
+            entities = kind.query().fetch()
+            for entity in entities:
+                entity.key.delete()
+
+    def test_write_gates_and_stages_for_feature(self):
+        """Test that stages and gates are created for a feature."""
+        from internals.review_models import Gate
+
+        feature = core_models.FeatureEntry(
+            name='feature one',
+            summary='sum',
+            category=1,
+            feature_type=0,
+        )
+        feature.put()
+        feature_id = feature.key.integer_id()
+
+        processes.write_gates_and_stages_for_feature(feature_id, 0)
+
+        stages = core_models.Stage.query().fetch()
+        gates = Gate.query().fetch()
+        self.assertEqual(len(stages), 6)
+        self.assertEqual(len(gates), 12)

--- a/scripts/seed_datastore.py
+++ b/scripts/seed_datastore.py
@@ -43,8 +43,8 @@ os.environ.setdefault('SERVER_SOFTWARE', 'gunicorn')
 # ruff: noqa: E402
 from internals import core_enums
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
+from internals.processes import write_gates_and_stages_for_feature
 from internals.user_models import AppUser
-from pages.guide import FeatureCreateHandler
 
 
 def add_features(server: str, after: datetime, detailsAfter: datetime):
@@ -255,9 +255,7 @@ def add_features(server: str, after: datetime, detailsAfter: datetime):
         fe.put()
 
         if details is None:
-            FeatureCreateHandler().write_gates_and_stages_for_feature(
-                fe.key.id(), fe.feature_type
-            )
+            write_gates_and_stages_for_feature(fe.key.id(), fe.feature_type)
 
 
 def add_admin(email: str):


### PR DESCRIPTION
## Overview
Extracts the `write_gates_and_stages_for_feature` method from `pages/guide.py` to `internals/processes.py` as a standalone function, and updates `scripts/seed_datastore.py` to use it.

## Root Cause / Motivation
This refactoring is a preparatory step to remove the legacy and deprecated `pages/guide.py` file. By moving this shared logic to a non-legacy directory, we can remove `pages/guide.py` without breaking the `seed_datastore.py` script.

## Detailed Changelog
* **`internals/processes.py`**: Added `write_gates_and_stages_for_feature` as a standalone function.
* **`scripts/seed_datastore.py`**: Updated import and usage to call the function from `internals.processes`.
* **`internals/processes_test.py`**: Added a unit test for `write_gates_and_stages_for_feature` to maintain coverage.
