### PR TITLE
Fix issue with rebuilding the devcontainer.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -68,6 +68,11 @@
 		8888
 	],
 
+	// Mount host's .npmrc for npm registry authentication
+	"mounts": [
+		"source=${localEnv:HOME}/.npmrc,target=/home/vscode/.npmrc,type=bind,consistency=cached"
+	],
+
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "npm install -g gulp-cli && npm run clean-setup",
 	// 'postStartCommand' runs each time the devcontainer is started.
@@ -92,6 +97,9 @@
 			// Match the version on Cloudtops
 			"version": "3.13"
 		}
+	},
+	"containerEnv": {
+		"PUPPETEER_SKIP_DOWNLOAD": "true"
 	},
 	"remoteEnv": {
 		"GEMINI_API_KEY": "${localEnv:GEMINI_API_KEY}"

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ build/
 
 # Temporary
 packages/playwright/playwright.config.ts
+.devcontainer/devcontainer-lock.json


### PR DESCRIPTION
The devcontainer was failing to build for a couple of folks. Turns out the problem was a partial install of Chrome in Puppeteer. This fixes that by simply disabling Chrome downloads for Puppeteer as they're not actually needed, and it also makes the devcontainer gain access to npm credentials which are sometimes needed within cerain environments. This also makes git ignore the devcontainer lock file.