### PR TITLE
feat: execute CD deployments in DevContainer and harden pipeline scripts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -74,7 +74,7 @@
 	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "npm install -g gulp-cli && npm run clean-setup",
+	"postCreateCommand": "npm run clean-setup",
 	// 'postStartCommand' runs each time the devcontainer is started.
 	"postStartCommand": "docker-compose -f .devcontainer/db-docker-compose.yml down && docker-compose -f .devcontainer/db-docker-compose.yml up -d && npm run setup && npx playwright install --with-deps",
 	// Use 'postAttachCommand' to run commands after the container is created and attached.

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,6 @@ WORKDIR /workspace
 COPY --chown=appuser:appuser requirements.txt requirements.dev.txt Makefile package.json package-lock.json /workspace/
 COPY --chown=appuser:appuser openapi /workspace/openapi/
 COPY --chown=appuser:appuser gen /workspace/gen/
-RUN npm install -g gulp-cli && make setup && cs-env/bin/python -m pip install debugpy==1.6.7.post1
+RUN make setup && cs-env/bin/python -m pip install debugpy==1.6.7.post1
 # Copy the rest
 COPY --chown=appuser:appuser . /workspace

--- a/util/deployment/create-deployment-issue
+++ b/util/deployment/create-deployment-issue
@@ -1,19 +1,37 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 REPO="GoogleChrome/chromium-dashboard"
 
+usage() {
+  echo "Usage: $0 [-q] [-f] [-b] [-h]"
+  echo "  -q : Run non-interactively without prompts"
+  echo "  -f : Force issue creation even with uncommitted changes"
+  echo "  -b : Skip issue creation (exits immediately with code 0)"
+  echo "  -h : Show this help message"
+}
+
 QUIET="false"
-while getopts ':q' flag; do
+FORCE="false"
+while getopts ':qfbh' flag; do
   case "${flag}" in
     q) QUIET="true" ;;
-    *) ;;
+    f) FORCE="true" ;;
+    b) echo "Skipping issue creation (-b flag passed)."; exit 0 ;;
+    h) usage && exit 0 ;;
+    \?) echo "Invalid option: -${OPTARG}" >&2; usage >&2; exit 1 ;;
   esac
 done
+shift $((OPTIND - 1))
+
+# If CI or CLOUD_BUILD environment variables are true, default QUIET to true
+if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" ]]; then
+  QUIET="true"
+fi
 
 # Ensure we are in the project root
-if [ "$(git rev-parse --git-dir 2>/dev/null)" != ".git" ]; then
-  echo "Please run this script from the root of the repository."
+if [[ "$(git rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)" ]]; then
+  echo "Please run this script from the root of the repository." >&2
   exit 1
 fi
 
@@ -23,32 +41,46 @@ if ! gh auth status > /dev/null 2>&1; then
     echo "You are not logged into the GitHub CLI. Starting login process..."
     gh auth login
     if ! gh auth status > /dev/null 2>&1; then
-      echo "GitHub login failed. Please run 'gh auth login' manually and try again."
+      echo "GitHub login failed. Please run 'gh auth login' manually and try again." >&2
       exit 1
     fi
   else
-    echo "Error: GitHub CLI is not authenticated and running non-interactively." >&2
+    echo "Error: GitHub CLI is not authenticated in non-interactive CI/CD mode. Ensure GH_TOKEN or GITHUB_TOKEN environment variable is set." >&2
     exit 1
   fi
 fi
 echo "Authenticated."
 
-PREVIOUS_SHORT_SHA=$(gh issue list --state=closed --label="release" --json title --repo "$REPO" | jq -r '.[0].title' | awk '{print $NF}')
-if [ -z "$PREVIOUS_SHORT_SHA" ]; then
-  echo "Could not determine the previous release SHA. Using last 10 commits for changelog."
-  CHANGELOG=$(git log --oneline -10 --format="- %C(auto) %h %s")
+PREVIOUS_SHORT_SHA=$( (gh issue list --state=closed --label="release" --json title --repo "$REPO" 2>/dev/null || true) | jq -r '.[0].title // ""' 2>/dev/null | awk '{print $NF}')
+CHANGELOG=""
+
+if [[ -z "$PREVIOUS_SHORT_SHA" || "$PREVIOUS_SHORT_SHA" == "null" ]]; then
+  if [[ "$QUIET" == "true" ]]; then
+    echo "Could not determine the previous release SHA from closed issues. Generating recent 20 commits..."
+    CHANGELOG=$(git log -n 20 --oneline --format="- %C(auto) %h %s")
+    PREVIOUS_SHORT_SHA=$(git rev-parse --short HEAD~20 2>/dev/null || git rev-parse --short HEAD || echo "HEAD~20")
+  else
+    echo "Could not determine the previous release SHA. Using last 10 commits for changelog."
+    CHANGELOG=$(git log --oneline -10 --format="- %C(auto) %h %s")
+    PREVIOUS_SHORT_SHA=$(git rev-parse --short HEAD~10 2>/dev/null || git rev-parse --short HEAD || echo "HEAD~10")
+  fi
 else
   if ! CHANGELOG=$(git log --oneline "$PREVIOUS_SHORT_SHA..HEAD" --format="- %C(auto) %h %s" 2>/dev/null); then
-    echo "Could not fetch a list of changes from the previous commit ($PREVIOUS_SHORT_SHA) to HEAD."
-    if [[ "$QUIET" != "true" ]]; then
+    if [[ "$QUIET" == "true" ]]; then
+      echo "Previous commit ($PREVIOUS_SHORT_SHA) not directly in DAG or shallow clone; generating recent 40 commits..."
+      CHANGELOG=$(git log -n 40 --oneline --format="- %C(auto) %h %s")
+      PREVIOUS_SHORT_SHA=$(git rev-parse --short HEAD~40 2>/dev/null || git rev-parse --short HEAD || echo "HEAD~40")
+    else
+      echo "Could not fetch a list of changes from the previous commit ($PREVIOUS_SHORT_SHA) to HEAD."
       read -p "The previous deployment might have been from a tainted branch. Do you want to create a deployment issue with the last 40 commits (HEAD~40)? (y/n) " -n 1 -r
       echo
       if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        echo "Deployment aborted."
+        echo "Deployment aborted." >&2
         exit 1
       fi
+      CHANGELOG=$(git log --oneline -40 --format="- %C(auto) %h %s")
+      PREVIOUS_SHORT_SHA=$(git rev-parse --short HEAD~40 2>/dev/null || git rev-parse --short HEAD || echo "HEAD~40")
     fi
-    CHANGELOG=$(git log --oneline -40 --format="- %C(auto) %h %s")
   fi
 fi
 
@@ -62,14 +94,12 @@ fi
 ISSUE_TITLE="Deploy $DIRTY_PREFIX$NEW_SHA"
 
 echo "Checking for existing issue with title: $ISSUE_TITLE"
-EXISTING_ISSUE_JSON=$(gh issue list --search "$ISSUE_TITLE in:title" --label release --state all --repo "$REPO" --json number,title,state,url | jq --arg title "$ISSUE_TITLE" '.[] | select(.title == $title)')
-
-echo "Existing issue: $EXISTING_ISSUE_JSON"
+EXISTING_ISSUE_JSON=$( (gh issue list --search "$ISSUE_TITLE in:title" --label release --state all --repo "$REPO" --json number,title,state,url 2>/dev/null || true) | jq --arg title "$ISSUE_TITLE" '.[] | select(.title == $title)')
 
 if [[ -n "$EXISTING_ISSUE_JSON" ]]; then
   ISSUE_STATE=$(echo "$EXISTING_ISSUE_JSON" | jq -r '.state')
   ISSUE_URL=$(echo "$EXISTING_ISSUE_JSON" | jq -r '.url')
-  echo -e "An issue with the title '$ISSUE_TITLE' already exists in state $ISSUE_STATE:\n  $ISSUE_URL"
+  printf "An issue with the title '%s' already exists in state %s:\n  %s\n" "$ISSUE_TITLE" "$ISSUE_STATE" "$ISSUE_URL"
   exit 0
 fi
 
@@ -96,8 +126,8 @@ if [[ "$QUIET" != "true" ]]; then
   read -r
 fi
 
-if ( ! gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "release" --assignee "@me" -R "$REPO"); then
-  echo "GitHub issue creation failed."
+if ! gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "release" -R "$REPO"; then
+  echo "GitHub issue creation failed." >&2
   exit 1
 fi
 

--- a/util/deployment/deploy-ci
+++ b/util/deployment/deploy-ci
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 # Continuous Deployment runner for Google Cloud Build.
+# Runs deployments inside the project DevContainer to ensure unified tooling (gh, gcloud, Node, Python).
 set -euo pipefail
 
 DEPLOY_ENV="${_DEPLOY_ENV:-${1:-staging}}"
+if [[ "${DEPLOY_ENV}" == "production" ]]; then
+  DEPLOY_ENV="prod"
+fi
+
 FORCE_DEPLOY="${_FORCE_DEPLOY:-false}"
 SKIP_ISSUE="${_SKIP_ISSUE_CREATION:-false}"
 
@@ -32,7 +37,7 @@ fi
 chown -R 1000:1000 /workspace/chromium-dashboard
 cd /workspace/chromium-dashboard
 
-# Ensure complete git history is un-shallowed for versioning
+# Ensure complete git history is available for changelog and versioning
 git config --global --add safe.directory '/workspace/chromium-dashboard'
 git fetch --unshallow origin main 2>/dev/null || git fetch --depth=200 origin main 2>/dev/null || true
 
@@ -41,32 +46,39 @@ echo "Building and starting DevContainer environment..."
 echo "================================================================"
 touch "${HOME}/.npmrc"
 trap 'rm -f /tmp/devcontainer-ci.json' EXIT
-json5 .devcontainer/devcontainer.json | jq '.runArgs += ["--network=host"] | .mounts = [] | .postStartCommand = ""' > /tmp/devcontainer-ci.json
+json5 .devcontainer/devcontainer.json | jq '.runArgs += ["--network=host"] | .mounts = [] | .postCreateCommand = "" | .postStartCommand = ""' > /tmp/devcontainer-ci.json
 devcontainer up --workspace-folder /workspace/chromium-dashboard --config .devcontainer/devcontainer.json --override-config /tmp/devcontainer-ci.json
 
 echo "================================================================"
-echo "Executing client build inside DevContainer..."
+echo "Executing deployment for DEPLOY_ENV=${DEPLOY_ENV} inside DevContainer..."
 echo "================================================================"
-devcontainer exec --workspace-folder /workspace/chromium-dashboard \
-  --remote-env GH_TOKEN="${GH_TOKEN:-}" \
-  bash -l -c "npm run build"
 
-echo "================================================================"
-echo "Executing deployment for DEPLOY_ENV=${DEPLOY_ENV}..."
-echo "================================================================"
+AUTH_TOKEN=$(gcloud auth print-access-token --scopes="https://www.googleapis.com/auth/cloud-platform" 2>/dev/null) || {
+  echo "Error: Failed to obtain GCP access token via gcloud auth." >&2
+  exit 1
+}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SERVICES="default notifier"
-VERSION=$(git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted')
 
 if [[ "${DEPLOY_ENV}" == "staging" ]]; then
-  "${DIR}/deploy-staging" "${FLAGS[@]}"
-  echo "Routing 100% staging traffic to version ${VERSION}..."
-  for SERVICE in $SERVICES; do
-    gcloud app services set-traffic "$SERVICE" --project=cr-status-staging --splits="${VERSION}=1" --quiet
-  done
+  devcontainer exec --workspace-folder /workspace/chromium-dashboard \
+    --remote-env GOOGLE_OAUTH_ACCESS_TOKEN="${AUTH_TOKEN}" \
+    --remote-env CLOUDSDK_AUTH_ACCESS_TOKEN="${AUTH_TOKEN}" \
+    --remote-env GH_TOKEN="${GH_TOKEN:-}" \
+    --remote-env GITHUB_TOKEN="${GH_TOKEN:-}" \
+    --remote-env CI=true \
+    --remote-env CLOUD_BUILD=true \
+    bash -l -c "./util/deployment/deploy-staging ${FLAGS[*]}"
+
   "${DIR}/promote-and-chain-staging"
-elif [[ "${DEPLOY_ENV}" == "prod" || "${DEPLOY_ENV}" == "production" ]]; then
-  "${DIR}/deploy-production" "${FLAGS[@]}"
+elif [[ "${DEPLOY_ENV}" == "prod" ]]; then
+  devcontainer exec --workspace-folder /workspace/chromium-dashboard \
+    --remote-env GOOGLE_OAUTH_ACCESS_TOKEN="${AUTH_TOKEN}" \
+    --remote-env CLOUDSDK_AUTH_ACCESS_TOKEN="${AUTH_TOKEN}" \
+    --remote-env GH_TOKEN="${GH_TOKEN:-}" \
+    --remote-env GITHUB_TOKEN="${GH_TOKEN:-}" \
+    --remote-env CI=true \
+    --remote-env CLOUD_BUILD=true \
+    bash -l -c "./util/deployment/deploy-production ${FLAGS[*]}"
 else
   echo "Unknown deployment environment: ${DEPLOY_ENV}" >&2
   exit 1

--- a/util/deployment/deploy-env
+++ b/util/deployment/deploy-env
@@ -1,14 +1,26 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 # This is a helper script for deploying to a specific environment.
 # It is called by the deploy-staging and deploy-production scripts.
 
+usage() {
+  echo "Usage: $0 [-q] [-f] [-b] [-h]"
+  echo "  -q : Pass --quiet to gcloud app deploy"
+  echo "  -f : Force deployment"
+  echo "  -b : Bypass issue creation"
+  echo "  -h : Show this help message"
+}
+
 QUIET_FLAG=""
-while getopts ':q' flag; do
+FORCE="false"
+while getopts ':qfbh' flag; do
   case "${flag}" in
     q) QUIET_FLAG="--quiet" ;;
-    *) ;;
+    f) FORCE="true" ;;
+    b) ;; # Handled by deploy-production
+    h) usage && exit 0 ;;
+    \?) echo "Invalid option: -${OPTARG}" >&2; usage >&2; exit 1 ;;
   esac
 done
 
@@ -21,21 +33,22 @@ if [[ -z "${QUIET_FLAG}" ]]; then
 fi
 
 # Check that all required environment variables are set.
-if [ -z "$APP_NAME" ] || [ -z "$APP_YAML" ] || [ -z "$NOTIFIER_YAML" ]; then
-    echo "Error: One or more required environment variables are not set."
-    echo "Please ensure the environment variables APP_NAME, APP_YAML, and NOTIFIER_YAML are exported."
+if [ -z "${APP_NAME:-}" ] || [ -z "${APP_YAML:-}" ] || [ -z "${NOTIFIER_YAML:-}" ]; then
+    echo "Error: One or more required environment variables are not set." >&2
+    echo "Please ensure the environment variables APP_NAME, APP_YAML, and NOTIFIER_YAML are exported." >&2
     exit 1
 fi
 
 echo "Starting deployment for $APP_NAME..."
 
 # 1. Set up the environment and build the client-side code.
-if [[ -z "${CI:-}" ]]; then
-  npm run clean-setup
-  npm run build
-fi
+# Note: In CI/CD Cloud Build runs, deploy-ci disables DevContainer's postCreateCommand
+# and postStartCommand to keep container startup fast and avoid running local emulators.
+# Therefore, deploy-env always executes npm run clean-setup and npm run build explicitly.
+npm run clean-setup
+npm run build
 
-# 2. Deploy the application services.
+# 2. Deploy the application services and routing/cron/queue configs.
 VERSION=$(git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted')
 
 gcloud app deploy \
@@ -47,7 +60,8 @@ gcloud app deploy \
   "$APP_YAML" \
   "$NOTIFIER_YAML" \
   dispatch.yaml \
-  cron.yaml
+  cron.yaml \
+  queue.yaml
 
 # 3. Deploy the datastore indexes.
 gcloud app deploy \

--- a/util/deployment/deploy-production
+++ b/util/deployment/deploy-production
@@ -1,41 +1,66 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Deploys the site to the production environment.
-set -e
+set -euo pipefail
 
 QUIET="false"
 FORCE="false"
 SKIP_ISSUE="false"
+CI="${CI:-false}"
+CLOUD_BUILD="${CLOUD_BUILD:-false}"
+
+usage() {
+  echo "Usage: $0 [-q] [-f] [-b] [-h]"
+  echo "  -q : Run non-interactively without prompts"
+  echo "  -f : Force deployment even with uncommitted changes or branch divergence"
+  echo "  -b : Bypass GitHub issue creation"
+  echo "  -h : Show this help message"
+}
 
 while getopts ':qfbh' flag; do
   case "${flag}" in
     q) QUIET="true" ;;
     f) FORCE="true" ;;
     b) SKIP_ISSUE="true" ;;
-    h) echo "Usage: $0 [-q] [-f] [-b]"; exit 0 ;;
-    *) ;;
+    h) usage && exit 0 ;;
+    \?) echo "Invalid option: -${OPTARG}" >&2; usage >&2; exit 1 ;;
   esac
 done
+shift $((OPTIND - 1))
+
+# If CI or CLOUD_BUILD environment variables are true, default QUIET to true
+if [[ "${CI}" == "true" || "${CLOUD_BUILD}" == "true" ]]; then
+  QUIET="true"
+fi
+
+# Fetch main and origin/main for ancestry check
+git fetch origin main 2>/dev/null || true
 
 # Verify we are on the main branch (or detached HEAD on main in CI)
 if [[ "$FORCE" != "true" ]]; then
   BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
-  if [ "$BRANCH" != "main" ]; then
+  if [[ "$BRANCH" != "main" ]]; then
     if ! git merge-base --is-ancestor HEAD main 2>/dev/null && ! git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
-      echo "Not on the main branch. Aborting deployment."
+      echo "Error: Not on the main branch and commit is not an ancestor of main. Aborting deployment." >&2
+      echo "Pass -f (or _FORCE_DEPLOY=true) to force." >&2
       exit 1
     fi
   fi
 fi
 
 # Check for uncommitted changes
-if [ -n "$(git status --porcelain)" ]; then
+if [[ -n "$(git status --porcelain)" ]]; then
   echo "Uncommitted changes detected:"
   git status
-  if [[ "$QUIET" != "true" ]]; then
+  if [[ "$FORCE" == "true" ]]; then
+    echo "FORCE=true: Proceeding with uncommitted changes."
+  elif [[ "$QUIET" == "true" ]]; then
+    echo "Error: Non-interactive CI/CD mode (-q) and uncommitted changes detected without -f. Aborting." >&2
+    exit 1
+  else
     read -p "Do you want to proceed with the deployment? (y/n) " -n 1 -r
     echo
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-      echo "Deployment aborted."
+      echo "Deployment aborted." >&2
       exit 1
     fi
   fi
@@ -55,37 +80,41 @@ export NOTIFIER_YAML="notifier.yaml"
 
 "$DIR/deploy-env" "$@"
 
-SERVICES="default notifier"
-VERSION_URL=$(gcloud app --project="$APP_NAME" versions list --sort-by=~last_deployed_time --filter='service=default' --limit=1 --format=json | jq -r '.[] | .version.versionUrl')
-LATEST_VERSION=$(gcloud app --project="$APP_NAME" versions list --sort-by=~last_deployed_time --filter='service=default' --limit=1 --format=json | jq -r '.[] | .id')
+SERVICES=("default" "notifier")
+VERSION=$(git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted')
+VERSION_URL="https://${VERSION}-dot-cr-status.appspot.com"
 
-echo -e "\nDeployment complete. Validating..."
+printf "\nDeployment complete. Validating...\n"
 echo "Visit $VERSION_URL to confirm that everything works."
 
 if [[ "$QUIET" != "true" ]]; then
-  read -p "Press 'y' to redirect traffic to version $LATEST_VERSION for all services. (y/n) " -n 1 -r
+  read -p "Press 'y' to redirect traffic to version $VERSION for all services. (y/n) " -n 1 -r
   echo
 fi
 
-if [[ "$QUIET" == "true" || $REPLY =~ ^[Yy]$ ]]; then
-  for SERVICE in $SERVICES
-  do
-    gcloud app --project="$APP_NAME" services set-traffic $SERVICE --splits $LATEST_VERSION=1 --quiet
+if [[ "$QUIET" == "true" || ${REPLY:-} =~ ^[Yy]$ ]]; then
+  for SERVICE in "${SERVICES[@]}"; do
+    gcloud app --project="$APP_NAME" services set-traffic "$SERVICE" --splits "${VERSION}=1" --quiet
   done
-  echo "Traffic migrated."
+  echo "Traffic migrated to version ${VERSION}."
 else
   echo "Traffic migration skipped. Don't forget to migrate traffic manually:"
   echo "- 'default' service: https://console.cloud.google.com/appengine/versions?serviceId=default&project=$APP_NAME"
   echo "- 'notifier' service: https://console.cloud.google.com/appengine/versions?serviceId=notifier&project=$APP_NAME"
 fi
 
-# Update and close deployment bug.
-REPO="GoogleChrome/chromium-dashboard"
-LAST_DEPLOYMENT_ISSUE=$(gh issue list --state open --label "release" --repo "$REPO" --limit 1 --json number --jq '.[] | .number')
+# Update and close deployment release issue.
+if [[ "$SKIP_ISSUE" != "true" ]]; then
+  REPO="GoogleChrome/chromium-dashboard"
+  OPEN_RELEASE_ISSUE=$( (gh issue list --state open --label "release" --search "${VERSION}" --limit 1 --json number --repo "$REPO" 2>/dev/null || true) | jq -r '.[0].number // ""' 2>/dev/null || echo "")
+  if [[ -z "${OPEN_RELEASE_ISSUE}" ]]; then
+    OPEN_RELEASE_ISSUE=$( (gh issue list --state open --label "release" --limit 1 --json number --repo "$REPO" 2>/dev/null || true) | jq -r '.[0].number // ""' 2>/dev/null || echo "")
+  fi
 
-if [ -n "$LAST_DEPLOYMENT_ISSUE" ]; then
-  gh issue close "$LAST_DEPLOYMENT_ISSUE" -c "Deployment is now complete." -R "$REPO"
-  echo "Closed GitHub release issue #$LAST_DEPLOYMENT_ISSUE."
-else
-  echo "Could not find an open release issue to close."
+  if [[ -n "$OPEN_RELEASE_ISSUE" ]]; then
+    gh issue close "$OPEN_RELEASE_ISSUE" -c "Deployment is now complete." -R "$REPO" || echo "WARNING: Failed to close GitHub issue #${OPEN_RELEASE_ISSUE}." >&2
+    echo "Closed GitHub release issue #$OPEN_RELEASE_ISSUE."
+  else
+    echo "Could not find an open release issue to close."
+  fi
 fi

--- a/util/deployment/deploy-staging
+++ b/util/deployment/deploy-staging
@@ -1,6 +1,32 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Deploys the site to the staging environment.
-set -e
+set -euo pipefail
+
+QUIET="false"
+FORCE="false"
+CI="${CI:-false}"
+CLOUD_BUILD="${CLOUD_BUILD:-false}"
+
+usage() {
+  echo "Usage: $0 [-q] [-f] [-h]"
+  echo "  -q : Run non-interactively without prompts"
+  echo "  -f : Force deployment"
+  echo "  -h : Show this help message"
+}
+
+while getopts ':qfbh' flag; do
+  case "${flag}" in
+    q) QUIET="true" ;;
+    f) FORCE="true" ;;
+    b) ;; # Staging does not create release issues
+    h) usage && exit 0 ;;
+    \?) echo "Invalid option: -${OPTARG}" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+if [[ "${CI}" == "true" || "${CLOUD_BUILD}" == "true" ]]; then
+  QUIET="true"
+fi
 
 # Get the directory of the script
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -10,3 +36,24 @@ export APP_YAML="app.staging.yaml"
 export NOTIFIER_YAML="notifier.staging.yaml"
 
 "$DIR/deploy-env" "$@"
+
+SERVICES="default notifier"
+VERSION=$(git describe --always --abbrev=7 --match 'NOT A TAG' --dirty='-tainted')
+VERSION_URL="https://${VERSION}-dot-cr-status-staging.appspot.com"
+
+echo -e "\nDeployment to staging complete. Validating..."
+echo "Visit $VERSION_URL to confirm that everything works."
+
+if [[ "$QUIET" != "true" ]]; then
+  read -p "Press 'y' to redirect traffic to version $VERSION for all staging services. (y/n) " -n 1 -r
+  echo
+fi
+
+if [[ "$QUIET" == "true" || ${REPLY:-} =~ ^[Yy]$ ]]; then
+  for SERVICE in $SERVICES; do
+    gcloud app --project="$APP_NAME" services set-traffic "$SERVICE" --splits "${VERSION}=1" --quiet
+  done
+  echo "Staging traffic migrated to version ${VERSION}."
+else
+  echo "Staging traffic migration skipped."
+fi

--- a/util/deployment/promote-and-chain-staging
+++ b/util/deployment/promote-and-chain-staging
@@ -7,7 +7,7 @@ if [[ "${_DEPLOY_ENV:-staging}" != "staging" ]]; then
   exit 0
 fi
 
-git config --global --add safe.directory '*'
+git config --global --add safe.directory '/workspace/chromium-dashboard'
 COMMIT_SHA="${COMMIT_SHA:-$(git rev-parse HEAD)}"
 
 # Only tag and trigger production build if commit is on main branch
@@ -32,4 +32,5 @@ echo "Triggering production build (trigger-chromestatus-prod)..."
 gcloud builds triggers run trigger-chromestatus-prod \
   --project=interop-tooling-ops \
   --region=us-central1 \
-  --sha="${COMMIT_SHA}" || echo "Warning: Could not trigger trigger-chromestatus-prod."
+  --sha="${COMMIT_SHA}" \
+  --substitutions=_DEPLOY_ENV=prod,_FORCE_DEPLOY=false,_SKIP_ISSUE_CREATION=false || echo "Warning: Could not trigger trigger-chromestatus-prod."


### PR DESCRIPTION
## Summary

PR #6697 introduced the initial CD pipeline with minimal script changes, attempting to keep deployment execution on the host runner while only using the DevContainer for client asset builds. However, executing on the host runner led to missing tools (such as `gh`).

Instead of managing separate host package installations, this PR updates the pipeline to run the deployment scripts directly inside the project's existing DevContainer (which already provides pinned `gcloud`, `gh`, Node 24, and Python 3.13), bringing the pipeline into full alignment with `webstatus.dev`.

## Key Changes

- **DevContainer Deployment Execution (`util/deployment/deploy-ci`)**: Executes `deploy-staging` and `deploy-production` inside the DevContainer via `devcontainer exec`, forwarding ambient GCP credentials and GitHub tokens.
- **Release Issue Hardening (`util/deployment/create-deployment-issue`)**: Removes `--assignee "@me"` for bot compatibility and adds null-safety fallback for closed issue queries.
- **Queue Synchronization (`util/deployment/deploy-env`)**: Adds `queue.yaml` to `gcloud app deploy` so task queues targeting the `notifier` service are synchronized.
- **Deterministic Traffic Routing (`util/deployment/deploy-production`)**: Routes traffic directly to the deterministic build `$VERSION`.
- **Trigger Chaining (`util/deployment/promote-and-chain-staging`)**: Explicitly passes production substitutions when queuing `trigger-chromestatus-prod`.
