### PR TITLE
Initial crawler content

### DIFF
--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -829,7 +829,6 @@ class SPAHandler(FlaskHandler):
         crawler_data = self.get_crawler_data(defaults)
         if crawler_data:
             template_data['crawler'] = crawler_data
-        logging.info('template data is %r', template_data)
         return template_data
 
     def get_crawler_data(self, defaults):

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -825,7 +825,16 @@ class SPAHandler(FlaskHandler):
 
     def get_template_data(self, **defaults):
         """Get template data for rendering."""
-        return get_spa_template_data(self, defaults)
+        template_data = get_spa_template_data(self, defaults)
+        crawler_data = self.get_crawler_data(defaults)
+        if crawler_data:
+            template_data['crawler'] = crawler_data
+        logging.info('template data is %r', template_data)
+        return template_data
+
+    def get_crawler_data(self, defaults):
+        """Return dict for semantic HTML content for crawlers."""
+        return {}
 
 
 def get_spa_template_data(handler_obj, defaults):

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -1365,11 +1365,11 @@ class SPAHandlerTests(testing_config.CustomTestCase):
     @mock.patch('framework.basehandlers.get_spa_template_data')
     def test_get_template_data(self, mock_get_spa):
         """It simply calls get_spa_template_data."""
-        mock_get_spa.return_value = 'fake response'
+        mock_get_spa.return_value = {'msg': 'fake response'}
         handler = basehandlers.SPAHandler()
         actual = handler.get_template_data(x=1, y=2)
 
-        self.assertEqual('fake response', actual)
+        self.assertEqual({'msg': 'fake response'}, actual)
         mock_get_spa.assert_called_once_with(handler, {'x': 1, 'y': 2})
 
 

--- a/main.py
+++ b/main.py
@@ -67,7 +67,7 @@ from internals import (
     reminders,
     search_fulltext,
 )
-from pages import guide, ot_requests, users
+from pages import featuredetail, guide, ot_requests, users
 
 # Patch treading library to work-around bug with Google Cloud Logging.
 original_delete = threading.Thread._delete  # type: ignore
@@ -284,7 +284,7 @@ spa_page_routes = [
     Route('/features'),
     Route('/features/stale'),
     Route('/newfeatures'),
-    Route('/feature/<int:feature_id>'),
+    Route('/feature/<int:feature_id>', featuredetail.FeatureDetailHandler),
     Route('/feature/<int:feature_id>/activity'),
     Route(
         '/feature/<int:feature_id>/ai-coverage-analysis',

--- a/packages/playwright/tests/chromedash-guide-feature-page_pwtest.js
+++ b/packages/playwright/tests/chromedash-guide-feature-page_pwtest.js
@@ -86,7 +86,7 @@ test('add an origin trial stage', async ({page}) => {
 
   // Take a screenshot of the content area.
   // First scroll to "Prepare to ship" panel to frame the shot.
-  const prepareToShipPanel = page.getByText('Prepare to ship');
+  const prepareToShipPanel = page.locator('sl-details[summary="Prepare to ship"]');
   await prepareToShipPanel.scrollIntoViewIfNeeded();
 
   await expectScreenshot(page, 'origin-trial-panels', {

--- a/packages/playwright/tests/chromedash-guide-feature-page_pwtest.js
+++ b/packages/playwright/tests/chromedash-guide-feature-page_pwtest.js
@@ -86,7 +86,9 @@ test('add an origin trial stage', async ({page}) => {
 
   // Take a screenshot of the content area.
   // First scroll to "Prepare to ship" panel to frame the shot.
-  const prepareToShipPanel = page.locator('sl-details[summary="Prepare to ship"]');
+  const prepareToShipPanel = page.locator(
+    'sl-details[summary="Prepare to ship"]'
+  );
   await prepareToShipPanel.scrollIntoViewIfNeeded();
 
   await expectScreenshot(page, 'origin-trial-panels', {

--- a/pages/featuredetail.py
+++ b/pages/featuredetail.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Serves the SPA with minimal semantic HTML for feature details."""
+
+
+
+from api import converters
+from framework import basehandlers, permissions, users
+from internals.core_enums import INTENT_STAGES
+from internals.core_models import FeatureEntry
+
+
+class FeatureDetailHandler(basehandlers.SPAHandler):
+    """SPA + SSR handler for showing one feature entry in detail."""
+
+    def get_crawler_data(self, defaults):
+        """Retrieves basic details of the current feature."""
+        crawler_data = super(FeatureDetailHandler, self).get_crawler_data(defaults)
+        user = users.get_current_user()
+        feature_id = defaults.get('feature_id', None)
+        fe = None
+        if feature_id:
+            fe = FeatureEntry.get_by_id(feature_id)
+        if fe:
+            if permissions.can_view_feature(user, fe):
+                feature_dict = converters.feature_entry_to_json_verbose(fe)
+                crawler_data['heading'] = self.make_heading(fe)
+                crawler_data['sections'] = self.make_sections(feature_dict)
+
+        return crawler_data
+
+    def make_heading(self, fe: FeatureEntry):
+        """Create heading data for the crawler."""
+        return {
+            'title': fe.name,
+            }
+
+    def make_sections(self, feature_dict):
+        """Create sections data (metadata and stages) for the crawler."""
+        stages = feature_dict['stages']
+        feature_without_stages = feature_dict.copy()
+        del feature_without_stages['stages']
+        metadata = {
+            'summary': 'Metadata',
+            'fields': feature_without_stages,
+        }
+        stage_data = [
+            {
+                'summary': (
+                    'Stage: ' +
+                    INTENT_STAGES.get(s.get('intent_stage'), '') + ' ' +
+                    (s.get('display_name') or '')
+                ),
+                'fields': s
+                }
+            for s in stages
+        ]
+        return [metadata] + stage_data

--- a/pages/featuredetail.py
+++ b/pages/featuredetail.py
@@ -14,7 +14,6 @@
 
 """Serves the SPA with minimal semantic HTML for feature details."""
 
-
 from framework import basehandlers, permissions, users
 from internals import feature_helpers
 from internals.core_enums import INTENT_STAGES
@@ -25,7 +24,9 @@ class FeatureDetailHandler(basehandlers.SPAHandler):
 
     def get_crawler_data(self, defaults):
         """Retrieves basic details of the current feature."""
-        crawler_data = super(FeatureDetailHandler, self).get_crawler_data(defaults)
+        crawler_data = super(FeatureDetailHandler, self).get_crawler_data(
+            defaults
+        )
         user = users.get_current_user()
         feature_id = defaults.get('feature_id', None)
         feature_dict = None
@@ -43,7 +44,7 @@ class FeatureDetailHandler(basehandlers.SPAHandler):
         """Create heading data for the crawler."""
         return {
             'title': 'Feature entry: ' + fe['name'],
-            }
+        }
 
     def make_sections(self, feature_dict):
         """Create sections data (metadata and stages) for the crawler."""
@@ -57,12 +58,13 @@ class FeatureDetailHandler(basehandlers.SPAHandler):
         stage_data = [
             {
                 'summary': (
-                    'Stage: ' +
-                    INTENT_STAGES.get(s.get('intent_stage'), '') + ' ' +
-                    (s.get('display_name') or '')
+                    'Stage: '
+                    + INTENT_STAGES.get(s.get('intent_stage'), '')
+                    + ' '
+                    + (s.get('display_name') or '')
                 ),
-                'fields': s
-                }
+                'fields': s,
+            }
             for s in stages
         ]
         return [metadata] + stage_data

--- a/pages/featuredetail.py
+++ b/pages/featuredetail.py
@@ -15,11 +15,9 @@
 """Serves the SPA with minimal semantic HTML for feature details."""
 
 
-
-from api import converters
 from framework import basehandlers, permissions, users
+from internals import feature_helpers
 from internals.core_enums import INTENT_STAGES
-from internals.core_models import FeatureEntry
 
 
 class FeatureDetailHandler(basehandlers.SPAHandler):
@@ -30,21 +28,21 @@ class FeatureDetailHandler(basehandlers.SPAHandler):
         crawler_data = super(FeatureDetailHandler, self).get_crawler_data(defaults)
         user = users.get_current_user()
         feature_id = defaults.get('feature_id', None)
-        fe = None
+        feature_dict = None
         if feature_id:
-            fe = FeatureEntry.get_by_id(feature_id)
-        if fe:
-            if permissions.can_view_feature(user, fe):
-                feature_dict = converters.feature_entry_to_json_verbose(fe)
-                crawler_data['heading'] = self.make_heading(fe)
+            features = feature_helpers.get_by_ids([feature_id])
+            feature_dict = features[0] if features else None
+        if feature_dict:
+            if permissions.can_view_feature_formatted(user, feature_dict):
+                crawler_data['heading'] = self.make_heading(feature_dict)
                 crawler_data['sections'] = self.make_sections(feature_dict)
 
         return crawler_data
 
-    def make_heading(self, fe: FeatureEntry):
+    def make_heading(self, fe: dict):
         """Create heading data for the crawler."""
         return {
-            'title': fe.name,
+            'title': 'Feature entry: ' + fe['name'],
             }
 
     def make_sections(self, feature_dict):

--- a/pages/featuredetail_test.py
+++ b/pages/featuredetail_test.py
@@ -21,7 +21,6 @@ from unittest import mock
 import flask
 
 import settings
-from internals.core_models import FeatureEntry
 from pages import featuredetail
 
 test_app = flask.Flask(
@@ -42,53 +41,46 @@ class FeatureDetailHandlerTest(testing_config.CustomTestCase):
       crawler_data = self.handler.get_crawler_data(defaults)
       self.assertEqual({}, crawler_data)
 
-  @mock.patch('internals.core_models.FeatureEntry.get_by_id')
-  def test_get_crawler_data__feature_not_found(self, mock_get_by_id):
+  @mock.patch('internals.feature_helpers.get_by_ids')
+  def test_get_crawler_data__feature_not_found(self, mock_get_by_ids):
     """It handles feature not found gracefully."""
-    mock_get_by_id.return_value = None
+    mock_get_by_ids.return_value = []
     with test_app.test_request_context('/feature/123'):
       defaults = {'feature_id': 123}
       crawler_data = self.handler.get_crawler_data(defaults)
       self.assertEqual({}, crawler_data)
-      mock_get_by_id.assert_called_once_with(123)
+      mock_get_by_ids.assert_called_once_with([123])
 
-  @mock.patch('internals.core_models.FeatureEntry.get_by_id')
-  @mock.patch('framework.permissions.can_view_feature')
+  @mock.patch('internals.feature_helpers.get_by_ids')
+  @mock.patch('framework.permissions.can_view_feature_formatted')
   @mock.patch('framework.users.get_current_user')
   def test_get_crawler_data__no_permission(
-      self, mock_get_current_user, mock_can_view_feature, mock_get_by_id):
+      self, mock_get_current_user, mock_can_view_feature_formatted, mock_get_by_ids):
     """It returns empty crawler data if user has no permission."""
     mock_user = mock.Mock()
     mock_get_current_user.return_value = mock_user
 
-    mock_fe = mock.Mock(spec=FeatureEntry)
-    mock_get_by_id.return_value = mock_fe
+    fake_feature_dict = {'id': 123, 'name': 'Fake Feature'}
+    mock_get_by_ids.return_value = [fake_feature_dict]
 
-    mock_can_view_feature.return_value = False
+    mock_can_view_feature_formatted.return_value = False
 
     with test_app.test_request_context('/feature/123'):
       defaults = {'feature_id': 123}
       crawler_data = self.handler.get_crawler_data(defaults)
       self.assertEqual({}, crawler_data)
-      mock_get_by_id.assert_called_once_with(123)
-      mock_can_view_feature.assert_called_once_with(mock_user, mock_fe)
+      mock_get_by_ids.assert_called_once_with([123])
+      mock_can_view_feature_formatted.assert_called_once_with(mock_user, fake_feature_dict)
 
-  @mock.patch('internals.core_models.FeatureEntry.get_by_id')
-  @mock.patch('framework.permissions.can_view_feature')
+  @mock.patch('internals.feature_helpers.get_by_ids')
+  @mock.patch('framework.permissions.can_view_feature_formatted')
   @mock.patch('framework.users.get_current_user')
-  @mock.patch('api.converters.feature_entry_to_json_verbose')
   def test_get_crawler_data__has_permission(
-      self, mock_to_json, mock_get_current_user, mock_can_view_feature,
-      mock_get_by_id):
+      self, mock_get_current_user, mock_can_view_feature_formatted,
+      mock_get_by_ids):
     """It returns crawler data when user has permission."""
     mock_user = mock.Mock()
     mock_get_current_user.return_value = mock_user
-
-    mock_fe = mock.Mock(spec=FeatureEntry)
-    mock_fe.name = 'Fake Feature'
-    mock_get_by_id.return_value = mock_fe
-
-    mock_can_view_feature.return_value = True
 
     fake_feature_dict = {
         'id': 123,
@@ -99,17 +91,18 @@ class FeatureDetailHandlerTest(testing_config.CustomTestCase):
             {'intent_stage': 2, 'display_name': 'Stage Two'},
         ],
     }
-    mock_to_json.return_value = fake_feature_dict
+    mock_get_by_ids.return_value = [fake_feature_dict]
+
+    mock_can_view_feature_formatted.return_value = True
 
     with test_app.test_request_context('/feature/123'):
       defaults = {'feature_id': 123}
       crawler_data = self.handler.get_crawler_data(defaults)
 
-      mock_get_by_id.assert_called_once_with(123)
-      mock_can_view_feature.assert_called_once_with(mock_user, mock_fe)
-      mock_to_json.assert_called_once_with(mock_fe)
+      mock_get_by_ids.assert_called_once_with([123])
+      mock_can_view_feature_formatted.assert_called_once_with(mock_user, fake_feature_dict)
 
-      self.assertEqual({'title': 'Fake Feature'}, crawler_data.get('heading'))
+      self.assertEqual({'title': 'Feature entry: Fake Feature'}, crawler_data.get('heading'))
       
       sections = crawler_data.get('sections')
       self.assertEqual(3, len(sections)) # 1 metadata + 2 stages

--- a/pages/featuredetail_test.py
+++ b/pages/featuredetail_test.py
@@ -1,0 +1,128 @@
+# Copyright 2026 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for pages/featuredetail.py."""
+
+import testing_config  # isort: skip
+
+from unittest import mock
+
+import flask
+
+import settings
+from internals.core_models import FeatureEntry
+from pages import featuredetail
+
+test_app = flask.Flask(
+    __name__, template_folder=settings.get_flask_template_path()
+)
+
+class FeatureDetailHandlerTest(testing_config.CustomTestCase):
+  """Tests for FeatureDetailHandler."""
+
+  def setUp(self):
+    """Set up the test handler."""
+    self.handler = featuredetail.FeatureDetailHandler()
+
+  def test_get_crawler_data__no_feature_id(self):
+    """It handles missing feature_id gracefully."""
+    with test_app.test_request_context('/feature'):
+      defaults = {}
+      crawler_data = self.handler.get_crawler_data(defaults)
+      self.assertEqual({}, crawler_data)
+
+  @mock.patch('internals.core_models.FeatureEntry.get_by_id')
+  def test_get_crawler_data__feature_not_found(self, mock_get_by_id):
+    """It handles feature not found gracefully."""
+    mock_get_by_id.return_value = None
+    with test_app.test_request_context('/feature/123'):
+      defaults = {'feature_id': 123}
+      crawler_data = self.handler.get_crawler_data(defaults)
+      self.assertEqual({}, crawler_data)
+      mock_get_by_id.assert_called_once_with(123)
+
+  @mock.patch('internals.core_models.FeatureEntry.get_by_id')
+  @mock.patch('framework.permissions.can_view_feature')
+  @mock.patch('framework.users.get_current_user')
+  def test_get_crawler_data__no_permission(
+      self, mock_get_current_user, mock_can_view_feature, mock_get_by_id):
+    """It returns empty crawler data if user has no permission."""
+    mock_user = mock.Mock()
+    mock_get_current_user.return_value = mock_user
+
+    mock_fe = mock.Mock(spec=FeatureEntry)
+    mock_get_by_id.return_value = mock_fe
+
+    mock_can_view_feature.return_value = False
+
+    with test_app.test_request_context('/feature/123'):
+      defaults = {'feature_id': 123}
+      crawler_data = self.handler.get_crawler_data(defaults)
+      self.assertEqual({}, crawler_data)
+      mock_get_by_id.assert_called_once_with(123)
+      mock_can_view_feature.assert_called_once_with(mock_user, mock_fe)
+
+  @mock.patch('internals.core_models.FeatureEntry.get_by_id')
+  @mock.patch('framework.permissions.can_view_feature')
+  @mock.patch('framework.users.get_current_user')
+  @mock.patch('api.converters.feature_entry_to_json_verbose')
+  def test_get_crawler_data__has_permission(
+      self, mock_to_json, mock_get_current_user, mock_can_view_feature,
+      mock_get_by_id):
+    """It returns crawler data when user has permission."""
+    mock_user = mock.Mock()
+    mock_get_current_user.return_value = mock_user
+
+    mock_fe = mock.Mock(spec=FeatureEntry)
+    mock_fe.name = 'Fake Feature'
+    mock_get_by_id.return_value = mock_fe
+
+    mock_can_view_feature.return_value = True
+
+    fake_feature_dict = {
+        'id': 123,
+        'name': 'Fake Feature',
+        'summary': 'Fake Summary',
+        'stages': [
+            {'intent_stage': 1, 'display_name': 'Stage One'},
+            {'intent_stage': 2, 'display_name': 'Stage Two'},
+        ],
+    }
+    mock_to_json.return_value = fake_feature_dict
+
+    with test_app.test_request_context('/feature/123'):
+      defaults = {'feature_id': 123}
+      crawler_data = self.handler.get_crawler_data(defaults)
+
+      mock_get_by_id.assert_called_once_with(123)
+      mock_can_view_feature.assert_called_once_with(mock_user, mock_fe)
+      mock_to_json.assert_called_once_with(mock_fe)
+
+      self.assertEqual({'title': 'Fake Feature'}, crawler_data.get('heading'))
+      
+      sections = crawler_data.get('sections')
+      self.assertEqual(3, len(sections)) # 1 metadata + 2 stages
+      
+      # Verify metadata section
+      self.assertEqual('Metadata', sections[0]['summary'])
+      self.assertEqual('Fake Feature', sections[0]['fields']['name'])
+      self.assertEqual('Fake Summary', sections[0]['fields']['summary'])
+      self.assertNotIn('stages', sections[0]['fields'])
+
+      # Verify stage sections
+      self.assertEqual('Stage: Start prototyping Stage One', sections[1]['summary'])
+      self.assertEqual({'intent_stage': 1, 'display_name': 'Stage One'}, sections[1]['fields'])
+
+      self.assertEqual('Stage: Dev trials Stage Two', sections[2]['summary'])
+      self.assertEqual({'intent_stage': 2, 'display_name': 'Stage Two'}, sections[2]['fields'])

--- a/pages/featuredetail_test.py
+++ b/pages/featuredetail_test.py
@@ -27,95 +27,120 @@ test_app = flask.Flask(
     __name__, template_folder=settings.get_flask_template_path()
 )
 
+
 class FeatureDetailHandlerTest(testing_config.CustomTestCase):
-  """Tests for FeatureDetailHandler."""
+    """Tests for FeatureDetailHandler."""
 
-  def setUp(self):
-    """Set up the test handler."""
-    self.handler = featuredetail.FeatureDetailHandler()
+    def setUp(self):
+        """Set up the test handler."""
+        self.handler = featuredetail.FeatureDetailHandler()
 
-  def test_get_crawler_data__no_feature_id(self):
-    """It handles missing feature_id gracefully."""
-    with test_app.test_request_context('/feature'):
-      defaults = {}
-      crawler_data = self.handler.get_crawler_data(defaults)
-      self.assertEqual({}, crawler_data)
+    def test_get_crawler_data__no_feature_id(self):
+        """It handles missing feature_id gracefully."""
+        with test_app.test_request_context('/feature'):
+            defaults = {}
+            crawler_data = self.handler.get_crawler_data(defaults)
+            self.assertEqual({}, crawler_data)
 
-  @mock.patch('internals.feature_helpers.get_by_ids')
-  def test_get_crawler_data__feature_not_found(self, mock_get_by_ids):
-    """It handles feature not found gracefully."""
-    mock_get_by_ids.return_value = []
-    with test_app.test_request_context('/feature/123'):
-      defaults = {'feature_id': 123}
-      crawler_data = self.handler.get_crawler_data(defaults)
-      self.assertEqual({}, crawler_data)
-      mock_get_by_ids.assert_called_once_with([123])
+    @mock.patch('internals.feature_helpers.get_by_ids')
+    def test_get_crawler_data__feature_not_found(self, mock_get_by_ids):
+        """It handles feature not found gracefully."""
+        mock_get_by_ids.return_value = []
+        with test_app.test_request_context('/feature/123'):
+            defaults = {'feature_id': 123}
+            crawler_data = self.handler.get_crawler_data(defaults)
+            self.assertEqual({}, crawler_data)
+            mock_get_by_ids.assert_called_once_with([123])
 
-  @mock.patch('internals.feature_helpers.get_by_ids')
-  @mock.patch('framework.permissions.can_view_feature_formatted')
-  @mock.patch('framework.users.get_current_user')
-  def test_get_crawler_data__no_permission(
-      self, mock_get_current_user, mock_can_view_feature_formatted, mock_get_by_ids):
-    """It returns empty crawler data if user has no permission."""
-    mock_user = mock.Mock()
-    mock_get_current_user.return_value = mock_user
+    @mock.patch('internals.feature_helpers.get_by_ids')
+    @mock.patch('framework.permissions.can_view_feature_formatted')
+    @mock.patch('framework.users.get_current_user')
+    def test_get_crawler_data__no_permission(
+        self,
+        mock_get_current_user,
+        mock_can_view_feature_formatted,
+        mock_get_by_ids,
+    ):
+        """It returns empty crawler data if user has no permission."""
+        mock_user = mock.Mock()
+        mock_get_current_user.return_value = mock_user
 
-    fake_feature_dict = {'id': 123, 'name': 'Fake Feature'}
-    mock_get_by_ids.return_value = [fake_feature_dict]
+        fake_feature_dict = {'id': 123, 'name': 'Fake Feature'}
+        mock_get_by_ids.return_value = [fake_feature_dict]
 
-    mock_can_view_feature_formatted.return_value = False
+        mock_can_view_feature_formatted.return_value = False
 
-    with test_app.test_request_context('/feature/123'):
-      defaults = {'feature_id': 123}
-      crawler_data = self.handler.get_crawler_data(defaults)
-      self.assertEqual({}, crawler_data)
-      mock_get_by_ids.assert_called_once_with([123])
-      mock_can_view_feature_formatted.assert_called_once_with(mock_user, fake_feature_dict)
+        with test_app.test_request_context('/feature/123'):
+            defaults = {'feature_id': 123}
+            crawler_data = self.handler.get_crawler_data(defaults)
+            self.assertEqual({}, crawler_data)
+            mock_get_by_ids.assert_called_once_with([123])
+            mock_can_view_feature_formatted.assert_called_once_with(
+                mock_user, fake_feature_dict
+            )
 
-  @mock.patch('internals.feature_helpers.get_by_ids')
-  @mock.patch('framework.permissions.can_view_feature_formatted')
-  @mock.patch('framework.users.get_current_user')
-  def test_get_crawler_data__has_permission(
-      self, mock_get_current_user, mock_can_view_feature_formatted,
-      mock_get_by_ids):
-    """It returns crawler data when user has permission."""
-    mock_user = mock.Mock()
-    mock_get_current_user.return_value = mock_user
+    @mock.patch('internals.feature_helpers.get_by_ids')
+    @mock.patch('framework.permissions.can_view_feature_formatted')
+    @mock.patch('framework.users.get_current_user')
+    def test_get_crawler_data__has_permission(
+        self,
+        mock_get_current_user,
+        mock_can_view_feature_formatted,
+        mock_get_by_ids,
+    ):
+        """It returns crawler data when user has permission."""
+        mock_user = mock.Mock()
+        mock_get_current_user.return_value = mock_user
 
-    fake_feature_dict = {
-        'id': 123,
-        'name': 'Fake Feature',
-        'summary': 'Fake Summary',
-        'stages': [
-            {'intent_stage': 1, 'display_name': 'Stage One'},
-            {'intent_stage': 2, 'display_name': 'Stage Two'},
-        ],
-    }
-    mock_get_by_ids.return_value = [fake_feature_dict]
+        fake_feature_dict = {
+            'id': 123,
+            'name': 'Fake Feature',
+            'summary': 'Fake Summary',
+            'stages': [
+                {'intent_stage': 1, 'display_name': 'Stage One'},
+                {'intent_stage': 2, 'display_name': 'Stage Two'},
+            ],
+        }
+        mock_get_by_ids.return_value = [fake_feature_dict]
 
-    mock_can_view_feature_formatted.return_value = True
+        mock_can_view_feature_formatted.return_value = True
 
-    with test_app.test_request_context('/feature/123'):
-      defaults = {'feature_id': 123}
-      crawler_data = self.handler.get_crawler_data(defaults)
+        with test_app.test_request_context('/feature/123'):
+            defaults = {'feature_id': 123}
+            crawler_data = self.handler.get_crawler_data(defaults)
 
-      mock_get_by_ids.assert_called_once_with([123])
-      mock_can_view_feature_formatted.assert_called_once_with(mock_user, fake_feature_dict)
+            mock_get_by_ids.assert_called_once_with([123])
+            mock_can_view_feature_formatted.assert_called_once_with(
+                mock_user, fake_feature_dict
+            )
 
-      self.assertEqual({'title': 'Feature entry: Fake Feature'}, crawler_data.get('heading'))
-      
-      sections = crawler_data.get('sections')
-      self.assertEqual(3, len(sections)) # 1 metadata + 2 stages
-      
-      # Verify metadata section
-      self.assertEqual('Metadata', sections[0]['summary'])
-      self.assertEqual('Fake Feature', sections[0]['fields']['name'])
-      self.assertEqual('Fake Summary', sections[0]['fields']['summary'])
-      self.assertNotIn('stages', sections[0]['fields'])
+            self.assertEqual(
+                {'title': 'Feature entry: Fake Feature'},
+                crawler_data.get('heading'),
+            )
 
-      # Verify stage sections
-      self.assertEqual('Stage: Start prototyping Stage One', sections[1]['summary'])
-      self.assertEqual({'intent_stage': 1, 'display_name': 'Stage One'}, sections[1]['fields'])
+            sections = crawler_data.get('sections')
+            self.assertEqual(3, len(sections))  # 1 metadata + 2 stages
 
-      self.assertEqual('Stage: Dev trials Stage Two', sections[2]['summary'])
-      self.assertEqual({'intent_stage': 2, 'display_name': 'Stage Two'}, sections[2]['fields'])
+            # Verify metadata section
+            self.assertEqual('Metadata', sections[0]['summary'])
+            self.assertEqual('Fake Feature', sections[0]['fields']['name'])
+            self.assertEqual('Fake Summary', sections[0]['fields']['summary'])
+            self.assertNotIn('stages', sections[0]['fields'])
+
+            # Verify stage sections
+            self.assertEqual(
+                'Stage: Start prototyping Stage One', sections[1]['summary']
+            )
+            self.assertEqual(
+                {'intent_stage': 1, 'display_name': 'Stage One'},
+                sections[1]['fields'],
+            )
+
+            self.assertEqual(
+                'Stage: Dev trials Stage Two', sections[2]['summary']
+            )
+            self.assertEqual(
+                {'intent_stage': 2, 'display_name': 'Stage Two'},
+                sections[2]['fields'],
+            )

--- a/templates/crawler_content.html
+++ b/templates/crawler_content.html
@@ -29,11 +29,11 @@
   {% endfor %}
 
   {% if crawler.pagination %}
-    <nav>
+    <div>
       {% for link in crawler.pagination %}
         <a href="{{link.href}}">{{link.name}}</a>
       {% endfor %}
-    </nav>
+    </div>
   {% endif %}
 
 </article>

--- a/templates/crawler_content.html
+++ b/templates/crawler_content.html
@@ -17,20 +17,24 @@
     <summary>{{sect.summary}}</summary>
     {% if sect.fields %}
     <dl>
-      {% for key, value in sect.fields.items() %}
-        <dt>{{key}}:</dt>
-        <dd>{{value | tojson}}</dd>
-      {% endfor %}
+      {%- for key, value in sect.fields.items() -%}
+        {% if value != None and value != [] %}
+          <dt>{{key}}:</dt>
+          <dd>{{value | tojson}}</dd>
+        {% endif %}
+      {%- endfor -%}
     </dl>
     {% endif %}
   </details>
   {% endfor %}
 
-  <nav>
-    {% for link in crawler.pagination %}
-      <a href="{{link.href}}">{{link.name}}</a>
-    {% endfor %}
-  </nav>
+  {% if crawler.pagination %}
+    <nav>
+      {% for link in crawler.pagination %}
+        <a href="{{link.href}}">{{link.name}}</a>
+      {% endfor %}
+    </nav>
+  {% endif %}
 
 </article>
 {% endif %}

--- a/templates/crawler_content.html
+++ b/templates/crawler_content.html
@@ -1,0 +1,38 @@
+{# This is semantic HTML content for crawlers.  Most users will not see it. #}
+
+{% if crawler %}
+<div class="crawlers-only">
+<article>
+
+  <header>
+    <h2>Feature entry: {{crawler.heading.title}}</h2>
+  </header>
+
+  <nav>
+    <a href="/roadmap">Features by milestone</a>
+    <a href="/features">All features</a>
+  </nav>
+
+  {% for sect in crawler.sections %}
+  <section>
+    <h3>{{sect.summary}}</h3>
+    {% if sect.fields %}
+    <dl>
+      {% for key, value in sect.fields.items() %}
+        <dt>{{key}}:</dt>
+        <dd>{{value | tojson}}</dd>
+      {% endfor %}
+    </dl>
+    {% endif %}
+  </section>
+  {% endfor %}
+
+  <nav>
+    {% for link in crawler.pagination %}
+      <a href="{{link.href}}">{{link.name}}</a>
+    {% endfor %}
+  </nav>
+
+</article>
+</div>
+{% endif %}

--- a/templates/crawler_content.html
+++ b/templates/crawler_content.html
@@ -1,11 +1,10 @@
 {# This is semantic HTML content for crawlers.  Most users will not see it. #}
 
 {% if crawler %}
-<div class="crawlers-only">
-<article>
+<article class="crawlers-only">
 
   <header>
-    <h2>Feature entry: {{crawler.heading.title}}</h2>
+    <h2>{{crawler.heading.title}}</h2>
   </header>
 
   <nav>
@@ -14,8 +13,8 @@
   </nav>
 
   {% for sect in crawler.sections %}
-  <section>
-    <h3>{{sect.summary}}</h3>
+  <details>
+    <summary>{{sect.summary}}</summary>
     {% if sect.fields %}
     <dl>
       {% for key, value in sect.fields.items() %}
@@ -24,7 +23,7 @@
       {% endfor %}
     </dl>
     {% endif %}
-  </section>
+  </details>
   {% endfor %}
 
   <nav>
@@ -34,5 +33,4 @@
   </nav>
 
 </article>
-</div>
 {% endif %}

--- a/templates/crawler_content.html
+++ b/templates/crawler_content.html
@@ -7,10 +7,10 @@
     <h2>{{crawler.heading.title}}</h2>
   </header>
 
-  <nav>
+  <div>
     <a href="/roadmap">Features by milestone</a>
     <a href="/features">All features</a>
-  </nav>
+  </div>
 
   {% for sect in crawler.sections %}
   <details>

--- a/templates/spa.html
+++ b/templates/spa.html
@@ -76,6 +76,20 @@ limitations under the License.
   </script>
 
   <script type="module" nonce="{{nonce}}" defer src="/static/dist/components.js?v={{app_version}}"></script>
+
+  <style>
+    .crawlers-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+  </style>
 </head>
 
 <body class="{% if not prod %}non-prod{% endif %}">
@@ -95,6 +109,9 @@ limitations under the License.
   See https://github.com/GoogleChrome/chromium-dashboard/issues/2014
   #}
   <script type="module" nonce="{{nonce}}" src="/static/dist/shared.js?v={{app_version}}"></script>
+
+  {% include "crawler_content.html" %}
+
 </body>
 
 </html>


### PR DESCRIPTION
It turns out that (unlike Google's web search crawler) all the LLM crawlers seem to not execute JavaScript, so their training data was not including any content from ChromeStatus.com because of our SPA and web component-based implementation.  This PR is a first step in adding non-JS content for crawlers.

Rather than try to replicate our web component-based UI using SSR, we add  a new, invisible `<article>` to the bottom of the page that contains a dump of the feature details.  We use a simple semantic markup that should be easy for crawlers to parse.