### PR TITLE
[Infra] Pin wpt-gen-lib to release v0.6.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,5 +42,5 @@ pillow==12.3.0
 ./gen/py/chromestatus_openapi
 ./gen/py/webstatus_openapi
 types-python-dateutil==2.9.0.20260716
-wpt-gen-lib @ git+https://github.com/GoogleChromeLabs/wpt-gen.git@fix-lib-packaging#subdirectory=lib
+wpt-gen-lib @ git+https://github.com/GoogleChromeLabs/wpt-gen.git@v0.6.4#subdirectory=lib
 pymmh3==0.0.5


### PR DESCRIPTION
## Problem

WPT coverage report generation in ChromeStatus currently fails with:
`Failed to generate WPT coverage report: 'requirements_extraction_categorized.jinja' not found in search path: '/layers/.../wptgen/templates'`

This occurred because `requirements.txt` was previously pinned to the `@fix-lib-packaging` branch of `wpt-gen`. While that branch fixed subpackage discovery, it lacked `[tool.setuptools.package-data]` in `lib/pyproject.toml`, resulting in all 16 `.jinja` templates being omitted during non-editable pip builds.

## Solution

Pin `wpt-gen-lib` to released tag `v0.6.4` (GoogleChromeLabs/wpt-gen#543 / GoogleChromeLabs/wpt-gen#547), which explicitly includes `[tool.setuptools.package-data]` for all templates and skills.

## Verification

- Ran unit tests (`api/wpt_coverage_api_test.py`, `framework/gemini_helpers_test.py`) - 12 tests passed (OK)
- Ran `make mypy` - 324 source files checked (0 issues)
- Ran `make lint` - Prettier, ESLint, TypeScript, Lit-Analyzer, Ruff all passed (0 errors)

TAG=agy
CONV=6d1493ac-6126-495c-814d-b9d38b654b6d