### PR TITLE
Refactor: Migrate server-rendered handlers to `api/`

### DIFF
--- a/api/ot_requests_handler.py
+++ b/api/ot_requests_handler.py
@@ -1,0 +1,88 @@
+# Copyright 2023 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Provides the admin page handler for viewing Origin Trial requests."""
+
+import logging
+
+from google.cloud import ndb
+
+from api.converters import stage_to_json_dict
+from framework import basehandlers, permissions
+from internals import core_enums
+from internals.core_models import Stage
+from internals.review_models import Gate, Vote
+
+
+class OriginTrialsRequests(basehandlers.FlaskHandler):
+    """Display any origin trials requests."""
+
+    TEMPLATE_PATH = 'admin/features/ot_requests.html'
+
+    @permissions.require_admin_site
+    def get_template_data(self, **kwargs):
+        """Retrieves and formats origin trial requests data for the admin view."""
+        stages_with_requests = Stage.query(
+            ndb.OR(
+                Stage.ot_action_requested == True,  # noqa: E712
+                Stage.ot_setup_status == core_enums.OT_READY_FOR_CREATION,
+            )
+        ).fetch()
+        stages_with_failures = Stage.query(
+            ndb.OR(
+                Stage.ot_setup_status == core_enums.OT_ACTIVATION_FAILED,
+                Stage.ot_setup_status == core_enums.OT_CREATION_FAILED,
+            )
+        ).fetch()
+        stages_awaiting_activation = Stage.query(
+            Stage.ot_setup_status == core_enums.OT_CREATED
+        ).fetch()
+        creation_stages = []
+        extension_stages = []
+        for stage in stages_with_requests:
+            stage_dict = stage_to_json_dict(stage)
+            # Group up creation and extension requests.
+            if stage_dict['stage_type'] in core_enums.OT_EXTENSION_STAGE_TYPES:
+                gate: Gate = Gate.query(Gate.stage_id == stage_dict['id']).get()
+                if gate and gate.state in (Vote.NA, Vote.APPROVED):
+                    # Information will be needed from the original OT stage.
+                    ot_stage = Stage.get_by_id(stage_dict['ot_stage_id'])
+                    if ot_stage is None:
+                        logging.warning(
+                            f'Extension stage {stage_dict["id"]} '
+                            f'found with invalid OT stage ID {stage_dict["ot_stage_id"]}.'
+                        )
+                        continue
+                    ot_stage_dict = stage_to_json_dict(ot_stage)
+                    # Supply both the OT stage and the extension stage.
+                    extension_stages.append(
+                        {
+                            'ot_stage': ot_stage_dict,
+                            'extension_stage': stage_dict,
+                        }
+                    )
+            else:
+                creation_stages.append(stage_dict)
+
+        failed_stages = [stage_to_json_dict(s) for s in stages_with_failures]
+        activation_pending_stages = [
+            stage_to_json_dict(s) for s in stages_awaiting_activation
+        ]
+        return {
+            'creation_stages': creation_stages,
+            'extension_stages': extension_stages,
+            'activation_pending_stages': activation_pending_stages,
+            'failed_stages': failed_stages,
+        }

--- a/api/ot_requests_test.py
+++ b/api/ot_requests_test.py
@@ -1,0 +1,207 @@
+# Copyright 2025 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Origin Trial requests admin page handler."""
+
+from unittest import mock
+
+import flask
+import werkzeug
+
+import settings
+import testing_config  # Must be imported before the module under test.
+from api import ot_requests_handler as ot_requests
+from internals import core_enums
+from internals.core_models import FeatureEntry, Stage
+from internals.review_models import Gate, Vote
+from internals.user_models import AppUser
+
+test_app = flask.Flask(
+    __name__, template_folder=settings.get_flask_template_path()
+)
+
+
+class OriginTrialsRequestsTest(testing_config.CustomTestCase):
+    """Tests for origin trial request operations."""
+
+    def setUp(self):
+        """Sets up feature and stage entities for the OT requests tests."""
+        self.feature_1 = FeatureEntry(
+            name='feature one', summary='sum', category=1
+        )
+        self.feature_1.put()
+        self.feature_id = self.feature_1.key.integer_id()
+
+        # 1. Stage with an action requested (will go into creation_stages)
+        self.creation_request_stage = Stage(
+            feature_id=self.feature_id, stage_type=150, ot_action_requested=True
+        )
+        self.creation_request_stage.put()
+
+        # 2. Stage ready for creation (will go into creation_stages)
+        self.ready_for_creation_stage = Stage(
+            feature_id=self.feature_id,
+            stage_type=150,
+            ot_setup_status=core_enums.OT_READY_FOR_CREATION,
+        )
+        self.ready_for_creation_stage.put()
+
+        # 3. An extension stage request needs an original OT stage and a valid Gate.
+        self.ot_stage_for_extension = Stage(
+            feature_id=self.feature_id, stage_type=150
+        )
+        self.ot_stage_for_extension.put()
+        # The extension stage itself (will go into extension_stages).
+        self.extension_stage = Stage(
+            feature_id=self.feature_id,
+            stage_type=core_enums.STAGE_BLINK_EXTEND_ORIGIN_TRIAL,
+            ot_action_requested=True,
+            ot_stage_id=self.ot_stage_for_extension.key.integer_id(),
+        )
+        self.extension_stage.put()
+        # Add the required Gate for the extension stage.
+        self.extension_gate = Gate(
+            feature_id=self.feature_id,
+            stage_id=self.extension_stage.key.integer_id(),
+            gate_type=core_enums.GATE_API_EXTEND_ORIGIN_TRIAL,
+            state=Vote.APPROVED,
+        )
+        self.extension_gate.put()
+
+        # 4. Stage awaiting activation (will go into activation_pending_stages)
+        self.awaiting_activation_stage = Stage(
+            feature_id=self.feature_id,
+            stage_type=150,
+            ot_setup_status=core_enums.OT_CREATED,
+        )
+        self.awaiting_activation_stage.put()
+
+        # 5. Stage with activation failure (will go into failed_stages)
+        self.activation_failed_stage = Stage(
+            feature_id=self.feature_id,
+            stage_type=150,
+            ot_setup_status=core_enums.OT_ACTIVATION_FAILED,
+        )
+        self.activation_failed_stage.put()
+
+        # 6. Stage with creation failure (will go into failed_stages)
+        self.creation_failed_stage = Stage(
+            feature_id=self.feature_id,
+            stage_type=150,
+            ot_setup_status=core_enums.OT_CREATION_FAILED,
+        )
+        self.creation_failed_stage.put()
+
+        self.handler = ot_requests.OriginTrialsRequests()
+        self.request_path = '/admin/features/ot_requests'
+
+        self.app_admin = AppUser(email='admin@example.com')
+        self.app_admin.is_admin = True
+        self.app_admin.put()
+
+    def test_get__anon(self):
+        """Anon user is redirected to the login page."""
+        testing_config.sign_out()
+        with test_app.test_request_context(self.request_path):
+            response = self.handler.get()
+        self.assertEqual(302, response.status_code)
+
+    def test_get__non_admin(self):
+        """A non-admin user receives a 403 Forbidden error."""
+        testing_config.sign_in('user@example.com', 111)
+        with test_app.test_request_context(self.request_path):
+            with self.assertRaises(werkzeug.exceptions.Forbidden):
+                self.handler.get()
+
+    def test_get_template_data__no_stages(self):
+        """Admin user sees empty lists when no stages match the queries."""
+        # Remove all stages created in setUp.
+        for kind in [Stage, Gate]:
+            for entity in kind.query():
+                entity.key.delete()
+
+        testing_config.sign_in('admin@example.com', 222)
+        with test_app.test_request_context(self.request_path):
+            template_data = self.handler.get_template_data()
+
+        self.assertEqual([], template_data['creation_stages'])
+        self.assertEqual([], template_data['extension_stages'])
+        self.assertEqual([], template_data['activation_pending_stages'])
+        self.assertEqual([], template_data['failed_stages'])
+
+    def test_get_template_data__all_stages(self):
+        """Admin user sees all relevant stages, correctly categorized."""
+        testing_config.sign_in('admin@example.com', 222)
+        with test_app.test_request_context(self.request_path):
+            actual_data = self.handler.get_template_data()
+
+        # Test that the extension stage (with an approved gate) is present.
+        self.assertEqual(1, len(actual_data['extension_stages']))
+        self.assertEqual(
+            self.extension_stage.key.integer_id(),
+            actual_data['extension_stages'][0]['extension_stage']['id'],
+        )
+
+        # Test that all other stage categories are also correctly populated.
+        self.assertEqual(2, len(actual_data['creation_stages']))
+        self.assertEqual(1, len(actual_data['activation_pending_stages']))
+        self.assertEqual(2, len(actual_data['failed_stages']))
+
+    def test_get_template_data__non_approved_extension_is_ignored(self):
+        """An extension stage with a denied gate is not included."""
+        self.extension_gate.state = Vote.DENIED
+        self.extension_gate.put()
+
+        testing_config.sign_in('admin@example.com', 222)
+        with test_app.test_request_context(self.request_path):
+            actual_data = self.handler.get_template_data()
+
+        self.assertEqual([], actual_data['extension_stages'])
+
+    def test_get_template_data__extension_with_na_gate_is_included(self):
+        """An extension stage with a gate state of N/A is included."""
+        self.extension_gate.state = Vote.NA
+        self.extension_gate.put()
+
+        testing_config.sign_in('admin@example.com', 222)
+        with test_app.test_request_context(self.request_path):
+            actual_data = self.handler.get_template_data()
+
+        self.assertEqual(1, len(actual_data['extension_stages']))
+        self.assertEqual(
+            self.extension_stage.key.integer_id(),
+            actual_data['extension_stages'][0]['extension_stage']['id'],
+        )
+
+    @mock.patch('logging.warning')
+    def test_get_template_data__extension_with_bad_ot_stage_id(
+        self, mock_logging_warning
+    ):
+        """An extension stage with a bad ot_stage_id is skipped and logs a warning."""  # noqa: E501
+        # Set the ot_stage_id to a non-existent ID
+        self.extension_stage.ot_stage_id = 99999
+        self.extension_stage.put()
+
+        testing_config.sign_in('admin@example.com', 222)
+        with test_app.test_request_context(self.request_path):
+            actual_data = self.handler.get_template_data()
+
+        # The malformed extension request should not be included.
+        self.assertEqual([], actual_data['extension_stages'])
+        # A warning should have been logged.
+        mock_logging_warning.assert_called_once()
+        self.assertIn(
+            'found with invalid OT stage ID 99999',
+            mock_logging_warning.call_args[0][0],
+        )

--- a/api/testdata/users_test/test_html_rendering.html
+++ b/api/testdata/users_test/test_html_rendering.html
@@ -1,0 +1,160 @@
+
+<!DOCTYPE html>
+<!--
+Copyright 2016 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Local testing</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+
+  <meta name="theme-color" content="#366597">
+
+  <link rel="stylesheet" href="/static/dist/styles.css?v=Undeployed" />
+
+  <link rel="icon" sizes="192x192" href="/static/img/crstatus_192.png">
+
+  <!-- iOS: run in full-screen mode and display upper status bar as translucent -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
+  <link rel="apple-touch-icon" href="/static/img/crstatus_128.png">
+  <link rel="apple-touch-icon-precomposed" href="/static/img/crstatus_128.png">
+  <link rel="shortcut icon" href="/static/img/crstatus_128.png">
+
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+  
+
+  <link rel="stylesheet" href="/static/css/main.css?v=Undeployed">
+
+  
+  <link rel="stylesheet" href="/static/css/forms.css?v=Undeployed">
+
+
+  
+  <script src="https://accounts.google.com/gsi/client" async defer nonce="fake nonce"></script>
+
+  <script nonce="fake nonce">
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get("loginStatus") == 'False') {
+      alert('Please log in.');
+      window.location.replace('/');
+    } else {
+      if (urlParams.get("error") == '403') {
+        alert('You do not have permission to access that page. You may need to sign in with an authorized account.');
+      }
+      if (urlParams.has("error")) {
+        urlParams.delete("error");
+        const newSearch = urlParams.toString() ? '?' + urlParams.toString() : '';
+        window.history.replaceState({}, document.title, window.location.pathname + newSearch + window.location.hash);
+      }
+    }
+  </script>
+  <script type="module" nonce="fake nonce">
+    import {ChromeStatusClient} from "/static/dist/cs-client.js?v=Undeployed"
+    window.csClient = new ChromeStatusClient(
+        '', 0);
+
+    
+    const drawer = document.querySelector('chromedash-drawer');
+    const header = document.querySelector('chromedash-header');
+    header.addEventListener('drawer-clicked', (e) => {
+      e.preventDefault();
+      open = drawer.toggleDrawerActions();
+    });
+  </script>
+
+  <script type="module" nonce="fake nonce" defer
+          src="/static/dist/components.js?v=Undeployed"></script>
+  
+
+  
+</head>
+
+<body class="loading" data-path="/request_path?">
+
+  <div id="app-content-container">
+    <div>
+      <div class="main-toolbar">
+        <div class="toolbar-content">
+          <chromedash-header
+            appTitle="Local testing"
+            currentPage="/request_path?"
+            googleSignInClientId="914217904764-enfcea61q4hqe7ak8kkuteglrbhk8el1.apps.googleusercontent.com"
+            devMode="False">
+          </chromedash-header>
+        </div>
+      </div>
+
+      <div id="content">
+        <div>
+          <chromedash-drawer
+            currentPage="/request_path?"
+            googleSignInClientId="914217904764-enfcea61q4hqe7ak8kkuteglrbhk8el1.apps.googleusercontent.com">
+          </chromedash-drawer>
+        </div>
+        <chromedash-banner
+          message=""
+          timestamp="None">
+        </chromedash-banner>
+        <div id="spinner">
+          <img src="/static/img/ring.svg">
+        </div>
+        <div id="content-flex-wrapper">
+          <div id="content-component-wrapper">
+            
+<div id="subheader">
+  <h2>Application users</h2>
+</div>
+
+            
+<section>
+
+  <chromedash-userlist></chromedash-userlist>
+
+</section>
+
+          </div>
+        </div>
+      </div>
+
+    </div>
+    <chromedash-footer></chromedash-footer>
+  </div>
+
+  
+
+  
+<script nonce="fake nonce">
+  const el = document.querySelector('chromedash-userlist');
+  el.users = [{"is_admin": true, "is_site_editor": false, "email": "admin@example.com", "id": 1}];
+
+  document.body.classList.remove('loading');
+</script>
+
+
+  <script src="https://www.googletagmanager.com/gtag/js?id=UA-179341418-1"
+          async nonce="fake nonce"></script>
+
+  
+  <script type="module" nonce="fake nonce" src="/static/dist/shared.js?v=Undeployed"></script>
+</body>
+</html>

--- a/api/users_handler.py
+++ b/api/users_handler.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2013 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provides the admin page handler for viewing and managing users."""
+
+__author__ = 'ericbidelman@chromium.org (Eric Bidelman)'
+
+
+import json
+import logging
+
+from api import accounts_api
+from framework import basehandlers, permissions
+from internals import user_models
+
+
+class UserListHandler(basehandlers.FlaskHandler):
+    """Handler for listing application users."""
+
+    TEMPLATE_PATH = 'admin/users/new.html'
+
+    @permissions.require_admin_site
+    def get_template_data(self, **kwargs):
+        """Retrieves a list of users for the admin dashboard."""
+        users = user_models.AppUser.query().fetch(None)
+        user_list = [accounts_api.user_to_json_dict(user) for user in users]
+
+        logging.info('user_list is %r', user_list)
+        template_data = {'users': json.dumps(user_list)}
+        return template_data

--- a/api/users_test.py
+++ b/api/users_test.py
@@ -1,0 +1,71 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Tests for the users admin page handler."""
+
+import flask
+import html5lib
+from google.cloud import ndb  # type: ignore
+
+import settings
+import testing_config  # Must be imported first
+from api import users_handler as users
+from internals import user_models
+
+test_app = flask.Flask(
+    __name__, template_folder=settings.get_flask_template_path()
+)
+
+
+# Load testdata to be used across all of the CustomTestCases
+TESTDATA = testing_config.Testdata(__file__)
+
+
+class UsersListTemplateTest(testing_config.CustomTestCase):
+    """Tests for the users list template rendering."""
+
+    def setUp(self):
+        """Sets up the test user and handler for the users list."""
+        self.handler = users.UserListHandler()
+
+        self.app_admin = user_models.AppUser(email='admin@example.com')
+        self.app_admin.is_admin = True
+        self.app_admin.key = ndb.Key('AppUser', 1)
+        self.app_admin.put()
+        testing_config.sign_in('admin@example.com', 123567890)
+
+        with test_app.test_request_context('/request_path'):
+            self.template_data = self.handler.get_template_data()
+            self.template_data.update(self.handler.get_common_data())
+            self.template_data['nonce'] = 'fake nonce'
+            self.template_data['xsrf_token'] = ''
+            self.template_data['xsrf_token_expires'] = 0
+        self.full_template_path = self.handler.get_template_path(
+            self.template_data
+        )
+        self.maxDiff = None
+
+    def test_html_rendering(self):
+        """We can render the template with valid html."""
+        with test_app.app_context():
+            template_text = self.handler.render(
+                self.template_data, self.full_template_path
+            )
+        parser = html5lib.HTMLParser(strict=True)
+        document = parser.parse(template_text)  # noqa: F841
+        # TESTDATA.make_golden(template_text, 'test_html_rendering.html')
+        self.assertMultiLineEqual(
+            TESTDATA['test_html_rendering.html'], template_text
+        )

--- a/main.py
+++ b/main.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass, field
 from typing import Any, Type
 
 import settings
+
+# TODO(jrobbins): Remove guide routes after a few weeks.
 from api import (
     accounts_api,
     attachments_api,
@@ -38,6 +40,7 @@ from api import (
     logout_api,
     metricsdata,
     origin_trials_api,
+    ot_requests_handler,
     permissions_api,
     processes_api,
     review_latency_api,
@@ -49,6 +52,7 @@ from api import (
     stale_features_api,
     stars_api,
     token_refresh_api,
+    users_handler,
     webdx_feature_api,
     wpt_coverage_api,
 )
@@ -64,9 +68,7 @@ from internals import (
     reminders,
     search_fulltext,
 )
-
-# TODO(jrobbins): Remove guide routes after a few weeks.
-from pages import featurelist, guide, metrics, ot_requests, users
+from pages import featurelist, guide, metrics
 
 # Patch treading library to work-around bug with Google Cloud Logging.
 original_delete = threading.Thread._delete  # type: ignore
@@ -388,8 +390,8 @@ spa_page_routes = [
 ]
 
 mpa_page_routes: list[Route] = [
-    Route('/admin/users/new', users.UserListHandler),
-    Route('/admin/ot_requests', ot_requests.OriginTrialsRequests),
+    Route('/admin/users/new', users_handler.UserListHandler),
+    Route('/admin/ot_requests', ot_requests_handler.OriginTrialsRequests),
     # Note: The only requests being made now hit /features.json and
     # /features_v2.json, but both of those cause version == 2.
     # There was logic to accept another version value, but it it was not used.


### PR DESCRIPTION
## Overview
Moves `ot_requests.py` and `users.py` from the legacy `pages/` directory to `api/` (renamed to `*_handler.py`), and updates `main.py` routes to use the new locations.

## Root Cause / Motivation
This is part of the effort to migrate away from the legacy `pages/` directory to comply with Project Rule #3. These handlers serve HTML templates but are moved to `api/` as a stopgap without full refactoring to APIs + SPAs, focusing on easy wins.

## Detailed Changelog
* **`api/ot_requests_handler.py`**: Migrated from `pages/ot_requests.py`.
* **`api/users_handler.py`**: Migrated from `pages/users.py`.
* **`api/ot_requests_test.py`**: Migrated from `pages/ot_requests_test.py`.
* **`api/users_test.py`**: Migrated from `pages/users_test.py`.
* **`api/testdata/users_test/test_html_rendering.html`**: Moved from `pages/testdata/`.
* **`main.py`**: Updated imports and routes for these handlers.
