### PR TITLE
Implement warmup handler for min_idle_instances

### DIFF
--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -48,3 +48,5 @@ env_variables:
 inbound_services:
 - mail
 - mail_bounce
+- warmup
+

--- a/app.yaml
+++ b/app.yaml
@@ -48,3 +48,5 @@ env_variables:
 inbound_services:
 - mail
 - mail_bounce
+- warmup
+

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -800,11 +800,11 @@ class ConstHandler(FlaskHandler):
 
 
 class WarmupHandler(BaseHandler):
-  """Warmup request handler to load application code into a new instance."""
+    """Warmup request handler to load application code into a new instance."""
 
-  def get(self, *args, **kwargs):
-    """Handle warmup request."""
-    return 'OK', 200
+    def get(self, *args, **kwargs):
+        """Handle warmup request."""
+        return 'OK', 200
 
 
 def ndb_wsgi_middleware(wsgi_app):

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -799,6 +799,14 @@ class ConstHandler(FlaskHandler):
         return flask.jsonify(defaults)
 
 
+class WarmupHandler(BaseHandler):
+  """Warmup request handler to load application code into a new instance."""
+
+  def get(self, *args, **kwargs):
+    """Handle warmup request."""
+    return 'OK', 200
+
+
 def ndb_wsgi_middleware(wsgi_app):
     """Create a new runtime context for cloud ndb for every request"""  # noqa: D415
     client = ndb.Client()

--- a/main.py
+++ b/main.py
@@ -583,6 +583,7 @@ internals_routes: list[Route] = [
         '/scripts/reset_outstanding_notifications',
         maintenance_scripts.ResetOutstandingNotifications,
     ),
+    Route('/_ah/warmup', basehandlers.WarmupHandler),
 ]
 
 dev_routes: list[Route] = []

--- a/main_test.py
+++ b/main_test.py
@@ -35,7 +35,9 @@ class MainTest(testing_config.CustomTestCase):
 
     def test_warmup_route_registered(self):
         """Verify that the warmup route is registered to WarmupHandler."""
-        rules = [r for r in main.app.url_map.iter_rules() if r.rule == '/_ah/warmup']
+        rules = [
+            r for r in main.app.url_map.iter_rules() if r.rule == '/_ah/warmup'
+        ]
         self.assertEqual(len(rules), 1)
         rule = rules[0]
         view_func = main.app.view_functions[rule.endpoint]
@@ -47,8 +49,6 @@ class MainTest(testing_config.CustomTestCase):
         response, status = handler.get()
         self.assertEqual(response, 'OK')
         self.assertEqual(status, 200)
-
-
 
 
 class ConstTemplateTest(testing_config.CustomTestCase):

--- a/main_test.py
+++ b/main_test.py
@@ -33,6 +33,23 @@ class MainTest(testing_config.CustomTestCase):
         """Just test that this file parses and creates an app object."""
         self.assertIsNotNone(main.app)
 
+    def test_warmup_route_registered(self):
+        """Verify that the warmup route is registered to WarmupHandler."""
+        rules = [r for r in main.app.url_map.iter_rules() if r.rule == '/_ah/warmup']
+        self.assertEqual(len(rules), 1)
+        rule = rules[0]
+        view_func = main.app.view_functions[rule.endpoint]
+        self.assertEqual(view_func.view_class, basehandlers.WarmupHandler)
+
+    def test_warmup_handler(self):
+        """Verify that WarmupHandler returns OK."""
+        handler = basehandlers.WarmupHandler()
+        response, status = handler.get()
+        self.assertEqual(response, 'OK')
+        self.assertEqual(status, 200)
+
+
+
 
 class ConstTemplateTest(testing_config.CustomTestCase):
     """Tests for constant template rendering."""


### PR DESCRIPTION
Enabled warmup service in app.yaml and app.staging.yaml, and
implemented WarmupHandler to handle /_ah/warmup requests.
This allows min_idle_instances to take effect.

