### PR TITLE
Add late change notifications for the enterprise team.

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -207,6 +207,10 @@ POST_BETA_RULE_REASON = (
     'Published aspects of this feature entry changed after it started beta'
 )
 POST_BETA_RULE_ADDRS = ['rachelandrew@google.com']
+ENTERPRISE_LATE_RULE_REASON = (
+    'Published aspects of this feature entry changed after it was first '
+    'included in release notes'
+)
 MILESTONE_FIELDS = {
     'shipped_milestone',
     'shipped_android_milestone',
@@ -214,6 +218,10 @@ MILESTONE_FIELDS = {
     'shipped_ios_milestone',
     'rollout_milestone',
 }
+RELEASENOTES_NOTIFY_ADDRS = [
+    core_enums.CBE_ESCLATION_EMAIL,
+    'siobhankeating@google.com',
+]
 
 
 def apply_subscription_rule_iwa(fe: FeatureEntry) -> dict[str, list[str]]:
@@ -244,40 +252,98 @@ def apply_subscription_rule_webview(
     return rule_results
 
 
-def apply_subscription_rule_docs(
-    fe: FeatureEntry,
-    ship_stages: list[Stage],
-    changes: list,
-    changed_field_names: set[str],
-) -> dict[str, list[str]]:
-    """Every change to a post-beta feature notifies the docs team."""
-    rule_results: dict[str, list[str]] = {}
-    # Case A: name or summary changing while any milestone is post-beta.
-    current_beta_milestone = fetchchannels.get_current_beta_milestone()
-    if 'name' in changed_field_names or 'summary' in changed_field_names:
-        earliest_from_feature = stage_helpers.find_earliest_milestone(
-            ship_stages
-        )
-        if (
-            earliest_from_feature is not None
-            and earliest_from_feature <= current_beta_milestone
-        ):
-            rule_results[POST_BETA_RULE_REASON] = POST_BETA_RULE_ADDRS
+def is_relevant_to_web_platform(fe: FeatureEntry) -> bool:
+    return fe.feature_type != core_enums.FEATURE_TYPE_ENTERPRISE_ID
 
-    # Case B: any milestone changed to or from a post-beta value.
+
+def is_relevant_to_enterprise(fe: FeatureEntry) -> bool:
+    return (fe.feature_type == core_enums.FEATURE_TYPE_ENTERPRISE_ID or
+            fe.enterprise_impact != core_enums.ENTERPRISE_IMPACT_NONE)
+
+
+def find_earliest_from_changes(
+    changes: list, fields: set[str] = MILESTONE_FIELDS) -> int | None:
     changed_milestone_strs = []
     for change in changes:
-        if change['prop_name'] in MILESTONE_FIELDS:
+        if change['prop_name'] in fields:
             changed_milestone_strs.append(change.get('old_val'))
             changed_milestone_strs.append(change.get('new_val'))
     changed_milestone_ints = [
         int(val) for val in changed_milestone_strs if val and val != 'None'
     ]
+    if changed_milestone_ints == []:
+        return None
+    return min(changed_milestone_ints)
+
+
+def apply_subscription_rule_docs(
+    fe: FeatureEntry,
+    earliest_from_stages: int | None,
+    changes: list,
+    changed_field_names: set[str],
+    current_beta_milestone: int,
+) -> dict[str, list[str]]:
+    """Every change to a post-beta WP feature notifies the docs team."""
+    if not is_relevant_to_web_platform(fe):
+        return {}
+    rule_results: dict[str, list[str]] = {}
+    # Case A: name or summary changing while any milestone is post-beta.
+    if 'name' in changed_field_names or 'summary' in changed_field_names:
+        if (
+            earliest_from_stages is not None
+            and earliest_from_stages <= current_beta_milestone
+        ):
+            rule_results[POST_BETA_RULE_REASON] = POST_BETA_RULE_ADDRS
+
+    # Case B: any milestone changed to or from a post-beta value.
+    earliest_from_changes = find_earliest_from_changes(changes)
     if (
-        changed_milestone_ints
-        and min(changed_milestone_ints) <= current_beta_milestone
+        earliest_from_changes
+        and earliest_from_changes <= current_beta_milestone
     ):
         rule_results[POST_BETA_RULE_REASON] = POST_BETA_RULE_ADDRS
+
+    return rule_results
+
+
+def apply_subscription_rule_enterprise(
+    fe: FeatureEntry,
+    earliest_from_stages: int | None,
+    changes: list,
+    changed_field_names: set[str],
+    current_beta_milestone: int,
+) -> dict[str, list[str]]:
+    """Every change to a post-beta enterprise feature notifies that team."""
+    if not is_relevant_to_enterprise(fe):
+        return {}
+    rule_results: dict[str, list[str]] = {}
+    # Case A: name or summary changing while any milestone is post-beta.
+    if 'name' in changed_field_names or 'summary' in changed_field_names:
+        if (
+            earliest_from_stages is not None
+            and earliest_from_stages <= current_beta_milestone
+        ) or (
+            fe.first_enterprise_notification_milestone is not None
+            and fe.first_enterprise_notification_milestone <= current_beta_milestone
+        ):
+            rule_results[ENTERPRISE_LATE_RULE_REASON] = RELEASENOTES_NOTIFY_ADDRS
+
+    # Case B: any milestone changed to or from a post-beta value.
+    earliest_from_changes = find_earliest_from_changes(changes)
+    if (
+        earliest_from_changes
+        and earliest_from_changes <= current_beta_milestone
+    ):
+        rule_results[POST_BETA_RULE_REASON] = RELEASENOTES_NOTIFY_ADDRS
+
+    if 'first_enterprise_notification_milestone' in changed_field_names:
+        earliest_first = find_earliest_from_changes(
+            changes, {'first_enterprise_notification_milestone'})
+        if (
+            earliest_first is not None
+            and earliest_first <= current_beta_milestone
+        ):
+            rule_results[ENTERPRISE_LATE_RULE_REASON] = RELEASENOTES_NOTIFY_ADDRS
 
     return rule_results
 
@@ -305,9 +371,18 @@ def apply_subscription_rules(
     )
 
     # Rule 3: Check if published aspects changed after beta start.
+    current_beta_milestone = fetchchannels.get_current_beta_milestone()
+    earliest_from_stages = stage_helpers.find_earliest_milestone(ship_stages)
     results.update(
         apply_subscription_rule_docs(
-            fe, ship_stages, changes, changed_field_names
+            fe, earliest_from_stages, changes, changed_field_names,
+            current_beta_milestone
+        )
+    )
+    results.update(
+        apply_subscription_rule_enterprise(
+            fe, earliest_from_stages, changes, changed_field_names,
+            current_beta_milestone
         )
     )
 
@@ -1590,10 +1665,6 @@ class ResetShippingMilestonesEmailHandler(basehandlers.FlaskHandler):
         }
 
 
-RELEASENOTES_NOTIFY_ADDRS = [
-    core_enums.CBE_ESCLATION_EMAIL,
-    'siobhankeating@google.com',
-]
 RESET_RELEASENOTES_TEMPLATE_PATH = 'reset-releasenotes-flags-email.html'
 
 

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -259,12 +259,15 @@ def is_relevant_to_web_platform(fe: FeatureEntry) -> bool:
 
 def is_relevant_to_enterprise(fe: FeatureEntry) -> bool:
     """Return true if the feature is an enterprise feature or has impact."""
-    return (fe.feature_type == core_enums.FEATURE_TYPE_ENTERPRISE_ID or
-            fe.enterprise_impact != core_enums.ENTERPRISE_IMPACT_NONE)
+    return (
+        fe.feature_type == core_enums.FEATURE_TYPE_ENTERPRISE_ID
+        or fe.enterprise_impact != core_enums.ENTERPRISE_IMPACT_NONE
+    )
 
 
 def find_earliest_from_changes(
-    changes: list, fields: set[str] = MILESTONE_FIELDS) -> int | None:
+    changes: list, fields: set[str] = MILESTONE_FIELDS
+) -> int | None:
     """Return the earliest milestone mentioned in the changes."""
     changed_milestone_strs = []
     for change in changes:
@@ -327,9 +330,12 @@ def apply_subscription_rule_enterprise(
             and earliest_from_stages <= current_beta_milestone
         ) or (
             fe.first_enterprise_notification_milestone is not None
-            and fe.first_enterprise_notification_milestone <= current_beta_milestone
+            and fe.first_enterprise_notification_milestone
+            <= current_beta_milestone
         ):
-            rule_results[ENTERPRISE_LATE_RULE_REASON] = RELEASENOTES_NOTIFY_ADDRS
+            rule_results[ENTERPRISE_LATE_RULE_REASON] = (
+                RELEASENOTES_NOTIFY_ADDRS
+            )
 
     # Case B: any milestone changed to or from a post-beta value.
     earliest_from_changes = find_earliest_from_changes(changes)
@@ -341,12 +347,15 @@ def apply_subscription_rule_enterprise(
 
     if 'first_enterprise_notification_milestone' in changed_field_names:
         earliest_first = find_earliest_from_changes(
-            changes, {'first_enterprise_notification_milestone'})
+            changes, {'first_enterprise_notification_milestone'}
+        )
         if (
             earliest_first is not None
             and earliest_first <= current_beta_milestone
         ):
-            rule_results[ENTERPRISE_LATE_RULE_REASON] = RELEASENOTES_NOTIFY_ADDRS
+            rule_results[ENTERPRISE_LATE_RULE_REASON] = (
+                RELEASENOTES_NOTIFY_ADDRS
+            )
 
     return rule_results
 
@@ -378,14 +387,20 @@ def apply_subscription_rules(
     earliest_from_stages = stage_helpers.find_earliest_milestone(ship_stages)
     results.update(
         apply_subscription_rule_docs(
-            fe, earliest_from_stages, changes, changed_field_names,
-            current_beta_milestone
+            fe,
+            earliest_from_stages,
+            changes,
+            changed_field_names,
+            current_beta_milestone,
         )
     )
     results.update(
         apply_subscription_rule_enterprise(
-            fe, earliest_from_stages, changes, changed_field_names,
-            current_beta_milestone
+            fe,
+            earliest_from_stages,
+            changes,
+            changed_field_names,
+            current_beta_milestone,
         )
     )
 

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -343,7 +343,7 @@ def apply_subscription_rule_enterprise(
         earliest_from_changes
         and earliest_from_changes <= current_beta_milestone
     ):
-        rule_results[POST_BETA_RULE_REASON] = RELEASENOTES_NOTIFY_ADDRS
+        rule_results[ENTERPRISE_LATE_RULE_REASON] = RELEASENOTES_NOTIFY_ADDRS
 
     if 'first_enterprise_notification_milestone' in changed_field_names:
         earliest_first = find_earliest_from_changes(

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -253,16 +253,19 @@ def apply_subscription_rule_webview(
 
 
 def is_relevant_to_web_platform(fe: FeatureEntry) -> bool:
+    """Return true if the feature is a WP feature."""
     return fe.feature_type != core_enums.FEATURE_TYPE_ENTERPRISE_ID
 
 
 def is_relevant_to_enterprise(fe: FeatureEntry) -> bool:
+    """Return true if the feature is an enterprise feature or has impact."""
     return (fe.feature_type == core_enums.FEATURE_TYPE_ENTERPRISE_ID or
             fe.enterprise_impact != core_enums.ENTERPRISE_IMPACT_NONE)
 
 
 def find_earliest_from_changes(
     changes: list, fields: set[str] = MILESTONE_FIELDS) -> int | None:
+    """Return the earliest milestone mentioned in the changes."""
     changed_milestone_strs = []
     for change in changes:
         if change['prop_name'] in fields:

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: I001
+
 """Tests for the notifier module, verifying email formatting and template rendering."""
 
 import collections
@@ -2197,7 +2199,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     self.fe.key.delete()
 
   def test_apply_subscription_rule_enterprise__not_relevant(self):
-    """Not enterprise type, and no enterprise impact"""
+    """Not enterprise type, and no enterprise impact."""
     self.fe.feature_type = core_enums.FEATURE_TYPE_INCUBATE_ID
     self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_NONE
     self.fe.put()
@@ -2212,7 +2214,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     self.assertEqual({}, actual)
 
   def test_apply_subscription_rule_enterprise__relevant_by_type(self):
-    """Enterprise type, no impact, no changes"""
+    """Enterprise type, no impact, no changes."""
     self.fe.feature_type = core_enums.FEATURE_TYPE_ENTERPRISE_ID
     self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_NONE
     self.fe.put()
@@ -2227,7 +2229,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     self.assertEqual({}, actual)
 
   def test_apply_subscription_rule_enterprise__relevant_by_impact(self):
-    """Not enterprise type, but has impact, no changes"""
+    """Not enterprise type, but has impact, no changes."""
     self.fe.feature_type = core_enums.FEATURE_TYPE_INCUBATE_ID
     self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_LOW
     self.fe.put()
@@ -2242,7 +2244,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     self.assertEqual({}, actual)
 
   def test_apply_subscription_rule_enterprise__case_a_name_changed_post_beta_stage(self):
-    """Name changed, earliest_from_stages is post-beta (<= current_beta)"""
+    """Name changed, earliest_from_stages is post-beta (<= current_beta)."""
     changed_field_names = {'name'}
     actual = notifier.apply_subscription_rule_enterprise(
         self.fe,
@@ -2257,7 +2259,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     )
 
   def test_apply_subscription_rule_enterprise__case_a_summary_changed_post_beta_fe(self):
-    """Summary changed, fe.first_enterprise_notification_milestone is post-beta (<= current_beta)"""
+    """Summary changed, fe.first_enterprise_notification_milestone is post-beta (<= current_beta)."""
     self.fe.first_enterprise_notification_milestone = 80
     self.fe.put()
     changed_field_names = {'summary'}
@@ -2274,7 +2276,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     )
 
   def test_apply_subscription_rule_enterprise__case_a_no_post_beta(self):
-    """Name changed, but milestones are pre-beta (> current_beta) or None"""
+    """Name changed, but milestones are pre-beta (> current_beta) or None."""
     self.fe.first_enterprise_notification_milestone = 120
     self.fe.put()
     changed_field_names = {'name'}
@@ -2288,7 +2290,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     self.assertEqual({}, actual)
 
   def test_apply_subscription_rule_enterprise__case_b_milestone_changed_post_beta(self):
-    """Milestone changed to/from post-beta"""
+    """Milestone changed to/from post-beta."""
     changes = [
         {
             'prop_name': 'shipped_milestone',
@@ -2309,7 +2311,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     )
 
   def test_apply_subscription_rule_enterprise__case_b_milestone_changed_pre_beta(self):
-    """Milestone changed to/from pre-beta"""
+    """Milestone changed to/from pre-beta."""
     changes = [
         {
             'prop_name': 'shipped_milestone',
@@ -2327,7 +2329,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     self.assertEqual({}, actual)
 
   def test_apply_subscription_rule_enterprise__case_c_first_enterprise_milestone_changed_post_beta(self):
-    """first_enterprise_notification_milestone changed to/from post-beta"""
+    """first_enterprise_notification_milestone changed to/from post-beta."""
     changed_field_names = {'first_enterprise_notification_milestone'}
     changes = [
         {
@@ -2349,7 +2351,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     )
 
   def test_apply_subscription_rule_enterprise__case_c_first_enterprise_milestone_changed_pre_beta(self):
-    """first_enterprise_notification_milestone changed to/from pre-beta"""
+    """first_enterprise_notification_milestone changed to/from pre-beta."""
     changed_field_names = {'first_enterprise_notification_milestone'}
     changes = [
         {

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -2179,3 +2179,191 @@ class FunctionsTest(testing_config.CustomTestCase):
             ]
         )
         self.assertEqual({'bounced@example.com'}, actual_3)
+
+
+class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
+
+  def setUp(self):
+    self.fe = FeatureEntry(
+        name='feature one',
+        summary='sum',
+        category=1,
+        feature_type=core_enums.FEATURE_TYPE_ENTERPRISE_ID,
+        enterprise_impact=core_enums.ENTERPRISE_IMPACT_NONE,
+    )
+    self.fe.put()
+
+  def tearDown(self):
+    self.fe.key.delete()
+
+  def test_apply_subscription_rule_enterprise__not_relevant(self):
+    # Not enterprise type, and no enterprise impact
+    self.fe.feature_type = core_enums.FEATURE_TYPE_CONCEPT_ID
+    self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_NONE
+    self.fe.put()
+
+    actual = notifier.apply_subscription_rule_enterprise(
+        self.fe,
+        earliest_from_stages=None,
+        changes=[],
+        changed_field_names=set(),
+        current_beta_milestone=100,
+    )
+    self.assertEqual({}, actual)
+
+  def test_apply_subscription_rule_enterprise__relevant_by_type(self):
+    # Enterprise type, no impact, no changes
+    self.fe.feature_type = core_enums.FEATURE_TYPE_ENTERPRISE_ID
+    self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_NONE
+    self.fe.put()
+
+    actual = notifier.apply_subscription_rule_enterprise(
+        self.fe,
+        earliest_from_stages=None,
+        changes=[],
+        changed_field_names=set(),
+        current_beta_milestone=100,
+    )
+    self.assertEqual({}, actual)
+
+  def test_apply_subscription_rule_enterprise__relevant_by_impact(self):
+    # Not enterprise type, but has impact, no changes
+    self.fe.feature_type = core_enums.FEATURE_TYPE_CONCEPT_ID
+    self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_LOW
+    self.fe.put()
+
+    actual = notifier.apply_subscription_rule_enterprise(
+        self.fe,
+        earliest_from_stages=None,
+        changes=[],
+        changed_field_names=set(),
+        current_beta_milestone=100,
+    )
+    self.assertEqual({}, actual)
+
+  def test_apply_subscription_rule_enterprise__case_a_name_changed_post_beta_stage(self):
+    # Name changed, earliest_from_stages is post-beta (<= current_beta)
+    changed_field_names = {'name'}
+    actual = notifier.apply_subscription_rule_enterprise(
+        self.fe,
+        earliest_from_stages=90,
+        changes=[],
+        changed_field_names=changed_field_names,
+        current_beta_milestone=100,
+    )
+    self.assertEqual(
+        {notifier.ENTERPRISE_LATE_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS},
+        actual
+    )
+
+  def test_apply_subscription_rule_enterprise__case_a_summary_changed_post_beta_fe(self):
+    # Summary changed, fe.first_enterprise_notification_milestone is post-beta (<= current_beta)
+    self.fe.first_enterprise_notification_milestone = 80
+    self.fe.put()
+    changed_field_names = {'summary'}
+    actual = notifier.apply_subscription_rule_enterprise(
+        self.fe,
+        earliest_from_stages=None,
+        changes=[],
+        changed_field_names=changed_field_names,
+        current_beta_milestone=100,
+    )
+    self.assertEqual(
+        {notifier.ENTERPRISE_LATE_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS},
+        actual
+    )
+
+  def test_apply_subscription_rule_enterprise__case_a_no_post_beta(self):
+    # Name changed, but milestones are pre-beta (> current_beta) or None
+    self.fe.first_enterprise_notification_milestone = 120
+    self.fe.put()
+    changed_field_names = {'name'}
+    actual = notifier.apply_subscription_rule_enterprise(
+        self.fe,
+        earliest_from_stages=110,
+        changes=[],
+        changed_field_names=changed_field_names,
+        current_beta_milestone=100,
+    )
+    self.assertEqual({}, actual)
+
+  def test_apply_subscription_rule_enterprise__case_b_milestone_changed_post_beta(self):
+    # Milestone changed to/from post-beta
+    changes = [
+        {
+            'prop_name': 'shipped_milestone',
+            'old_val': 'None',
+            'new_val': '90',
+        }
+    ]
+    actual = notifier.apply_subscription_rule_enterprise(
+        self.fe,
+        earliest_from_stages=None,
+        changes=changes,
+        changed_field_names=set(),
+        current_beta_milestone=100,
+    )
+    self.assertEqual(
+        {notifier.POST_BETA_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS},
+        actual
+    )
+
+  def test_apply_subscription_rule_enterprise__case_b_milestone_changed_pre_beta(self):
+    # Milestone changed to/from pre-beta
+    changes = [
+        {
+            'prop_name': 'shipped_milestone',
+            'old_val': 'None',
+            'new_val': '110',
+        }
+    ]
+    actual = notifier.apply_subscription_rule_enterprise(
+        self.fe,
+        earliest_from_stages=None,
+        changes=changes,
+        changed_field_names=set(),
+        current_beta_milestone=100,
+    )
+    self.assertEqual({}, actual)
+
+  def test_apply_subscription_rule_enterprise__case_c_first_enterprise_milestone_changed_post_beta(self):
+    # first_enterprise_notification_milestone changed to/from post-beta
+    changed_field_names = {'first_enterprise_notification_milestone'}
+    changes = [
+        {
+            'prop_name': 'first_enterprise_notification_milestone',
+            'old_val': 'None',
+            'new_val': '90',
+        }
+    ]
+    actual = notifier.apply_subscription_rule_enterprise(
+        self.fe,
+        earliest_from_stages=None,
+        changes=changes,
+        changed_field_names=changed_field_names,
+        current_beta_milestone=100,
+    )
+    self.assertEqual(
+        {notifier.ENTERPRISE_LATE_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS},
+        actual
+    )
+
+  def test_apply_subscription_rule_enterprise__case_c_first_enterprise_milestone_changed_pre_beta(self):
+    # first_enterprise_notification_milestone changed to/from pre-beta
+    changed_field_names = {'first_enterprise_notification_milestone'}
+    changes = [
+        {
+            'prop_name': 'first_enterprise_notification_milestone',
+            'old_val': 'None',
+            'new_val': '110',
+        }
+    ]
+    actual = notifier.apply_subscription_rule_enterprise(
+        self.fe,
+        earliest_from_stages=None,
+        changes=changes,
+        changed_field_names=changed_field_names,
+        current_beta_milestone=100,
+    )
+    self.assertEqual({}, actual)
+

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -21,8 +21,8 @@ from unittest import mock
 import flask
 from google.cloud import ndb  # type: ignore
 
-import settings
 import testing_config  # Must be imported before the module under test.
+import settings
 from api import converters
 from internals import approval_defs, core_enums, notifier, stage_helpers
 from internals.core_models import FeatureEntry, MilestoneSet, Stage
@@ -2197,8 +2197,8 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     self.fe.key.delete()
 
   def test_apply_subscription_rule_enterprise__not_relevant(self):
-    # Not enterprise type, and no enterprise impact
-    self.fe.feature_type = core_enums.FEATURE_TYPE_CONCEPT_ID
+    """Not enterprise type, and no enterprise impact"""
+    self.fe.feature_type = core_enums.FEATURE_TYPE_INCUBATE_ID
     self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_NONE
     self.fe.put()
 
@@ -2212,7 +2212,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     self.assertEqual({}, actual)
 
   def test_apply_subscription_rule_enterprise__relevant_by_type(self):
-    # Enterprise type, no impact, no changes
+    """Enterprise type, no impact, no changes"""
     self.fe.feature_type = core_enums.FEATURE_TYPE_ENTERPRISE_ID
     self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_NONE
     self.fe.put()
@@ -2227,8 +2227,8 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     self.assertEqual({}, actual)
 
   def test_apply_subscription_rule_enterprise__relevant_by_impact(self):
-    # Not enterprise type, but has impact, no changes
-    self.fe.feature_type = core_enums.FEATURE_TYPE_CONCEPT_ID
+    """Not enterprise type, but has impact, no changes"""
+    self.fe.feature_type = core_enums.FEATURE_TYPE_INCUBATE_ID
     self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_LOW
     self.fe.put()
 
@@ -2242,7 +2242,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     self.assertEqual({}, actual)
 
   def test_apply_subscription_rule_enterprise__case_a_name_changed_post_beta_stage(self):
-    # Name changed, earliest_from_stages is post-beta (<= current_beta)
+    """Name changed, earliest_from_stages is post-beta (<= current_beta)"""
     changed_field_names = {'name'}
     actual = notifier.apply_subscription_rule_enterprise(
         self.fe,
@@ -2257,7 +2257,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     )
 
   def test_apply_subscription_rule_enterprise__case_a_summary_changed_post_beta_fe(self):
-    # Summary changed, fe.first_enterprise_notification_milestone is post-beta (<= current_beta)
+    """Summary changed, fe.first_enterprise_notification_milestone is post-beta (<= current_beta)"""
     self.fe.first_enterprise_notification_milestone = 80
     self.fe.put()
     changed_field_names = {'summary'}
@@ -2274,7 +2274,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     )
 
   def test_apply_subscription_rule_enterprise__case_a_no_post_beta(self):
-    # Name changed, but milestones are pre-beta (> current_beta) or None
+    """Name changed, but milestones are pre-beta (> current_beta) or None"""
     self.fe.first_enterprise_notification_milestone = 120
     self.fe.put()
     changed_field_names = {'name'}
@@ -2288,7 +2288,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     self.assertEqual({}, actual)
 
   def test_apply_subscription_rule_enterprise__case_b_milestone_changed_post_beta(self):
-    # Milestone changed to/from post-beta
+    """Milestone changed to/from post-beta"""
     changes = [
         {
             'prop_name': 'shipped_milestone',
@@ -2309,7 +2309,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     )
 
   def test_apply_subscription_rule_enterprise__case_b_milestone_changed_pre_beta(self):
-    # Milestone changed to/from pre-beta
+    """Milestone changed to/from pre-beta"""
     changes = [
         {
             'prop_name': 'shipped_milestone',
@@ -2327,7 +2327,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     self.assertEqual({}, actual)
 
   def test_apply_subscription_rule_enterprise__case_c_first_enterprise_milestone_changed_post_beta(self):
-    # first_enterprise_notification_milestone changed to/from post-beta
+    """first_enterprise_notification_milestone changed to/from post-beta"""
     changed_field_names = {'first_enterprise_notification_milestone'}
     changes = [
         {
@@ -2349,7 +2349,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
     )
 
   def test_apply_subscription_rule_enterprise__case_c_first_enterprise_milestone_changed_pre_beta(self):
-    # first_enterprise_notification_milestone changed to/from pre-beta
+    """first_enterprise_notification_milestone changed to/from pre-beta"""
     changed_field_names = {'first_enterprise_notification_milestone'}
     changes = [
         {
@@ -2366,4 +2366,3 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
         current_beta_milestone=100,
     )
     self.assertEqual({}, actual)
-

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -2320,7 +2320,7 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
         )
         self.assertEqual(
             {
-                notifier.POST_BETA_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS
+                notifier.ENTERPRISE_LATE_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS
             },
             actual,
         )

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -2184,187 +2184,210 @@ class FunctionsTest(testing_config.CustomTestCase):
 
 
 class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
+    """Tests for apply_subscription_rule_enterprise."""
 
-  def setUp(self):
-    self.fe = FeatureEntry(
-        name='feature one',
-        summary='sum',
-        category=1,
-        feature_type=core_enums.FEATURE_TYPE_ENTERPRISE_ID,
-        enterprise_impact=core_enums.ENTERPRISE_IMPACT_NONE,
-    )
-    self.fe.put()
+    def setUp(self):
+        """Set up the test environment."""
+        self.fe = FeatureEntry(
+            name='feature one',
+            summary='sum',
+            category=1,
+            feature_type=core_enums.FEATURE_TYPE_ENTERPRISE_ID,
+            enterprise_impact=core_enums.ENTERPRISE_IMPACT_NONE,
+        )
+        self.fe.put()
 
-  def tearDown(self):
-    self.fe.key.delete()
+    def tearDown(self):
+        """Clean up the test environment."""
+        self.fe.key.delete()
 
-  def test_apply_subscription_rule_enterprise__not_relevant(self):
-    """Not enterprise type, and no enterprise impact."""
-    self.fe.feature_type = core_enums.FEATURE_TYPE_INCUBATE_ID
-    self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_NONE
-    self.fe.put()
+    def test_apply_subscription_rule_enterprise__not_relevant(self):
+        """Not enterprise type, and no enterprise impact."""
+        self.fe.feature_type = core_enums.FEATURE_TYPE_INCUBATE_ID
+        self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_NONE
+        self.fe.put()
 
-    actual = notifier.apply_subscription_rule_enterprise(
-        self.fe,
-        earliest_from_stages=None,
-        changes=[],
-        changed_field_names=set(),
-        current_beta_milestone=100,
-    )
-    self.assertEqual({}, actual)
+        actual = notifier.apply_subscription_rule_enterprise(
+            self.fe,
+            earliest_from_stages=None,
+            changes=[],
+            changed_field_names=set(),
+            current_beta_milestone=100,
+        )
+        self.assertEqual({}, actual)
 
-  def test_apply_subscription_rule_enterprise__relevant_by_type(self):
-    """Enterprise type, no impact, no changes."""
-    self.fe.feature_type = core_enums.FEATURE_TYPE_ENTERPRISE_ID
-    self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_NONE
-    self.fe.put()
+    def test_apply_subscription_rule_enterprise__relevant_by_type(self):
+        """Enterprise type, no impact, no changes."""
+        self.fe.feature_type = core_enums.FEATURE_TYPE_ENTERPRISE_ID
+        self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_NONE
+        self.fe.put()
 
-    actual = notifier.apply_subscription_rule_enterprise(
-        self.fe,
-        earliest_from_stages=None,
-        changes=[],
-        changed_field_names=set(),
-        current_beta_milestone=100,
-    )
-    self.assertEqual({}, actual)
+        actual = notifier.apply_subscription_rule_enterprise(
+            self.fe,
+            earliest_from_stages=None,
+            changes=[],
+            changed_field_names=set(),
+            current_beta_milestone=100,
+        )
+        self.assertEqual({}, actual)
 
-  def test_apply_subscription_rule_enterprise__relevant_by_impact(self):
-    """Not enterprise type, but has impact, no changes."""
-    self.fe.feature_type = core_enums.FEATURE_TYPE_INCUBATE_ID
-    self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_LOW
-    self.fe.put()
+    def test_apply_subscription_rule_enterprise__relevant_by_impact(self):
+        """Not enterprise type, but has impact, no changes."""
+        self.fe.feature_type = core_enums.FEATURE_TYPE_INCUBATE_ID
+        self.fe.enterprise_impact = core_enums.ENTERPRISE_IMPACT_LOW
+        self.fe.put()
 
-    actual = notifier.apply_subscription_rule_enterprise(
-        self.fe,
-        earliest_from_stages=None,
-        changes=[],
-        changed_field_names=set(),
-        current_beta_milestone=100,
-    )
-    self.assertEqual({}, actual)
+        actual = notifier.apply_subscription_rule_enterprise(
+            self.fe,
+            earliest_from_stages=None,
+            changes=[],
+            changed_field_names=set(),
+            current_beta_milestone=100,
+        )
+        self.assertEqual({}, actual)
 
-  def test_apply_subscription_rule_enterprise__case_a_name_changed_post_beta_stage(self):
-    """Name changed, earliest_from_stages is post-beta (<= current_beta)."""
-    changed_field_names = {'name'}
-    actual = notifier.apply_subscription_rule_enterprise(
-        self.fe,
-        earliest_from_stages=90,
-        changes=[],
-        changed_field_names=changed_field_names,
-        current_beta_milestone=100,
-    )
-    self.assertEqual(
-        {notifier.ENTERPRISE_LATE_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS},
-        actual
-    )
+    def test_apply_subscription_rule_enterprise__case_a_name_changed_post_beta_stage(
+        self,
+    ):
+        """Name changed, earliest_from_stages is post-beta (<= current_beta)."""
+        changed_field_names = {'name'}
+        actual = notifier.apply_subscription_rule_enterprise(
+            self.fe,
+            earliest_from_stages=90,
+            changes=[],
+            changed_field_names=changed_field_names,
+            current_beta_milestone=100,
+        )
+        self.assertEqual(
+            {
+                notifier.ENTERPRISE_LATE_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS
+            },
+            actual,
+        )
 
-  def test_apply_subscription_rule_enterprise__case_a_summary_changed_post_beta_fe(self):
-    """Summary changed, fe.first_enterprise_notification_milestone is post-beta (<= current_beta)."""
-    self.fe.first_enterprise_notification_milestone = 80
-    self.fe.put()
-    changed_field_names = {'summary'}
-    actual = notifier.apply_subscription_rule_enterprise(
-        self.fe,
-        earliest_from_stages=None,
-        changes=[],
-        changed_field_names=changed_field_names,
-        current_beta_milestone=100,
-    )
-    self.assertEqual(
-        {notifier.ENTERPRISE_LATE_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS},
-        actual
-    )
+    def test_apply_subscription_rule_enterprise__case_a_summary_changed_post_beta_fe(
+        self,
+    ):
+        """Summary changed, fe.first_enterprise_notification_milestone is post-beta (<= current_beta)."""
+        self.fe.first_enterprise_notification_milestone = 80
+        self.fe.put()
+        changed_field_names = {'summary'}
+        actual = notifier.apply_subscription_rule_enterprise(
+            self.fe,
+            earliest_from_stages=None,
+            changes=[],
+            changed_field_names=changed_field_names,
+            current_beta_milestone=100,
+        )
+        self.assertEqual(
+            {
+                notifier.ENTERPRISE_LATE_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS
+            },
+            actual,
+        )
 
-  def test_apply_subscription_rule_enterprise__case_a_no_post_beta(self):
-    """Name changed, but milestones are pre-beta (> current_beta) or None."""
-    self.fe.first_enterprise_notification_milestone = 120
-    self.fe.put()
-    changed_field_names = {'name'}
-    actual = notifier.apply_subscription_rule_enterprise(
-        self.fe,
-        earliest_from_stages=110,
-        changes=[],
-        changed_field_names=changed_field_names,
-        current_beta_milestone=100,
-    )
-    self.assertEqual({}, actual)
+    def test_apply_subscription_rule_enterprise__case_a_no_post_beta(self):
+        """Name changed, but milestones are pre-beta (> current_beta) or None."""
+        self.fe.first_enterprise_notification_milestone = 120
+        self.fe.put()
+        changed_field_names = {'name'}
+        actual = notifier.apply_subscription_rule_enterprise(
+            self.fe,
+            earliest_from_stages=110,
+            changes=[],
+            changed_field_names=changed_field_names,
+            current_beta_milestone=100,
+        )
+        self.assertEqual({}, actual)
 
-  def test_apply_subscription_rule_enterprise__case_b_milestone_changed_post_beta(self):
-    """Milestone changed to/from post-beta."""
-    changes = [
-        {
-            'prop_name': 'shipped_milestone',
-            'old_val': 'None',
-            'new_val': '90',
-        }
-    ]
-    actual = notifier.apply_subscription_rule_enterprise(
-        self.fe,
-        earliest_from_stages=None,
-        changes=changes,
-        changed_field_names=set(),
-        current_beta_milestone=100,
-    )
-    self.assertEqual(
-        {notifier.POST_BETA_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS},
-        actual
-    )
+    def test_apply_subscription_rule_enterprise__case_b_milestone_changed_post_beta(
+        self,
+    ):
+        """Milestone changed to/from post-beta."""
+        changes = [
+            {
+                'prop_name': 'shipped_milestone',
+                'old_val': 'None',
+                'new_val': '90',
+            }
+        ]
+        actual = notifier.apply_subscription_rule_enterprise(
+            self.fe,
+            earliest_from_stages=None,
+            changes=changes,
+            changed_field_names=set(),
+            current_beta_milestone=100,
+        )
+        self.assertEqual(
+            {
+                notifier.POST_BETA_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS
+            },
+            actual,
+        )
 
-  def test_apply_subscription_rule_enterprise__case_b_milestone_changed_pre_beta(self):
-    """Milestone changed to/from pre-beta."""
-    changes = [
-        {
-            'prop_name': 'shipped_milestone',
-            'old_val': 'None',
-            'new_val': '110',
-        }
-    ]
-    actual = notifier.apply_subscription_rule_enterprise(
-        self.fe,
-        earliest_from_stages=None,
-        changes=changes,
-        changed_field_names=set(),
-        current_beta_milestone=100,
-    )
-    self.assertEqual({}, actual)
+    def test_apply_subscription_rule_enterprise__case_b_milestone_changed_pre_beta(
+        self,
+    ):
+        """Milestone changed to/from pre-beta."""
+        changes = [
+            {
+                'prop_name': 'shipped_milestone',
+                'old_val': 'None',
+                'new_val': '110',
+            }
+        ]
+        actual = notifier.apply_subscription_rule_enterprise(
+            self.fe,
+            earliest_from_stages=None,
+            changes=changes,
+            changed_field_names=set(),
+            current_beta_milestone=100,
+        )
+        self.assertEqual({}, actual)
 
-  def test_apply_subscription_rule_enterprise__case_c_first_enterprise_milestone_changed_post_beta(self):
-    """first_enterprise_notification_milestone changed to/from post-beta."""
-    changed_field_names = {'first_enterprise_notification_milestone'}
-    changes = [
-        {
-            'prop_name': 'first_enterprise_notification_milestone',
-            'old_val': 'None',
-            'new_val': '90',
-        }
-    ]
-    actual = notifier.apply_subscription_rule_enterprise(
-        self.fe,
-        earliest_from_stages=None,
-        changes=changes,
-        changed_field_names=changed_field_names,
-        current_beta_milestone=100,
-    )
-    self.assertEqual(
-        {notifier.ENTERPRISE_LATE_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS},
-        actual
-    )
+    def test_apply_subscription_rule_enterprise__case_c_first_enterprise_milestone_changed_post_beta(
+        self,
+    ):
+        """first_enterprise_notification_milestone changed to/from post-beta."""
+        changed_field_names = {'first_enterprise_notification_milestone'}
+        changes = [
+            {
+                'prop_name': 'first_enterprise_notification_milestone',
+                'old_val': 'None',
+                'new_val': '90',
+            }
+        ]
+        actual = notifier.apply_subscription_rule_enterprise(
+            self.fe,
+            earliest_from_stages=None,
+            changes=changes,
+            changed_field_names=changed_field_names,
+            current_beta_milestone=100,
+        )
+        self.assertEqual(
+            {
+                notifier.ENTERPRISE_LATE_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS
+            },
+            actual,
+        )
 
-  def test_apply_subscription_rule_enterprise__case_c_first_enterprise_milestone_changed_pre_beta(self):
-    """first_enterprise_notification_milestone changed to/from pre-beta."""
-    changed_field_names = {'first_enterprise_notification_milestone'}
-    changes = [
-        {
-            'prop_name': 'first_enterprise_notification_milestone',
-            'old_val': 'None',
-            'new_val': '110',
-        }
-    ]
-    actual = notifier.apply_subscription_rule_enterprise(
-        self.fe,
-        earliest_from_stages=None,
-        changes=changes,
-        changed_field_names=changed_field_names,
-        current_beta_milestone=100,
-    )
-    self.assertEqual({}, actual)
+    def test_apply_subscription_rule_enterprise__case_c_first_enterprise_milestone_changed_pre_beta(
+        self,
+    ):
+        """first_enterprise_notification_milestone changed to/from pre-beta."""
+        changed_field_names = {'first_enterprise_notification_milestone'}
+        changes = [
+            {
+                'prop_name': 'first_enterprise_notification_milestone',
+                'old_val': 'None',
+                'new_val': '110',
+            }
+        ]
+        actual = notifier.apply_subscription_rule_enterprise(
+            self.fe,
+            earliest_from_stages=None,
+            changes=changes,
+            changed_field_names=changed_field_names,
+            current_beta_milestone=100,
+        )
+        self.assertEqual({}, actual)


### PR DESCRIPTION
This should resolve b/511135154.

The enterprise team requested this change to help keep on top of changes that sneak in after release notes have gone out.