### PR TITLE
[Backend APIs] Implement Lean V1 Read-Only Release Notes API (GET /releasenotes/{milestone})

### DIFF
--- a/api/releasenotes_api.py
+++ b/api/releasenotes_api.py
@@ -19,10 +19,39 @@ from typing import Any
 
 from chromestatus_openapi.models import (
     ReleaseNotesL10nResponse,
+    ReleaseNotesResponse,
 )
 
 from framework import basehandlers
 from internals import core_enums, feature_helpers
+
+
+class ReleaseNotesAPI(basehandlers.APIHandler):
+    """API handler for fetching public release notes features for a milestone (GET /api/v0/releasenotes/{milestone})."""
+
+    def do_get(self, **kwargs: Any) -> dict[str, Any]:
+        """Get public release notes features for a specific milestone.
+
+        Args:
+            **kwargs: Keyword arguments containing path or query parameters.
+
+        Returns:
+            A dictionary matching the ReleaseNotesResponse OpenAPI schema:
+            { "milestone": milestone, "features": [ReleaseNoteFeature, ...] }
+        """
+        milestone = self._extract_id_param(kwargs, 'milestone')
+        if milestone is None or milestone <= 0:
+            self.abort(400, msg='Milestone must be a positive integer')
+
+        release_note_features = (
+            feature_helpers.get_developer_release_notes_features(milestone)
+        )
+
+        payload = {
+            'milestone': milestone,
+            'features': release_note_features,
+        }
+        return ReleaseNotesResponse.from_dict(payload).to_dict()
 
 
 class ReleaseNotesL10nAPI(basehandlers.APIHandler):

--- a/api/releasenotes_api_test.py
+++ b/api/releasenotes_api_test.py
@@ -16,12 +16,18 @@
 
 import testing_config  # isort: split
 
+from unittest import mock
+
 import flask
 import werkzeug.exceptions  # Flask HTTP stuff.
 
-from api import releasenotes_api
+from api import converters, releasenotes_api
 from internals import core_enums
-from internals.core_models import FeatureEntry, MilestoneSet, Stage
+from internals.core_models import (
+    FeatureEntry,
+    MilestoneSet,
+    Stage,
+)
 from internals.review_models import Gate
 
 test_app = flask.Flask(__name__)
@@ -335,3 +341,106 @@ class ReleaseNotesL10nAPITest(testing_config.CustomTestCase):
         feature_after_filtered.key.delete()
         after_filtered_stage.key.delete()
         after_filtered_gate.key.delete()
+
+
+class ReleaseNotesAPITest(testing_config.CustomTestCase):
+    """Tests for ReleaseNotesAPI (GET /api/v0/releasenotes/{milestone})."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.handler = releasenotes_api.ReleaseNotesAPI()
+
+    def test_do_get__invalid_milestone(self):
+        """It aborts HTTP 400 if milestone <= 0."""
+        with test_app.test_request_context('/api/v0/releasenotes/0'):
+            with self.assertRaises(werkzeug.exceptions.BadRequest) as cm:
+                self.handler.do_get(milestone=0)
+            self.assertEqual(400, cm.exception.code)
+
+        with test_app.test_request_context('/api/v0/releasenotes/-5'):
+            with self.assertRaises(werkzeug.exceptions.BadRequest) as cm:
+                self.handler.do_get(milestone=-5)
+            self.assertEqual(400, cm.exception.code)
+
+        with test_app.test_request_context('/api/v0/releasenotes/abc'):
+            with self.assertRaises(werkzeug.exceptions.BadRequest) as cm:
+                self.handler.do_get(milestone='abc')
+            self.assertEqual(400, cm.exception.code)
+
+    @mock.patch(
+        'internals.feature_helpers.get_developer_release_notes_features'
+    )
+    def test_do_get__success_human_fallback(self, mock_get_features):
+        """It returns feature with summary_source = HUMAN when no AI suggestion exists."""
+        mock_get_features.return_value = [
+            {
+                'id': 101,
+                'name': 'CSS Anchor Positioning',
+                'summary': 'Human summary for anchor positioning.',
+                'category_name': 'CSS',
+                'summary_source': converters.OpenAPISummarySource.HUMAN,
+                'baseline_status': converters.OpenAPIBaselineStatus.NONE,
+            }
+        ]
+
+        with test_app.test_request_context('/api/v0/releasenotes/132'):
+            response = self.handler.do_get(milestone=132)
+
+        mock_get_features.assert_called_once_with(132)
+        self.assertEqual(132, response['milestone'])
+        self.assertEqual(1, len(response['features']))
+        feat = response['features'][0]
+        self.assertEqual(101, feat['id'])
+        self.assertEqual('CSS Anchor Positioning', feat['name'])
+        self.assertEqual(
+            'Human summary for anchor positioning.', feat['summary']
+        )
+        self.assertEqual(
+            converters.OpenAPISummarySource.HUMAN, feat['summary_source']
+        )
+
+    @mock.patch(
+        'internals.feature_helpers.get_developer_release_notes_features'
+    )
+    def test_do_get__success_ai_applied(self, mock_get_features):
+        """It overrides summary and sets summary_source = AI_APPLIED when an applied suggestion exists."""
+        mock_get_features.return_value = [
+            {
+                'id': 101,
+                'name': 'CSS Anchor Positioning',
+                'summary': 'AI-generated approved summary text.',
+                'category_name': 'CSS',
+                'summary_source': converters.OpenAPISummarySource.AI_APPLIED,
+                'baseline_status': converters.OpenAPIBaselineStatus.NEWLY,
+            }
+        ]
+
+        with test_app.test_request_context('/api/v0/releasenotes/132'):
+            response = self.handler.do_get(milestone=132)
+
+        mock_get_features.assert_called_once_with(132)
+        self.assertEqual(132, response['milestone'])
+        self.assertEqual(1, len(response['features']))
+        feat = response['features'][0]
+        self.assertEqual(101, feat['id'])
+        self.assertEqual('AI-generated approved summary text.', feat['summary'])
+        self.assertEqual(
+            converters.OpenAPISummarySource.AI_APPLIED, feat['summary_source']
+        )
+        self.assertEqual(
+            converters.OpenAPIBaselineStatus.NEWLY, feat['baseline_status']
+        )
+
+    @mock.patch(
+        'internals.feature_helpers.get_developer_release_notes_features'
+    )
+    def test_do_get__empty(self, mock_get_features):
+        """It returns empty list when no shipping features exist in milestone."""
+        mock_get_features.return_value = []
+
+        with test_app.test_request_context('/api/v0/releasenotes/999'):
+            response = self.handler.do_get(milestone=999)
+
+        mock_get_features.assert_called_once_with(999)
+        self.assertEqual(999, response['milestone'])
+        self.assertEqual([], response['features'])

--- a/internals/feature_helpers.py
+++ b/internals/feature_helpers.py
@@ -29,7 +29,12 @@ from api import converters
 from framework import permissions, rediscache, users
 from framework.utils import get_current_milestone_info
 from internals import core_enums
-from internals.core_models import FeatureEntry, MilestoneSet, Stage
+from internals.core_models import (
+    FeatureEntry,
+    FeatureSummarySuggestion,
+    MilestoneSet,
+    Stage,
+)
 from internals.review_models import Gate, Vote
 from internals.stage_helpers import organize_all_stages_by_feature
 
@@ -198,10 +203,77 @@ def _filter_out_wp_features_lacking_enterprise_approval(
     return result
 
 
+def get_developer_release_notes_features(
+    milestone: int,
+) -> list[dict[str, Any]]:
+    """Fetches and formats web platform features for developer.chrome.com release notes.
+
+    Note: This helper retrieves general shipping web standards features (incubations,
+    existing implementations, code changes, and deprecations) via get_in_milestone(),
+    applies confidentiality and unlisted visibility filters, and converts them to lean
+    OpenAPI ReleaseNoteFeature dictionaries with attached AI summary suggestions and
+    WebDX baseline statuses. For Chrome Enterprise IT administrator release notes
+    tracking enterprise impact and rollout stages, use
+    get_features_in_release_notes(milestone) instead.
+
+    Args:
+        milestone: The integer Chrome milestone (e.g., 135) to retrieve release notes for.
+
+    Returns:
+        A list of dictionaries matching the OpenAPI ReleaseNoteFeature schema.
+    """
+    milestone_data = get_in_milestone(milestone)
+    seen_ids: set[int] = set()
+    for reason, feature_dicts in milestone_data.items():
+        for fdict in feature_dicts:
+            fid = fdict.get('id')
+            if fid:
+                seen_ids.add(fid)
+
+    if not seen_ids:
+        return []
+
+    # Batch fetch FeatureEntry entities (prevents N+1 query loop)
+    feature_keys = [ndb.Key(FeatureEntry, fid) for fid in seen_ids]
+    raw_features = ndb.get_multi(feature_keys)
+    feature_entries = filter_unlisted(filter_confidential(raw_features))
+    feature_entries.sort(key=lambda f: f.name or '')
+
+    # Batch fetch FeatureSummarySuggestion entities by key (prevents unbounded table scan)
+    valid_fids = [fe.key.integer_id() for fe in feature_entries if fe.key]
+    suggestion_keys = [
+        ndb.Key(FeatureSummarySuggestion, fid) for fid in valid_fids
+    ]
+    suggestions = ndb.get_multi(suggestion_keys)
+    applied_map = {
+        s.key.id(): s
+        for s in suggestions
+        if s and s.status == core_enums.SummarySuggestionStatus.APPLIED
+    }
+
+    formatted_features = []
+    for fe in feature_entries:
+        fid = fe.key.integer_id() if fe.key else 0
+        applied_suggestion = applied_map.get(fid)
+        rn_dict = converters.feature_entry_to_release_note_feature_dict(
+            fe, applied_suggestion=applied_suggestion
+        )
+        formatted_features.append(rn_dict)
+
+    return formatted_features
+
+
 def get_features_in_release_notes(
     milestone: int, end_milestone: int | None = None
 ):
-    """Fetches features slated for release notes in the specified milestone or milestone range."""
+    """Fetches Chrome Enterprise IT admin release notes features for a milestone or range.
+
+    Note: This helper specifically queries features with enterprise impact or enterprise
+    feature types, and formats them using the verbose dictionary schema with rollout
+    and approval fields for enterprise administrators. For public web developer and
+    web standards release notes (developer.chrome.com), use
+    get_developer_release_notes_features(milestone) instead.
+    """
     actual_end_milestone = (
         end_milestone if end_milestone is not None else milestone
     )

--- a/internals/feature_helpers_test.py
+++ b/internals/feature_helpers_test.py
@@ -21,7 +21,12 @@ import testing_config  # Must be imported before the module under test.
 from api import converters
 from framework import rediscache
 from internals import core_enums, feature_helpers, stage_helpers
-from internals.core_models import FeatureEntry, MilestoneSet, Stage
+from internals.core_models import (
+    FeatureEntry,
+    FeatureSummarySuggestion,
+    MilestoneSet,
+    Stage,
+)
 from internals.review_models import Gate, Vote
 from internals.user_models import AppUser
 
@@ -152,6 +157,15 @@ class FeatureHelpersTest(testing_config.CustomTestCase):
         self.app_admin = AppUser(email='admin@example.com')
         self.app_admin.is_admin = True
         self.app_admin.put()
+
+    def tearDown(self):
+        """Tear down test database."""
+        for fe in FeatureEntry.query():
+            fe.key.delete()
+        for s in Stage.query():
+            s.key.delete()
+        for s in FeatureSummarySuggestion.query():
+            s.key.delete()
 
     def test_get_by_participant(self):
         """The people who are involve in a feature can edit it, others can't."""
@@ -2062,3 +2076,136 @@ class ShippingFeatureHelpersTest(testing_config.CustomTestCase):
         self.assertNotIn('Feature 12 (Confidential)', incomplete_map)
         self.assertNotIn('Feature 13 (Deleted)', incomplete_map)
         self.assertNotIn('Feature 14 (Archived Stage)', incomplete_map)
+
+
+class DeveloperReleaseNotesFeaturesTest(testing_config.CustomTestCase):
+    """Tests for feature_helpers.get_developer_release_notes_features."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.feature_1 = FeatureEntry(
+            id=101,
+            name='CSS Anchor Positioning',
+            summary='Human summary for anchor positioning.',
+            category=1,
+            feature_type=1,
+            unlisted=False,
+            confidential=False,
+        )
+        self.feature_1.put()
+
+        self.stage_1 = Stage(
+            feature_id=101,
+            stage_type=core_enums.STAGE_BLINK_SHIPPING,
+            milestones=MilestoneSet(desktop_first=132),
+        )
+        self.stage_1.put()
+
+    def tearDown(self):
+        """Tear down test database."""
+        for fe in FeatureEntry.query():
+            fe.key.delete()
+        for s in Stage.query():
+            s.key.delete()
+        for s in FeatureSummarySuggestion.query():
+            s.key.delete()
+
+    def test_get_developer_release_notes_features__normal(self):
+        """It returns feature with summary_source = HUMAN when no AI suggestion exists."""
+        features = feature_helpers.get_developer_release_notes_features(132)
+        self.assertEqual(1, len(features))
+        feat = features[0]
+        self.assertEqual(101, feat['id'])
+        self.assertEqual('CSS Anchor Positioning', feat['name'])
+        self.assertEqual(
+            'Human summary for anchor positioning.', feat['summary']
+        )
+        self.assertEqual(
+            converters.OpenAPISummarySource.HUMAN, feat['summary_source']
+        )
+
+    def test_get_developer_release_notes_features__ai_applied(self):
+        """It overrides summary and sets summary_source = AI_APPLIED when an applied suggestion exists."""
+        suggestion = FeatureSummarySuggestion(
+            id=101,
+            suggested_summary='AI-generated approved summary text.',
+            status=core_enums.SummarySuggestionStatus.APPLIED,
+            baseline_status=core_enums.BaselineStatus.NEWLY,
+        )
+        suggestion.put()
+
+        features = feature_helpers.get_developer_release_notes_features(132)
+        self.assertEqual(1, len(features))
+        feat = features[0]
+        self.assertEqual('AI-generated approved summary text.', feat['summary'])
+        self.assertEqual(
+            converters.OpenAPISummarySource.AI_APPLIED, feat['summary_source']
+        )
+        self.assertEqual(
+            converters.OpenAPIBaselineStatus.NEWLY, feat['baseline_status']
+        )
+
+    def test_get_developer_release_notes_features__unapplied_ignored(self):
+        """It ignores PROPOSED or REJECTED suggestions and falls back to HUMAN summary."""
+        suggestion = FeatureSummarySuggestion(
+            id=101,
+            suggested_summary='AI-generated unapproved summary text.',
+            status=core_enums.SummarySuggestionStatus.PROPOSED,
+        )
+        suggestion.put()
+
+        features = feature_helpers.get_developer_release_notes_features(132)
+        self.assertEqual(1, len(features))
+        feat = features[0]
+        self.assertEqual(
+            'Human summary for anchor positioning.', feat['summary']
+        )
+        self.assertEqual(
+            converters.OpenAPISummarySource.HUMAN, feat['summary_source']
+        )
+
+    def test_get_developer_release_notes_features__empty_milestone(self):
+        """It returns empty list when no shipping features exist in milestone."""
+        features = feature_helpers.get_developer_release_notes_features(999)
+        self.assertEqual(0, len(features))
+
+    def test_get_developer_release_notes_features__confidential_filtered(self):
+        """It shields confidential features from public developer release notes."""
+        self.feature_1.confidential = True
+        self.feature_1.put()
+        testing_config.sign_out()
+
+        features = feature_helpers.get_developer_release_notes_features(132)
+        self.assertEqual(0, len(features))
+
+    def test_get_developer_release_notes_features__unlisted_filtered(self):
+        """It shields unlisted features from public developer release notes."""
+        self.feature_1.unlisted = True
+        self.feature_1.put()
+
+        features = feature_helpers.get_developer_release_notes_features(132)
+        self.assertEqual(0, len(features))
+
+    def test_get_developer_release_notes_features__alphabetical_sorting(self):
+        """It returns release notes features sorted alphabetically by name."""
+        feature_2 = FeatureEntry(
+            id=102,
+            name='Alpha Feature',
+            summary='Summary for alpha.',
+            category=1,
+            feature_type=1,
+            unlisted=False,
+            confidential=False,
+        )
+        feature_2.put()
+        stage_2 = Stage(
+            feature_id=102,
+            stage_type=core_enums.STAGE_BLINK_SHIPPING,
+            milestones=MilestoneSet(desktop_first=132),
+        )
+        stage_2.put()
+
+        features = feature_helpers.get_developer_release_notes_features(132)
+        self.assertEqual(2, len(features))
+        self.assertEqual('Alpha Feature', features[0]['name'])
+        self.assertEqual('CSS Anchor Positioning', features[1]['name'])

--- a/main.py
+++ b/main.py
@@ -258,6 +258,10 @@ api_routes: list[Route] = [
     Route(
         f'{API_BASE}/releasenotes/l10n', releasenotes_api.ReleaseNotesL10nAPI
     ),
+    Route(
+        f'{API_BASE}/releasenotes/<int:milestone>',
+        releasenotes_api.ReleaseNotesAPI,
+    ),
 ]
 
 # The Routes below that have no handler specified use SPAHandler.


### PR DESCRIPTION
[Backend APIs] Implement Lean V1 Read-Only Release Notes API (GET /releasenotes/{milestone})

## Summary

Implements `GET /api/v0/releasenotes/{milestone}` for fetching public web developer release notes features for a specific milestone.

Centralizes domain retrieval logic in `internals/feature_helpers.py`, clearly contrasting the developer standard pipeline against the Chrome Enterprise IT admin pipeline (`get_features_in_release_notes`). Uses converters from #6621 and schemas from #6620 to serialize `FeatureEntry` items. Returns `summary_source = 'AI_APPLIED'` when an approved AI summary exists, and `'HUMAN'` otherwise.

## Key Changes

- **Domain Logic (`internals/feature_helpers.py`)**: Adds `get_developer_release_notes_features(milestone)` to fetch shipping features via `get_in_milestone()`, apply `filter_confidential()` and `filter_unlisted()`, sort alphabetically, and attach approved AI summary suggestions in O(1) lookup time. Includes clear docstrings contrasting developer vs. Enterprise IT release notes.
- **Controller (`api/releasenotes_api.py`)**: Adds `ReleaseNotesAPI.do_get` handler for `/releasenotes/<int:milestone>`. Validates positive integer milestones and delegates directly to `feature_helpers`.
- **Route (`main.py`)**: Registers `GET /api/v0/releasenotes/<int:milestone>`.
- **Two-Tiered Testing Architecture**:
  - **Service Layer (`internals/feature_helpers_test.py`)**: Added `DeveloperReleaseNotesFeaturesTest` testing normal features, AI summary overrides, unapplied suggestion ignoring, empty milestones, unlisted/confidential visibility shielding, and alphabetical sorting directly against NDB. Added `tearDown()` to `FeatureHelpersTest` to ensure Datastore cleanup between test methods.
  - **Controller Layer (`api/releasenotes_api_test.py`)**: Added `ReleaseNotesAPITest` using `@mock.patch` to isolate and test HTTP parameter validation (HTTP 400), query extraction, and OpenAPI schema wrapping cleanly.

TAG=agy
CONV=86f63625-bdb5-4d50-ac8d-2f8ca5128ca9
