### PR TITLE
Give 400 for bad channel range.

### DIFF
--- a/api/channels_api.py
+++ b/api/channels_api.py
@@ -144,7 +144,7 @@ class ChannelsAPI(basehandlers.APIHandler):
             return construct_chrome_channels_details()
 
         if start > end:
-            raise ValueError
+            self.abort(400, 'start is greater than end')
 
         if settings.UNIT_TEST_MODE or settings.PLAYWRIGHT_MODE:
             return {

--- a/api/channels_api_test.py
+++ b/api/channels_api_test.py
@@ -17,6 +17,7 @@
 from unittest import mock
 
 import flask
+import werkzeug.exceptions  # Flask HTTP stuff.
 
 import testing_config  # Must be imported first
 from api import channels_api
@@ -283,8 +284,13 @@ class ChannelsAPITest(testing_config.CustomTestCase):
         with test_app.test_request_context(
             self.request_path + '?start=2&end=1'
         ):
-            with self.assertRaises(ValueError):
+            with self.assertRaises(werkzeug.exceptions.BadRequest) as cm:
                 self.handler.do_get()
+            self.assertEqual(400, cm.exception.code)
+            self.assertEqual(
+                'start is greater than end',
+                cm.exception.description,
+            )
 
     @mock.patch('settings.UNIT_TEST_MODE', False)
     @mock.patch('api.channels_api.construct_specified_milestones_details')


### PR DESCRIPTION
Resolves #6441.

When the start parameter is greater than the end parameter, we give a 400 response.

The convention that we should follow is that code in the `api/` directory will call `self.abort(400, "...")` when bad user input is detected.  That give us a chance to include a specific error message.  That is better than using a generic `except` handler in `basehandlers.py` because such an `except` might mask coding errors.