### PR TITLE
[Frontend SSR] Implement Server-Side Rendered Release Notes Page & HTML Templates

### DIFF
--- a/framework/seo.py
+++ b/framework/seo.py
@@ -1,0 +1,35 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SEO metadata models and helpers for Server-Side Rendering (SSR)."""
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Metadata:
+    """Strongly-typed container for page SEO and social sharing metadata."""
+
+    canonical_url: str | None = None
+    seo_title: str | None = None
+    seo_description: str | None = None
+    site_logo_url: str | None = None
+    og_type: str = 'website'
+    schema_type: str = 'WebPage'
+    twitter_card: str = 'summary_large_image'
+
+    def to_dict(self) -> dict[str, Any]:
+        """Export non-None metadata fields as a template context dictionary."""
+        return {k: v for k, v in asdict(self).items() if v is not None}

--- a/framework/seo_test.py
+++ b/framework/seo_test.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for framework/seo.py Metadata dataclass."""
+
+import testing_config  # noqa: F401, I001
+
+from framework import seo
+import settings
+
+
+class SEOMetadataTest(testing_config.CustomTestCase):
+    """Unit tests for seo.Metadata dataclass."""
+
+    def test_instantiation_defaults(self):
+        """It applies default values for og_type, schema_type, and twitter_card."""
+        metadata = seo.Metadata(
+            canonical_url='https://chromestatus.com/release-notes/151',
+            seo_title='Chrome 151 Release Notes',
+            seo_description='Release notes description.',
+            site_logo_url='https://chromestatus.com/static/img/crstatus_192.png',
+        )
+
+        self.assertEqual(
+            'https://chromestatus.com/release-notes/151', metadata.canonical_url
+        )
+        self.assertEqual('Chrome 151 Release Notes', metadata.seo_title)
+        self.assertEqual('Release notes description.', metadata.seo_description)
+        self.assertEqual(
+            'https://chromestatus.com/static/img/crstatus_192.png',
+            metadata.site_logo_url,
+        )
+        self.assertEqual('website', metadata.og_type)
+        self.assertEqual('WebPage', metadata.schema_type)
+        self.assertEqual('summary_large_image', metadata.twitter_card)
+
+    def test_to_dict__exports_non_none_fields(self):
+        """It exports metadata attributes as a template context dictionary."""
+        metadata = seo.Metadata(
+            canonical_url=f'{settings.SITE_URL.rstrip("/")}/feature/123',
+            seo_title='Feature Detail',
+            seo_description='Feature Description',
+        )
+
+        d = metadata.to_dict()
+        self.assertIn('canonical_url', d)
+        self.assertIn('seo_title', d)
+        self.assertIn('seo_description', d)
+        self.assertNotIn('site_logo_url', d)
+        self.assertEqual('website', d['og_type'])
+        self.assertEqual('WebPage', d['schema_type'])
+        self.assertEqual('summary_large_image', d['twitter_card'])

--- a/internals/fetchchannels.py
+++ b/internals/fetchchannels.py
@@ -86,26 +86,37 @@ def get_omaha_data():
     return json.loads(omaha_data)
 
 
-def get_current_beta_milestone() -> int:
-    """Return the milestone number that is current on the beta channel."""
-    if flask.has_app_context() and hasattr(flask.g, 'current_beta_milestone'):
-        return flask.g.current_beta_milestone
+def get_current_channel_milestone(channel: str = 'stable') -> int:
+    """Return the milestone number that is current on the given channel."""
+    cache_attr = f'current_{channel}_milestone'
+    if flask.has_app_context() and hasattr(flask.g, cache_attr):
+        return getattr(flask.g, cache_attr)
 
     omaha_data = get_omaha_data()
-    beta_version = next(
+    version_str = next(
         (
             v['version']
             for v in omaha_data[0]['versions']
-            if v['channel'] == 'beta'
+            if v['channel'] == channel
         ),
         '0.0',
     )
-    milestone = int(beta_version.split('.')[0])
+    milestone = int(version_str.split('.')[0])
 
     if flask.has_app_context():
-        flask.g.current_beta_milestone = milestone
+        setattr(flask.g, cache_attr, milestone)
 
     return milestone
+
+
+def get_current_stable_milestone() -> int:
+    """Return the milestone number that is current on the stable channel."""
+    return get_current_channel_milestone('stable')
+
+
+def get_current_beta_milestone() -> int:
+    """Return the milestone number that is current on the beta channel."""
+    return get_current_channel_milestone('beta')
 
 
 SCHEDULE_CACHE_TIME = 60 * 60  # 1 hour

--- a/internals/fetchchannels_test.py
+++ b/internals/fetchchannels_test.py
@@ -86,3 +86,22 @@ class ChannelsAPITest(testing_config.CustomTestCase):
             },
             actual,
         )
+
+    @mock.patch('internals.fetchchannels.get_omaha_data')
+    def test_get_current_channel_milestone(self, mock_get_omaha):
+        """It returns the integer milestone for the specified channel."""
+        mock_get_omaha.return_value = [
+            {
+                'versions': [
+                    {'channel': 'stable', 'version': '147.0.7727.56'},
+                    {'channel': 'beta', 'version': '148.0.7778.5'},
+                    {'channel': 'dev', 'version': '149.0.7779.3'},
+                ]
+            }
+        ]
+
+        self.assertEqual(147, fetchchannels.get_current_stable_milestone())
+        self.assertEqual(148, fetchchannels.get_current_beta_milestone())
+        self.assertEqual(
+            149, fetchchannels.get_current_channel_milestone('dev')
+        )

--- a/main.py
+++ b/main.py
@@ -68,7 +68,14 @@ from internals import (
     reminders,
     search_fulltext,
 )
-from pages import featuredetail, guide, ot_requests, sitemap, users
+from pages import (
+    featuredetail,
+    guide,
+    ot_requests,
+    releasenotes,
+    sitemap,
+    users,
+)
 
 # Patch treading library to work-around bug with Google Cloud Logging.
 original_delete = threading.Thread._delete  # type: ignore
@@ -432,6 +439,8 @@ mpa_page_routes: list[Route] = [
     ),
     Route('/sitemap.txt', sitemap.SitemapHandler),
     Route('/feature-ssr/<int:feature_id>', featuredetail.FeatureDetailHandler),
+    Route('/release-notes/<int:milestone>', releasenotes.ReleaseNotesHandler),
+    Route('/release-notes', releasenotes.ReleaseNotesHandler),
 ]
 
 internals_routes: list[Route] = [

--- a/packages/playwright/tests/chromedash-release-notes-ssr_pwtest.js
+++ b/packages/playwright/tests/chromedash-release-notes-ssr_pwtest.js
@@ -1,0 +1,168 @@
+// @ts-check
+import {test, expect} from '@playwright/test';
+import {
+  captureConsoleMessages,
+  login,
+  logout,
+  createNewFeature,
+} from './test_utils';
+
+test.describe('Release Notes SSR Page', () => {
+  let sharedFeatureName = '';
+
+  test.beforeAll(async ({browser}) => {
+    const page = await browser.newPage();
+    captureConsoleMessages(page);
+    await login(page);
+
+    sharedFeatureName = `Release Notes Test Feature M151 ${Date.now()}`;
+    await createNewFeature(page, {
+      name: sharedFeatureName,
+      summary: 'Test summary description for milestone 151 release notes.',
+      milestone: 151,
+    });
+
+    await logout(page);
+    await page.close();
+  });
+
+  test.beforeEach(async ({page}, testInfo) => {
+    captureConsoleMessages(page);
+    testInfo.setTimeout(60000);
+    await login(page);
+  });
+
+  test.afterEach(async ({page}) => {
+    await logout(page);
+  });
+
+  test('should render symmetrical navigation strip with channel quick-jumps and active pills', async ({
+    page,
+  }) => {
+    await page.goto('/release-notes/151', {timeout: 30000});
+
+    const pageHeading = page.getByRole('heading', {
+      name: 'Chrome 151 Release Notes',
+    });
+    await expect(pageHeading).toBeVisible();
+
+    const navStrip = page.locator('.nav-strip');
+    await expect(navStrip).toBeVisible();
+
+    const stableLink = page.getByRole('link', {name: /Stable/i});
+    const betaLink = page.getByRole('link', {name: /Beta/i});
+    const devLink = page.getByRole('link', {name: /Dev/i});
+
+    await expect(stableLink).toBeVisible();
+    await expect(betaLink).toBeVisible();
+    await expect(devLink).toBeVisible();
+
+    await expect(stableLink).toHaveAttribute('href', /\/release-notes\/\d+/);
+    await expect(betaLink).toHaveAttribute('href', /\/release-notes\/\d+/);
+    await expect(devLink).toHaveAttribute('href', /\/release-notes\/\d+/);
+
+    const activePill = page.locator('.channel-pill.active');
+    await expect(activePill).toBeVisible();
+  });
+
+  test('should navigate to selected milestone via milestone combobox selector dropdown', async ({
+    page,
+  }) => {
+    await page.goto('/release-notes/151', {timeout: 30000});
+
+    const milestoneSelect = page.getByLabel('Milestone:');
+    await expect(milestoneSelect).toBeVisible();
+    await expect(milestoneSelect).toHaveValue('151');
+
+    await milestoneSelect.selectOption('152');
+    await page.waitForURL(/\/release-notes\/152/, {timeout: 10000});
+
+    const newHeading = page.getByRole('heading', {
+      name: 'Chrome 152 Release Notes',
+    });
+    await expect(newHeading).toBeVisible();
+    await expect(milestoneSelect).toHaveValue('152');
+  });
+
+  test('should render created feature card and navigate to feature detail page', async ({
+    page,
+  }) => {
+    await page.goto('/release-notes/151', {timeout: 30000});
+
+    const featureLink = page.getByRole('link', {name: sharedFeatureName});
+    await expect(featureLink).toBeVisible({timeout: 20000});
+    await expect(featureLink).toHaveClass(/feature-name/);
+
+    await featureLink.click();
+    await page.waitForURL(/\/feature\/\d+/, {timeout: 10000});
+
+    const featureDetail = page.locator('chromedash-feature-detail');
+    await expect(featureDetail).toBeVisible();
+  });
+
+  test('should render documentation and spec links with target=_blank and rel=noopener', async ({
+    page,
+  }) => {
+    await page.goto('/release-notes/151', {timeout: 30000});
+
+    const docLinks = page.locator('.feature-doc-links a');
+    const docLinksCount = await docLinks.count();
+
+    if (docLinksCount > 0) {
+      for (let i = 0; i < docLinksCount; i++) {
+        const link = docLinks.nth(i);
+        await expect(link).toHaveAttribute('target', '_blank');
+        await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+      }
+    }
+  });
+
+  test('should perform HTTP 302 redirect for historical milestones prior to M151 cutoff', async ({
+    page,
+  }) => {
+    await page.goto('/release-notes/150', {timeout: 30000});
+    await expect(page).toHaveURL(/developer\.chrome\.com\/release-notes\/150/);
+  });
+
+  test('should render category section anchors and feature card ID anchors', async ({
+    page,
+  }) => {
+    await page.goto('/release-notes/151', {timeout: 30000});
+
+    const categorySections = page.locator('.category-section');
+    const categoryCount = await categorySections.count();
+
+    if (categoryCount > 0) {
+      const firstCategory = categorySections.first();
+      await expect(firstCategory).toHaveAttribute('id', /^[a-z0-9-]+$/);
+
+      const categoryTitle = firstCategory.locator('.category-title');
+      await expect(categoryTitle).toBeVisible();
+      await expect(categoryTitle).toHaveAttribute(
+        'id',
+        /^category-[a-z0-9-]+$/
+      );
+
+      const featureCards = firstCategory.locator('.feature-card');
+      const cardCount = await featureCards.count();
+      if (cardCount > 0) {
+        await expect(featureCards.first()).toHaveAttribute(
+          'id',
+          /^feature-\d+$/
+        );
+      }
+    }
+  });
+
+  test('should render empty state banner when milestone has no release notes features', async ({
+    page,
+  }) => {
+    await page.goto('/release-notes/999', {timeout: 30000});
+
+    const emptyState = page.locator('.empty-state');
+    await expect(emptyState).toBeVisible();
+    await expect(emptyState.getByRole('heading')).toHaveText(
+      'No release notes features available for Chrome 999.'
+    );
+  });
+});

--- a/packages/playwright/tests/test_utils.js
+++ b/packages/playwright/tests/test_utils.js
@@ -324,16 +324,20 @@ export async function enterWebFeatureId(page) {
 /**
  * Create a new feature, starting from top-level page, ending up on feature page.
  * @param {import('@playwright/test').Page} page
+ * @param {{name?: string, summary?: string, milestone?: number|string}} [options]
  */
-export async function createNewFeature(page) {
+export async function createNewFeature(page, options = {}) {
   await gotoNewFeaturePage(page);
+  const name = options.name || 'Test feature name';
+  const summary = options.summary || 'Test summary description';
+
   // Enter feature name
   const featureNameInput = page.locator('input[name="name"]');
-  await featureNameInput.fill('Test feature name');
+  await featureNameInput.fill(name);
 
   // Enter summary description
   const summaryInput = page.locator('textarea[name="summary"]');
-  await summaryInput.fill('Test summary description');
+  await summaryInput.fill(summary);
 
   await enterBlinkComponent(page);
   await enterWebFeatureId(page);
@@ -362,6 +366,29 @@ export async function createNewFeature(page) {
   }
 
   await expect(detail).toBeVisible({timeout: 30000});
+
+  // If an explicit milestone was provided, set the shipping milestone on the feature.
+  if (options.milestone) {
+    const url = page.url();
+    const featureIdMatch = url.match(/\/feature\/(\d+)/);
+    if (featureIdMatch) {
+      const featureId = featureIdMatch[1];
+      await page.goto(`/guide/editall/${featureId}`);
+      const shippedInput = page
+        .locator(
+          'input[name="shipped_milestone"], input[name="shipped_desktop"], input[name="desktop_first"]'
+        )
+        .first();
+      if (await shippedInput.isVisible()) {
+        await shippedInput.fill(String(options.milestone));
+        const submitBtn = page
+          .locator('input[type="submit"], button[type="submit"]')
+          .first();
+        await submitBtn.click();
+        await page.waitForURL(`**/feature/${featureId}`);
+      }
+    }
+  }
 }
 
 /**

--- a/pages/releasenotes.py
+++ b/pages/releasenotes.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Handler for displaying release notes via Server-Side Rendering (SSR)."""
+
+from typing import Any
+
+import flask
+
+import settings
+from framework import basehandlers, seo
+from internals import feature_helpers, fetchchannels
+
+# Milestones prior to M151 were published as standalone blog posts on developer.chrome.com.
+# ChromeStatus SSR release notes curation begins with Chrome 151.
+MIN_SSR_RELEASE_NOTES_MILESTONE: int = 151
+EXTERNAL_RELEASE_NOTES_URL_TEMPLATE: str = (
+    'https://developer.chrome.com/release-notes/{milestone}'
+)
+
+
+class ReleaseNotesHandler(basehandlers.FlaskHandler):
+    """Flask handler for rendering the Server-Side Rendered (SSR) Release Notes page."""
+
+    # Public caching policy: Release notes are public content suitable for global CDN caching.
+    HTTP_CACHE_TYPE = 'public'
+
+    def get_template_data(
+        self, **kwargs: Any
+    ) -> dict[str, Any] | flask.Response:
+        """Assembles template context data for rendering release notes."""
+        milestone_param = kwargs.get('milestone')
+
+        if milestone_param is None:
+            milestone = fetchchannels.get_current_stable_milestone()
+        else:
+            try:
+                milestone = int(milestone_param)
+            except (ValueError, TypeError):
+                self.abort(
+                    400, f'Invalid milestone parameter: {milestone_param}'
+                )
+
+        if milestone <= 0:
+            self.abort(400, f'Invalid milestone parameter: {milestone}')
+
+        # Milestones prior to 151 redirect immediately to developer.chrome.com/release-notes/<milestone>
+        if milestone < MIN_SSR_RELEASE_NOTES_MILESTONE:
+            redirect_url = EXTERNAL_RELEASE_NOTES_URL_TEMPLATE.format(
+                milestone=milestone
+            )
+            return self.redirect(redirect_url)
+
+        # Channel quick-jumps (Stable, Beta, Dev)
+        try:
+            omaha_data = fetchchannels.get_omaha_data()
+            channels = {}
+            for v in omaha_data[0].get('versions', []):
+                channel_name = v.get('channel')
+                version_str = v.get('version', '0.0')
+                if channel_name:
+                    channels[channel_name] = int(version_str.split('.')[0])
+            stable_milestone = channels.get('stable', milestone - 2)
+            beta_milestone = channels.get('beta', milestone)
+            dev_milestone = channels.get('dev', milestone + 1)
+        except Exception:
+            stable_milestone = milestone - 2
+            beta_milestone = milestone
+            dev_milestone = milestone + 1
+
+        release_note_features = (
+            feature_helpers.get_developer_release_notes_features(milestone)
+        )
+
+        features_by_category: dict[str, list[dict[str, Any]]] = {}
+        for feature in release_note_features:
+            category = feature.get('category') or 'Other'
+            features_by_category.setdefault(category, []).append(feature)
+
+        milestones_list = list(range(1, max(150, milestone + 10)))
+
+        site_url = settings.SITE_URL.rstrip('/')
+        seo_metadata = seo.Metadata(
+            canonical_url=f'{site_url}/release-notes/{milestone}',
+            seo_title=f'Chrome {milestone} Release Notes',
+            seo_description=(
+                f'Discover web platform features, deprecations, and developer updates '
+                f'shipped in Google Chrome {milestone}.'
+            ),
+            site_logo_url=f'{site_url}{settings.DEFAULT_SITE_LOGO_PATH}',
+            schema_type='ItemPage',
+        )
+
+        return {
+            'milestone': milestone,
+            'stable_milestone': stable_milestone,
+            'beta_milestone': beta_milestone,
+            'dev_milestone': dev_milestone,
+            'features_by_category': features_by_category,
+            'total_features_count': len(release_note_features),
+            'milestones_list': milestones_list,
+            'seo': seo_metadata.to_dict(),
+        }

--- a/pages/releasenotes_test.py
+++ b/pages/releasenotes_test.py
@@ -1,0 +1,151 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for pages/releasenotes module."""
+
+from html.parser import HTMLParser
+from unittest import mock
+
+import flask
+import werkzeug.exceptions
+
+import testing_config
+from pages import releasenotes
+
+test_app = flask.Flask(__name__, template_folder='../templates')
+
+
+class ReleaseNotesHTMLParser(HTMLParser):
+    """Collector parser using Python's built-in html.parser library."""
+
+    def __init__(self) -> None:
+        """Initialize parser attributes."""
+        super().__init__()
+        self.tags: list[tuple[str, dict[str, str]]] = []
+        self.links: list[str] = []
+        self.headings: list[str] = []
+        self._current_tag: str | None = None
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        """Collect start tags, attributes, and href links."""
+        attr_dict = {k: (v or '') for k, v in attrs}
+        self.tags.append((tag, attr_dict))
+        if tag == 'a' and 'href' in attr_dict:
+            self.links.append(attr_dict['href'])
+        self._current_tag = tag
+
+    def handle_data(self, data: str) -> None:
+        """Collect text data for h2 and h3 headings."""
+        text = data.strip()
+        if text and self._current_tag in ('h2', 'h3'):
+            self.headings.append(text)
+
+
+class ReleaseNotesHandlerTest(testing_config.CustomTestCase):
+    """Unit tests for ReleaseNotesHandler SSR page controller."""
+
+    def setUp(self):
+        """Set up test environment and mock data."""
+        super().setUp()
+        self.handler = releasenotes.ReleaseNotesHandler()
+
+    def test_http_cache_type_public(self):
+        """It configures public HTTP caching for global CDN caching."""
+        self.assertEqual(
+            'public', releasenotes.ReleaseNotesHandler.HTTP_CACHE_TYPE
+        )
+
+    def test_get_template_data__specific_milestone(self):
+        """It returns template context data for a specific milestone >= 151."""
+        with test_app.test_request_context('/release-notes/151'):
+            data = self.handler.get_template_data(milestone=151)
+            self.assertEqual(151, data['milestone'])
+            self.assertIn('features_by_category', data)
+            self.assertIn('milestones_list', data)
+
+    def test_get_template_data__m151_cutoff_redirect(self):
+        """It returns an HTTP 302 redirect to developer.chrome.com/release-notes/<milestone> for milestones < 151."""
+        with test_app.test_request_context('/release-notes/150'):
+            resp = self.handler.get_template_data(milestone=150)
+            self.assertEqual(302, resp.status_code)
+            self.assertEqual(
+                'https://developer.chrome.com/release-notes/150',
+                resp.headers['Location'],
+            )
+
+    def test_get_template_data__default_milestone(self):
+        """It defaults to current stable milestone when no milestone param is provided."""
+        with test_app.test_request_context('/release-notes'):
+            with mock.patch(
+                'internals.fetchchannels.get_current_stable_milestone',
+                return_value=151,
+            ):
+                data = self.handler.get_template_data()
+                self.assertEqual(151, data['milestone'])
+
+    def test_get_template_data__string_milestone(self):
+        """It accepts string milestone parameters and coerces them to int."""
+        with test_app.test_request_context('/release-notes/151'):
+            data = self.handler.get_template_data(milestone='151')
+            self.assertEqual(151, data['milestone'])
+
+    def test_get_template_data__invalid_milestone_400(self):
+        """It aborts HTTP 400 for non-positive milestone values or invalid strings."""
+        with test_app.test_request_context('/release-notes/0'):
+            with self.assertRaises(werkzeug.exceptions.HTTPException) as cm:
+                self.handler.get_template_data(milestone=0)
+            self.assertEqual(400, cm.exception.code)
+
+        with test_app.test_request_context('/release-notes/abc'):
+            with self.assertRaises(werkzeug.exceptions.HTTPException) as cm:
+                self.handler.get_template_data(milestone='abc')
+            self.assertEqual(400, cm.exception.code)
+
+    def test_render_template_html_structure(self):
+        """It asserts HTML elements and navigation links using built-in html.parser."""
+        with test_app.test_request_context('/release-notes/151'):
+            with mock.patch(
+                'internals.fetchchannels.get_omaha_data',
+                return_value=[
+                    {
+                        'versions': [
+                            {'channel': 'stable', 'version': '150.0'},
+                            {'channel': 'beta', 'version': '151.0'},
+                            {'channel': 'dev', 'version': '152.0'},
+                        ]
+                    }
+                ],
+            ):
+                data = self.handler.get_template_data(milestone=151)
+                html_str = flask.render_template('release-notes.html', **data)
+
+                parser = ReleaseNotesHTMLParser()
+                parser.feed(html_str)
+
+                # Verify subheader title
+                self.assertIn('Chrome 151 Release Notes', parser.headings)
+
+                # Verify channel quick-jump href links (stable=150, beta=151, dev=152)
+                self.assertIn('/release-notes/151', parser.links)
+
+                # Verify active button class on current milestone pill
+                active_buttons = [
+                    attrs
+                    for tag, attrs in parser.tags
+                    if tag == 'a'
+                    and 'primary' in attrs.get('class', '').split()
+                ]
+                self.assertTrue(len(active_buttons) > 0)

--- a/settings.py
+++ b/settings.py
@@ -40,6 +40,9 @@ DEFAULT_COMPONENT = 'Blink'
 # The default component for enterprise features.
 DEFAULT_ENTERPRISE_COMPONENT = 'Enterprise'
 
+# The default site logo asset path.
+DEFAULT_SITE_LOGO_PATH = '/static/img/crstatus_192.png'
+
 # Enable to activate the automated OT creation process
 AUTOMATED_OT_CREATION = True
 

--- a/templates/release-notes.html
+++ b/templates/release-notes.html
@@ -1,0 +1,225 @@
+{% extends "_base.html" %}
+
+{% block page_title %}{{ seo_title }} - {% endblock %}
+
+{% block meta %}
+{% include "seo/_meta.html" with context %}
+{% endblock %}
+
+{% block css %}
+<style>
+  #release-notes-container {
+    width: 100%;
+    max-width: var(--max-content-width);
+    margin: 0 auto;
+    padding: 0 0 var(--content-padding-large) 0;
+  }
+
+  .nav-strip {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--content-padding);
+    padding: var(--content-padding);
+    background-color: var(--card-background);
+    border: var(--default-border);
+    border-radius: var(--border-radius);
+    margin-bottom: var(--content-padding-large);
+  }
+
+  .channel-pills {
+    display: flex;
+    align-items: center;
+    gap: var(--content-padding-half);
+  }
+
+  .milestone-select-group {
+    display: flex;
+    align-items: center;
+    gap: var(--content-padding-half);
+  }
+
+  .milestone-select {
+    padding: var(--content-padding-quarter) var(--content-padding-half);
+    border-radius: var(--border-radius);
+    border: var(--default-border);
+    background-color: var(--card-background);
+    color: var(--default-color);
+    font-size: var(--default-font);
+    cursor: pointer;
+  }
+
+  .category-section {
+    margin-bottom: var(--content-padding-large);
+  }
+
+  .category-title {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--heading-color);
+    border-bottom: var(--default-border);
+    padding-bottom: var(--content-padding-quarter);
+    margin-bottom: var(--content-padding);
+  }
+
+  .feature-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--content-padding);
+  }
+
+  .feature-card {
+    flex: 1 1 calc(50% - var(--content-padding));
+    border: var(--default-border);
+    border-radius: var(--border-radius);
+    padding: var(--content-padding);
+    background-color: var(--card-background);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
+  .feature-name {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: var(--content-padding-half);
+    display: inline-block;
+  }
+
+  .feature-summary {
+    font-size: var(--default-font);
+    line-height: 1.5;
+    color: var(--default-color);
+    margin-bottom: var(--content-padding);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .feature-doc-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--content-padding-quarter) var(--content-padding-half);
+    font-size: 0.85rem;
+    border-top: var(--default-border);
+    padding-top: var(--content-padding-half);
+  }
+
+  .feature-doc-links a {
+    display: inline-block;
+    max-width: 100%;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  .empty-state {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: var(--unimportant-text-color);
+  }
+
+  @media (max-width: 700px) {
+    .nav-strip {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .channel-pills, .milestone-select-group {
+      width: 100%;
+      justify-content: space-between;
+    }
+
+    .feature-card {
+      flex: 1 1 100%;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block subheader %}
+<div id="subheader" class="actionlinks">
+  <div>
+    <h2>Chrome {{ milestone }} Release Notes</h2>
+  </div>
+</div>
+{% endblock %}
+
+{% block content %}
+<section id="release-notes-container">
+  {# Symmetrical Navigation Strip #}
+  <div class="nav-strip">
+    <div class="channel-pills">
+      <a href="/release-notes/{{ stable_milestone }}" class="button {% if milestone == stable_milestone %}primary{% endif %}">
+        Stable (M{{ stable_milestone }})
+      </a>
+      <a href="/release-notes/{{ beta_milestone }}" class="button {% if milestone == beta_milestone %}primary{% endif %}">
+        Beta (M{{ beta_milestone }})
+      </a>
+      <a href="/release-notes/{{ dev_milestone }}" class="button {% if milestone == dev_milestone %}primary{% endif %}">
+        Dev (M{{ dev_milestone }})
+      </a>
+    </div>
+
+    <div class="milestone-select-group">
+      <label for="milestone-select">Milestone:</label>
+      <select id="milestone-select" class="milestone-select">
+        {% for m in milestones_list %}
+          <option value="{{ m }}" {% if m == milestone %}selected{% endif %}>
+            Chrome {{ m }}
+          </option>
+        {% endfor %}
+      </select>
+    </div>
+  </div>
+
+  {# Category-Grouped Feature Grid #}
+  {% if features_by_category %}
+    {% for category_name, category_features in features_by_category.items() %}
+      <div class="category-section" id="{{ category_name | lower | replace(' ', '-') }}">
+        <h3 class="category-title" id="category-{{ category_name | lower | replace(' ', '-') }}">{{ category_name }}</h3>
+        <div class="feature-grid">
+          {% for feature in category_features %}
+            <div class="feature-card" id="feature-{{ feature.id }}">
+              <div>
+                <a class="feature-name" href="/feature/{{ feature.id }}">{{ feature.name }}</a>
+                <div class="feature-summary">{{ feature.summary }}</div>
+              </div>
+              {% if feature.doc_links %}
+                <div class="feature-doc-links">
+                  {% for link in feature.doc_links %}
+                    <a href="{{ link }}" target="_blank" rel="noopener noreferrer" title="{{ link }}">{{ link }}</a>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  {% else %}
+    <div class="empty-state">
+      <h3>No release notes features available for Chrome {{ milestone }}.</h3>
+    </div>
+  {% endif %}
+</section>
+{% endblock %}
+
+{% block js %}
+<script nonce="{{nonce}}">
+  document.body.classList.remove('loading');
+
+  const milestoneSelect = document.getElementById('milestone-select');
+  if (milestoneSelect) {
+    milestoneSelect.addEventListener('change', (e) => {
+      const target = e.target;
+      if (target && 'value' in target) {
+        const val = parseInt(String(target.value), 10);
+        if (!isNaN(val) && val > 0) {
+          window.location.href = `/release-notes/${val}`;
+        }
+      }
+    });
+  }
+</script>
+{% endblock %}

--- a/templates/seo/_json_ld.html
+++ b/templates/seo/_json_ld.html
@@ -1,0 +1,20 @@
+{#
+  Schema.org JSON-LD Structured Data Sub-Template (templates/seo/_json_ld.html)
+
+  Included automatically via templates/seo/_meta.html.
+
+  Context Variables Used:
+    - seo.schema_type: Schema.org entity type ('ItemPage', 'WebPage', etc. Default: 'WebPage').
+    - seo.seo_title / page_title / APP_TITLE: Structured name field.
+    - seo.seo_description: Structured description field.
+    - seo.canonical_url: Structured page URL field.
+#}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "{{ (seo and seo.schema_type) | default('WebPage') }}",
+  "name": "{{ (seo and seo.seo_title) | default(page_title) | default(APP_TITLE) }}",
+  "description": "{{ (seo and seo.seo_description) | default('') }}",
+  "url": "{{ seo and seo.canonical_url }}"
+}
+</script>

--- a/templates/seo/_meta.html
+++ b/templates/seo/_meta.html
@@ -1,0 +1,22 @@
+{#
+  Primary SEO Meta Include (templates/seo/_meta.html)
+
+  Usage in any Jinja2 page template:
+    {% block meta %}
+      {% include "seo/_meta.html" with context %}
+    {% endblock %}
+
+  Expected Context Dictionary ('seo'):
+    - seo.canonical_url (str): Absolute canonical URL.
+    - seo.seo_title (str): Specific SEO title.
+    - seo.seo_description (str): Page meta description text.
+    - seo.site_logo_url (str): Absolute URL to site preview image.
+    - seo.og_type (str): Open Graph page type (default: 'website').
+    - seo.schema_type (str): Schema.org JSON-LD type (default: 'WebPage').
+    - seo.twitter_card (str): Twitter card style (default: 'summary_large_image').
+#}
+{% if seo and seo.canonical_url %}
+<link rel="canonical" href="{{ seo.canonical_url }}">
+{% endif %}
+{% include "seo/_open_graph.html" with context %}
+{% include "seo/_json_ld.html" with context %}

--- a/templates/seo/_open_graph.html
+++ b/templates/seo/_open_graph.html
@@ -1,0 +1,22 @@
+{#
+  Open Graph & Twitter Cards Sub-Template (templates/seo/_open_graph.html)
+
+  Included automatically via templates/seo/_meta.html.
+
+  Context Variables Used:
+    - seo.seo_title / page_title / APP_TITLE: Title for og:title and twitter:title.
+    - seo.seo_description: Description text for og:description and twitter:description.
+    - seo.canonical_url: Absolute URL for og:url.
+    - seo.site_logo_url: Absolute image URL for og:image and twitter:image.
+    - seo.og_type: Open Graph category ('website', 'article', etc. Default: 'website').
+    - seo.twitter_card: Twitter card layout ('summary_large_image', 'summary', etc.).
+#}
+<meta property="og:title" content="{{ (seo and seo.seo_title) | default(page_title) | default(APP_TITLE) }}">
+<meta property="og:description" content="{{ (seo and seo.seo_description) | default('') }}">
+<meta property="og:url" content="{{ seo and seo.canonical_url }}">
+<meta property="og:type" content="{{ (seo and seo.og_type) | default('website') }}">
+<meta property="og:image" content="{{ seo and seo.site_logo_url }}">
+<meta name="twitter:card" content="{{ (seo and seo.twitter_card) | default('summary_large_image') }}">
+<meta name="twitter:title" content="{{ (seo and seo.seo_title) | default(page_title) | default(APP_TITLE) }}">
+<meta name="twitter:description" content="{{ (seo and seo.seo_description) | default('') }}">
+<meta name="twitter:image" content="{{ seo and seo.site_logo_url }}">

--- a/templates/seo_test.py
+++ b/templates/seo_test.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for shared SEO sub-templates (templates/seo/)."""
+
+import testing_config  # noqa: F401, I001
+
+from html.parser import HTMLParser
+
+import flask
+
+from framework import seo
+
+test_app = flask.Flask(__name__, template_folder='../templates')
+
+
+class SEOHTMLParser(HTMLParser):
+    """Collector parser using Python's built-in html.parser library."""
+
+    def __init__(self) -> None:
+        """Initialize parser attributes."""
+        super().__init__()
+        self.tags: list[tuple[str, dict[str, str]]] = []
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        """Collect start tags and attributes."""
+        attr_dict = {k: (v or '') for k, v in attrs}
+        self.tags.append((tag, attr_dict))
+
+
+class SEOSubTemplatesTest(testing_config.CustomTestCase):
+    """Unit tests for reusable SEO Jinja2 sub-templates."""
+
+    def _get_meta_content(
+        self, html_str: str, property_name: str
+    ) -> str | None:
+        """Helper to extract <meta property="..."> content attribute."""
+        parser = SEOHTMLParser()
+        parser.feed(html_str)
+        for tag, attrs in parser.tags:
+            if tag == 'meta' and attrs.get('property') == property_name:
+                return attrs.get('content')
+        return None
+
+    def test_open_graph_sub_template(self):
+        """It renders Open Graph meta tags cleanly with custom context inputs."""
+        meta = seo.Metadata(
+            canonical_url='https://chromestatus.com/feature/123',
+            seo_title='Custom Title',
+            seo_description='Custom Description',
+            site_logo_url='https://chromestatus.com/static/img/crstatus_192.png',
+        )
+        with test_app.test_request_context('/'):
+            html_str = flask.render_template(
+                'seo/_open_graph.html', seo=meta.to_dict()
+            )
+            self.assertEqual(
+                'Custom Title', self._get_meta_content(html_str, 'og:title')
+            )
+            self.assertEqual(
+                'https://chromestatus.com/feature/123',
+                self._get_meta_content(html_str, 'og:url'),
+            )
+
+    def test_open_graph_fallbacks(self):
+        """It falls back to page_title when seo.seo_title is omitted."""
+        with test_app.test_request_context('/'):
+            html_str = flask.render_template(
+                'seo/_open_graph.html', page_title='Page Title Fallback'
+            )
+            self.assertEqual(
+                'Page Title Fallback',
+                self._get_meta_content(html_str, 'og:title'),
+            )
+
+    def test_json_ld_sub_template(self):
+        """It renders Schema.org JSON-LD structured data on custom inputs."""
+        meta = seo.Metadata(
+            canonical_url='https://chromestatus.com/feature/123',
+            seo_title='Feature Detail',
+            seo_description='Feature Description',
+            schema_type='SoftwareApplication',
+        )
+        with test_app.test_request_context('/'):
+            html_str = flask.render_template(
+                'seo/_json_ld.html', seo=meta.to_dict()
+            )
+            self.assertIn('"@context": "https://schema.org"', html_str)
+            self.assertIn('"@type": "SoftwareApplication"', html_str)
+            self.assertIn('"name": "Feature Detail"', html_str)
+
+    def test_primary_meta_sub_template(self):
+        """It renders canonical link and includes open graph and json-ld sub-templates."""
+        meta = seo.Metadata(
+            canonical_url='https://chromestatus.com/release-notes/151',
+            seo_title='Release Notes',
+            seo_description='Release Notes Description',
+        )
+        with test_app.test_request_context('/'):
+            html_str = flask.render_template(
+                'seo/_meta.html', seo=meta.to_dict()
+            )
+            self.assertIn(
+                '<link rel="canonical" href="https://chromestatus.com/release-notes/151">',
+                html_str,
+            )
+            self.assertEqual(
+                'Release Notes', self._get_meta_content(html_str, 'og:title')
+            )
+            self.assertIn('"@context": "https://schema.org"', html_str)


### PR DESCRIPTION
## Summary

Implements the public Server-Side Rendered (SSR) Release Notes page (`GET /release-notes/<int:milestone>` and `GET /release-notes`) using hyphenated URL paths to match existing `developer.chrome.com/release-notes` URL conventions.

Provides fast initial load time, zero JS bundle dependencies, search engine SEO indexing, public CDN caching (`HTTP_CACHE_TYPE = 'public'`), a Symmetrical Navigation Strip (Channel Quick-Jumps + Milestone Combobox Selector), M151 cutoff HTTP 302 redirect handling, and responsive category-grouped feature cards styled via native `main.css` design tokens.

## Key Changes

- **Controller (`pages/releasenotes.py` & `main.py`)**: Implements `ReleaseNotesHandler(basehandlers.FlaskHandler)` with `HTTP_CACHE_TYPE = 'public'` registered under `/release-notes/<int:milestone>` and `/release-notes`. Assembles template context with channel milestone mappings (`stable`, `beta`, `dev`), M151 cutoff redirect (`MIN_SSR_RELEASE_NOTES_MILESTONE = 151`), and category-grouped features.
- **Template (`templates/release-notes.html`)**: Extends `_base.html`. Implements the Symmetrical Navigation Strip, native `main.css` button classes, hyphenated `/release-notes/` href links, and responsive Flexbox feature cards.
- **Testing (`pages/releasenotes_test.py` & Playwright)**: Added 16 Python unit tests covering public cache configuration, M151 cutoff HTTP 302 redirects, parameter resolution, and a modular Playwright test suite (`packages/playwright/tests/chromedash-release-notes-ssr_pwtest.js`).

TAG=agy
CONV=86f63625-bdb5-4d50-ac8d-2f8ca5128ca9