### PR TITLE
Fix error reporting and TypeError in user creation flow

### DIFF
--- a/client-src/elements/chromedash-userlist.ts
+++ b/client-src/elements/chromedash-userlist.ts
@@ -120,19 +120,22 @@ class ChromedashUserlist extends LitElement {
       const email = emailInput?.value;
       const isAdmin = adminCheckbox?.checked;
       const isSiteEditor = siteEditorCheckbox?.checked;
-      window.csClient.createAccount(email, isAdmin, isSiteEditor).then(json => {
-        if (json.error_message) {
-          alert(json.error_message);
-        } else {
-          this.addUser(json);
-          formEl.reset();
-          (
-            formEl.querySelector(
-              'input[name="is_site_editor"]'
-            ) as HTMLInputElement
-          ).disabled = false;
-        }
-      });
+      window.csClient
+        .createAccount(email, isAdmin, isSiteEditor)
+        .then(json => {
+          if (json.error_message) {
+            alert(json.error_message);
+          } else {
+            this.addUser(json);
+            formEl.reset();
+            if (siteEditorCheckbox) {
+              siteEditorCheckbox.disabled = false;
+            }
+          }
+        })
+        .catch(error => {
+          alert(error.message || 'An error occurred');
+        });
     }
   }
 

--- a/client-src/js-src/cs-client.ts
+++ b/client-src/js-src/cs-client.ts
@@ -341,22 +341,25 @@ export interface GateDict {
 /**
  * Generic Chrome Status Http Error.
  */
-class ChromeStatusHttpError extends Error {
+export class ChromeStatusHttpError extends Error {
   resource: string;
   method: string;
   status: number;
+  body: string;
 
   constructor(
     message: string,
     resource: string,
     method: string,
-    status: number
+    status: number,
+    body: string = ''
   ) {
     super(message);
     this.name = 'ChromeStatusHttpError';
     this.resource = resource;
     this.method = method;
     this.status = status;
+    this.body = body;
   }
 }
 
@@ -439,11 +442,19 @@ export class ChromeStatusClient {
     const response = await fetch(url, options);
 
     if (response.status !== 200) {
+      let body = '';
+      try {
+        body = await response.text();
+      } catch {
+        // ignore
+      }
       throw new ChromeStatusHttpError(
-        `Got error response from server ${resource}: ${response.status}`,
+        body ||
+          `Got error response from server ${resource}: ${response.status}`,
         resource,
         httpMethod,
-        response.status
+        response.status,
+        body
       );
     }
     const rawResponseText = await response.text();


### PR DESCRIPTION
## Overview
This PR improves error reporting when adding a new user fails and fixes a TypeError (UI crash) that occurred after successfully adding a user.

## Root Cause / Motivation
1. **Error Reporting**: When the `/api/v0/accounts` API returned a `400 Bad Request` (e.g., due to duplicate email or invalid XSRF token), the frontend component `ajaxSubmit` did not catch the promise rejection. This resulted in a silent failure in the UI and an uncaught error in the console. Additionally, `doFetch` did not propagate the response body, making it hard to see the specific reason for the 400 error.
2. **TypeError**: Upon successful user creation, the success handler tried to re-enable the "User is site editor" checkbox using an incorrect query selector `input[name="is_site_editor"]`. Since the element is a Shoelace custom element (`sl-checkbox`), it returned `null`, causing a `Cannot set properties of null (setting 'disabled')` error.

## Detailed Changelog
* **`client-src/js-src/cs-client.ts`**:
  - Exported `ChromeStatusHttpError`.
  - Updated `ChromeStatusHttpError` to store the response body.
  - Modified `doFetch` to read the response body as text on non-200 responses and use it as the error message.
* **`client-src/elements/chromedash-userlist.ts`**:
  - Added `.catch()` block to `createAccount` call in `ajaxSubmit` to display the server error message via `alert()`.
  - Fixed the query selector in the success handler to use the pre-selected `siteEditorCheckbox` variable (which refers to `sl-checkbox`), avoiding the TypeError.
