### PR TITLE
[Frontend Infrastructure] Implement Shared SEO Sub-Templates & Channel Milestone Infrastructure

### DIFF
--- a/framework/seo.py
+++ b/framework/seo.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SEO metadata models and helpers for Server-Side Rendering (SSR)."""
+
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from typing import Any
+
+
+class OpenGraphType(StrEnum):
+    """Open Graph protocol entity type values used in ChromeStatus.
+
+    Reference: https://ogp.me/#types
+    """
+
+    WEBSITE = 'website'
+
+
+class SchemaType(StrEnum):
+    """Schema.org structured data entity type values used in ChromeStatus.
+
+    Reference: https://schema.org/docs/full.html
+    """
+
+    WEB_PAGE = 'WebPage'
+    ITEM_PAGE = 'ItemPage'
+
+
+@dataclass(frozen=True)
+class Metadata:
+    """Strongly-typed container for page SEO and social sharing metadata.
+
+    Attributes:
+        canonical_url: Absolute canonical URL for preferred search indexing.
+            Ref: https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls
+        seo_title: Specific SEO title tag content.
+            Ref: https://developers.google.com/search/docs/appearance/title-link
+        seo_description: Concise page summary for search engine snippet display.
+            Ref: https://developers.google.com/search/docs/appearance/snippet
+        site_logo_url: Absolute image URL for social preview cards (og:image).
+            Ref: https://ogp.me/#metadata
+        og_type: Open Graph category type (default: OpenGraphType.WEBSITE).
+            Ref: https://ogp.me/#types
+        schema_type: Schema.org entity type (default: SchemaType.WEB_PAGE).
+            Ref: https://schema.org/WebPage
+    """
+
+    canonical_url: str | None = None
+    seo_title: str | None = None
+    seo_description: str | None = None
+    site_logo_url: str | None = None
+    og_type: OpenGraphType | str = OpenGraphType.WEBSITE
+    schema_type: SchemaType | str = SchemaType.WEB_PAGE
+
+    def to_dict(self) -> dict[str, Any]:
+        """Export non-None metadata fields as a template context dictionary."""
+        return {k: v for k, v in asdict(self).items() if v is not None}

--- a/framework/seo_test.py
+++ b/framework/seo_test.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for framework/seo.py Metadata dataclass and StrEnums."""
+
+import testing_config  # noqa: F401, I001
+
+from framework import seo
+import settings
+
+
+class SEOMetadataTest(testing_config.CustomTestCase):
+    """Unit tests for seo.Metadata dataclass and StrEnums."""
+
+    def test_instantiation_defaults(self):
+        """It applies default StrEnum values for og_type and schema_type."""
+        metadata = seo.Metadata(
+            canonical_url='https://chromestatus.com/release-notes/151',
+            seo_title='Chrome 151 Release Notes',
+            seo_description='Release notes description.',
+            site_logo_url='https://chromestatus.com/static/img/crstatus_192.png',
+        )
+
+        self.assertEqual(
+            'https://chromestatus.com/release-notes/151', metadata.canonical_url
+        )
+        self.assertEqual('Chrome 151 Release Notes', metadata.seo_title)
+        self.assertEqual('Release notes description.', metadata.seo_description)
+        self.assertEqual(
+            'https://chromestatus.com/static/img/crstatus_192.png',
+            metadata.site_logo_url,
+        )
+        self.assertEqual(seo.OpenGraphType.WEBSITE, metadata.og_type)
+        self.assertEqual(seo.SchemaType.WEB_PAGE, metadata.schema_type)
+
+    def test_strenum_custom_values(self):
+        """It accepts explicit StrEnum members for og_type and schema_type."""
+        metadata = seo.Metadata(
+            canonical_url='https://chromestatus.com/release-notes/151',
+            og_type=seo.OpenGraphType.WEBSITE,
+            schema_type=seo.SchemaType.ITEM_PAGE,
+        )
+
+        d = metadata.to_dict()
+        self.assertEqual('website', d['og_type'])
+        self.assertEqual('ItemPage', d['schema_type'])
+
+    def test_to_dict__exports_non_none_fields(self):
+        """It exports metadata attributes as a primitive string template context dictionary."""
+        metadata = seo.Metadata(
+            canonical_url=f'{settings.SITE_URL.rstrip("/")}/feature/123',
+            seo_title='Feature Detail',
+            seo_description='Feature Description',
+        )
+
+        d = metadata.to_dict()
+        self.assertIn('canonical_url', d)
+        self.assertIn('seo_title', d)
+        self.assertIn('seo_description', d)
+        self.assertNotIn('site_logo_url', d)
+        self.assertEqual('website', d['og_type'])
+        self.assertEqual('WebPage', d['schema_type'])

--- a/internals/fetchchannels.py
+++ b/internals/fetchchannels.py
@@ -17,6 +17,8 @@
 
 import json
 import logging
+from enum import StrEnum
+from typing import TypedDict
 
 import flask
 import requests
@@ -29,6 +31,23 @@ OMAHA_URL_TEMPLATE = (
     'https://versionhistory.googleapis.com'
     '/v1/chrome/platforms/win/channels/%s/versions/?pageSize=1'
 )
+
+
+class Channel(StrEnum):
+    """Chrome release channel names."""
+
+    STABLE = 'stable'
+    BETA = 'beta'
+    DEV = 'dev'
+    CANARY = 'canary'
+
+
+class ChannelVersionMapping(TypedDict):
+    """Typed dictionary representing a channel version entry in Omaha data."""
+
+    channel: Channel
+    version: str
+
 
 # Expected response for the "stable" channel looks like:
 # {
@@ -43,14 +62,14 @@ OMAHA_URL_TEMPLATE = (
 # We really only need the version string.
 
 
-def get_channel_version(channel: str) -> str:
+def get_channel_version(channel: Channel) -> str:
     """Return the version string that is live on the given channel."""
     if settings.UNIT_TEST_MODE or settings.PLAYWRIGHT_MODE:
-        if channel == 'stable':
+        if channel == Channel.STABLE:
             return '147.0.7727.56'
-        if channel == 'beta':
+        if channel == Channel.BETA:
             return '148.0.7778.5'
-        if channel == 'dev':
+        if channel == Channel.DEV:
             return '149.0.7779.3'
 
     url = OMAHA_URL_TEMPLATE % channel
@@ -65,7 +84,7 @@ def get_channel_version(channel: str) -> str:
     return version
 
 
-def get_omaha_data():
+def get_omaha_data() -> list[dict[str, list[ChannelVersionMapping]]]:
     """Fetch and return the Omaha data, caching it in Redis.
 
     Returns:
@@ -74,10 +93,19 @@ def get_omaha_data():
     omaha_data = rediscache.get('omaha_data')
 
     if omaha_data is None:
-        win_versions = [
-            {'channel': 'stable', 'version': get_channel_version('stable')},
-            {'channel': 'beta', 'version': get_channel_version('beta')},
-            {'channel': 'dev', 'version': get_channel_version('dev')},
+        win_versions: list[ChannelVersionMapping] = [
+            {
+                'channel': Channel.STABLE,
+                'version': get_channel_version(Channel.STABLE),
+            },
+            {
+                'channel': Channel.BETA,
+                'version': get_channel_version(Channel.BETA),
+            },
+            {
+                'channel': Channel.DEV,
+                'version': get_channel_version(Channel.DEV),
+            },
         ]
         omaha_info = [{'versions': win_versions}]
         omaha_data = json.dumps(omaha_info)
@@ -86,26 +114,39 @@ def get_omaha_data():
     return json.loads(omaha_data)
 
 
-def get_current_beta_milestone() -> int:
-    """Return the milestone number that is current on the beta channel."""
-    if flask.has_app_context() and hasattr(flask.g, 'current_beta_milestone'):
-        return flask.g.current_beta_milestone
+def get_current_channel_milestone(
+    channel: Channel = Channel.STABLE,
+) -> int:
+    """Return the milestone number that is current on the given channel."""
+    cache_attr = f'current_{channel}_milestone'
+    if flask.has_app_context() and hasattr(flask.g, cache_attr):
+        return getattr(flask.g, cache_attr)
 
     omaha_data = get_omaha_data()
-    beta_version = next(
+    version_str = next(
         (
             v['version']
             for v in omaha_data[0]['versions']
-            if v['channel'] == 'beta'
+            if v['channel'] == channel
         ),
         '0.0',
     )
-    milestone = int(beta_version.split('.')[0])
+    milestone = int(version_str.split('.')[0])
 
     if flask.has_app_context():
-        flask.g.current_beta_milestone = milestone
+        setattr(flask.g, cache_attr, milestone)
 
     return milestone
+
+
+def get_current_stable_milestone() -> int:
+    """Return the milestone number that is current on the stable channel."""
+    return get_current_channel_milestone(Channel.STABLE)
+
+
+def get_current_beta_milestone() -> int:
+    """Return the milestone number that is current on the beta channel."""
+    return get_current_channel_milestone(Channel.BETA)
 
 
 SCHEDULE_CACHE_TIME = 60 * 60  # 1 hour

--- a/internals/fetchchannels_test.py
+++ b/internals/fetchchannels_test.py
@@ -17,6 +17,8 @@
 import json
 from unittest import mock
 
+import flask
+
 import testing_config  # Must be imported first
 from internals import fetchchannels
 
@@ -86,3 +88,50 @@ class ChannelsAPITest(testing_config.CustomTestCase):
             },
             actual,
         )
+
+    @mock.patch('internals.fetchchannels.get_omaha_data')
+    def test_get_current_channel_milestone(self, mock_get_omaha):
+        """It sets flask.g attributes on first call and reads from flask.g on cache hits."""
+        mock_get_omaha.return_value = [
+            {
+                'versions': [
+                    {'channel': 'stable', 'version': '147.0.7727.56'},
+                    {'channel': 'beta', 'version': '148.0.7778.5'},
+                    {'channel': 'dev', 'version': '149.0.7779.3'},
+                ]
+            }
+        ]
+
+        app = flask.Flask(__name__)
+        with app.test_request_context('/'):
+            # First calls compute milestones for stable, beta, dev and set flask.g attributes
+            self.assertEqual(147, fetchchannels.get_current_stable_milestone())
+            self.assertEqual(148, fetchchannels.get_current_beta_milestone())
+            self.assertEqual(
+                149,
+                fetchchannels.get_current_channel_milestone(
+                    fetchchannels.Channel.DEV
+                ),
+            )
+
+            # Verify get_omaha_data was called exactly 3 times (once per channel)
+            self.assertEqual(3, mock_get_omaha.call_count)
+
+            # Verify attributes are set on flask.g with exact key names
+            self.assertEqual(147, getattr(flask.g, 'current_stable_milestone'))
+            self.assertEqual(148, getattr(flask.g, 'current_beta_milestone'))
+            self.assertEqual(149, getattr(flask.g, 'current_dev_milestone'))
+
+            # Reset mock call counter
+            mock_get_omaha.reset_mock()
+
+            # Subsequent calls read directly from flask.g without querying get_omaha_data()
+            self.assertEqual(147, fetchchannels.get_current_stable_milestone())
+            self.assertEqual(148, fetchchannels.get_current_beta_milestone())
+            self.assertEqual(
+                149,
+                fetchchannels.get_current_channel_milestone(
+                    fetchchannels.Channel.DEV
+                ),
+            )
+            mock_get_omaha.assert_not_called()

--- a/settings.py
+++ b/settings.py
@@ -40,6 +40,10 @@ DEFAULT_COMPONENT = 'Blink'
 # The default component for enterprise features.
 DEFAULT_ENTERPRISE_COMPONENT = 'Enterprise'
 
+# The default site logo asset path.
+DEFAULT_SITE_LOGO_PATH = '/static/img/crstatus_192.png'
+MIN_SSR_RELEASE_NOTES_MILESTONE = 151
+
 # Enable to activate the automated OT creation process
 AUTOMATED_OT_CREATION = True
 

--- a/templates/seo/_json_ld.html
+++ b/templates/seo/_json_ld.html
@@ -1,0 +1,20 @@
+{#
+  Schema.org JSON-LD Structured Data Sub-Template (templates/seo/_json_ld.html)
+
+  Included automatically via templates/seo/_meta.html.
+
+  Context Variables Used:
+    - seo.schema_type: Schema.org entity type ('ItemPage', 'WebPage', etc. Default: 'WebPage').
+    - seo.seo_title / page_title / APP_TITLE: Structured name field.
+    - seo.seo_description: Structured description field.
+    - seo.canonical_url: Structured page URL field.
+#}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "{{ (seo and seo.schema_type) | default('WebPage') }}",
+  "name": "{{ (seo and seo.seo_title) | default(page_title) | default(APP_TITLE) }}",
+  "description": "{{ (seo and seo.seo_description) | default('') }}",
+  "url": "{{ seo and seo.canonical_url }}"
+}
+</script>

--- a/templates/seo/_meta.html
+++ b/templates/seo/_meta.html
@@ -1,0 +1,21 @@
+{#
+  Primary SEO Meta Include (templates/seo/_meta.html)
+
+  Usage in any Jinja2 page template:
+    {% block meta %}
+      {% include "seo/_meta.html" with context %}
+    {% endblock %}
+
+  Expected Context Dictionary ('seo'):
+    - seo.canonical_url (str): Absolute canonical URL.
+    - seo.seo_title (str): Specific SEO title.
+    - seo.seo_description (str): Page meta description text.
+    - seo.site_logo_url (str): Absolute URL to site preview image.
+    - seo.og_type (str): Open Graph page type (default: 'website').
+    - seo.schema_type (str): Schema.org JSON-LD type (default: 'WebPage').
+#}
+{% if seo and seo.canonical_url %}
+<link rel="canonical" href="{{ seo.canonical_url }}">
+{% endif %}
+{% include "seo/_open_graph.html" with context %}
+{% include "seo/_json_ld.html" with context %}

--- a/templates/seo/_open_graph.html
+++ b/templates/seo/_open_graph.html
@@ -1,0 +1,17 @@
+{#
+  Open Graph Sub-Template (templates/seo/_open_graph.html)
+
+  Included automatically via templates/seo/_meta.html.
+
+  Context Variables Used:
+    - seo.seo_title / page_title / APP_TITLE: Title for og:title.
+    - seo.seo_description: Description text for og:description.
+    - seo.canonical_url: Absolute URL for og:url.
+    - seo.site_logo_url: Absolute image URL for og:image.
+    - seo.og_type: Open Graph category (Default: 'website').
+#}
+<meta property="og:title" content="{{ (seo and seo.seo_title) | default(page_title) | default(APP_TITLE) }}">
+<meta property="og:description" content="{{ (seo and seo.seo_description) | default('') }}">
+<meta property="og:url" content="{{ seo and seo.canonical_url }}">
+<meta property="og:type" content="{{ (seo and seo.og_type) | default('website') }}">
+<meta property="og:image" content="{{ seo and seo.site_logo_url }}">

--- a/templates/seo_test.py
+++ b/templates/seo_test.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for shared SEO sub-templates (templates/seo/)."""
+
+import testing_config  # noqa: F401, I001
+
+from html.parser import HTMLParser
+
+import flask
+
+from framework import seo
+
+test_app = flask.Flask(__name__, template_folder='../templates')
+
+
+class SEOHTMLParser(HTMLParser):
+    """Collector parser using Python's built-in html.parser library."""
+
+    def __init__(self) -> None:
+        """Initialize parser attributes."""
+        super().__init__()
+        self.tags: list[tuple[str, dict[str, str]]] = []
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        """Collect start tags and attributes."""
+        attr_dict = {k: (v or '') for k, v in attrs}
+        self.tags.append((tag, attr_dict))
+
+
+class SEOSubTemplatesTest(testing_config.CustomTestCase):
+    """Unit tests for reusable SEO Jinja2 sub-templates."""
+
+    def _get_meta_content(
+        self, html_str: str, property_name: str
+    ) -> str | None:
+        """Helper to extract <meta property="..."> content attribute."""
+        parser = SEOHTMLParser()
+        parser.feed(html_str)
+        for tag, attrs in parser.tags:
+            if tag == 'meta' and attrs.get('property') == property_name:
+                return attrs.get('content')
+        return None
+
+    def test_open_graph_sub_template(self):
+        """It renders Open Graph meta tags cleanly with custom context inputs."""
+        meta = seo.Metadata(
+            canonical_url='https://chromestatus.com/feature/123',
+            seo_title='Custom Title',
+            seo_description='Custom Description',
+            site_logo_url='https://chromestatus.com/static/img/crstatus_192.png',
+        )
+        with test_app.test_request_context('/'):
+            html_str = flask.render_template(
+                'seo/_open_graph.html', seo=meta.to_dict()
+            )
+            self.assertEqual(
+                'Custom Title', self._get_meta_content(html_str, 'og:title')
+            )
+            self.assertEqual(
+                'https://chromestatus.com/feature/123',
+                self._get_meta_content(html_str, 'og:url'),
+            )
+
+    def test_open_graph_fallbacks(self):
+        """It falls back to page_title when seo.seo_title is omitted."""
+        with test_app.test_request_context('/'):
+            html_str = flask.render_template(
+                'seo/_open_graph.html', page_title='Page Title Fallback'
+            )
+            self.assertEqual(
+                'Page Title Fallback',
+                self._get_meta_content(html_str, 'og:title'),
+            )
+
+    def test_json_ld_sub_template(self):
+        """It renders Schema.org JSON-LD structured data on custom inputs."""
+        meta = seo.Metadata(
+            canonical_url='https://chromestatus.com/feature/123',
+            seo_title='Feature Detail',
+            seo_description='Feature Description',
+            schema_type='SoftwareApplication',
+        )
+        with test_app.test_request_context('/'):
+            html_str = flask.render_template(
+                'seo/_json_ld.html', seo=meta.to_dict()
+            )
+            self.assertIn('"@context": "https://schema.org"', html_str)
+            self.assertIn('"@type": "SoftwareApplication"', html_str)
+            self.assertIn('"name": "Feature Detail"', html_str)
+
+    def test_primary_meta_sub_template(self):
+        """It renders canonical link and includes open graph and json-ld sub-templates."""
+        meta = seo.Metadata(
+            canonical_url='https://chromestatus.com/release-notes/151',
+            seo_title='Release Notes',
+            seo_description='Release Notes Description',
+        )
+        with test_app.test_request_context('/'):
+            html_str = flask.render_template(
+                'seo/_meta.html', seo=meta.to_dict()
+            )
+            self.assertIn(
+                '<link rel="canonical" href="https://chromestatus.com/release-notes/151">',
+                html_str,
+            )
+            self.assertEqual(
+                'Release Notes', self._get_meta_content(html_str, 'og:title')
+            )
+            self.assertIn('"@context": "https://schema.org"', html_str)


### PR DESCRIPTION
## Summary

Implements modular Server-Side Rendering (SSR) SEO infrastructure and channel milestone resolution helpers to support public page indexing and social card sharing across social platforms.

Provides reusable Jinja2 sub-templates (`seo/_meta.html`, `seo/_open_graph.html`, `seo/_json_ld.html`), a strongly-typed `seo.Metadata` dataclass with standard Open Graph protocol support, and unified `fetchchannels.get_current_channel_milestone()` resolution across Chrome release channels (stable, beta, dev).

## Key Changes

- **SEO Metadata Model (framework/seo.py & framework/seo_test.py)**: Implements `@dataclass(frozen=True) class Metadata` with default arguments (`og_type=OpenGraphType.WEBSITE`, `schema_type=SchemaType.WEB_PAGE`) and `.to_dict()` context exporting. Relies on standard Open Graph protocol meta tags (`og:title`, `og:description`, `og:url`, `og:type`, `og:image`) parsed natively across social platforms (Twitter/X, Slack, LinkedIn, Discord). Includes dedicated unit test suite.
- **Reusable SEO Sub-Templates (templates/seo/)**: Added `_open_graph.html` (Open Graph Protocol), `_json_ld.html` (Schema.org JSON-LD structured data), and `_meta.html` (Primary SEO include with canonical URL). Namespaced under `seo.` dictionary key to prevent context variable collisions.
- **SEO Sub-Template Testing (templates/seo_test.py)**: Added test suite using Python's built-in `html.parser.HTMLParser` standard library to verify rendered HTML tags, fallbacks, and structured data scripts.
- **Channel Milestone & Type Infrastructure (internals/fetchchannels.py & internals/fetchchannels_test.py)**: Added `Channel(StrEnum)` (`STABLE`, `BETA`, `DEV`, `CANARY`), `ChannelVersionMapping(TypedDict)`, DRY `get_current_channel_milestone(channel: Channel)` and `get_current_stable_milestone()` with request-level caching (`flask.g`). Added unit tests verifying `flask.g` attribute setting, key name parity, and cache hit retrieval without redundant external lookups.
- **Site Assets (settings.py)**: Added `DEFAULT_SITE_LOGO_PATH = '/static/img/crstatus_192.png'` asset configuration constant.

TAG=agy
CONV=86f63625-bdb5-4d50-ac8d-2f8ca5128ca9