### PR TITLE
Make permission checks more consistent

### DIFF
--- a/api/attachments_api.py
+++ b/api/attachments_api.py
@@ -28,16 +28,10 @@ class AttachmentsAPI(basehandlers.EntitiesAPIHandler):
     @permissions.require_create_feature
     def do_post(self, **kwargs) -> dict[str, str]:
         """Handle POST requests to create a single attachment."""
-        feature_id: int | None = kwargs.get('feature_id', None)
-
-        if feature_id is None:
-            self.abort(400, msg='Feature ID is required')
+        fe = self.get_specified_feature(**kwargs)
 
         # Validate the user has edit permissions and redirect if needed.
-        redirect_resp = permissions.validate_feature_edit_permission(
-            self, feature_id
-        )
-        if redirect_resp:
+        if permissions.validate_feature_edit_permission(self, fe):
             self.abort(403, msg='User lacks permission to edit')
 
         logging.info('files are %r', self.request.files)
@@ -50,7 +44,7 @@ class AttachmentsAPI(basehandlers.EntitiesAPIHandler):
         content = file.read()
 
         attach = attachments.store_attachment(
-            feature_id, content, file.mimetype
+            fe.key.integer_id(), content, file.mimetype
         )
         url = attachments.get_attachment_url(attach)
         return AddAttachmentResponse.from_dict(

--- a/api/comments_api.py
+++ b/api/comments_api.py
@@ -114,7 +114,7 @@ class CommentsAPI(basehandlers.APIHandler):
         if comment_content:
             can_comment = permissions.can_comment(
                 user
-            ) or permissions.can_edit_feature(user, feature_id)
+            ) or permissions.can_edit_feature(user, feature)
             if not can_comment:
                 self.abort(403, msg='User is not allowed to comment')
 

--- a/api/features_api.py
+++ b/api/features_api.py
@@ -66,18 +66,8 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
 
     def get_one_feature(self, feature_id: int) -> VerboseFeatureDict:
         """Get a single feature by ID."""
-        feature = FeatureEntry.get_by_id(feature_id)
-        if not feature:
-            self.abort(404, msg='Feature %r not found' % feature_id)
-        user = users.get_current_user()
-        if feature.deleted and not permissions.can_edit_feature(
-            user, feature_id
-        ):
-            self.abort(404, msg='Feature %r not found' % feature_id)
-        if not permissions.can_view_feature(user, feature):
-            self.abort(404, msg='Feature %r not found' % feature_id)
-
-        return converters.feature_entry_to_json_verbose(feature)
+        fe = self.get_specified_feature(feature_id=feature_id)
+        return converters.feature_entry_to_json_verbose(fe)
 
     def do_search(self):
         """Search for features."""
@@ -164,7 +154,7 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
 
     def _shared_update_special_fields(
         self,
-        feature: FeatureEntry,
+        fe: FeatureEntry,
         feature_changes: dict[str, Any],
     ) -> bool:
         """Handle any special FeatureEntry fields common to creating or updating."""
@@ -174,12 +164,12 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
             new_markdown = feature_changes.get(field + '_is_markdown')
             if new_markdown is None:
                 continue
-            if new_markdown and field not in feature.markdown_fields:
-                feature.markdown_fields.append(field)
+            if new_markdown and field not in fe.markdown_fields:
+                fe.markdown_fields.append(field)
                 has_updated = True
-            elif not new_markdown and field in feature.markdown_fields:
-                feature.markdown_fields = [
-                    mf for mf in feature.markdown_fields if mf != field
+            elif not new_markdown and field in fe.markdown_fields:
+                fe.markdown_fields = [
+                    mf for mf in fe.markdown_fields if mf != field
                 ]
                 has_updated = True
 
@@ -187,34 +177,34 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
 
     def _post_update_special_fields(
         self,
-        feature: FeatureEntry,
+        fe: FeatureEntry,
         feature_changes: dict[str, Any],
     ) -> None:
         """Handle any special FeatureEntry fields when creating."""
-        self._shared_update_special_fields(feature, feature_changes)
+        self._shared_update_special_fields(fe, feature_changes)
 
         if 'first_enterprise_notification_milestone' in feature_changes:
-            feature.first_enterprise_notification_milestone = int(
+            fe.first_enterprise_notification_milestone = int(
                 feature_changes['first_enterprise_notification_milestone']
             )
         elif needs_default_first_notification_milestone(
             new_fields=feature_changes
         ):
-            feature.first_enterprise_notification_milestone = (
+            fe.first_enterprise_notification_milestone = (
                 get_default_first_notice_milestone_for_feature()
             )
 
-        if feature.feature_type == core_enums.FEATURE_TYPE_ENTERPRISE_ID:
-            feature.blink_components = [settings.DEFAULT_ENTERPRISE_COMPONENT]
-            feature.tag_review_status = core_enums.REVIEW_NA
+        if fe.feature_type == core_enums.FEATURE_TYPE_ENTERPRISE_ID:
+            fe.blink_components = [settings.DEFAULT_ENTERPRISE_COMPONENT]
+            fe.tag_review_status = core_enums.REVIEW_NA
         else:
-            feature.tag_review_status = processes.initial_tag_review_status(
-                feature.feature_type
+            fe.tag_review_status = processes.initial_tag_review_status(
+                fe.feature_type
             )
 
-        feature.creator_email = self.get_current_user().email()
-        feature.updater_email = self.get_current_user().email()
-        feature.accurate_as_of = datetime.now()
+        fe.creator_email = self.get_current_user().email()
+        fe.updater_email = self.get_current_user().email()
+        fe.accurate_as_of = datetime.now()
 
     @permissions.require_create_feature
     def do_post(self, **kwargs):
@@ -241,19 +231,19 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
 
         # Try to create the feature using the provided data.
         try:
-            feature = FeatureEntry(**fields_dict)
-            self._post_update_special_fields(feature, feature_changes)
-            feature.put()
+            fe = FeatureEntry(**fields_dict)
+            self._post_update_special_fields(fe, feature_changes)
+            fe.put()
         except Exception as e:
             self.abort(400, msg=str(e))
-        id = feature.key.integer_id()
+        feature_id = fe.key.integer_id()
 
-        search_fulltext.index_feature(feature)
-        self._write_stages_and_gates_for_feature(id, feature.feature_type)
+        search_fulltext.index_feature(fe)
+        self._write_stages_and_gates_for_feature(feature_id, fe.feature_type)
 
         activity = Activity(
             log_type=Activity.USER_CHANGE,
-            feature_id=id,
+            feature_id=feature_id,
             author=user_email,
             content='Feature entry created',
         )
@@ -263,7 +253,10 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
         rediscache.delete_keys_with_prefix(FeatureEntry.DEFAULT_CACHE_KEY)
         rediscache.delete_keys_with_prefix(FeatureEntry.SEARCH_CACHE_KEY)
 
-        return {'message': f'Feature {id} created.', 'feature_id': id}
+        return {
+            'message': f'Feature {feature_id} created.',
+            'feature_id': feature_id,
+        }
 
     def _write_stages_and_gates_for_feature(
         self, feature_id: int, feature_type: int
@@ -566,15 +559,13 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
         # Check if valid ID is provided and fetch feature if it exists.
         if 'id' not in body['feature_changes']:
             self.abort(400, msg='Missing feature ID in feature updates')
-        feature_id = body['feature_changes']['id']
-        feature: FeatureEntry | None = FeatureEntry.get_by_id(feature_id)
-        if not feature:
-            self.abort(400, msg=f'Feature not found for ID {feature_id}')
+        fe = self.get_specified_feature(
+            feature_id=body['feature_changes']['id']
+        )
+        feature_id = fe.key.integer_id()
 
         # Validate the user has edit permissions and redirect if needed.
-        redirect_resp = permissions.validate_feature_edit_permission(
-            self, feature_id
-        )
+        redirect_resp = permissions.validate_feature_edit_permission(self, fe)
         if redirect_resp:
             return redirect_resp
 
@@ -587,11 +578,11 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
         )
         # Reset outstanding notifications if the user updated any ship/rollout milestones.
         if ship_milestones_were_updated:
-            feature.outstanding_notifications = 0
-            self._maybe_reset_releasenotes_flags(feature, changed_fields)
+            fe.outstanding_notifications = 0
+            self._maybe_reset_releasenotes_flags(fe, changed_fields)
 
         self._patch_update_feature(
-            feature,
+            fe,
             body['feature_changes'],
             updated_stages,
             changed_fields,
@@ -599,48 +590,39 @@ class FeaturesAPI(basehandlers.EntitiesAPIHandler):
         )
 
         notifier_helpers.notify_subscribers_and_save_amendments(
-            feature, changed_fields, notify=True
+            fe, changed_fields, notify=True
         )
         # Remove all feature-related cache.
         rediscache.delete_keys_with_prefix(FeatureEntry.DEFAULT_CACHE_KEY)
         rediscache.delete_keys_with_prefix(FeatureEntry.SEARCH_CACHE_KEY)
         # Update full-text index.
-        if feature:
-            search_fulltext.index_feature(feature)
-            feature_links.update_feature_links(feature, changed_fields)
+        if fe:
+            search_fulltext.index_feature(fe)
+            feature_links.update_feature_links(fe, changed_fields)
 
         return {'message': f'Feature {feature_id} updated.'}
 
     def do_delete(self, **kwargs) -> flask.Response | dict[str, str]:
         """Delete the specified feature."""
         # TODO(jrobbins): implement undelete UI.  For now, use cloud console.
-        if 'feature_id' not in kwargs:
-            self.abort(404, msg='Feature ID not specified')
-        feature_id: int = kwargs['feature_id']
+        fe = self.get_specified_feature(**kwargs)
         # Validate the user has edit permissions and redirect if needed.
-        redirect_resp = permissions.validate_feature_edit_permission(
-            self, feature_id
-        )
+        redirect_resp = permissions.validate_feature_edit_permission(self, fe)
         if redirect_resp:
-            self.abort(
-                403, msg='User does not have permission to edit this feature.'
-            )
+            return redirect_resp
 
-        feature: FeatureEntry = self.get_specified_feature(
-            feature_id=feature_id
-        )
-        feature.deleted = True
+        fe.deleted = True
         # Delete any AI-generated content during archival.
-        feature.ai_test_eval_report = None
-        feature.put()
+        fe.ai_test_eval_report = None
+        fe.put()
 
         user = users.get_current_user()
         email = user.email() if user else None
         activity = Activity(
             log_type=Activity.USER_COMMENT,
-            feature_id=feature_id,
+            feature_id=fe.key.integer_id(),
             author=email,
-            content=f'Feature "{feature.name}" was archived.',
+            content=f'Feature "{fe.name}" was archived.',
         )
         activity.put()
 

--- a/api/features_api_test.py
+++ b/api/features_api_test.py
@@ -130,7 +130,7 @@ class FeaturesAPITestDelete(testing_config.CustomTestCase):
         testing_config.sign_in('admin@example.com', 123567890)
 
         with test_app.test_request_context(self.request_path):
-            with self.assertRaises(werkzeug.exceptions.NotFound):
+            with self.assertRaises(werkzeug.exceptions.BadRequest):
                 self.handler.do_delete()
 
         revised_feature = FeatureEntry.get_by_id(self.feature_id)

--- a/api/intents_api.py
+++ b/api/intents_api.py
@@ -70,8 +70,8 @@ class IntentsAPI(basehandlers.APIHandler):
 
     def do_get(self, **kwargs) -> Response | dict | str:
         """Get the body of a draft intent."""
-        feature, stage = self.get_specified_feature_and_stage(**kwargs)
-        feature_id = feature.key.integer_id()
+        fe, stage = self.get_specified_feature_and_stage(**kwargs)
+        feature_id = fe.key.integer_id()
         stage_id = stage.key.integer_id()
 
         intent_type = None
@@ -94,13 +94,11 @@ class IntentsAPI(basehandlers.APIHandler):
                 self.abort(400, msg='Given gate does not belong to stage')
 
         # Check that the user has feature edit permissions.
-        redirect_resp = permissions.validate_feature_edit_permission(
-            self, feature_id
-        )
+        redirect_resp = permissions.validate_feature_edit_permission(self, fe)
         if redirect_resp:
             return redirect_resp
 
-        stage_info = stage_helpers.get_stage_info_for_templates(feature)
+        stage_info = stage_helpers.get_stage_info_for_templates(fe)
         default_url = (
             f'{self.request.scheme}://{self.request.host}/feature/{feature_id}'
         )
@@ -108,8 +106,8 @@ class IntentsAPI(basehandlers.APIHandler):
             default_url += f'?gate={gate_id}'
 
         template_data = {
-            'feature': converters.feature_entry_to_json_verbose(feature),
-            'stage_info': stage_helpers.get_stage_info_for_templates(feature),
+            'feature': converters.feature_entry_to_json_verbose(fe),
+            'stage_info': stage_helpers.get_stage_info_for_templates(fe),
             'should_render_mstone_table': stage_info[
                 'should_render_mstone_table'
             ],
@@ -120,8 +118,8 @@ class IntentsAPI(basehandlers.APIHandler):
         }
         return GetIntentResponse(
             subject=(
-                f'{compute_subject_prefix(feature.feature_type, intent_type)}: '
-                f'{feature.name}'
+                f'{compute_subject_prefix(fe.feature_type, intent_type)}: '
+                f'{fe.name}'
             ),
             email_body=render_template(
                 'blink/intent_to_implement.html', **template_data
@@ -130,8 +128,8 @@ class IntentsAPI(basehandlers.APIHandler):
 
     def do_post(self, **kwargs) -> Response | dict | MessageResponse:
         """Submit an intent email directly to blink-dev."""
-        feature, stage = self.get_specified_feature_and_stage(**kwargs)
-        feature_id = feature.key.integer_id()
+        fe, stage = self.get_specified_feature_and_stage(**kwargs)
+        feature_id = fe.key.integer_id()
 
         intent_type = None
         if stage.stage_type in core_enums.INTENT_DRAFT_TYPES_BY_STAGE_TYPE:
@@ -145,9 +143,7 @@ class IntentsAPI(basehandlers.APIHandler):
             )
 
         # Check that the user has feature edit permissions.
-        redirect_resp = permissions.validate_feature_edit_permission(
-            self, feature_id
-        )
+        redirect_resp = permissions.validate_feature_edit_permission(self, fe)
         if redirect_resp:
             return redirect_resp
 
@@ -163,7 +159,9 @@ class IntentsAPI(basehandlers.APIHandler):
         if gate:
             default_url += f'?gate={parsed_args.gate_id}'
 
-        subject = f'{compute_subject_prefix(feature.feature_type, intent_type)}: {feature.name}'  # noqa: E501
+        subject = (
+            f'{compute_subject_prefix(fe.feature_type, intent_type)}: {fe.name}'  # noqa: E501
+        )
         cc_emails = parsed_args.intent_cc_emails or []
         # Make sure emails are not empty and are unique.
         cc_emails = sorted(list(set([email for email in cc_emails if email])))

--- a/api/origin_trials_api.py
+++ b/api/origin_trials_api.py
@@ -296,46 +296,27 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
 
         return validation_errors
 
-    def check_post_permissions(self, feature_id) -> flask.Response | dict:
+    def check_post_permissions(self, fe: FeatureEntry) -> flask.Response | dict:
         """Raise an exception or redirect if the user cannot request OT."""
         if permissions.is_google_or_chromium_account(self.get_current_user()):
             return {}
 
-        redirect_resp = permissions.validate_feature_edit_permission(
-            self, feature_id
-        )
+        redirect_resp = permissions.validate_feature_edit_permission(self, fe)
         return redirect_resp
 
     def do_post(self, **kwargs):
         """Handle POST requests."""
-        feature_id = int(kwargs['feature_id'])
-        # Check that feature ID is valid.
-        if not feature_id:
-            self.abort(404, msg='No feature specified.')
-        feature: FeatureEntry | None = FeatureEntry.get_by_id(feature_id)
-        if feature is None:
-            self.abort(404, msg=f'Feature {feature_id} not found')
-
-        # Check that stage ID is valid.
-        ot_stage_id = int(kwargs['stage_id'])
-        if not ot_stage_id:
-            self.abort(404, msg='No stage specified.')
-        ot_stage: Stage | None = Stage.get_by_id(ot_stage_id)
-        if ot_stage is None:
-            self.abort(404, msg=f'Stage {ot_stage_id} not found')
-        if ot_stage.feature_id != feature_id:
-            self.abort(
-                403,
-                msg=f'Stage {ot_stage_id} does not belong to Feature {feature_id}',
-            )
+        fe, ot_stage = self.get_specified_feature_and_stage(**kwargs)
 
         # Check that user has permission to edit the feature associated
         # with the origin trial, or has a @google or @chromium account.
-        redirect_resp = self.check_post_permissions(feature_id)
+        redirect_resp = self.check_post_permissions(fe)
         if redirect_resp:
             return redirect_resp
 
-        gates: list[Gate] = Gate.query(Gate.stage_id == ot_stage_id)
+        gates: list[Gate] = Gate.query(
+            Gate.stage_id == ot_stage.key.integer_id()
+        )
         for gate in gates:
             if gate.state not in Gate.APPROVED_STATES:
                 self.abort(400, 'Unapproved gate found for trial stage.')
@@ -383,20 +364,9 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
         ).to_dict()  # noqa: E501
 
     def _validate_extension_args(
-        self, feature_id: int, ot_stage: Stage, extension_stage: Stage
+        self, ot_stage: Stage, extension_stage: Stage
     ) -> None:
         """Abort if any arguments used for origin trial extension are invalid."""
-        # The stage should belong to the feature.
-        if feature_id != extension_stage.feature_id:
-            self.abort(
-                400,
-                (
-                    'Stage does not belong to feature. '
-                    f'feature_id: {feature_id}, '
-                    f'stage_id: {extension_stage.key.integer_id()}'
-                ),
-            )
-
         trial_id = ot_stage.origin_trial_id
         if trial_id is None:
             self.abort(400, f'Invalid argument for trial_id: {trial_id}')
@@ -421,21 +391,12 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
 
     def do_patch(self, **kwargs):
         """Extends an existing origin trial"""  # noqa: D415
-        feature_id = int(kwargs['feature_id'])
-        extension_stage_id = int(kwargs['extension_stage_id'])
-        # Check that feature ID is valid.
-        if not feature_id:
-            self.abort(404, msg='No feature specified.')
-        feature: FeatureEntry | None = FeatureEntry.get_by_id(feature_id)
-        if feature is None:
-            self.abort(404, msg=f'Feature {feature_id} not found')
+        fe, extension_stage = self.get_specified_feature_and_stage(
+            feature_id=kwargs['feature_id'],
+            stage_id=kwargs['extension_stage_id'],
+        )
+        extension_stage_id = extension_stage.key.integer_id()
 
-        # Check that stage ID is valid.
-        if not extension_stage_id:
-            self.abort(404, msg='No stage specified.')
-        extension_stage: Stage | None = Stage.get_by_id(extension_stage_id)
-        if extension_stage is None:
-            self.abort(404, msg=f'Stage {extension_stage_id} not found')
         if extension_stage.ot_stage_id is None:
             self.abort(
                 400,
@@ -452,13 +413,11 @@ class OriginTrialsAPI(basehandlers.EntitiesAPIHandler):
 
         # Check that user has permission to edit the feature
         # associated with the origin trial.
-        redirect_resp = permissions.validate_feature_edit_permission(
-            self, feature_id
-        )
+        redirect_resp = permissions.validate_feature_edit_permission(self, fe)
         if redirect_resp:
             return redirect_resp
 
-        self._validate_extension_args(feature_id, ot_stage, extension_stage)
+        self._validate_extension_args(ot_stage, extension_stage)
 
         try:
             origin_trials_client.extend_origin_trial(

--- a/api/origin_trials_api_test.py
+++ b/api/origin_trials_api_test.py
@@ -238,7 +238,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
             self.request_path, method='POST', json={}
         ):
             with self.assertRaises(werkzeug.exceptions.Forbidden):
-                self.handler.check_post_permissions(self.feature_1_id)
+                self.handler.check_post_permissions(self.feature_1)
 
     def test_check_post_permissions__rando(self):
         """Random users cannot request origin trials."""
@@ -247,7 +247,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
             self.request_path, method='POST', json={}
         ):
             with self.assertRaises(werkzeug.exceptions.Forbidden):
-                self.handler.check_post_permissions(self.feature_1_id)
+                self.handler.check_post_permissions(self.feature_1)
 
     def test_check_post_permissions__googler_chromie(self):
         """Googlers and chromies can request origin trials."""
@@ -255,14 +255,14 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
         with test_app.test_request_context(
             self.request_path, method='POST', json={}
         ):
-            result = self.handler.check_post_permissions(self.feature_1_id)
+            result = self.handler.check_post_permissions(self.feature_1)
         self.assertEqual({}, result)
 
         testing_config.sign_in('user@chromium.org', 1234567890)
         with test_app.test_request_context(
             self.request_path, method='POST', json={}
         ):
-            result = self.handler.check_post_permissions(self.feature_1_id)
+            result = self.handler.check_post_permissions(self.feature_1)
         self.assertEqual({}, result)
 
     def test_check_post_permissions__feature_owner(self):
@@ -271,7 +271,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
         with test_app.test_request_context(
             self.request_path, method='POST', json={}
         ):
-            result = self.handler.check_post_permissions(self.feature_1_id)
+            result = self.handler.check_post_permissions(self.feature_1)
         self.assertEqual({}, result)
 
     def test_do_post__feature_not_found(self):
@@ -831,7 +831,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
         # No exception should be raised.
         with test_app.test_request_context(self.request_path):
             self.handler._validate_extension_args(
-                self.feature_1_id, self.ot_stage_1, self.extension_stage_1
+                self.ot_stage_1, self.extension_stage_1
             )
 
     def test_validate_extension_args__missing_ot_id(self):
@@ -841,7 +841,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
         with test_app.test_request_context(self.request_path):
             with self.assertRaises(werkzeug.exceptions.BadRequest):
                 self.handler._validate_extension_args(
-                    self.feature_1_id, self.ot_stage_1, self.extension_stage_1
+                    self.ot_stage_1, self.extension_stage_1
                 )
 
     def test_validate_extension_args__missing_end_milestone(self):
@@ -851,7 +851,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
         with test_app.test_request_context(self.request_path):
             with self.assertRaises(werkzeug.exceptions.NotFound):
                 self.handler._validate_extension_args(
-                    self.feature_1_id, self.ot_stage_1, self.extension_stage_1
+                    self.ot_stage_1, self.extension_stage_1
                 )
 
     def test_validate_extension_args__invalid_intent_url(self):
@@ -861,7 +861,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
         with test_app.test_request_context(self.request_path):
             with self.assertRaises(werkzeug.exceptions.BadRequest):
                 self.handler._validate_extension_args(
-                    self.feature_1_id, self.ot_stage_1, self.extension_stage_1
+                    self.ot_stage_1, self.extension_stage_1
                 )
 
     def test_validate_extension_args__missing_intent_url(self):
@@ -871,7 +871,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
         with test_app.test_request_context(self.request_path):
             with self.assertRaises(werkzeug.exceptions.BadRequest):
                 self.handler._validate_extension_args(
-                    self.feature_1_id, self.ot_stage_1, self.extension_stage_1
+                    self.ot_stage_1, self.extension_stage_1
                 )
 
     def test_validate_extension_args__na(self):
@@ -880,7 +880,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
         self.extension_gate_1.put()
         with test_app.test_request_context(self.request_path):
             self.handler._validate_extension_args(
-                self.feature_1_id, self.ot_stage_1, self.extension_stage_1
+                self.ot_stage_1, self.extension_stage_1
             )
 
     def test_validate_extension_args__not_approved(self):
@@ -890,7 +890,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
         with test_app.test_request_context(self.request_path):
             with self.assertRaises(werkzeug.exceptions.BadRequest):
                 self.handler._validate_extension_args(
-                    self.feature_1_id, self.ot_stage_1, self.extension_stage_1
+                    self.ot_stage_1, self.extension_stage_1
                 )
 
     def test_post__mismatched_stage_feature(self):
@@ -899,7 +899,7 @@ bool FeatureHasExpiryGracePeriod(blink::mojom::OriginTrialFeature feature) {
         stage2 = Stage(feature_id=999, stage_type=150)
         stage2.put()
         with test_app.test_request_context(self.request_path, json={}):
-            with self.assertRaises(werkzeug.exceptions.Forbidden):
+            with self.assertRaises(werkzeug.exceptions.BadRequest):
                 self.handler.do_post(
                     feature_id=self.feature_1_id,
                     stage_id=stage2.key.integer_id(),

--- a/api/review_latency_api.py
+++ b/api/review_latency_api.py
@@ -37,15 +37,11 @@ PENDING_LATENCY = -2
 
 
 class ReviewLatencyAPI(basehandlers.APIHandler):
-    """Implements the OpenAPI /spec_mentors path."""
+    """Implements the OpenAPI /review-latency path."""
 
     @permissions.require_create_feature
     def do_get(self, **kwargs):
-        """Get a list of matching spec mentors.
-
-        Returns:
-          A list of data on all public origin trials.
-        """
+        """Get information about review latency."""
         today = kwargs.get('today')
         gates = self.get_recently_reviewed_gates(
             DEFAULT_RECENT_DAYS, today=today

--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -123,7 +123,7 @@ class VotesAPI(basehandlers.APIHandler):
             Vote.NA_REQUESTED,
         )
         is_approving = new_state in Gate.APPROVED_STATES
-        is_editor = permissions.can_edit_feature(user, feature.key.integer_id())
+        is_editor = permissions.can_edit_feature(user, feature)
         approvers = approval_defs.get_approvers(gate.gate_type)
         is_approver = permissions.can_review_gate(
             user, feature, gate, approvers
@@ -163,14 +163,9 @@ class GatesAPI(basehandlers.APIHandler):
 
     def do_get(self, **kwargs) -> dict[str, Any]:
         """Return a list of all gates associated with the given feature."""
-        feature_id = kwargs.get('feature_id', None)
-        feature: FeatureEntry = self.get_specified_feature(
-            feature_id=feature_id
-        )
-        gates: list[Gate] = []
-
-        if not feature.deleted or self.get_bool_arg('include_deleted'):
-            gates = Gate.query(Gate.feature_id == feature_id).fetch()
+        fe: FeatureEntry = self.get_specified_feature(**kwargs)
+        feature_id = fe.key.integer_id()
+        gates: list[Gate] = Gate.query(Gate.feature_id == feature_id).fetch()
 
         dicts = [converters.gate_value_to_json_dict(g) for g in gates]
         for g in dicts:
@@ -222,7 +217,7 @@ class GatesAPI(basehandlers.APIHandler):
 
     def require_permissions(self, user, feature, gate):
         """Abort the request if the user lacks permission to set assignees."""
-        is_editor = permissions.can_edit_feature(user, feature.key.integer_id())
+        is_editor = permissions.can_edit_feature(user, feature)
         approvers = approval_defs.get_approvers(gate.gate_type)
         is_approver = permissions.can_review_gate(
             user, feature, gate, approvers
@@ -307,21 +302,12 @@ class XfnGatesAPI(basehandlers.APIHandler):
 
     def do_post(self, **kwargs) -> dict[str, str]:
         """Add a full set of cross-functional gates to a stage."""
-        feature_id: int = kwargs['feature_id']
-        fe: FeatureEntry | None = self.get_specified_feature(
-            feature_id=feature_id
-        )
-        if fe is None:
-            self.abort(404, msg=f'Feature {feature_id} not found')
-        stage_id: int = kwargs['stage_id']
-        stage: Stage | None = Stage.get_by_id(stage_id)
-        if stage is None:
-            self.abort(404, msg=f'Stage {stage_id} not found')
+        fe, stage = self.get_specified_feature_and_stage(**kwargs)
+        feature_id = fe.key.integer_id()
+        stage_id = stage.key.integer_id()
 
         user: User = self.get_current_user(required=True)
-        is_editor = fe and permissions.can_edit_feature(
-            user, fe.key.integer_id()
-        )
+        is_editor = fe and permissions.can_edit_feature(user, fe)
         is_approver = approval_defs.fields_approvable_by(user)
         if not is_editor and not is_approver:
             self.abort(403, msg='User lacks permission to create gates')

--- a/api/reviews_api_test.py
+++ b/api/reviews_api_test.py
@@ -513,24 +513,8 @@ class GatesAPITest(testing_config.CustomTestCase):
         self.feature_1.put()
 
         with test_app.test_request_context(self.request_path):
-            actual = self.handler.do_get(feature_id=self.feature_id)
-
-        expected = {
-            'gates': [],
-        }
-        self.assertEqual(actual, expected)
-
-    def test_do_get__include_deleted(self):
-        """If a feature is deleted, return gates if include_deleted=1."""
-        self.feature_1.deleted = True
-        self.feature_1.put()
-
-        with test_app.test_request_context(
-            self.request_path + '?include_deleted=1'
-        ):
-            actual = self.handler.do_get(feature_id=self.feature_id)
-
-        self.assertEqual(1, len(actual['gates']))
+            with self.assertRaises(werkzeug.exceptions.Forbidden):
+                self.handler.do_get(feature_id=self.feature_id)
 
 
 class XfnGatesAPITest(testing_config.CustomTestCase):

--- a/api/stages_api.py
+++ b/api/stages_api.py
@@ -55,7 +55,8 @@ class StagesAPI(basehandlers.EntitiesAPIHandler):
 
     def do_get(self, **kwargs):
         """Return a specified stage based on the given ID."""
-        feature, stage = self.get_specified_feature_and_stage(**kwargs)
+        # We get both the feature and stage for the permission checks.
+        unused_fe, stage = self.get_specified_feature_and_stage(**kwargs)
         stage_dict = converters.stage_to_json_dict(stage)
         # Add extensions associated with the stage if they exist.
         extensions = stage_helpers.get_ot_stage_extensions(stage_dict['id'])
@@ -67,7 +68,7 @@ class StagesAPI(basehandlers.EntitiesAPIHandler):
 
         return stage_dict
 
-    def _validate_edit_permissions(self, feature_id: int, request_body: dict):
+    def _validate_edit_permissions(self, fe: FeatureEntry, request_body: dict):
         """Validate the user has permission to submit this request."""
         user = self.get_current_user()
         is_ot_request = request_body.get('ot_action_requested', False)
@@ -82,9 +83,7 @@ class StagesAPI(basehandlers.EntitiesAPIHandler):
             )
         ):
             # Validate the user has edit permissions and redirect if needed.
-            return permissions.validate_feature_edit_permission(
-                self, feature_id
-            )
+            return permissions.validate_feature_edit_permission(self, fe)
         return None
 
     def do_post(self, **kwargs):
@@ -98,7 +97,7 @@ class StagesAPI(basehandlers.EntitiesAPIHandler):
             self.abort(400, msg='Stage type not specified.')
         stage_type = int(body['stage_type']['value'])
 
-        redirect_resp = self._validate_edit_permissions(feature_id, body)
+        redirect_resp = self._validate_edit_permissions(feature, body)
         if redirect_resp:
             return redirect_resp
 
@@ -120,11 +119,9 @@ class StagesAPI(basehandlers.EntitiesAPIHandler):
         stage_id = kwargs.get('stage_id')
         stage = self.get_validated_entity(stage_id, Stage)
         feature = self.get_validated_entity(stage.feature_id, FeatureEntry)
-
-        feature_id = feature.key.integer_id()
         body = self.get_json_param_dict()
 
-        redirect_resp = self._validate_edit_permissions(feature_id, body)
+        redirect_resp = self._validate_edit_permissions(feature, body)
         if redirect_resp:
             return redirect_resp
 
@@ -156,13 +153,10 @@ class StagesAPI(basehandlers.EntitiesAPIHandler):
 
     def do_delete(self, **kwargs):
         """Delete an existing stage."""
-        stage_id = kwargs.get('stage_id')
-        stage = self.get_validated_entity(stage_id, Stage)
+        fe, stage = self.get_specified_feature_and_stage(**kwargs)
 
         # Validate the user has edit permissions and redirect if needed.
-        redirect_resp = permissions.validate_feature_edit_permission(
-            self, stage.feature_id
-        )
+        redirect_resp = permissions.validate_feature_edit_permission(self, fe)
         if redirect_resp:
             return redirect_resp
 

--- a/api/stages_api_test.py
+++ b/api/stages_api_test.py
@@ -1015,7 +1015,7 @@ class StagesAPITest(testing_config.CustomTestCase):
         mock_abort.side_effect = werkzeug.exceptions.Forbidden
         with test_app.test_request_context(f'{self.request_path}1/stages/10'):
             with self.assertRaises(werkzeug.exceptions.Forbidden):
-                self.handler.do_delete(stage_id=10)
+                self.handler.do_delete(feature_id=1, stage_id=10)
         mock_abort.assert_called_once_with(
             403, description='User cannot edit feature 1'
         )
@@ -1030,7 +1030,7 @@ class StagesAPITest(testing_config.CustomTestCase):
             with self.assertRaises(werkzeug.exceptions.BadRequest):
                 self.handler.do_delete(feature_id=1)
         mock_abort.assert_called_once_with(
-            400, description='No Stage ID specified.'
+            400, description="Missing parameter 'stage_id'"
         )
 
     @mock.patch('flask.abort')
@@ -1040,10 +1040,8 @@ class StagesAPITest(testing_config.CustomTestCase):
         mock_abort.side_effect = werkzeug.exceptions.BadRequest
         with test_app.test_request_context(f'{self.request_path}1/stages/3001'):
             with self.assertRaises(werkzeug.exceptions.BadRequest):
-                self.handler.do_delete(stage_id=3001)
-        mock_abort.assert_called_once_with(
-            404, description='Stage 3001 not found.'
-        )
+                self.handler.do_delete(feature_id=1, stage_id=3001)
+        mock_abort.assert_called_once_with(404, description='Stage not found')
 
     def test_delete__valid(self):
         """A valid DELETE request should mark the existing stage as archived."""

--- a/api/wpt_coverage_api.py
+++ b/api/wpt_coverage_api.py
@@ -39,7 +39,7 @@ class WPTCoverageAPI(basehandlers.EntitiesAPIHandler):
 
         # Validate the user has edit permissions.
         can_edit = permissions.can_edit_feature(
-            self.get_current_user(), feature_id
+            self.get_current_user(), feature
         )
         if not can_edit:
             self.abort(
@@ -122,7 +122,7 @@ class WPTCoverageAPI(basehandlers.EntitiesAPIHandler):
 
         # Validate the user has edit permissions.
         can_edit = permissions.can_edit_feature(
-            self.get_current_user(), feature_id
+            self.get_current_user(), feature
         )
         if not can_edit:
             self.abort(

--- a/client-src/js-src/cs-client.ts
+++ b/client-src/js-src/cs-client.ts
@@ -615,7 +615,7 @@ export class ChromeStatusClient {
 
   getGates(featureId: number): Promise<{gates: GateDict[]}> {
     return this.doGet(
-      `/features/${featureId}/gates?include_deleted=1`
+      `/features/${featureId}/gates`
     ) as Promise<{gates: GateDict[]}>;
   }
 

--- a/client-src/js-src/cs-client.ts
+++ b/client-src/js-src/cs-client.ts
@@ -614,9 +614,9 @@ export class ChromeStatusClient {
   }
 
   getGates(featureId: number): Promise<{gates: GateDict[]}> {
-    return this.doGet(
-      `/features/${featureId}/gates`
-    ) as Promise<{gates: GateDict[]}>;
+    return this.doGet(`/features/${featureId}/gates`) as Promise<{
+      gates: GateDict[];
+    }>;
   }
 
   getPendingGates(): Promise<{gates: GateDict[]}> {

--- a/framework/basehandlers.py
+++ b/framework/basehandlers.py
@@ -896,11 +896,9 @@ def get_spa_template_data(handler_obj, defaults):
 
         # Validate the user has edit permissions and redirect if needed.
         if defaults.get('require_edit_feature'):
-            feature_id = defaults.get('feature_id')
-            if not feature_id:
-                handler_obj.abort(500, msg='Cannot get feature ID from the URL')
+            fe = handler_obj.get_specified_feature(**defaults)
             redirect_resp = permissions.validate_feature_edit_permission(
-                handler_obj, feature_id
+                handler_obj, fe
             )
             if redirect_resp:
                 return redirect_resp

--- a/framework/basehandlers_test.py
+++ b/framework/basehandlers_test.py
@@ -1528,13 +1528,11 @@ class GetSPATemplateDataTests(testing_config.CustomTestCase):
         testing_config.sign_in('admin@chromium.org', 111)
         with test_app.test_request_context('/must_have_edit'):
             defaults = {'require_edit_feature': True}  # no feature_id.
-            with self.assertRaises(
-                werkzeug.exceptions.InternalServerError
-            ) as cm:
+            with self.assertRaises(werkzeug.exceptions.BadRequest) as cm:
                 basehandlers.get_spa_template_data(self.handler, defaults)
 
         self.assertEqual(
-            cm.exception.description, 'Cannot get feature ID from the URL'
+            cm.exception.description, "Missing parameter 'feature_id'"
         )
 
     def test_get_spa_template_data__edit_perm_anon(self):

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -20,8 +20,6 @@ Provides functions to verify if users have the necessary privileges to
 view, edit, or administer features and other resources.
 """
 
-from typing import Optional
-
 import flask
 from google.cloud import ndb  # type: ignore
 
@@ -95,6 +93,9 @@ def _can_view_confidential_feature_formatted(user: User, feature: dict):
 def can_view_feature(user: User, feature: FeatureEntry) -> bool:
     """Return True if the user is allowed to view the given feature."""
     if not feature:
+        return False
+
+    if feature.deleted and not can_edit_feature(user, feature):
         return False
 
     return not feature.confidential or _can_view_confidential_feature(
@@ -202,18 +203,13 @@ def feature_edit_list(user: User) -> list[int]:
     return list(set([fk.integer_id() for fk in editable_feature_keys]))
 
 
-def can_edit_feature(user: User, feature_id: int) -> bool:
+def can_edit_feature(user: User, feature: FeatureEntry) -> bool:
     """Return True if the user is allowed to edit the given feature."""
     # If the user can edit any feature, they can edit this feature.
     if can_edit_any_feature(user):
         return True
 
-    if not feature_id or not user:
-        return False
-
-    # Load feature directly from NDB so as to never get a stale cached copy.
-    feature: Optional[FeatureEntry] = FeatureEntry.get_by_id(feature_id)
-    if not feature:
+    if not feature or not user:
         return False
 
     email = user.email()
@@ -326,7 +322,7 @@ def validate_feature_create_permission(handler_obj):
 
 
 def validate_feature_edit_permission(
-    handler_obj, feature_id: int
+    handler_obj, fe: FeatureEntry
 ) -> flask.Response | dict:
     """Check if user has permission to edit feature and abort if not."""
     user = handler_obj.get_current_user()
@@ -338,13 +334,14 @@ def validate_feature_edit_permission(
         if redirect:
             return redirect
 
-    # Respond with 404 if feature is not found.
+    # Respond with 404 if feature was not found.
     # Load feature directly from NDB so as to never get a stale cached copy.
-    if FeatureEntry.get_by_id(feature_id) is None:
+    if not fe:
         handler_obj.abort(404, msg='Feature not found')
 
     # Respond with 403 if user does not have edit permission for feature.
-    if not can_edit_feature(user, feature_id):
+    feature_id = fe.key.integer_id()
+    if not can_edit_feature(user, fe):
         handler_obj.abort(403, msg='User cannot edit feature %r' % feature_id)
 
     return {}

--- a/framework/permissions_test.py
+++ b/framework/permissions_test.py
@@ -348,7 +348,7 @@ class PermissionFunctionTests(testing_config.CustomTestCase):
         # Check in context of specific feature.
         self.check_function_results_with_feature(
             permissions.can_edit_feature,
-            (self.feature_id,),
+            (self.feature_1,),
             unregistered=False,
             registered=False,
             feature_owner=True,


### PR DESCRIPTION
This PR goes through all the API class's `do_get()` methods and makes them consistently use `self.get_specified_feature()` or a similar method.  Also:
* `get_specified_feature()` now checks for deleted features and only allows participants to view them.
* I am using the local variable naming convention of `fe` for a `FeatureEntry`.  
* Some of the permission checking functions now accept a FeatureEntry rather than an ID to prevent redundant lookups. 
*  Some test cases changed to use an HTTP exception that seems more proper.
* The GatesAPI doesn't need the ?include_deleted=1 query string parameter because we check if the user is allowed to view the deleted feature at all and that controls whether they can view the gates.