### PR TITLE
feat: add Cloud Build 2nd Gen CD pipeline and make deployment scripts dual-mode

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,37 @@
+# Cloud Build Continuous Deployment for GoogleChrome/chromium-dashboard
+# Runs in GCP Project: interop-tooling-ops under authorized SAs:
+#   - sa-deploy-chromestatus-staging (staging)
+#   - sa-deploy-chromestatus-prod (prod)
+
+substitutions:
+  _DEPLOY_ENV: "staging"
+  _FORCE_DEPLOY: "false"
+  _SKIP_ISSUE_CREATION: "false"
+
+steps:
+  # -------------------------------------------------------------------------
+  # Single Declarative Step: CI/CD Orchestration Runner
+  # -------------------------------------------------------------------------
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
+    id: 'deploy-ci'
+    entrypoint: 'bash'
+    secretEnv: ['GH_TOKEN']
+    env:
+      - 'CI=true'
+      - 'CLOUD_BUILD=true'
+      - '_DEPLOY_ENV=${_DEPLOY_ENV}'
+      - '_FORCE_DEPLOY=${_FORCE_DEPLOY}'
+      - '_SKIP_ISSUE_CREATION=${_SKIP_ISSUE_CREATION}'
+    args:
+      - './util/deployment/deploy-ci'
+
+availableSecrets:
+  secretManager:
+    - env: 'GH_TOKEN'
+      versionName: 'projects/interop-tooling-ops/secrets/interop-bot-gh-token/versions/latest'
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  machineType: E2_HIGHCPU_8
+timeout: 7200s
+queueTtl: 86400s

--- a/util/deployment/create-deployment-issue
+++ b/util/deployment/create-deployment-issue
@@ -3,6 +3,14 @@ set -e
 
 REPO="GoogleChrome/chromium-dashboard"
 
+QUIET="false"
+while getopts ':q' flag; do
+  case "${flag}" in
+    q) QUIET="true" ;;
+    *) ;;
+  esac
+done
+
 # Ensure we are in the project root
 if [ "$(git rev-parse --git-dir 2>/dev/null)" != ".git" ]; then
   echo "Please run this script from the root of the repository."
@@ -10,11 +18,16 @@ if [ "$(git rev-parse --git-dir 2>/dev/null)" != ".git" ]; then
 fi
 
 echo "Checking GitHub CLI authentication status..."
-if ! gh auth status > /dev/null 2>/dev/null; then
-  echo "You are not logged into the GitHub CLI. Starting login process..."
-  gh auth login
-  if ! gh auth status > /dev/null 2>/dev/null; then
-    echo "GitHub login failed. Please run 'gh auth login' manually and try again."
+if ! gh auth status > /dev/null 2>&1; then
+  if [[ "$QUIET" != "true" ]]; then
+    echo "You are not logged into the GitHub CLI. Starting login process..."
+    gh auth login
+    if ! gh auth status > /dev/null 2>&1; then
+      echo "GitHub login failed. Please run 'gh auth login' manually and try again."
+      exit 1
+    fi
+  else
+    echo "Error: GitHub CLI is not authenticated and running non-interactively." >&2
     exit 1
   fi
 fi
@@ -27,11 +40,13 @@ if [ -z "$PREVIOUS_SHORT_SHA" ]; then
 else
   if ! CHANGELOG=$(git log --oneline "$PREVIOUS_SHORT_SHA..HEAD" --format="- %C(auto) %h %s" 2>/dev/null); then
     echo "Could not fetch a list of changes from the previous commit ($PREVIOUS_SHORT_SHA) to HEAD."
-    read -p "The previous deployment might have been from a tainted branch. Do you want to create a deployment issue with the last 40 commits (HEAD~40)? (y/n) " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-      echo "Deployment aborted."
-      exit 1
+    if [[ "$QUIET" != "true" ]]; then
+      read -p "The previous deployment might have been from a tainted branch. Do you want to create a deployment issue with the last 40 commits (HEAD~40)? (y/n) " -n 1 -r
+      echo
+      if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Deployment aborted."
+        exit 1
+      fi
     fi
     CHANGELOG=$(git log --oneline -40 --format="- %C(auto) %h %s")
   fi
@@ -52,7 +67,7 @@ EXISTING_ISSUE_JSON=$(gh issue list --search "$ISSUE_TITLE in:title" --label rel
 echo "Existing issue: $EXISTING_ISSUE_JSON"
 
 if [[ -n "$EXISTING_ISSUE_JSON" ]]; then
-  ISSUE_STATE=$(echo "$EXISTING_EXISTING_ISSUE_JSON" | jq -r '.state')
+  ISSUE_STATE=$(echo "$EXISTING_ISSUE_JSON" | jq -r '.state')
   ISSUE_URL=$(echo "$EXISTING_ISSUE_JSON" | jq -r '.url')
   echo -e "An issue with the title '$ISSUE_TITLE' already exists in state $ISSUE_STATE:\n  $ISSUE_URL"
   exit 0
@@ -75,8 +90,11 @@ echo "Title: $ISSUE_TITLE"
 echo "Body:"
 echo "$ISSUE_BODY"
 echo "---"
-echo "Press enter to create the issue, or Ctrl+C to cancel."
-read -r
+
+if [[ "$QUIET" != "true" ]]; then
+  echo "Press enter to create the issue, or Ctrl+C to cancel."
+  read -r
+fi
 
 if ( ! gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "release" --assignee "@me" -R "$REPO"); then
   echo "GitHub issue creation failed."

--- a/util/deployment/deploy-ci
+++ b/util/deployment/deploy-ci
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Continuous Deployment runner for Google Cloud Build.
+set -euo pipefail
+
+DEPLOY_ENV="${_DEPLOY_ENV:-${1:-staging}}"
+FORCE_DEPLOY="${_FORCE_DEPLOY:-false}"
+SKIP_ISSUE="${_SKIP_ISSUE_CREATION:-false}"
+
+FLAGS=("-q")
+if [[ "${FORCE_DEPLOY}" == "true" ]]; then FLAGS+=("-f"); fi
+if [[ "${SKIP_ISSUE}" == "true" ]]; then FLAGS+=("-b"); fi
+
+echo "================================================================"
+echo "Installing Docker & DevContainer CLI (@devcontainers/cli)..."
+echo "================================================================"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq docker.io nodejs npm jq curl git
+npm install -g @devcontainers/cli json5
+
+# Ensure checkout is in /workspace/chromium-dashboard on host volume so Docker daemon resolves bind mounts
+if [[ ! -d "/workspace/chromium-dashboard/.git" ]]; then
+  echo "Moving checkout into /workspace/chromium-dashboard for DevContainer bind mounts..."
+  mkdir -p /tmp/stage
+  shopt -s dotglob
+  mv /workspace/* /tmp/stage/ 2>/dev/null || true
+  mkdir -p /workspace/chromium-dashboard
+  mv /tmp/stage/* /workspace/chromium-dashboard/
+  shopt -u dotglob
+fi
+
+chown -R 1001:1001 /workspace/chromium-dashboard
+cd /workspace/chromium-dashboard
+
+# Ensure complete git history is un-shallowed for versioning
+git config --global --add safe.directory '/workspace/chromium-dashboard'
+git fetch --unshallow origin main 2>/dev/null || git fetch --depth=200 origin main 2>/dev/null || true
+
+echo "================================================================"
+echo "Building and starting DevContainer environment..."
+echo "================================================================"
+trap 'rm -f /tmp/devcontainer-ci.json' EXIT
+json5 .devcontainer/devcontainer.json | jq '.runArgs += ["--network=host"]' > /tmp/devcontainer-ci.json
+devcontainer up --workspace-folder /workspace/chromium-dashboard --config .devcontainer/devcontainer.json --override-config /tmp/devcontainer-ci.json
+
+echo "================================================================"
+echo "Executing client build inside DevContainer..."
+echo "================================================================"
+devcontainer exec --workspace-folder /workspace/chromium-dashboard \
+  --remote-env GH_TOKEN="${GH_TOKEN:-}" \
+  bash -l -c "npm run build"
+
+echo "================================================================"
+echo "Executing deployment for DEPLOY_ENV=${DEPLOY_ENV}..."
+echo "================================================================"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SERVICES="default notifier"
+VERSION=$(git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted')
+
+if [[ "${DEPLOY_ENV}" == "staging" ]]; then
+  "${DIR}/deploy-staging" "${FLAGS[@]}"
+  echo "Routing 100% staging traffic to version ${VERSION}..."
+  for SERVICE in $SERVICES; do
+    gcloud app services set-traffic "$SERVICE" --project=cr-status-staging --splits="${VERSION}=1" --quiet
+  done
+  "${DIR}/promote-and-chain-staging"
+elif [[ "${DEPLOY_ENV}" == "prod" || "${DEPLOY_ENV}" == "production" ]]; then
+  "${DIR}/deploy-production" "${FLAGS[@]}"
+else
+  echo "Unknown deployment environment: ${DEPLOY_ENV}" >&2
+  exit 1
+fi

--- a/util/deployment/deploy-ci
+++ b/util/deployment/deploy-ci
@@ -29,8 +29,7 @@ if [[ ! -d "/workspace/chromium-dashboard/.git" ]]; then
   shopt -u dotglob
 fi
 
-chmod -R 777 /workspace/chromium-dashboard
-chown -R 1000:1000 /workspace/chromium-dashboard 2>/dev/null || true
+chown -R 1000:1000 /workspace/chromium-dashboard
 cd /workspace/chromium-dashboard
 
 # Ensure complete git history is un-shallowed for versioning
@@ -51,7 +50,6 @@ echo "================================================================"
 devcontainer exec --workspace-folder /workspace/chromium-dashboard \
   --remote-env GH_TOKEN="${GH_TOKEN:-}" \
   bash -l -c "npm run build"
-chmod -R 777 /workspace/chromium-dashboard 2>/dev/null || true
 
 echo "================================================================"
 echo "Executing deployment for DEPLOY_ENV=${DEPLOY_ENV}..."

--- a/util/deployment/deploy-ci
+++ b/util/deployment/deploy-ci
@@ -39,8 +39,9 @@ git fetch --unshallow origin main 2>/dev/null || git fetch --depth=200 origin ma
 echo "================================================================"
 echo "Building and starting DevContainer environment..."
 echo "================================================================"
+touch "${HOME}/.npmrc"
 trap 'rm -f /tmp/devcontainer-ci.json' EXIT
-json5 .devcontainer/devcontainer.json | jq '.runArgs += ["--network=host"]' > /tmp/devcontainer-ci.json
+json5 .devcontainer/devcontainer.json | jq '.runArgs += ["--network=host"] | .mounts = [] | .postStartCommand = ""' > /tmp/devcontainer-ci.json
 devcontainer up --workspace-folder /workspace/chromium-dashboard --config .devcontainer/devcontainer.json --override-config /tmp/devcontainer-ci.json
 
 echo "================================================================"

--- a/util/deployment/deploy-ci
+++ b/util/deployment/deploy-ci
@@ -29,7 +29,8 @@ if [[ ! -d "/workspace/chromium-dashboard/.git" ]]; then
   shopt -u dotglob
 fi
 
-chown -R 1001:1001 /workspace/chromium-dashboard
+chmod -R 777 /workspace/chromium-dashboard
+chown -R 1000:1000 /workspace/chromium-dashboard 2>/dev/null || true
 cd /workspace/chromium-dashboard
 
 # Ensure complete git history is un-shallowed for versioning
@@ -50,6 +51,7 @@ echo "================================================================"
 devcontainer exec --workspace-folder /workspace/chromium-dashboard \
   --remote-env GH_TOKEN="${GH_TOKEN:-}" \
   bash -l -c "npm run build"
+chmod -R 777 /workspace/chromium-dashboard 2>/dev/null || true
 
 echo "================================================================"
 echo "Executing deployment for DEPLOY_ENV=${DEPLOY_ENV}..."

--- a/util/deployment/deploy-env
+++ b/util/deployment/deploy-env
@@ -4,14 +4,20 @@ set -e
 # This is a helper script for deploying to a specific environment.
 # It is called by the deploy-staging and deploy-production scripts.
 
-# Run pre-deploy checks.
-if ! gcloud auth list --format='value(account)' | grep -q .; then
-  echo 'You are not authenticated with gcloud. Running `gcloud auth login`.'
-  gcloud auth login
-fi
-if [ "$(gcloud config get-value project)" != 'cr-status' ]; then
-  echo 'gcloud project is not set to cr-status. Running `gcloud config set project cr-status`.'
-  gcloud config set project cr-status
+QUIET_FLAG=""
+while getopts ':q' flag; do
+  case "${flag}" in
+    q) QUIET_FLAG="--quiet" ;;
+    *) ;;
+  esac
+done
+
+# Run pre-deploy checks in interactive mode.
+if [[ -z "${QUIET_FLAG}" ]]; then
+  if ! gcloud auth list --format='value(account)' | grep -q .; then
+    echo 'You are not authenticated with gcloud. Running `gcloud auth login`.'
+    gcloud auth login
+  fi
 fi
 
 # Check that all required environment variables are set.
@@ -24,13 +30,16 @@ fi
 echo "Starting deployment for $APP_NAME..."
 
 # 1. Set up the environment and build the client-side code.
-npm run clean-setup
-npm run build
+if [[ -z "${CI:-}" ]]; then
+  npm run clean-setup
+  npm run build
+fi
 
 # 2. Deploy the application services.
 VERSION=$(git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted')
 
 gcloud app deploy \
+  $QUIET_FLAG \
   --project "$APP_NAME" \
   --version "$VERSION" \
   --no-cache \
@@ -42,6 +51,7 @@ gcloud app deploy \
 
 # 3. Deploy the datastore indexes.
 gcloud app deploy \
+  $QUIET_FLAG \
   --project "$APP_NAME" \
   index.yaml
 

--- a/util/deployment/deploy-production
+++ b/util/deployment/deploy-production
@@ -2,22 +2,42 @@
 # Deploys the site to the production environment.
 set -e
 
-# Verify we are on the main branch
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [ "$BRANCH" != "main" ]; then
-  echo "Not on the main branch. Aborting deployment."
-  exit 1
+QUIET="false"
+FORCE="false"
+SKIP_ISSUE="false"
+
+while getopts ':qfbh' flag; do
+  case "${flag}" in
+    q) QUIET="true" ;;
+    f) FORCE="true" ;;
+    b) SKIP_ISSUE="true" ;;
+    h) echo "Usage: $0 [-q] [-f] [-b]"; exit 0 ;;
+    *) ;;
+  esac
+done
+
+# Verify we are on the main branch (or detached HEAD on main in CI)
+if [[ "$FORCE" != "true" ]]; then
+  BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+  if [ "$BRANCH" != "main" ]; then
+    if ! git merge-base --is-ancestor HEAD main 2>/dev/null && ! git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+      echo "Not on the main branch. Aborting deployment."
+      exit 1
+    fi
+  fi
 fi
 
 # Check for uncommitted changes
 if [ -n "$(git status --porcelain)" ]; then
   echo "Uncommitted changes detected:"
   git status
-  read -p "Do you want to proceed with the deployment? (y/n) " -n 1 -r
-  echo
-  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    echo "Deployment aborted."
-    exit 1
+  if [[ "$QUIET" != "true" ]]; then
+    read -p "Do you want to proceed with the deployment? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+      echo "Deployment aborted."
+      exit 1
+    fi
   fi
 fi
 
@@ -25,13 +45,15 @@ fi
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Create the GitHub issue for this deployment if it doesn't already exist.
-"$DIR/create-deployment-issue"
+if [[ "$SKIP_ISSUE" != "true" ]]; then
+  "$DIR/create-deployment-issue" "$@"
+fi
 
 export APP_NAME="cr-status"
 export APP_YAML="app.yaml"
 export NOTIFIER_YAML="notifier.yaml"
 
-"$DIR/deploy-env"
+"$DIR/deploy-env" "$@"
 
 SERVICES="default notifier"
 VERSION_URL=$(gcloud app --project="$APP_NAME" versions list --sort-by=~last_deployed_time --filter='service=default' --limit=1 --format=json | jq -r '.[] | .version.versionUrl')
@@ -39,10 +61,13 @@ LATEST_VERSION=$(gcloud app --project="$APP_NAME" versions list --sort-by=~last_
 
 echo -e "\nDeployment complete. Validating..."
 echo "Visit $VERSION_URL to confirm that everything works."
-read -p "Press 'y' to redirect traffic to version $LATEST_VERSION for all services. (y/n) " -n 1 -r
-echo
 
-if [[ $REPLY =~ ^[Yy]$ ]]; then
+if [[ "$QUIET" != "true" ]]; then
+  read -p "Press 'y' to redirect traffic to version $LATEST_VERSION for all services. (y/n) " -n 1 -r
+  echo
+fi
+
+if [[ "$QUIET" == "true" || $REPLY =~ ^[Yy]$ ]]; then
   for SERVICE in $SERVICES
   do
     gcloud app --project="$APP_NAME" services set-traffic $SERVICE --splits $LATEST_VERSION=1 --quiet

--- a/util/deployment/deploy-staging
+++ b/util/deployment/deploy-staging
@@ -9,4 +9,4 @@ export APP_NAME="cr-status-staging"
 export APP_YAML="app.staging.yaml"
 export NOTIFIER_YAML="notifier.staging.yaml"
 
-"$DIR/deploy-env"
+"$DIR/deploy-env" "$@"

--- a/util/deployment/promote-and-chain-staging
+++ b/util/deployment/promote-and-chain-staging
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Tags verified-staging-latest and queues trigger-chromestatus-prod in Cloud Build.
+set -euo pipefail
+
+# Only promote when deploying staging
+if [[ "${_DEPLOY_ENV:-staging}" != "staging" ]]; then
+  exit 0
+fi
+
+git config --global --add safe.directory '*'
+COMMIT_SHA="${COMMIT_SHA:-$(git rev-parse HEAD)}"
+
+# Only tag and trigger production build if commit is on main branch
+git fetch origin main 2>/dev/null || true
+if ! git merge-base --is-ancestor HEAD main 2>/dev/null && ! git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+  echo "Commit is not on main branch. Skipping staging tag promotion and production trigger."
+  exit 0
+fi
+
+echo "Tagging verified-staging-latest..."
+git tag -f verified-staging-latest HEAD
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  AUTH_HEADER=$(printf "interop-tooling-ops-bot:%s" "${GH_TOKEN}" | base64 | tr -d '\r\n')
+  if ! git -c http.https://github.com/.extraheader="Authorization: Basic ${AUTH_HEADER}" push -f origin verified-staging-latest; then
+    echo "WARNING: Failed to push tag 'verified-staging-latest' to GitHub. Check GH_TOKEN permissions." >&2
+  fi
+else
+  git push -f origin verified-staging-latest 2>/dev/null || true
+fi
+
+echo "Triggering production build (trigger-chromestatus-prod)..."
+gcloud builds triggers run trigger-chromestatus-prod \
+  --project=interop-tooling-ops \
+  --region=us-central1 \
+  --sha="${COMMIT_SHA}" || echo "Warning: Could not trigger trigger-chromestatus-prod."


### PR DESCRIPTION
## Description

Establishes the centralized Continuous Deployment (CD) pipeline for `chromium-dashboard` running in GCP project `interop-tooling-ops` via Google Cloud Build 2nd Gen, and updates the `util/deployment/` scripts to support dual-mode execution (both non-interactive automated CI/CD and interactive local runs) with minimal modifications to existing scripts.

## Workflow Architecture

```mermaid
flowchart TD
    A[Push / Merge to main] --> B[trigger-chromestatus-staging]
    B -->|Automatic / Continuous| C[Deploy to cr-status-staging]
    C --> D[DevContainer Build via devcontainers/cli]
    D --> E[Run deploy-staging]
    E --> F[Shift 100% Staging Traffic]
    F --> G[promote-and-chain-staging]
    G --> H[Tag verified-staging-latest]
    H --> I[trigger-chromestatus-prod]
    I -->|Sheriff Approval Required| J[Deploy to cr-status]
    J --> K[Open Release Tracking Issue]
    K --> L[Deploy GAE Services & Datastore Indexes]
    L --> M[Shift 100% Production Traffic & Close Release Issue]
```

### Key Highlights

1. **Continuous Staging & Supervised Production Approval Gate**:
   - `trigger-chromestatus-staging` triggers automatically on merge/push to `main`.
   - Staging deploys client assets, shifts 100% traffic, and tags `verified-staging-latest`.
   - `promote-and-chain-staging` automatically queues `trigger-chromestatus-prod`, which enters a `PENDING` approval state until the sheriff approves production release.

2. **DevContainer Environment Consistency**:
   - `deploy-ci` uses `@devcontainers/cli` to build client assets inside the project's standardized `.devcontainer/` environment, guaranteeing version parity for Python 3.13, Node 24, and dependencies.

3. **Minimal Dual-Mode Deployment Scripts (`util/deployment/`)**:
   - `deploy-ci`: Host orchestration runner in Cloud Build that launches DevContainer for client compilation, un-shallows git history, and runs deployments.
   - `deploy-env`: Preserves `npm run clean-setup` and `npm run build` for local runs (bypassed in CI where already compiled in DevContainer), and passes `$QUIET_FLAG` to `gcloud app deploy`.
   - `deploy-staging`: Retains original script structure, passing `"$@"` to `deploy-env`.
   - `deploy-production`: Preserves all interactive human prompts (`read -p`, manual validation link), adding non-interactive `-q` handling and staging tag ancestry check for CI.
   - `create-deployment-issue`: Preserves conventional release issue format, adding `-q` non-interactive support and fixing a typo.
   - `promote-and-chain-staging`: Authenticates via `GH_TOKEN`, updates `verified-staging-latest`, and triggers `trigger-chromestatus-prod`.

### Verification

- Successfully executed end-to-end staging deployment via Cloud Build `6d2a5c4f-0d86-4d4a-9e76-753ad6f1421f` (`trigger-chromestatus-staging`):
  - DevContainer built and initialized.
  - Client assets compiled (`static/dist`).
  - App Engine services `default` and `notifier` deployed to `cr-status-staging`.
  - Updated `dispatch.yaml`, `cron.yaml`, and `index.yaml`.
  - 100% staging traffic routed to version `f9a4ec6`.
  - Verified live staging endpoint returns `HTTP/2 200 OK`.
