### PR TITLE
[Backend APIs] Implement Pending Reviews Dashboard Queue and Fast Aggregated Count APIs

### DIFF
--- a/api/summary_suggestion_api.py
+++ b/api/summary_suggestion_api.py
@@ -14,18 +14,36 @@
 
 """API handler for AI summary suggestions (GET and PATCH /api/v0/summary-suggestions/<int:feature_id>)."""
 
+import re
 from typing import Any
 
-from chromestatus_openapi.models import SummarySuggestionResponse
+from chromestatus_openapi.models import (
+    PendingSuggestionsCountResponse,
+    SummarySuggestionListResponse,
+    SummarySuggestionResponse,
+)
 from google.cloud import ndb
 
 from api import converters
 from framework import basehandlers, permissions
 from internals import core_enums
 from internals.core_models import (
+    FeatureEntry,
     FeatureSummaryProgressStep,
     FeatureSummarySuggestion,
 )
+
+
+def strip_markdown_hover_snippet(text: str | None, max_len: int = 150) -> str:
+    """Strips markdown formatting and collapses whitespace for plain-text hover previews."""
+    if not text:
+        return ''
+    cleaned = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', text)
+    cleaned = re.sub(r'[*_`#]', '', cleaned)
+    cleaned = ' '.join(cleaned.split())
+    if len(cleaned) > max_len:
+        return cleaned[: max_len - 3] + '...'
+    return cleaned
 
 
 class SummarySuggestionAPI(basehandlers.APIHandler):
@@ -139,3 +157,98 @@ class SummarySuggestionAPI(basehandlers.APIHandler):
             ],
         }
         return SummarySuggestionResponse.from_dict(payload).to_dict()
+
+
+class PendingSuggestionsCountAPI(basehandlers.APIHandler):
+    """API handler for fetching total count of pending summary suggestions (GET /api/v0/summary-suggestions/pending-count)."""
+
+    def do_get(self, **kwargs: Any) -> dict[str, Any]:
+        """Returns total count of pending AI summary suggestions in review queue."""
+        user = self.get_current_user()
+        if not user or not permissions.can_edit_any_feature(user):
+            self.abort(
+                403,
+                msg='User does not have permission to view pending suggestions queue',
+            )
+
+        count = FeatureSummarySuggestion.query(
+            FeatureSummarySuggestion.status
+            == core_enums.SummarySuggestionStatus.PENDING.value
+        ).count()
+
+        return PendingSuggestionsCountResponse.from_dict(
+            {'count': count}
+        ).to_dict()
+
+
+class PendingSuggestionsQueueAPI(basehandlers.APIHandler):
+    """API handler for fetching paginated pending summary suggestions (GET /api/v0/summary-suggestions/pending)."""
+
+    def do_get(self, **kwargs: Any) -> dict[str, Any]:
+        """Returns cursor-paginated list of pending AI summary suggestions in review queue."""
+        user = self.get_current_user()
+        if not user or not permissions.can_edit_any_feature(user):
+            self.abort(
+                403,
+                msg='User does not have permission to view pending suggestions queue',
+            )
+
+        # 1. Parse pagination query parameters.
+        limit_param = self.request.args.get('limit', '25')
+        try:
+            limit = int(limit_param)
+            if limit < 1 or limit > 100:
+                self.abort(400, msg='Limit must be between 1 and 100')
+        except (ValueError, TypeError):
+            self.abort(400, msg='Limit must be an integer')
+
+        cursor_str = self.request.args.get('cursor', None)
+        start_cursor = None
+        if cursor_str:
+            try:
+                start_cursor = ndb.Cursor(urlsafe=cursor_str.encode('utf-8'))
+            except Exception:
+                self.abort(400, msg='Invalid cursor parameter')
+
+        # 2. Query pending summary suggestions with cursor pagination.
+        query = FeatureSummarySuggestion.query(
+            FeatureSummarySuggestion.status
+            == core_enums.SummarySuggestionStatus.PENDING.value
+        ).order(-FeatureSummarySuggestion.created)
+
+        suggestions, next_cursor, more = query.fetch_page(
+            limit, start_cursor=start_cursor
+        )
+        total_count = query.count()
+
+        has_more = len(suggestions) == limit and more
+        next_cursor_str = (
+            next_cursor.urlsafe().decode('utf-8')
+            if (has_more and next_cursor)
+            else None
+        )
+
+        # 3. Batch lookup parent FeatureEntries to attach feature metadata.
+        feature_keys = [ndb.Key(FeatureEntry, s.key.id()) for s in suggestions]
+        features = ndb.get_multi(feature_keys)
+        feature_map = {f.key.id(): f for f in features if f}
+
+        # 4. Serialize suggestion dicts and attach hover snippets.
+        suggestion_dicts = []
+        for s in suggestions:
+            feature_id = s.key.id()
+            fe = feature_map.get(feature_id)
+            d = converters.feature_summary_suggestion_to_dict(s)
+            d['feature_id'] = feature_id
+            d['feature_name'] = fe.name if fe else 'Unknown Feature'
+            d['hover_snippet'] = strip_markdown_hover_snippet(
+                s.suggested_summary
+            )
+            suggestion_dicts.append(d)
+
+        payload = {
+            'suggestions': suggestion_dicts,
+            'next_cursor': next_cursor_str,
+            'total_count': total_count,
+        }
+        return SummarySuggestionListResponse.from_dict(payload).to_dict()

--- a/api/summary_suggestion_api_test.py
+++ b/api/summary_suggestion_api_test.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 import flask
 import werkzeug.exceptions
+from google.cloud import ndb
 
 import testing_config
 from api import converters, summary_suggestion_api
@@ -29,6 +30,7 @@ from internals.core_models import (
     FeatureSummaryProgressStep,
     FeatureSummarySuggestion,
 )
+from internals.user_models import AppUser
 
 test_app = flask.Flask(__name__)
 
@@ -288,3 +290,235 @@ class SummarySuggestionAPITest(testing_config.CustomTestCase):
             with self.assertRaises(werkzeug.exceptions.HTTPException) as cm:
                 self.handler.do_patch(feature_id=101)
             self.assertEqual(403, cm.exception.code)
+
+
+class PendingSuggestionsCountAPITest(testing_config.CustomTestCase):
+    """Unit tests for PendingSuggestionsCountAPI handler."""
+
+    def setUp(self):
+        """Set up test environment and pending suggestions."""
+        super().setUp()
+        self.handler = summary_suggestion_api.PendingSuggestionsCountAPI()
+        self.app_user = AppUser(email='admin@example.com', is_site_editor=True)
+        self.app_user.put()
+        testing_config.sign_in('admin@example.com', 12345)
+
+        self.suggestion_1 = FeatureSummarySuggestion(
+            id=101,
+            suggested_summary='Pending summary 1',
+            status=core_enums.SummarySuggestionStatus.PENDING.value,
+        )
+        self.suggestion_2 = FeatureSummarySuggestion(
+            id=102,
+            suggested_summary='Applied summary 2',
+            status=core_enums.SummarySuggestionStatus.APPLIED.value,
+        )
+        self.suggestion_3 = FeatureSummarySuggestion(
+            id=103,
+            suggested_summary='Pending summary 3',
+            status=core_enums.SummarySuggestionStatus.PENDING.value,
+        )
+        ndb.put_multi([self.suggestion_1, self.suggestion_2, self.suggestion_3])
+
+    def tearDown(self):
+        """Clean up test NDB entities."""
+        ndb.delete_multi(
+            [
+                self.app_user.key,
+                self.suggestion_1.key,
+                self.suggestion_2.key,
+                self.suggestion_3.key,
+            ]
+        )
+        testing_config.sign_out()
+        super().tearDown()
+
+    def test_get__unauthorized_403(self):
+        """It aborts HTTP 403 when user is not a site editor or admin."""
+        testing_config.sign_out()
+        with test_app.test_request_context(
+            '/api/v0/summary-suggestions/pending-count'
+        ):
+            with self.assertRaises(werkzeug.exceptions.HTTPException) as cm:
+                self.handler.do_get()
+            self.assertEqual(403, cm.exception.code)
+
+    def test_get__success_count(self):
+        """It returns the accurate count of PENDING summary suggestions."""
+        with test_app.test_request_context(
+            '/api/v0/summary-suggestions/pending-count'
+        ):
+            actual = self.handler.do_get()
+            self.assertEqual(2, actual['count'])
+
+
+class PendingSuggestionsQueueAPITest(testing_config.CustomTestCase):
+    """Unit tests for PendingSuggestionsQueueAPI handler."""
+
+    def setUp(self):
+        """Set up test environment, features, and pending suggestions."""
+        super().setUp()
+        self.handler = summary_suggestion_api.PendingSuggestionsQueueAPI()
+        self.app_user = AppUser(email='admin@example.com', is_site_editor=True)
+        self.app_user.put()
+        testing_config.sign_in('admin@example.com', 12345)
+
+        self.feature_1 = FeatureEntry(
+            id=101, name='Feature One', summary='F1', category=1, feature_type=1
+        )
+        self.feature_2 = FeatureEntry(
+            id=102, name='Feature Two', summary='F2', category=1, feature_type=1
+        )
+        ndb.put_multi([self.feature_1, self.feature_2])
+
+        self.suggestion_1 = FeatureSummarySuggestion(
+            id=101,
+            suggested_summary='[Link](http://example.com) *Pending* suggestion **one**.',
+            status=core_enums.SummarySuggestionStatus.PENDING.value,
+        )
+        self.suggestion_2 = FeatureSummarySuggestion(
+            id=102,
+            suggested_summary='Pending suggestion two.',
+            status=core_enums.SummarySuggestionStatus.PENDING.value,
+        )
+        ndb.put_multi([self.suggestion_1, self.suggestion_2])
+
+    def tearDown(self):
+        """Clean up test NDB entities."""
+        ndb.delete_multi(
+            [
+                self.app_user.key,
+                self.feature_1.key,
+                self.feature_2.key,
+                self.suggestion_1.key,
+                self.suggestion_2.key,
+            ]
+        )
+        testing_config.sign_out()
+        super().tearDown()
+
+    def test_get__unauthorized_403(self):
+        """It aborts HTTP 403 when user lacks permissions to view pending queue."""
+        testing_config.sign_out()
+        with test_app.test_request_context(
+            '/api/v0/summary-suggestions/pending'
+        ):
+            with self.assertRaises(werkzeug.exceptions.HTTPException) as cm:
+                self.handler.do_get()
+            self.assertEqual(403, cm.exception.code)
+
+    def test_get__non_editor_user_403(self):
+        """It aborts HTTP 403 when user is authenticated but not a site editor or admin."""
+        testing_config.sign_in('regular_user@example.com', 54321)
+        with test_app.test_request_context(
+            '/api/v0/summary-suggestions/pending'
+        ):
+            with self.assertRaises(werkzeug.exceptions.HTTPException) as cm:
+                self.handler.do_get()
+            self.assertEqual(403, cm.exception.code)
+
+    def test_get__invalid_limit_400(self):
+        """It aborts HTTP 400 when limit parameter is invalid or out of bounds."""
+        with test_app.test_request_context(
+            '/api/v0/summary-suggestions/pending?limit=invalid'
+        ):
+            with self.assertRaises(werkzeug.exceptions.HTTPException) as cm:
+                self.handler.do_get()
+            self.assertEqual(400, cm.exception.code)
+
+        with test_app.test_request_context(
+            '/api/v0/summary-suggestions/pending?limit=0'
+        ):
+            with self.assertRaises(werkzeug.exceptions.HTTPException) as cm:
+                self.handler.do_get()
+            self.assertEqual(400, cm.exception.code)
+
+        with test_app.test_request_context(
+            '/api/v0/summary-suggestions/pending?limit=150'
+        ):
+            with self.assertRaises(werkzeug.exceptions.HTTPException) as cm:
+                self.handler.do_get()
+            self.assertEqual(400, cm.exception.code)
+
+    def test_get__invalid_cursor_400(self):
+        """It aborts HTTP 400 when cursor parameter is malformed."""
+        with test_app.test_request_context(
+            '/api/v0/summary-suggestions/pending?cursor=invalid_base64_garbage'
+        ):
+            with self.assertRaises(werkzeug.exceptions.HTTPException) as cm:
+                self.handler.do_get()
+            self.assertEqual(400, cm.exception.code)
+
+    def test_get__success_queue_multipage(self):
+        """It returns paginated pending suggestions across multiple pages using cursor tokens."""
+        with test_app.test_request_context(
+            '/api/v0/summary-suggestions/pending?limit=1'
+        ):
+            page1 = self.handler.do_get()
+            self.assertEqual(2, page1['total_count'])
+            self.assertEqual(1, len(page1['suggestions']))
+            self.assertIsNotNone(page1['next_cursor'])
+
+        cursor_token_1 = page1['next_cursor']
+        with test_app.test_request_context(
+            f'/api/v0/summary-suggestions/pending?limit=1&cursor={cursor_token_1}'
+        ):
+            page2 = self.handler.do_get()
+            self.assertEqual(2, page2['total_count'])
+            self.assertEqual(1, len(page2['suggestions']))
+            self.assertIsNotNone(page2['next_cursor'])
+
+        cursor_token_2 = page2['next_cursor']
+        with test_app.test_request_context(
+            f'/api/v0/summary-suggestions/pending?limit=1&cursor={cursor_token_2}'
+        ):
+            page3 = self.handler.do_get()
+            self.assertEqual(2, page3['total_count'])
+            self.assertEqual(0, len(page3['suggestions']))
+            self.assertIsNone(page3['next_cursor'])
+
+    def test_get__success_queue(self):
+        """It returns paginated pending suggestions with plain-text hover snippets."""
+        with test_app.test_request_context(
+            '/api/v0/summary-suggestions/pending?limit=25'
+        ):
+            actual = self.handler.do_get()
+            self.assertEqual(2, actual['total_count'])
+            self.assertEqual(2, len(actual['suggestions']))
+            self.assertIsNone(actual['next_cursor'])
+
+            # Verify plain-text markdown stripping on hover snippet
+            first_sug = next(
+                s for s in actual['suggestions'] if s['feature_id'] == 101
+            )
+            self.assertEqual(101, first_sug['feature_id'])
+            hover = summary_suggestion_api.strip_markdown_hover_snippet(
+                first_sug['suggested_summary']
+            )
+            self.assertEqual('Link Pending suggestion one.', hover)
+
+
+class StripMarkdownHoverSnippetTest(testing_config.CustomTestCase):
+    """Unit tests for strip_markdown_hover_snippet helper utility."""
+
+    def test_strip_markdown_hover_snippet(self):
+        """It strips links, markdown formatting characters, and collapses whitespace."""
+        self.assertEqual(
+            '', summary_suggestion_api.strip_markdown_hover_snippet(None)
+        )
+        self.assertEqual(
+            '', summary_suggestion_api.strip_markdown_hover_snippet('')
+        )
+
+        text = '  [MDN Documentation](https://developer.mozilla.org) for *CSS* `anchor` **positioning**.  '
+        expected = 'MDN Documentation for CSS anchor positioning.'
+        self.assertEqual(
+            expected, summary_suggestion_api.strip_markdown_hover_snippet(text)
+        )
+
+        long_text = 'A' * 200
+        truncated = summary_suggestion_api.strip_markdown_hover_snippet(
+            long_text, max_len=50
+        )
+        self.assertEqual(50, len(truncated))
+        self.assertTrue(truncated.endswith('...'))

--- a/index.yaml
+++ b/index.yaml
@@ -11,6 +11,12 @@ indexes:
   - name: start_timestamp
     direction: desc
 
+- kind: FeatureSummarySuggestion
+  properties:
+  - name: status
+  - name: created
+    direction: desc
+
 - kind: FeatureEntry
   properties:
   - name: deleted

--- a/main.py
+++ b/main.py
@@ -264,6 +264,14 @@ api_routes: list[Route] = [
         releasenotes_api.ReleaseNotesAPI,
     ),
     Route(
+        f'{API_BASE}/summary-suggestions/pending-count',
+        summary_suggestion_api.PendingSuggestionsCountAPI,
+    ),
+    Route(
+        f'{API_BASE}/summary-suggestions/pending',
+        summary_suggestion_api.PendingSuggestionsQueueAPI,
+    ),
+    Route(
         f'{API_BASE}/summary-suggestions/<int:feature_id>',
         summary_suggestion_api.SummarySuggestionAPI,
     ),


### PR DESCRIPTION
[Backend APIs] Implement Pending Reviews Dashboard Queue and Fast Aggregated Count APIs

## Summary

Implements `GET /api/v0/summary-suggestions/pending-count` and `GET /api/v0/summary-suggestions/pending` for the release notes editorial dashboard review queue.

Enforces site editor / reviewer permissions (`permissions.can_edit_any_feature`), cursor-based query pagination (`limit` default 25, max 100), and provides plain-text hover snippets for pending AI summary suggestions.

## Key Changes

- **Controller (`api/summary_suggestion_api.py`)**: Adds `PendingSuggestionsCountAPI` for fast total count queries (`FeatureSummarySuggestion.query(status == PENDING).count()`) and `PendingSuggestionsQueueAPI` for cursor-paginated review queue retrieval. Performs batch `ndb.get_multi` lookups for parent `FeatureEntry` metadata and extracts plain-text hover snippets using `strip_markdown_hover_snippet`.
- **Routes (`main.py`)**: Registers `/summary-suggestions/pending-count` and `/summary-suggestions/pending` before path-parameter routes.
- **Testing (`api/summary_suggestion_api_test.py`)**: Added `PendingSuggestionsCountAPITest` and `PendingSuggestionsQueueAPITest` verifying authorized count retrieval, cursor pagination, invalid limit/cursor parameter handling (HTTP 400), and unauthorized access shielding (HTTP 403).

TAG=agy
CONV=86f63625-bdb5-4d50-ac8d-2f8ca5128ca9
