### PR TITLE
Highlight links that are initially 404.

### DIFF
--- a/api/external_reviews_api.py
+++ b/api/external_reviews_api.py
@@ -219,7 +219,11 @@ class ExternalReviewsAPI(basehandlers.APIHandler):
         review_links = {
             reviewer_info.review_link(fe) for fe in unreviewed_features
         }
-        previewable_urls = {fl['url'] for fl in feature_links}
+        previewable_urls = {
+            fl['url']
+            for fl in feature_links
+            if fl.get('information') is not None
+        }
 
         # Build the response objects.
         reviews = [
@@ -256,6 +260,7 @@ class ExternalReviewsAPI(basehandlers.APIHandler):
             )
             for feature_link in feature_links
             if feature_link['url'] in review_links
+            and feature_link.get('information') is not None
         ]
         link_previews.sort(key=lambda link: link.url)
 

--- a/api/external_reviews_api_test.py
+++ b/api/external_reviews_api_test.py
@@ -367,6 +367,39 @@ class ExternalReviewsAPITest(testing_config.CustomTestCase):
         result = self.handler.do_get(review_group='tag')
         self.assertEqual(0, len(result['reviews']))
 
+    def test_feature_with_error_link_isnt_shown(self):
+        """Test feature with an error/404 review link isn't shown."""
+        tag = 'https://github.com/w3ctag/design-reviews/issues/99999'
+        fe = FeatureEntry(
+            name='Feature with 404 review link',
+            category=1,
+            summary='Summary',
+            tag_review=tag,
+            tag_review_resolution=None,
+        )
+        fe.put()
+        fe_id = fe.key.integer_id()
+        stage = Stage(
+            feature_id=fe_id,
+            stage_type=core_enums.STAGE_BLINK_PROTOTYPE,
+            milestones=MilestoneSet(desktop_first=100),
+        )
+        stage.put()
+        fe.active_stage_id = stage.key.id()
+        fe.put()
+        fl = FeatureLinks(
+            feature_ids=[fe_id],
+            url=tag,
+            type=LINK_TYPE_GITHUB_ISSUE,
+            information=None,
+            is_error=True,
+            http_error_code=404,
+        )
+        fl.put()
+
+        actual = self.handler.do_get(review_group='tag')
+        self.assertEqual({'reviews': [], 'link_previews': []}, actual)
+
     class FeatureDict(TypedDict):
         """A dictionary representation of a feature for testing."""
 

--- a/internals/feature_links.py
+++ b/internals/feature_links.py
@@ -121,8 +121,6 @@ def _get_index_link(
     else:
         if should_parse_new_link:
             link.parse()
-            if link.is_error:
-                return None
         feature_link = FeatureLinks(
             feature_ids=[feature_id],
             type=link.type,

--- a/internals/feature_links_test.py
+++ b/internals/feature_links_test.py
@@ -233,6 +233,16 @@ class LinkTest(testing_config.CustomTestCase):
         # add invalid url to feature
         self.mock_user_change_fields(changed_fields)
         link = query.get()
+        self.assertIsNotNone(link)
+        self.assertEqual(link.url, url)
+        self.assertIn(self.feature_id, link.feature_ids)
+        self.assertTrue(link.is_error)
+        self.assertEqual(link.http_error_code, 404)
+
+        # remove invalid url field, the link should be deleted
+        changed_fields_remove = [('bug_url', url, None)]
+        self.mock_user_change_fields(changed_fields_remove)
+        link = query.get()
         self.assertIsNone(link)
 
     @mock.patch.object(Link, 'parse', autospec=True)


### PR DESCRIPTION
I made a change to the feature_links functionality last week and I thought that I somehow broke the 404 detection.  It turns out that we were never detecting links that were initially 404, only links that were initially 200 and that later become 404.  

IIRC, that requirement was decided that way to avoid UI clutter for long text that includes link-like text like `https://foo.com/bar` or `http://DOMAIN.TLD/PATH`.  However, we never added the 404 labels to links inside the long text fields, they are only added to fields that are expected to contain only URLs.

In this PR:
* Record when a newly edited link is initially 404
* Don't try to preview them on the external reviewers page because they are 404