### PR TITLE
Exclude confidential features from other WP reports.

### DIFF
--- a/api/external_reviews_api.py
+++ b/api/external_reviews_api.py
@@ -170,18 +170,18 @@ class ExternalReviewsAPI(basehandlers.APIHandler):
         # WP features cannot be confidential, so this should not matter.
         # But if any is ever somehow confidential, remove it.
         unreviewed_features = [
-            feature
-            for feature in unreviewed_features
-            if not feature.confidential
+            fe
+            for fe in unreviewed_features
+            if not fe.confidential and not fe.deleted
         ]
 
         # Remove features for which the review link isn't a request for the review group to review the  # noqa: E501
         # feature.
         unreviewed_features = [
-            feature
-            for feature in unreviewed_features
+            fe
+            for fe in unreviewed_features
             if reviewer_info.review_pattern.search(
-                reviewer_info.review_link(feature)
+                reviewer_info.review_link(fe)
             )
         ]
 
@@ -190,9 +190,9 @@ class ExternalReviewsAPI(basehandlers.APIHandler):
             stage.feature_id: stage
             for stage in ndb.get_multi(
                 [
-                    ndb.Key('Stage', feature.active_stage_id)
-                    for feature in unreviewed_features
-                    if feature.active_stage_id
+                    ndb.Key('Stage', fe.active_stage_id)
+                    for fe in unreviewed_features
+                    if fe.active_stage_id
                 ]
             )
             if stage
@@ -200,21 +200,20 @@ class ExternalReviewsAPI(basehandlers.APIHandler):
 
         # Filter to reviews for which we could fetch a preview.
         feature_links, _has_stale_links = get_feature_links_by_feature_ids(
-            [feature.key.id() for feature in unreviewed_features],
+            [fe.key.id() for fe in unreviewed_features],
             update_stale_links=True,  # noqa: E501
         )
         review_links = {
-            reviewer_info.review_link(feature)
-            for feature in unreviewed_features
+            reviewer_info.review_link(fe) for fe in unreviewed_features
         }
         previewable_urls = {fl['url'] for fl in feature_links}
 
         # Build the response objects.
         reviews = [
             OutstandingReview(
-                review_link=reviewer_info.review_link(feature),
-                feature=FeatureLink(id=feature.key.id(), name=feature.name),
-                current_stage=stage_type(feature, stage),
+                review_link=reviewer_info.review_link(fe),
+                feature=FeatureLink(id=fe.key.id(), name=fe.name),
+                current_stage=stage_type(fe, stage),
                 estimated_start_milestone=min_of_present(
                     stage.milestones.desktop_first,
                     stage.milestones.android_first,
@@ -232,9 +231,9 @@ class ExternalReviewsAPI(basehandlers.APIHandler):
                 if stage and stage.milestones
                 else None,
             )
-            for feature in unreviewed_features
-            for stage in [active_stage.get(feature.key.id(), None)]
-            if reviewer_info.review_link(feature) in previewable_urls
+            for fe in unreviewed_features
+            for stage in [active_stage.get(fe.key.id(), None)]
+            if reviewer_info.review_link(fe) in previewable_urls
         ]
         reviews.sort(
             key=lambda review: (

--- a/api/external_reviews_api.py
+++ b/api/external_reviews_api.py
@@ -167,6 +167,14 @@ class ExternalReviewsAPI(basehandlers.APIHandler):
         reviewer_info = ExternalReviewerInfo(review_group)
         unreviewed_features = reviewer_info.unreviewed_features_query.fetch()
 
+        # WP features cannot be confidential, so this should not matter.
+        # But if any is ever somehow confidential, remove it.
+        unreviewed_features = [
+            feature
+            for feature in unreviewed_features
+            if not feature.confidential
+        ]
+
         # Remove features for which the review link isn't a request for the review group to review the  # noqa: E501
         # feature.
         unreviewed_features = [

--- a/api/external_reviews_api_test.py
+++ b/api/external_reviews_api_test.py
@@ -213,6 +213,26 @@ class ExternalReviewsAPITest(testing_config.CustomTestCase):
             result,
         )
 
+    def test_omit_confidential_features(self):
+        """Test confidential feature isn't shown."""
+        tag = 'https://github.com/w3ctag/design-reviews/issues/1'
+        fe = make_feature(
+            'Feature confidential',
+            core_enums.STAGE_BLINK_PROTOTYPE,
+            tag=tag,
+        )
+        fe.confidential = True
+        fe.put()
+
+        result = self.handler.do_get(review_group='tag')
+        self.assertEqual(
+            {
+                'reviews': [],
+                'link_previews': [],
+            },
+            result,
+        )
+
     def test_milestones_summarize(self):
         """We take the earliest start milestone and the latest end milestone.
 

--- a/api/external_reviews_api_test.py
+++ b/api/external_reviews_api_test.py
@@ -233,6 +233,26 @@ class ExternalReviewsAPITest(testing_config.CustomTestCase):
             result,
         )
 
+    def test_omit_deleted_features(self):
+        """Test deleted feature isn't shown."""
+        tag = 'https://github.com/w3ctag/design-reviews/issues/1'
+        fe = make_feature(
+            'Feature deleted',
+            core_enums.STAGE_BLINK_PROTOTYPE,
+            tag=tag,
+        )
+        fe.deleted = True
+        fe.put()
+
+        result = self.handler.do_get(review_group='tag')
+        self.assertEqual(
+            {
+                'reviews': [],
+                'link_previews': [],
+            },
+            result,
+        )
+
     def test_milestones_summarize(self):
         """We take the earliest start milestone and the latest end milestone.
 

--- a/api/spec_mentors_api.py
+++ b/api/spec_mentors_api.py
@@ -57,6 +57,9 @@ class SpecMentorsAPI(basehandlers.APIHandler):
             if feature.unlisted:
                 # TODO: Consider showing these when the caller is logged in and has the right to see them.  # noqa: E501
                 continue
+            if feature.confidential:
+                # WP features cannot be confidential, but skip them just in case.
+                continue
             for mentor in feature.spec_mentor_emails:
                 mentors.setdefault(mentor, []).append(
                     FeatureLink(id=feature.key.integer_id(), name=feature.name)

--- a/api/spec_mentors_api.py
+++ b/api/spec_mentors_api.py
@@ -47,22 +47,20 @@ class SpecMentorsAPI(basehandlers.APIHandler):
         features: list[FeatureEntry] = query.fetch()
         if after is not None:
             # Do this in Python rather than the NDB query because NDB queries only support one inequality.  # noqa: E501
-            features = [
-                feature for feature in features if feature.updated > after
-            ]
-        features.sort(key=lambda f: f.updated, reverse=True)
+            features = [fe for fe in features if fe.updated > after]
+        features.sort(key=lambda fe: fe.updated, reverse=True)
 
         mentors: dict[str, list[FeatureLink]] = {}
-        for feature in features:
-            if feature.unlisted:
+        for fe in features:
+            if fe.unlisted:
                 # TODO: Consider showing these when the caller is logged in and has the right to see them.  # noqa: E501
                 continue
-            if feature.confidential:
+            if fe.confidential or fe.deleted:
                 # WP features cannot be confidential, but skip them just in case.
                 continue
-            for mentor in feature.spec_mentor_emails:
+            for mentor in fe.spec_mentor_emails:
                 mentors.setdefault(mentor, []).append(
-                    FeatureLink(id=feature.key.integer_id(), name=feature.name)
+                    FeatureLink(id=fe.key.integer_id(), name=fe.name)
                 )  # noqa: E501
 
         return [

--- a/api/spec_mentors_api_test.py
+++ b/api/spec_mentors_api_test.py
@@ -123,6 +123,22 @@ class SpecMentorsAPITest(testing_config.CustomTestCase):
 
         self.assertEqual(response, [])
 
+    def test_omits_confidential_feature(self):
+        """Does not return a confidential feature that has a mentor."""
+        # Create a feature using the admin user.
+        testing_config.sign_in(self.app_admin.email, 123567890)
+
+        feature = self.createFeature({'name': 'The feature'})
+        feature.spec_mentor_emails = ['mentor@example.org']
+        feature.confidential = True
+        feature.put()
+        testing_config.sign_out()
+
+        with test_app.test_request_context(self.request_path):
+            response = self.spec_mentors_handler.do_get()
+
+        self.assertEqual(response, [])
+
     def test_obeys_after_param(self):
         """The ?after URL parameter filters features."""
         # Create a feature using the admin user.

--- a/api/spec_mentors_api_test.py
+++ b/api/spec_mentors_api_test.py
@@ -139,6 +139,22 @@ class SpecMentorsAPITest(testing_config.CustomTestCase):
 
         self.assertEqual(response, [])
 
+    def test_omits_deleted_feature(self):
+        """Does not return a deleted feature that has a mentor."""
+        # Create a feature using the admin user.
+        testing_config.sign_in(self.app_admin.email, 123567890)
+
+        feature = self.createFeature({'name': 'The feature'})
+        feature.spec_mentor_emails = ['mentor@example.org']
+        feature.deleted = True
+        feature.put()
+        testing_config.sign_out()
+
+        with test_app.test_request_context(self.request_path):
+            response = self.spec_mentors_handler.do_get()
+
+        self.assertEqual(response, [])
+
     def test_obeys_after_param(self):
         """The ?after URL parameter filters features."""
         # Create a feature using the admin user.

--- a/api/stale_features_api.py
+++ b/api/stale_features_api.py
@@ -47,6 +47,11 @@ class StaleFeaturesAPI(basehandlers.EntitiesAPIHandler):
         stale_features = feature_helpers.get_stale_features()
         stale_features_info: list[StaleFeatureInfo] = []
         for feature, mstone, mstone_field in stale_features:
+            if feature.unlisted:
+                continue
+            if feature.confidential:
+                # WP features cannot be confidential, but skip them just in case.
+                continue
             stale_features_info.append(
                 {
                     'id': feature.key.integer_id(),

--- a/api/stale_features_api_test.py
+++ b/api/stale_features_api_test.py
@@ -128,3 +128,42 @@ class StaleFeaturesAPITest(testing_config.CustomTestCase):
         mock_get_stale_features.assert_called_once()
         self.assertIn('stale_features', response)
         self.assertEqual(response['stale_features'], [])
+
+    @mock.patch('internals.feature_helpers.get_stale_features')
+    def test_do_get__omits_unlisted_and_confidential_features(
+        self, mock_get_stale_features
+    ):
+        """The API should omit unlisted and confidential features from the response."""
+        feature_unlisted = FeatureEntry(
+            id=3,
+            name='Unlisted Stale Feature',
+            summary='summary',
+            category=1,
+            owner_emails=['owner@example.com'],
+            unlisted=True,
+        )
+        feature_confidential = FeatureEntry(
+            id=4,
+            name='Confidential Stale Feature',
+            summary='summary',
+            category=1,
+            owner_emails=['owner@example.com'],
+            confidential=True,
+        )
+
+        mock_get_stale_features.return_value = [
+            (self.feature_1, 120, 'shipped_milestone'),
+            (feature_unlisted, 121, 'shipped_android_milestone'),
+            (feature_confidential, 122, 'shipped_ios_milestone'),
+        ]
+
+        with test_app.test_request_context('/api/v0/stalefeatures'):
+            response = self.handler.do_get()
+
+        mock_get_stale_features.assert_called_once()
+        self.assertIn('stale_features', response)
+        stale_features_info = response['stale_features']
+        self.assertEqual(len(stale_features_info), 1)
+        self.assertEqual(
+            stale_features_info[0]['id'], self.feature_1.key.integer_id()
+        )


### PR DESCRIPTION
These reports were flagged in a section of an internal issue.
WP features cannot be confidential, so this is moot at present, but with this PR we explicitly exclude any confidential features.  