### PR TITLE
Consider more fields when checking for late change notifications.

### DIFF
--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -312,6 +312,16 @@ def apply_subscription_rule_docs(
     return rule_results
 
 
+ENTERPRISE_RELEASENOTES_FIELDS = {
+    'name',
+    'summary',
+    'enterprise_product_category',
+    'rollout_platforms',
+    'enterprise_feature_categories',
+    'enterprise_impact',
+}
+
+
 def apply_subscription_rule_enterprise(
     fe: FeatureEntry,
     earliest_from_stages: int | None,
@@ -324,7 +334,7 @@ def apply_subscription_rule_enterprise(
         return {}
     rule_results: dict[str, list[str]] = {}
     # Case A: name or summary changing while any milestone is post-beta.
-    if 'name' in changed_field_names or 'summary' in changed_field_names:
+    if not ENTERPRISE_RELEASENOTES_FIELDS.isdisjoint(changed_field_names):
         if (
             earliest_from_stages is not None
             and earliest_from_stages <= current_beta_milestone

--- a/internals/notifier.py
+++ b/internals/notifier.py
@@ -333,7 +333,7 @@ def apply_subscription_rule_enterprise(
     if not is_relevant_to_enterprise(fe):
         return {}
     rule_results: dict[str, list[str]] = {}
-    # Case A: name or summary changing while any milestone is post-beta.
+    # Case A: Any enterprise release notes field changing while any milestone is post-beta.
     if not ENTERPRISE_RELEASENOTES_FIELDS.isdisjoint(changed_field_names):
         if (
             earliest_from_stages is not None

--- a/internals/notifier_test.py
+++ b/internals/notifier_test.py
@@ -2286,6 +2286,27 @@ class ApplySubscriptionRuleEnterpriseTest(testing_config.CustomTestCase):
             actual,
         )
 
+    def test_apply_subscription_rule_enterprise__case_a_impact_changed_post_beta_fe(
+        self,
+    ):
+        """Impact changed, fe.first_enterprise_notification_milestone is post-beta (<= current_beta)."""
+        self.fe.first_enterprise_notification_milestone = 80
+        self.fe.put()
+        changed_field_names = {'enterprise_impact', 'some_irrelevant_field'}
+        actual = notifier.apply_subscription_rule_enterprise(
+            self.fe,
+            earliest_from_stages=None,
+            changes=[],
+            changed_field_names=changed_field_names,
+            current_beta_milestone=100,
+        )
+        self.assertEqual(
+            {
+                notifier.ENTERPRISE_LATE_RULE_REASON: notifier.RELEASENOTES_NOTIFY_ADDRS
+            },
+            actual,
+        )
+
     def test_apply_subscription_rule_enterprise__case_a_no_post_beta(self):
         """Name changed, but milestones are pre-beta (> current_beta) or None."""
         self.fe.first_enterprise_notification_milestone = 120


### PR DESCRIPTION
This is a follow-up to #6470.

I implemented the code for the Enterprise late-change notification rule by copying the similar rule for Web Platform features.  However, the Enterprise release notes display more fields, so the team will want to know if any of those fields change.