### PR TITLE
Update OT reminders for 2-week release cycle (starting M153)

### DIFF
--- a/docs/ot-process-reminders.md
+++ b/docs/ot-process-reminders.md
@@ -1,0 +1,150 @@
+# Origin Trial Process Reminders
+
+This document describes the automated system that sends reminder emails to Origin Trial (OT) contacts about upcoming milestones (e.g., when a trial is branching, entering beta, or ending).
+
+## System Overview
+
+The system runs as a weekly cron job. It identifies active origin trials that match specific milestone criteria based on the current Chrome release schedule (fetched from Chromium Dash), and schedules tasks to send reminder emails to the trial owners and contacts.
+
+## Architecture & Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Cron as App Engine Cron
+    participant Handler as SendOTReminderEmailsHandler (reminders.py)
+    participant Core as ot_process_reminders.py
+    participant ChDash as chromiumdash.appspot.com
+    participant OTClient as origin_trials_client
+    participant Datastore as NDB Datastore (Stage)
+    participant Tasks as Cloud Tasks
+    participant Worker as Task Handlers (notifier.py)
+    participant Email as Sendgrid/Mail
+
+    Cron->>Handler: GET /cron/send-ot-process-reminders
+    Handler->>Core: send_email_reminders()
+    Core->>ChDash: Fetch release info (current milestone, branch dates)
+    Core->>OTClient: get_trials_list()
+    Core->>Datastore: Query Stage entities matching Trial IDs
+    Core->>Core: Filter trials matching milestones
+    Core->>Tasks: Enqueue /tasks/email-ot-* tasks
+    Tasks->>Worker: POST /tasks/email-ot-*
+    Worker->>Email: send_emails()
+```
+
+## Key Files and Directory Structure
+
+*   **Cron Configuration**:
+    *   [cron.yaml](/cron.yaml): Schedules `/cron/send-ot-process-reminders` (currently every Monday at 10:00).
+*   **Routing**:
+    *   [main.py](/main.py): Routes the cron URL and the task queue URLs (`/tasks/email-ot-*`).
+*   **Handlers & Logic**:
+    *   [internals/reminders.py](/internals/reminders.py): Contains `SendOTReminderEmailsHandler` (the Flask handler for the cron job).
+    *   [internals/ot_process_reminders.py](/internals/ot_process_reminders.py): Core logic for calculating milestones, fetching trials, and enqueuing tasks.
+    *   [internals/notifier.py](/internals/notifier.py): Task handlers that render email templates and call `send_emails()`.
+*   **Templates**:
+    *   [templates/origintrials/](/templates/origintrials/): HTML email templates used by the task handlers.
+*   **Tests**:
+    *   [internals/ot_process_reminders_test.py](/internals/ot_process_reminders_test.py): Unit tests for the filtering and data building logic in `ot_process_reminders.py`.
+    *   [internals/reminders_test.py](/internals/reminders_test.py): Unit tests for the reminder cron handlers in `reminders.py`.
+    *   [internals/notifier_test.py](/internals/notifier_test.py): Unit tests for the email rendering and sending handlers in `notifier.py`.
+
+## Core Logic Breakdown (`ot_process_reminders.py`)
+
+The entry point is `send_email_reminders()`. It performs the following steps:
+
+1.  **Determine Milestones**:
+    *   Fetches current release data from Chromium Dash.
+    *   Calculates `next_branch_release`, `current_stable_release`, and `next_stable_release`.
+2.  **Evaluate Timing**:
+    *   Checks the number of weeks/days until key dates (e.g., `next_branch_date`, `earliest_beta`).
+    *   If a milestone event is happening "this week" (diff is 0 weeks, or 1 week for stable updates), it triggers the corresponding email sends.
+3.  **Fetch & Filter Trials**:
+    *   `get_trials(release)` fetches all trials from the Origin Trials API.
+    *   It filters trials where `start_milestone` or `end_milestone` matches the target `release`.
+    *   It loads the corresponding `Stage` entity from NDB Datastore to get contact emails (`ot_owner_email` and `ot_emails`).
+4.  **Enqueue Tasks**:
+    *   Calls `cloud_tasks_helpers.enqueue_task()` to delegate email sending to Task Queue workers, avoiding timeouts in the cron handler.
+
+## Release Cycle Transition (4-Week to 2-Week)
+
+Starting with milestone 153 (scheduled for September 8th, 2026), Chrome moves from a 4-week release cycle to a 2-week release cycle. This affects how we calculate milestone offsets for reminders to ensure owners receive warnings at similar time intervals (e.g., ~8 weeks notice).
+
+### Dynamic Offset Calculations
+
+To handle this transition, the system dynamically calculates offsets based on the milestone number:
+
+*   **Milestone Offset for Trial End Reminders**:
+    In [ot_process_reminders.py](file:///usr/local/google/home/danielrsmith/projects/chromium-dashboard/internals/ot_process_reminders.py), `get_trial_end_release_offset(release)` determines how many milestones ahead we look for trials ending.
+    *   `release` <= 151: Offset is **2 milestones** (~8 weeks on 4-week cycle).
+    *   `release` == 152: Offset is **3 milestones** (transition to 2-week cycle, target M155 is 8 weeks away).
+    *   `release` >= 153: Offset is **4 milestones** (~8 weeks on 2-week cycle).
+    
+    The helper `get_release_plus_n(release, n)` is used to calculate the target milestone, correctly handling milestone increments.
+
+*   **Future Milestones to Consider for Accuracy Reminders**:
+    In [reminders.py](file:///usr/local/google/home/danielrsmith/projects/chromium-dashboard/internals/reminders.py), `FeatureAccuracyHandler` overrides `get_future_milestones_to_consider(current_milestone)` to adjust the lookahead window:
+    *   `current_milestone` <= 151: Looks **2 milestones** ahead.
+    *   `current_milestone` == 152: Looks **3 milestones** ahead.
+    *   `current_milestone` >= 153: Looks **4 milestones** ahead.
+
+This ensures that reminders continue to be sent with approximately 8 weeks of lead time before the relevant milestone event, regardless of the release cycle duration.
+
+## Task to Template Mapping
+
+When `ot_process_reminders.py` enqueues a task, it maps to a handler in `notifier.py` which renders a specific template:
+
+| Task URL | Handler in `notifier.py` | Template in `templates/origintrials/` | Description |
+| :--- | :--- | :--- | :--- |
+| `/tasks/email-ot-first-branch` | `OTFirstBranchReminderHandler` | `ot-first-branch-email.html` | Sent to contacts when their trial is branching for the first time. |
+| `/tasks/email-ot-last-branch` | `OTLastBranchReminderHandler` | `ot-last-branch-email.html` | Sent to contacts when their trial has branched for its last milestone. |
+| `/tasks/email-ot-beta-availability` | `OTBetaAvailabilityReminderHandler` | `ot-beta-availability-email.html` | Sent to contacts when their trial is entering beta. |
+| `/tasks/email-ot-ending-next-release` | `OTEndingNextReleaseReminderHandler` | `ot-ending-next-release-email.html` | Sent to contacts when their trial is ending in the next release. |
+| `/tasks/email-ot-ending-this-release` | `OTEndingThisReleaseReminderHandler` | `ot-ending-this-release-email.html` | (Optional/Draft) Sent when trial ends in current release. |
+| `/tasks/email-ot-automated-process` | `OTAutomatedProcessEmailHandler` | `ot-automated-process-email.html` | Summary email sent to the OT admin/support list listing what was processed. |
+
+## How to Make Changes
+
+### 1. Modifying Email Content
+To change the wording or layout of a reminder email:
+1.  Locate the template in `templates/origintrials/`.
+2.  Modify the HTML/Django template syntax.
+3.  If you add new variables to the template, update the corresponding handler's `build_email` method in [internals/notifier.py](/internals/notifier.py) to pass them in `body_data`.
+4.  Update the tests in [internals/notifier_test.py](/internals/notifier_test.py) (you may need to update the golden files if the test asserts on exact HTML structure).
+
+### 2. Adding a New Reminder Type
+To add a new type of reminder (e.g., 2 weeks before ending):
+1.  **Define Task Route**: Add the new task route to `internals_routes` in [main.py](/main.py).
+2.  **Implement Handler**: Create a new handler class in [internals/notifier.py](/internals/notifier.py) (e.g., `OTNearEndReminderHandler`). Specify `EMAIL_TEMPLATE_PATH` and implement `process_post_data` and `build_email`.
+3.  **Create Template**: Add the HTML template under `templates/origintrials/`.
+4.  **Update Core Logic**: In [internals/ot_process_reminders.py](/internals/ot_process_reminders.py):
+    *   Calculate the time difference that should trigger this reminder.
+    *   Call `cloud_tasks_helpers.enqueue_task('/tasks/email-ot-your-new-task', params)` when the criteria are met.
+5.  **Add Tests**:
+    *   Add unit tests in [internals/ot_process_reminders_test.py](/internals/ot_process_reminders_test.py) to verify the logic triggers the enqueue call under correct milestone conditions.
+    *   Add unit tests in [internals/notifier_test.py](/internals/notifier_test.py) to verify the handler correctly renders and sends the email.
+
+## Running Tests
+
+You can run all backend tests locally using the standard test command:
+
+```bash
+# Run all Python tests (including reminders tests)
+npm test
+```
+
+If you want to run only specific test files to save time, you must manually run `pytest` within the virtual environment while the Datastore emulator is running:
+
+```bash
+# 1. Start the Datastore emulator in one terminal (keeps running)
+make start-emulator
+
+# 2. In another terminal, run pytest for the specific files
+. cs-env/bin/activate
+pytest internals/ot_process_reminders_test.py
+pytest internals/reminders_test.py
+pytest internals/notifier_test.py
+
+# 3. Stop the emulator when done
+make stop-emulator
+```
+

--- a/internals/ot_process_reminders.py
+++ b/internals/ot_process_reminders.py
@@ -218,11 +218,27 @@ def send_beta_availability_emails(release):
     return send_count
 
 
+def get_trial_end_release_offset(release: int) -> int:
+    """Determine the milestone offset for trial end reminders based on release cycle."""
+    if release >= 153:
+        return 4
+    if release == 152:
+        return 3
+    return 2
+
+
+def get_release_plus_n(release: int, n: int) -> int:
+    """Get the milestone number N releases after the given release."""
+    res = release
+    for _ in range(n):
+        res = get_next_release_number(res)
+    return res
+
+
 def send_stable_update_emails(release):
     """Send reminders about trials that are entering stable."""
-    trial_end_release = get_next_release_number(
-        get_next_release_number(release)
-    )
+    offset = get_trial_end_release_offset(release)
+    trial_end_release = get_release_plus_n(release, offset)
     after_end_release = get_next_release_number(trial_end_release)
     after_end_branch_date = get_branch_date(get_release(after_end_release))
     formatted_branch_date = (

--- a/internals/ot_process_reminders_test.py
+++ b/internals/ot_process_reminders_test.py
@@ -277,3 +277,28 @@ class OTProcessRemindersTest(testing_config.CustomTestCase):
         self.assertEqual(
             set(ending_trial['contacts']), set(expected_ending_trial_contacts)
         )
+
+    def test_get_trial_end_release_offset(self):
+        """Test that the correct offset is returned based on release milestone."""
+        self.assertEqual(
+            ot_process_reminders.get_trial_end_release_offset(150), 2
+        )
+        self.assertEqual(
+            ot_process_reminders.get_trial_end_release_offset(151), 2
+        )
+        self.assertEqual(
+            ot_process_reminders.get_trial_end_release_offset(152), 3
+        )
+        self.assertEqual(
+            ot_process_reminders.get_trial_end_release_offset(153), 4
+        )
+        self.assertEqual(
+            ot_process_reminders.get_trial_end_release_offset(154), 4
+        )
+
+    def test_get_release_plus_n(self):
+        """Test that get_release_plus_n correctly increments milestones."""
+        self.assertEqual(ot_process_reminders.get_release_plus_n(150, 2), 152)
+        self.assertEqual(ot_process_reminders.get_release_plus_n(150, 4), 154)
+        # Test skipping milestone 82
+        self.assertEqual(ot_process_reminders.get_release_plus_n(80, 2), 83)

--- a/internals/reminders.py
+++ b/internals/reminders.py
@@ -188,6 +188,10 @@ class AbstractReminderHandler(basehandlers.FlaskHandler):
         self.changes_after_sending_notifications(features_to_notify)
         return {'message': message}
 
+    def get_future_milestones_to_consider(self, current_milestone: int) -> int:
+        """Return the number of future milestones to consider."""
+        return self.FUTURE_MILESTONES_TO_CONSIDER
+
     def prefilter_features(
         self, current_milestone_info: dict, features: list[FeatureEntry]
     ) -> list[FeatureEntry]:
@@ -202,7 +206,8 @@ class AbstractReminderHandler(basehandlers.FlaskHandler):
         # We send notifications to any feature planned for beta or stable launch
         # in the next 4 * FUTURE_MILESTONES_TO_CONSIDER weeks.
         min_mstone = int(current_milestone_info['mstone'])
-        max_mstone = min_mstone + self.FUTURE_MILESTONES_TO_CONSIDER
+        future_milestones = self.get_future_milestones_to_consider(min_mstone)
+        max_mstone = min_mstone + future_milestones
 
         feature_ids = [f.key.integer_id() for f in features]
         futures = []
@@ -309,6 +314,14 @@ class FeatureAccuracyHandler(AbstractReminderHandler):
         'shipped_webview_milestone',
         'rollout_milestone',
     ]
+
+    def get_future_milestones_to_consider(self, current_milestone: int) -> int:
+        """Return the number of future milestones to consider."""
+        if current_milestone >= 153:
+            return 4
+        if current_milestone == 152:
+            return 3
+        return self.FUTURE_MILESTONES_TO_CONSIDER
 
     def prefilter_features(
         self, current_milestone_info: dict, features: list[FeatureEntry]

--- a/internals/reminders_test.py
+++ b/internals/reminders_test.py
@@ -506,6 +506,55 @@ class FeatureAccuracyHandlerTest(testing_config.CustomTestCase):
         self.assertEqual(self.feature_1.outstanding_notifications, 2)
         self.assertEqual(self.feature_2.outstanding_notifications, 2)
 
+    @mock.patch('requests.get')
+    def test_determine_features_to_notify__valid_features_post_153(
+        self, mock_get
+    ):
+        """Test determine features to notify for milestones >= 153 (2-week cycle)."""
+        feature_post_153 = FeatureEntry(
+            id=4,
+            name='feature post 153',
+            summary='sum',
+            owner_emails=['owner_post_153@example.com'],
+            category=1,
+            feature_type=1,
+        )
+        feature_post_153.put()
+        stage = Stage(
+            id=264,
+            feature_id=4,
+            stage_type=260,
+        )
+        stage.milestones = MilestoneSet(desktop_first=156)
+        stage.put()
+
+        owner_pref = UserPref(
+            email='owner_post_153@example.com', notify_as_starrer=False
+        )
+        owner_pref.put()
+
+        mock_return = MockResponse(
+            text=(
+                '{"mstones":[{"mstone": "153", '
+                '"earliest_beta": "2026-09-08T01:23:45"}]}'
+            )
+        )
+        mock_get.return_value = mock_return
+        with test_app.app_context():
+            result = self.handler.get_template_data()
+
+        expected_message = (
+            '1 email(s) sent or logged.\n'
+            'Recipients:\n'
+            'owner_post_153@example.com'
+        )
+        expected = {'message': expected_message}
+        self.assertEqual(result, expected)
+
+        feature_post_153.key.delete()
+        stage.key.delete()
+        owner_pref.key.delete()
+
 
 class PrepublicationHandlerTest(testing_config.CustomTestCase):
     """Tests for PrepublicationHandler."""


### PR DESCRIPTION
Resolves #6435

## Overview
Updates the Origin Trial (OT) process reminders and feature accuracy reminders to support Chrome's transition to a 2-week release cycle starting at milestone 153.

## Root Cause / Motivation
Chrome is moving to a 2-week release cycle starting with M153 on September 8th, 2026. This changes the duration between milestones from 4 weeks to 2 weeks. The existing reminders system assumed a 4-week cycle and used fixed milestone offsets (e.g., looking 2 milestones ahead for a ~8-week warning). To maintain the same real-time warning windows (~8 weeks notice) under the new 2-week cycle, the system now dynamically calculates milestone offsets based on the milestone number.

## Detailed Changelog
* **`internals/ot_process_reminders.py`**:
    *   Added `get_trial_end_release_offset(release)` to dynamically return the milestone offset based on the release cycle (2 milestones for <=151, 3 for 152, and 4 for >=153).
    *   Added `get_release_plus_n(release, n)` helper to safely increment milestone numbers (handling edge cases like skipping milestone 82).
    *   Updated `send_stable_update_emails()` to use these helpers for calculating the target `trial_end_release`.
* **`internals/reminders.py`**:
    *   Added `get_future_milestones_to_consider(current_milestone)` to `AbstractReminderHandler` and updated `filter_by_milestones()` to use it.
    *   Overrode `get_future_milestones_to_consider()` in `FeatureAccuracyHandler` to dynamically adjust the lookahead window (2 milestones for <=151, 3 for 152, and 4 for >=153) to preserve the ~8-week notice window.
* **`internals/ot_process_reminders_test.py`**:
    *   Added `test_get_trial_end_release_offset` and `test_get_release_plus_n` to test the new transition logic.
* **`internals/reminders_test.py`**:
    *   Added `test_determine_features_to_notify__valid_features_post_153` to verify that `FeatureAccuracyHandler` correctly expands its lookahead window to 4 milestones for milestones >= 153.
* **`docs/ot-process-reminders.md`**:
    *   Created comprehensive documentation explaining the OT process reminders architecture, data flow, key files, and how to handle the 2-week release cycle transition.
