### PR TITLE
Refactor: Migrate JSON handlers to `api/`

### DIFF
--- a/api/featurelist_api.py
+++ b/api/featurelist_api.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# from google.appengine.api import users
+"""Provides the JSON feed handler for the features list page."""
+
+from framework import basehandlers, permissions, users
+from internals import feature_helpers
+
+
+class FeaturesJsonHandler(basehandlers.FlaskHandler):
+    """Handler for returning features list in JSON format."""
+
+    HTTP_CACHE_TYPE = 'private'
+    JSONIFY = True
+
+    def get_template_data(self, **kwargs):
+        """Returns feature data in JSON format."""
+        user = users.get_current_user()
+        feature_list = feature_helpers.get_features_by_impl_status(
+            show_unlisted=permissions.can_edit_any_feature(user)
+        )
+        return feature_list

--- a/api/featurelist_api.py
+++ b/api/featurelist_api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2021 Google Inc.
+# Copyright 2026 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
 # you may not use this file except in compliance with the License.
@@ -21,13 +21,10 @@ from framework import basehandlers, permissions, users
 from internals import feature_helpers
 
 
-class FeaturesJsonHandler(basehandlers.FlaskHandler):
+class FeaturesJsonHandler(basehandlers.EntitiesAPIHandler):
     """Handler for returning features list in JSON format."""
 
-    HTTP_CACHE_TYPE = 'private'
-    JSONIFY = True
-
-    def get_template_data(self, **kwargs):
+    def do_get(self, **kwargs):
         """Returns feature data in JSON format."""
         user = users.get_current_user()
         feature_list = feature_helpers.get_features_by_impl_status(

--- a/api/featurelist_api_test.py
+++ b/api/featurelist_api_test.py
@@ -1,0 +1,101 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the features list JSON feed handler."""
+
+from typing import Optional
+
+import flask
+
+import settings
+import testing_config  # Must be imported first
+from api import featurelist_api as featurelist
+from internals import core_enums, user_models
+from internals.core_models import FeatureEntry
+
+test_app = flask.Flask(
+    __name__, template_folder=settings.get_flask_template_path()
+)
+
+
+class TestWithFeature(testing_config.CustomTestCase):
+    """Base test class providing common feature setup."""
+
+    REQUEST_PATH_FORMAT: Optional[str] = None
+    HANDLER_CLASS: Optional[object] = None
+
+    def setUp(self):
+        """Sets up common user and feature entries for tests."""
+        self.app_user = user_models.AppUser(email='registered@example.com')
+        self.app_user.put()
+
+        self.app_admin = user_models.AppUser(email='admin@example.com')
+        self.app_admin.is_admin = True
+        self.app_admin.put()
+
+        self.fe_1 = FeatureEntry(
+            name='feature one',
+            summary='detailed sum',
+            owner_emails=['owner@example.com'],
+            category=1,
+            intent_stage=core_enums.INTENT_IMPLEMENT,
+        )
+        self.fe_1.put()
+        self.feature_id = self.fe_1.key.integer_id()
+
+        self.request_path = (
+            self.REQUEST_PATH_FORMAT % {'feature_id': self.feature_id}
+            if self.REQUEST_PATH_FORMAT
+            else ''
+        )
+        if self.HANDLER_CLASS:
+            self.handler = self.HANDLER_CLASS()
+
+
+class FeaturesJsonHandlerTest(TestWithFeature):
+    """Tests for the FeaturesJsonHandler."""
+
+    REQUEST_PATH_FORMAT = '/features.json'
+    HANDLER_CLASS = featurelist.FeaturesJsonHandler
+
+    def test_get_template_data(self):
+        """User can get a JSON feed of all features."""
+        testing_config.sign_in('user@example.com', 111)
+        with test_app.test_request_context(self.request_path):
+            json_data = self.handler.get_template_data()
+
+        self.assertEqual(1, len(json_data))
+        self.assertEqual('feature one', json_data[0]['name'])
+
+    def test_get_template_data__unlisted_no_perms(self):
+        """JSON feed does not include unlisted features for users who can't edit."""
+        self.fe_1.unlisted = True
+        self.fe_1.put()
+
+        testing_config.sign_out()
+        with test_app.test_request_context(self.request_path):
+            json_data = self.handler.get_template_data()
+        self.assertEqual(0, len(json_data))
+
+        testing_config.sign_in('user@example.com', 111)
+        with test_app.test_request_context(self.request_path):
+            json_data = self.handler.get_template_data()
+        self.assertEqual(0, len(json_data))
+
+    def test_get_template_data__unlisted_can_edit(self):
+        """JSON feed includes unlisted features for site editors and admins."""
+        testing_config.sign_in('admin@example.com', 111)
+        with test_app.test_request_context(self.request_path):
+            json_data = self.handler.get_template_data()
+        self.assertEqual(1, len(json_data))
+        self.assertEqual('feature one', json_data[0]['name'])

--- a/api/featurelist_api_test.py
+++ b/api/featurelist_api_test.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
 # you may not use this file except in compliance with the License.
@@ -72,7 +73,7 @@ class FeaturesJsonHandlerTest(TestWithFeature):
         """User can get a JSON feed of all features."""
         testing_config.sign_in('user@example.com', 111)
         with test_app.test_request_context(self.request_path):
-            json_data = self.handler.get_template_data()
+            json_data = self.handler.do_get()
 
         self.assertEqual(1, len(json_data))
         self.assertEqual('feature one', json_data[0]['name'])
@@ -84,18 +85,18 @@ class FeaturesJsonHandlerTest(TestWithFeature):
 
         testing_config.sign_out()
         with test_app.test_request_context(self.request_path):
-            json_data = self.handler.get_template_data()
+            json_data = self.handler.do_get()
         self.assertEqual(0, len(json_data))
 
         testing_config.sign_in('user@example.com', 111)
         with test_app.test_request_context(self.request_path):
-            json_data = self.handler.get_template_data()
+            json_data = self.handler.do_get()
         self.assertEqual(0, len(json_data))
 
     def test_get_template_data__unlisted_can_edit(self):
         """JSON feed includes unlisted features for site editors and admins."""
         testing_config.sign_in('admin@example.com', 111)
         with test_app.test_request_context(self.request_path):
-            json_data = self.handler.get_template_data()
+            json_data = self.handler.do_get()
         self.assertEqual(1, len(json_data))
         self.assertEqual('feature one', json_data[0]['name'])

--- a/api/metrics_api.py
+++ b/api/metrics_api.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Provides handlers for metrics data, such as Omaha release data."""
+
+from framework import basehandlers
+from internals import fetchchannels
+
+
+class OmahaDataHandler(basehandlers.FlaskHandler):
+    """Handler for retrieving Omaha data metrics."""
+
+    JSONIFY = True
+
+    def get_template_data(self, **kwargs):
+        """Returns Omaha data metrics as JSON."""
+        omaha_data = fetchchannels.get_omaha_data()
+        return omaha_data

--- a/api/metrics_api.py
+++ b/api/metrics_api.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google Inc.
+# Copyright 2026 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
 # you may not use this file except in compliance with the License.
@@ -19,12 +19,10 @@ from framework import basehandlers
 from internals import fetchchannels
 
 
-class OmahaDataHandler(basehandlers.FlaskHandler):
+class OmahaDataHandler(basehandlers.EntitiesAPIHandler):
     """Handler for retrieving Omaha data metrics."""
 
-    JSONIFY = True
-
-    def get_template_data(self, **kwargs):
+    def do_get(self, **kwargs):
         """Returns Omaha data metrics as JSON."""
         omaha_data = fetchchannels.get_omaha_data()
         return omaha_data

--- a/api/metrics_api_test.py
+++ b/api/metrics_api_test.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google Inc.
+# Copyright 2026 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 """Tests for the metrics data handlers."""
 
 import flask
 
+import testing_config
+from api import metrics_api
+
 test_app = flask.Flask(__name__)
 
 
-# TODO(jrobbins): Write unit test for OmahaDataHandler
+class OmahaDataHandlerTest(testing_config.CustomTestCase):
+    """Tests for OmahaDataHandler."""
+
+    def setUp(self):
+        """Set up the test handler."""
+        self.handler = metrics_api.OmahaDataHandler()
+
+    def test_do_get(self):
+        """User can get Omaha data metrics."""
+        with test_app.test_request_context('/api/v0/omaha_data'):
+            response = self.handler.do_get()
+
+        self.assertEqual(1, len(response))
+        self.assertIn('versions', response[0])
+        versions = response[0]['versions']
+        self.assertEqual(3, len(versions))
+
+        channels = {v['channel']: v['version'] for v in versions}
+        self.assertEqual('147.0.7727.56', channels['stable'])
+        self.assertEqual('148.0.7778.5', channels['beta'])
+        self.assertEqual('149.0.7779.3', channels['dev'])

--- a/api/metrics_api_test.py
+++ b/api/metrics_api_test.py
@@ -1,0 +1,23 @@
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Tests for the metrics data handlers."""
+
+import flask
+
+test_app = flask.Flask(__name__)
+
+
+# TODO(jrobbins): Write unit test for OmahaDataHandler

--- a/main.py
+++ b/main.py
@@ -20,8 +20,6 @@ from dataclasses import dataclass, field
 from typing import Any, Type
 
 import settings
-
-# TODO(jrobbins): Remove guide routes after a few weeks.
 from api import (
     accounts_api,
     attachments_api,

--- a/main.py
+++ b/main.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass, field
 from typing import Any, Type
 
 import settings
+
+# TODO(jrobbins): Remove guide routes after a few weeks.
 from api import (
     accounts_api,
     attachments_api,
@@ -32,10 +34,12 @@ from api import (
     external_reviews_api,
     feature_latency_api,
     feature_links_api,
+    featurelist_api,
     features_api,
     intents_api,
     login_api,
     logout_api,
+    metrics_api,
     metricsdata,
     origin_trials_api,
     permissions_api,
@@ -64,9 +68,7 @@ from internals import (
     reminders,
     search_fulltext,
 )
-
-# TODO(jrobbins): Remove guide routes after a few weeks.
-from pages import featurelist, guide, metrics, ot_requests, users
+from pages import guide, ot_requests, users
 
 # Patch treading library to work-around bug with Google Cloud Logging.
 original_delete = threading.Thread._delete  # type: ignore
@@ -393,8 +395,8 @@ mpa_page_routes: list[Route] = [
     # Note: The only requests being made now hit /features.json and
     # /features_v2.json, but both of those cause version == 2.
     # There was logic to accept another version value, but it it was not used.
-    Route(r'/features.json', featurelist.FeaturesJsonHandler),
-    Route(r'/features_v2.json', featurelist.FeaturesJsonHandler),
+    Route(r'/features.json', featurelist_api.FeaturesJsonHandler),
+    Route(r'/features_v2.json', featurelist_api.FeaturesJsonHandler),
     Route(
         '/features.xml',
         basehandlers.ConstHandler,
@@ -405,7 +407,7 @@ mpa_page_routes: list[Route] = [
         basehandlers.ConstHandler,
         defaults={'template_path': 'farewell-samples.html'},
     ),
-    Route('/omaha_data', metrics.OmahaDataHandler),
+    Route('/omaha_data', metrics_api.OmahaDataHandler),
     Route(
         '/feature/<int:feature_id>/attachment/<int:attachment_id>',
         attachments_api.AttachmentServing,


### PR DESCRIPTION
## Overview

Moves `featurelist.py` and `metrics.py` from the legacy `pages/` directory to `api/`, updates `main.py` routes, and refactors the handlers to use `EntitiesAPIHandler`.

## Root Cause / Motivation

This is part of the effort to migrate away from the legacy `pages/` directory and to standardize API handlers to use `EntitiesAPIHandler` for consistent response formatting (including XSSI prefix) and helper methods.

## Detailed Changelog

- `api/featurelist_api.py`: Migrated from `pages/featurelist.py` and refactored `FeaturesJsonHandler` to inherit from `EntitiesAPIHandler` and use `do_get`.
- `api/metrics_api.py`: Migrated from `pages/metrics.py` and refactored `OmahaDataHandler` to inherit from `EntitiesAPIHandler` and use `do_get`.
- `api/featurelist_api_test.py`: Migrated from `pages/featurelist_test.py` and updated to call `do_get`.
- `api/metrics_api_test.py`: Migrated from `pages/metrics_test.py` and added unit tests for `OmahaDataHandler`.
- `main.py`: Updated imports and routes for these handlers.
