### PR TITLE
Fixed roadmap icon when a gate is NA_VERIFIED.

### DIFF
--- a/client-src/elements/chromedash-review-status-icon.ts
+++ b/client-src/elements/chromedash-review-status-icon.ts
@@ -23,6 +23,7 @@ import {
   GATE_PREPARING,
   VOTE_OPTIONS,
   VOTE_NA_SELF,
+  VOTE_NA_VERIFIED,
 } from './form-field-enums.js';
 
 type statusEnum =
@@ -106,7 +107,8 @@ export class ChromedashReviewStatusIcon extends LitElement {
       if (
         g.state !== VOTE_OPTIONS['APPROVED'][0] &&
         g.state !== VOTE_OPTIONS['NA'][0] &&
-        g.state !== VOTE_NA_SELF
+        g.state !== VOTE_NA_SELF &&
+        g.state !== VOTE_NA_VERIFIED
       ) {
         targetGateId = g.id;
       }
@@ -124,7 +126,8 @@ export class ChromedashReviewStatusIcon extends LitElement {
         g =>
           g.state === VOTE_OPTIONS['APPROVED'][0] ||
           g.state === VOTE_OPTIONS['NA'][0] ||
-          g.state === VOTE_NA_SELF
+          g.state === VOTE_NA_SELF ||
+          g.state === VOTE_NA_VERIFIED
       )
     ) {
       status = 'Approved';

--- a/client-src/elements/chromedash-review-status-icon_test.ts
+++ b/client-src/elements/chromedash-review-status-icon_test.ts
@@ -23,6 +23,7 @@ import {
   GATE_PREPARING,
   VOTE_OPTIONS,
   VOTE_NA_SELF,
+  VOTE_NA_VERIFIED,
   FEATURE_TYPES,
 } from './form-field-enums.js';
 
@@ -110,6 +111,13 @@ const GATE_PRIVACY_NA_SELF = {
   stage_id: 57463,
   team_name: 'Privacy',
   state: VOTE_NA_SELF,
+};
+
+const GATE_PRIVACY_NA_VERIFIED = {
+  id: 12345001,
+  stage_id: 57463,
+  team_name: 'Privacy',
+  state: VOTE_NA_VERIFIED,
 };
 
 describe('chromedash-review-status-icon', () => {
@@ -227,7 +235,12 @@ describe('chromedash-review-status-icon', () => {
   it('renders "approved" when all gates are approved', async () => {
     getGatesStub.returns(
       Promise.resolve({
-        gates: [GATE_API_APPROVED, GATE_PRIVACY_NA_SELF, GATE_SECURITY_NA],
+        gates: [
+          GATE_API_APPROVED,
+          GATE_PRIVACY_NA_SELF,
+          GATE_PRIVACY_NA_VERIFIED,
+          GATE_SECURITY_NA,
+        ],
       })
     );
     const component = await fixture(COMPONENT_HTML);


### PR DESCRIPTION
This resolves a bug reported by a user via email today.  When I added support for NA_VERIFIED, I must have failed to add it to the logic for choosing the icon shown on the roadmap page.

This PR adds NA_VERIFIED to that logic and treats it as another form of approval.