### PR TITLE
Exclude confidential features from shipping API.

### DIFF
--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -1123,6 +1123,12 @@ def aggregate_shipping_features(
             logging.warning(f'Feature {stage.feature_id} not found.')
             continue
 
+        # WP feature entries cannot be confidential, so this should not matter.
+        # But, if they ever did exist, we exclude them from the report because
+        # the user is not authenticated.
+        if feature.confidential:
+            continue
+
         feature_info = build_feature_info(feature, stage)
 
         # PSA features do not require strict validation

--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -1118,27 +1118,27 @@ def aggregate_shipping_features(
     incomplete_features: list[tuple[ShippingFeatureInfo, list[str]]] = []
 
     for stage in shipping_stages:
-        feature: FeatureEntry | None = FeatureEntry.get_by_id(stage.feature_id)
-        if feature is None:
+        fe = FeatureEntry.get_by_id(stage.feature_id)
+        if fe is None:
             logging.warning(f'Feature {stage.feature_id} not found.')
             continue
 
         # WP feature entries cannot be confidential, so this should not matter.
         # But, if they ever did exist, we exclude them from the report because
         # the user is not authenticated.
-        if feature.confidential:
+        if fe.confidential or fe.deleted or stage.archived:
             continue
 
-        feature_info = build_feature_info(feature, stage)
+        feature_info = build_feature_info(fe, stage)
 
         # PSA features do not require strict validation
-        if feature.feature_type == core_enums.FEATURE_TYPE_CODE_CHANGE_ID:
+        if fe.feature_type == core_enums.FEATURE_TYPE_CODE_CHANGE_ID:
             complete_features.append(feature_info)
             continue
 
         # Perform strict validation
         criteria_missing = validate_shipping_criteria(
-            feature, stage, enabled_features_json, content_features_file
+            fe, stage, enabled_features_json, content_features_file
         )
 
         if criteria_missing:

--- a/internals/feature_helpers_test.py
+++ b/internals/feature_helpers_test.py
@@ -1821,6 +1821,66 @@ class ShippingFeatureHelpersTest(testing_config.CustomTestCase):
             state=Vote.APPROVED,
         ).put()
 
+        # Feature 13: Deleted (Should be excluded).
+        self.feature_13 = FeatureEntry(
+            id=13,
+            name='Feature 13 (Deleted)',
+            summary='sum',
+            category=1,
+            feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID,
+            finch_name='feature13Finch',
+            owner_emails=['owner@example.com'],
+            bug_url='https://example.com/bug13',
+            launch_bug_url='https://example.com/launch13',
+            deleted=True,
+        )
+        self.feature_13.put()
+        self.stage_13 = Stage(
+            id=113,
+            feature_id=13,
+            stage_type=160,
+            intent_thread_url='https://example.com/intent13',
+            milestones=MilestoneSet(desktop_first=self.milestone),
+        )
+        self.stage_13.put()
+        Gate(
+            id=1013,
+            feature_id=13,
+            stage_id=113,
+            gate_type=core_enums.GATE_API_SHIP,
+            state=Vote.APPROVED,
+        ).put()
+
+        # Feature 14: Archived Stage (Should be excluded).
+        self.feature_14 = FeatureEntry(
+            id=14,
+            name='Feature 14 (Archived Stage)',
+            summary='sum',
+            category=1,
+            feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID,
+            finch_name='feature14Finch',
+            owner_emails=['owner@example.com'],
+            bug_url='https://example.com/bug14',
+            launch_bug_url='https://example.com/launch14',
+        )
+        self.feature_14.put()
+        self.stage_14 = Stage(
+            id=114,
+            feature_id=14,
+            stage_type=160,
+            intent_thread_url='https://example.com/intent14',
+            milestones=MilestoneSet(desktop_first=self.milestone),
+            archived=True,
+        )
+        self.stage_14.put()
+        Gate(
+            id=1014,
+            feature_id=14,
+            stage_id=114,
+            gate_type=core_enums.GATE_API_SHIP,
+            state=Vote.APPROVED,
+        ).put()
+
     def test_validate_feature_in_chromium(self):
         """Tests parsing logic for JSON and C++ mock data."""
         # Case 1: Found in JSON and stable -> No missing criteria.
@@ -1953,6 +2013,8 @@ class ShippingFeatureHelpersTest(testing_config.CustomTestCase):
             self.stage_10,
             self.stage_11,
             self.stage_12,
+            self.stage_13,
+            self.stage_14,
         ]
 
         complete, incomplete = feature_helpers.aggregate_shipping_features(
@@ -1973,6 +2035,8 @@ class ShippingFeatureHelpersTest(testing_config.CustomTestCase):
             ],
         )
         self.assertNotIn('Feature 12 (Confidential)', complete_names)
+        self.assertNotIn('Feature 13 (Deleted)', complete_names)
+        self.assertNotIn('Feature 14 (Archived Stage)', complete_names)
 
         # Verify Incomplete Features
         self.assertEqual(len(incomplete), 6)
@@ -1996,3 +2060,5 @@ class ShippingFeatureHelpersTest(testing_config.CustomTestCase):
         )  # noqa: E501
 
         self.assertNotIn('Feature 12 (Confidential)', incomplete_map)
+        self.assertNotIn('Feature 13 (Deleted)', incomplete_map)
+        self.assertNotIn('Feature 14 (Archived Stage)', incomplete_map)

--- a/internals/feature_helpers_test.py
+++ b/internals/feature_helpers_test.py
@@ -1791,6 +1791,36 @@ class ShippingFeatureHelpersTest(testing_config.CustomTestCase):
             state=Vote.APPROVED,
         ).put()
 
+        # Feature 12: Confidential (Should be excluded).
+        self.feature_12 = FeatureEntry(
+            id=12,
+            name='Feature 12 (Confidential)',
+            summary='sum',
+            category=1,
+            feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID,
+            finch_name='feature12Finch',
+            owner_emails=['owner@example.com'],
+            bug_url='https://example.com/bug12',
+            launch_bug_url='https://example.com/launch12',
+            confidential=True,
+        )
+        self.feature_12.put()
+        self.stage_12 = Stage(
+            id=112,
+            feature_id=12,
+            stage_type=160,
+            intent_thread_url='https://example.com/intent12',
+            milestones=MilestoneSet(desktop_first=self.milestone),
+        )
+        self.stage_12.put()
+        Gate(
+            id=1012,
+            feature_id=12,
+            stage_id=112,
+            gate_type=core_enums.GATE_API_SHIP,
+            state=Vote.APPROVED,
+        ).put()
+
     def test_validate_feature_in_chromium(self):
         """Tests parsing logic for JSON and C++ mock data."""
         # Case 1: Found in JSON and stable -> No missing criteria.
@@ -1922,6 +1952,7 @@ class ShippingFeatureHelpersTest(testing_config.CustomTestCase):
             self.stage_9,
             self.stage_10,
             self.stage_11,
+            self.stage_12,
         ]
 
         complete, incomplete = feature_helpers.aggregate_shipping_features(
@@ -1941,6 +1972,7 @@ class ShippingFeatureHelpersTest(testing_config.CustomTestCase):
                 'Feature 5 (PSA)',
             ],
         )
+        self.assertNotIn('Feature 12 (Confidential)', complete_names)
 
         # Verify Incomplete Features
         self.assertEqual(len(incomplete), 6)
@@ -1962,3 +1994,5 @@ class ShippingFeatureHelpersTest(testing_config.CustomTestCase):
         self.assertEqual(
             incomplete_map['F9 Disabled'], ['content_feature_not_enabled']
         )  # noqa: E501
+
+        self.assertNotIn('Feature 12 (Confidential)', incomplete_map)


### PR DESCRIPTION
This addresses a concern raised in as section of an internal issue about `aggregate_shipping_features()`.

We only offer the `confidential` checkbox for enterprise features.  Enterprise features use rollout step stages.  WP features cannot normally be confidential, they can only be unlisted.  The query used to retrieve shipping stages only considers the milestone fields used with WP features.  So, it does not seem possible that any confidential features would be in the set of candidate features for this report.

However, to make that explicit, and to protect against any scenario in which there were confidential WP features in the future, this PR excludes them from the shipping features report response.