### PR TITLE
Filter out stages without rollout details in get_features_for_l10n_extraction

### DIFF
--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -329,18 +329,20 @@ def get_features_for_l10n_extraction(
     for f in formatted_features:
         stages_list = []
         for s in f.get('stages', []):
-            stage_item = {'id': s.get('id')}
             if s.get('rollout_details'):
-                stage_item['rolloutDetails'] = s.get('rollout_details')
-            stages_list.append(stage_item)
+                stage_item = {
+                    'id': s.get('id'),
+                    'rolloutDetails': s.get('rollout_details'),
+                }
+                stages_list.append(stage_item)
+        item = {
+            'id': f.get('id'),
+            'name': f.get('name'),
+            'summary': f.get('summary'),
+        }
         if stages_list:
-            item = {
-                'id': f.get('id'),
-                'name': f.get('name'),
-                'summary': f.get('summary'),
-                'stages': stages_list,
-            }
-            l10n_features.append(item)
+            item['stages'] = stages_list
+        l10n_features.append(item)
 
     return l10n_features
 

--- a/internals/feature_helpers_test.py
+++ b/internals/feature_helpers_test.py
@@ -873,16 +873,8 @@ class FeatureHelpersTest(testing_config.CustomTestCase):
 
         # --- Construct Expected Results dynamically to avoid ID mismatch ---
 
-        # Feature 1's expected stages:
-        # It gets default stages from `setUp`: types [110, 120, 130, 140, 150].
-        # Note that stage type 151 (extend origin trial) is omitted because it is
-        # an extension stage. Since its `ot_stage_id` was not set in `setUp`,
-        # `converters.py` skips it from the main stage list.
-        default_f1_ids = [
-            self.fe_1_stages_dict[st][0].key.integer_id()
-            for st in [110, 120, 130, 140, 150]
-        ]
-        expected_f1_stages = [{'id': idx} for idx in default_f1_ids] + [
+        # Feature 1's expected stages (only stages with non-empty rolloutDetails):
+        expected_f1_stages = [
             {
                 'id': shipping_stage.key.integer_id(),
                 'rolloutDetails': '2SV enforcement starts',
@@ -899,24 +891,10 @@ class FeatureHelpersTest(testing_config.CustomTestCase):
         # Sort expected stages by ID to align with standard response comparison
         expected_f1_stages.sort(key=lambda s: s['id'])
 
-        # Feature 2's expected stages:
-        # It gets all stages created in `setUp`: types [220, 230, 250, 251, 260].
-        # Note: Although type 251 (Fast Track origin trial extension) is an extension
-        # stage, it is NOT skipped here. This is because we overridden the feature type
-        # of `feature_2` to `FEATURE_TYPE_ENTERPRISE_ID`. Because of this type change,
-        # `converters.py` no longer identifies type 251 as an extension stage for
-        # this feature (since `STAGE_TYPES_EXTEND_ORIGIN_TRIAL` is None for enterprise
-        # features). Therefore, it gets returned as a normal, non-extension stage.
-        default_f2_ids = [
-            self.fe_2_stages_dict[st][0].key.integer_id()
-            for st in [220, 230, 250, 251, 260]
-        ]
-        expected_f2_stages = [{'id': idx} for idx in default_f2_ids]
-        expected_f2_stages.sort(key=lambda s: s['id'])
-
         # Sort returned lists in-place to ensure stable comparison
         for f in res:
-            f['stages'].sort(key=lambda s: s['id'])
+            if 'stages' in f:
+                f['stages'].sort(key=lambda s: s['id'])
         res.sort(key=lambda f: f['id'])
 
         expected_res = [
@@ -930,7 +908,6 @@ class FeatureHelpersTest(testing_config.CustomTestCase):
                 'id': self.feature_2.key.integer_id(),
                 'name': 'feature b',
                 'summary': 'sum',
-                'stages': expected_f2_stages,
             },
         ]
         expected_res.sort(key=lambda f: f['id'])


### PR DESCRIPTION
Before it returns 
`"stages": [
				 {
					"id": 5117298414977024,
					"rolloutDetails": "Show the warnings to the user based on the server verdict which uses the brand and intent of the pages that the server reputation system scored."
	},
				 {
					"id": 5097036743573504
	}
]
`,
But we want to filter out stage with no rolloutDetails and it should be look like
`"stages": [
				 {
					"id": 5117298414977024,
					"rolloutDetails": "Show the warnings to the user based on the server verdict which uses the brand and intent of the pages that the server reputation system scored."
	}
]`
, so we make this fix.