### PR TITLE
Add two registered organizations.

### DIFF
--- a/api/permissions_api_test.py
+++ b/api/permissions_api_test.py
@@ -19,6 +19,7 @@ import flask
 
 import testing_config  # Must be imported before the module under test.
 from api import permissions_api
+from framework import permissions
 
 test_app = flask.Flask(__name__)
 
@@ -96,3 +97,24 @@ class PermissionsAPITest(testing_config.CustomTestCase):
             }
         }
         self.assertEqual(expected, actual)
+
+    def test_get__registered_org_user(self):
+        """Users from registered orgs have default permissions to create features."""
+        for domain in permissions.REGISTERED_USER_ORGANIZATIONS:
+            email = f'one{domain}'
+            testing_config.sign_in(email, 67890)
+            with test_app.test_request_context(self.request_path):
+                actual = self.handler.do_get()
+            expected = {
+                'user': {
+                    'can_create_feature': True,
+                    'approvable_gate_types': [],
+                    'can_comment': True,
+                    'can_edit_all': False,
+                    'can_review_release_notes': False,
+                    'is_admin': False,
+                    'email': email,
+                    'editable_features': [],
+                }
+            }
+            self.assertEqual(expected, actual)

--- a/framework/permissions.py
+++ b/framework/permissions.py
@@ -126,6 +126,18 @@ def _can_view_confidential_feature(user: User, feature: FeatureEntry):
     return False
 
 
+# Note: Once an organization has over 10 registered users and there
+# are no concerns, we can register the entire organization for
+# streamlining.  Other folks, and anyone needing to be a site editor,
+# should email a request to become a registered user.
+REGISTERED_USER_ORGANIZATIONS = (
+    '@chromium.org',
+    '@google.com',
+    '@microsoft.com',
+    '@igalia.com',
+)
+
+
 def can_create_feature(user: User) -> bool:
     """Return True if the user is allowed to create features."""
     if not user:
@@ -134,8 +146,7 @@ def can_create_feature(user: User) -> bool:
     if can_admin_site(user):
         return True
 
-    # TODO(jrobbins): generalize this.
-    if user.email().endswith(('@chromium.org', '@google.com')):
+    if user.email().endswith(REGISTERED_USER_ORGANIZATIONS):
         return True
 
     app_user = AppUser.get_app_user(user.email())

--- a/framework/permissions_test.py
+++ b/framework/permissions_test.py
@@ -157,14 +157,11 @@ class PermissionFunctionTests(testing_config.CustomTestCase):
         user = users.get_current_user()
         self.assertEqual(registered, func(user, *additional_args))
 
-        # Test special users
-        # TODO(jrobbins): generalize this.
-        testing_config.sign_in('user@google.com', 123)
-        user = users.get_current_user()
-        self.assertEqual(special, func(user, *additional_args))
-        testing_config.sign_in('user@chromium.org', 123)
-        user = users.get_current_user()
-        self.assertEqual(special, func(user, *additional_args))
+        # Test special users (registered orgs)
+        for domain in permissions.REGISTERED_USER_ORGANIZATIONS:
+            testing_config.sign_in(f'user{domain}', 123)
+            user = users.get_current_user()
+            self.assertEqual(special, func(user, *additional_args))
 
         # Test site editor user
         testing_config.sign_in('editor@example.com', 123)
@@ -299,6 +296,25 @@ class PermissionFunctionTests(testing_config.CustomTestCase):
             admin=True,
             anon=False,
         )
+
+    def test_can_create_feature__registered_orgs(self):
+        """Users from any registered org domain can create features."""
+        for domain in permissions.REGISTERED_USER_ORGANIZATIONS:
+            testing_config.sign_in(f'user{domain}', 123)
+            user = users.get_current_user()
+            self.assertTrue(permissions.can_create_feature(user))
+
+    def test_can_create_feature__unregistered_orgs(self):
+        """Unregistered users from non-whitelisted orgs cannot create features."""
+        unregistered_emails = [
+            'user@example.com',
+            'user@otherdomain.com',
+            'user@fakechromium.org.evil.com',
+        ]
+        for email in unregistered_emails:
+            testing_config.sign_in(email, 123)
+            user = users.get_current_user()
+            self.assertFalse(permissions.can_create_feature(user))
 
     def test_can_edit_any_feature(self):
         """Test can edit any feature."""


### PR DESCRIPTION
There are a couple of organizations that have more than 10 registered users on ChromeStatus.com.  Streamline the process by registering those entire organizations.