### PR TITLE
Catch unicode errors in inbound emails.

### DIFF
--- a/framework/sendemail.py
+++ b/framework/sendemail.py
@@ -248,8 +248,13 @@ def handle_incoming_mail(addr=None):
         # We only process plain text emails.
         if part.get_content_type() == 'text/plain':
             body = part.get_payload(decode=True)
+            logging.info('Considering: %r', body[:2000])
             if not isinstance(body, str):
-                body = body.decode('utf-8')
+                try:
+                    body = body.decode('utf-8')
+                except UnicodeDecodeError:
+                    logging.info('Bad unicode')
+                    return {'message': 'Bad unicode'}
             break  # Only consider the first text part.
 
     to_addr = urllib.parse.unquote(addr)

--- a/framework/sendemail.py
+++ b/framework/sendemail.py
@@ -253,7 +253,7 @@ def handle_incoming_mail(addr=None):
                 try:
                     body = body.decode('utf-8')
                 except UnicodeDecodeError:
-                    logging.info('Bad unicode')
+                    logging.error('Bad unicode')
                     return {'message': 'Bad unicode'}
             break  # Only consider the first text part.
 

--- a/framework/sendemail_test.py
+++ b/framework/sendemail_test.py
@@ -341,6 +341,19 @@ class InboundEmailHandlerTest(testing_config.CustomTestCase):
 
         self.assertEqual({'message': 'Missing From'}, actual)
 
+    @mock.patch('framework.sendemail.get_incoming_message')
+    def test_handle_incoming_mail__bad_unicode(self, mock_get_incoming_message):
+        """A incoming email with invalid unicode is rejected."""
+        msg = MakeMessage(HEADER_LINES, b'\x80 is not valid unicode')
+        mock_get_incoming_message.return_value = msg
+
+        with test_app.test_request_context(
+            '/_ah/mail/%s' % settings.INBOUND_EMAIL_ADDR, data='fake msg'
+        ):
+            actual = sendemail.handle_incoming_mail(settings.INBOUND_EMAIL_ADDR)
+
+        self.assertEqual({'message': 'Bad unicode'}, actual)
+
     @mock.patch('framework.cloud_tasks_helpers.enqueue_task')
     @mock.patch('framework.sendemail.get_incoming_message')
     def test_handle_incoming_mail__normal(


### PR DESCRIPTION
We had some exceptions this week for bad inbound email messages.  This adds logging so that we can see what those messages are, and catches the exception.