### PR TITLE
[Infra] Upgrade ghapi==2.0.5 to support fastspec 0.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ MarkupSafe==3.0.3
 Werkzeug==3.1.8
 click==8.4.2
 itsdangerous==2.2.0
-ghapi==2.0.4
+ghapi==2.0.5
 validators==0.35.0
 # Work-around for failure to deploy
 # https://stackoverflow.com/questions/69936420/google-cloud-platform-app-deploy-failure-due-to-pyparsing


### PR DESCRIPTION
## Problem

On 2026-07-31 at 02:46:51 UTC, fast.ai released `fastspec 0.1.3` on PyPI which refactored `fastspec.oapi` and removed `_build_groups`.
Immediately following at 02:48:43 UTC, fast.ai released `ghapi 2.0.5` with updated imports compatible with `fastspec 0.1.3`.

Because `requirements.txt` previously pinned `ghapi==2.0.4`, pip on fresh CI runners resolved the unpinned transient dependency `fastspec` to `0.1.3` while holding `ghapi` back at `2.0.4`. This caused an immediate `ImportError: cannot import name '_build_groups' from 'fastspec.oapi'` on any fresh environment importing `ghapi` (breaking `internals/feature_links.py`, unit tests, Playwright web container startup, and merge queue runs today).

## Solution

Upgrade `ghapi==2.0.5` directly in `requirements.txt` to align with the latest `fastspec 0.1.3` release and restore full compatibility without pinning to older versions.

TAG=agy
CONV=86f63625-bdb5-4d50-ac8d-2f8ca5128ca9
