### PR TITLE
Make an Activity record when a FeatureEntry is created.

### DIFF
--- a/api/features_api.py
+++ b/api/features_api.py
@@ -238,7 +238,6 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
         search_fulltext.index_feature(feature)
         self._write_stages_and_gates_for_feature(id, feature.feature_type)
 
-        user = self.get_current_user()
         activity = Activity(
             log_type=Activity.USER_CHANGE,
             feature_id=id,

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -207,6 +207,7 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
     def do_post(self, **kwargs):
         """Handle POST requests to create a single feature."""
         feature_changes = self.get_json_param_dict()
+        user_email = self.get_current_user().email()
 
         # A feature creation request should have all required fields.
         for field in FeatureEntry.REQUIRED_FIELDS:
@@ -214,7 +215,7 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
                 self.abort(400, msg=f'Required field "{field}" not provided.')
 
         fields_dict = {
-            'owner_emails': [self.get_current_user().email()],
+            'owner_emails': [user_email],
             'devrel_emails': [DEVREL_EMAIL],
             'category': int(core_enums.MISC),
             'blink_components': [settings.DEFAULT_COMPONENT],
@@ -236,6 +237,15 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
 
         search_fulltext.index_feature(feature)
         self._write_stages_and_gates_for_feature(id, feature.feature_type)
+
+        user = self.get_current_user()
+        activity = Activity(
+            log_type=Activity.USER_CHANGE,
+            feature_id=id,
+            author=user_email,
+            content='Feature entry created',
+        )
+        activity.put()
 
         # Remove all feature-related cache.
         rediscache.delete_keys_with_prefix(FeatureEntry.DEFAULT_CACHE_KEY)

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -1434,6 +1434,14 @@ class FeaturesAPITest(testing_config.CustomTestCase):
         # User's email should match creator_email field.
         self.assertEqual(new_feature.creator_email, 'admin@example.com')
 
+        # Check that an activity log record was created
+        activities = Activity.get_activities(response['feature_id'])
+        self.assertEqual(1, len(activities))
+        activity = activities[0]
+        self.assertEqual('admin@example.com', activity.author)
+        self.assertEqual(Activity.USER_CHANGE, activity.log_type)
+        self.assertEqual('Feature entry created', activity.content)
+
     def test_post__valid_stage_and_gate_creation(self):
         """POST request successful with valid input from user with permissions."""
         # Signed-in user with permissions.


### PR DESCRIPTION
This should help make the activity log for features look more complete.

The reason to add it now was that the enterprise team was investigating a question about how a particular feature entry was created, and were confused they only saw the first edit in the activity log (because there was no Activity for creation).