### PR TITLE
[AI Engine] Add Error Classification and ProgressReporter Telemetry

### DIFF
--- a/framework/ai_errors.py
+++ b/framework/ai_errors.py
@@ -1,0 +1,115 @@
+# Copyright 2026 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Error classification and diagnostic utilities for AI generation pipelines.
+
+Reference:
+    Google Agent Development Kit (ADK) Documentation:
+    https://google.github.io/adk-docs/
+
+Follows ADK error handling guidelines:
+- Allows standard SDK exceptions to propagate from tools to the application layer.
+- Classifies typed RESOURCE_EXHAUSTED (429) and ServerError (5xx) for retry control.
+- Avoids over-catching or trapping BaseException.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+
+import httpx
+from google.genai import errors
+
+TRANSIENT_HTTP_STATUS_CODES = {429, 503, 504}
+
+
+def is_transient_error(e: Exception) -> bool:
+    """Classifies whether an exception represents a transient/retryable failure.
+
+    Identifies retryable HTTP status codes (429 Rate Limit, 503 Service Unavailable,
+    504 Gateway Timeout), connection timeouts, and socket dropouts using typed
+    exception classes.
+    """
+    # 1. Google GenAI API typed errors
+    if isinstance(e, errors.APIError):
+        return e.code in TRANSIENT_HTTP_STATUS_CODES or (
+            e.code is not None and 500 <= e.code < 600
+        )
+
+    # 2. Network timeouts and connection drops
+    if isinstance(e, (httpx.TimeoutException, TimeoutError)):
+        return True
+    if isinstance(e, (httpx.NetworkError, ConnectionError)):
+        return True
+    if isinstance(e, urllib.error.URLError) and isinstance(
+        e.reason, (TimeoutError, ConnectionError, OSError)
+    ):
+        return True
+
+    # 3. Malformed streaming / parse drops
+    if isinstance(e, json.JSONDecodeError):
+        return True
+
+    return False
+
+
+def get_error_source_and_message(e: Exception) -> tuple[str, str]:
+    """Returns a user-friendly error source title and actionable message for UI presentation.
+
+    Inspects structured exception types and HTTP status codes to generate clean,
+    human-readable failure reasons.
+    """
+    # 1. Google GenAI SDK typed errors
+    if isinstance(e, errors.APIError):
+        if e.code == 429:
+            return (
+                'Rate Limit Exceeded',
+                'Gemini API quota exceeded. Please retry shortly.',
+            )
+        if e.code in (503, 504) or (e.code is not None and 500 <= e.code < 600):
+            return (
+                'Gemini API Unavailable',
+                'Service temporarily unavailable. Please retry.',
+            )
+        return (
+            'API Error',
+            e.message or f'Gemini API returned error code {e.code}.',
+        )
+
+    # 2. Network timeouts
+    if isinstance(e, (httpx.TimeoutException, TimeoutError)):
+        return (
+            'Connection Timeout',
+            'Request to Gemini API timed out. Please retry.',
+        )
+
+    # 3. Network connection failures
+    if isinstance(
+        e, (httpx.NetworkError, ConnectionError, urllib.error.URLError)
+    ):
+        return (
+            'Network Error',
+            'Failed to connect to Gemini API. Please check network connectivity.',
+        )
+
+    # 4. JSON parsing failures
+    if isinstance(e, json.JSONDecodeError):
+        return (
+            'JSON Parsing Error',
+            f'Failed to parse LLM structured output: {e}',
+        )
+
+    # 5. Generic fallback
+    return 'Generation Error', str(e)

--- a/framework/ai_errors_test.py
+++ b/framework/ai_errors_test.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for typed AI error classification and diagnostic helpers."""
+
+from __future__ import annotations
+
+import testing_config  # isort: skip  # Must be imported before other project modules.
+
+import json
+import urllib.error
+
+import httpx
+from google.genai import errors
+
+from framework.ai_errors import get_error_source_and_message, is_transient_error
+
+
+class AIErrorsTest(testing_config.CustomTestCase):
+    """Tests typed transient error detection and user-facing diagnostic mapping."""
+
+    def test_is_transient_error_identified_correctly(self):
+        """Tests that typed GenAI errors, timeouts, and network drops are classified as transient."""
+        # Typed GenAI SDK errors
+        rate_limit_err = errors.ClientError(
+            429, {'error': {'code': 429, 'message': 'Quota exceeded'}}
+        )
+        self.assertTrue(is_transient_error(rate_limit_err))
+
+        server_err_503 = errors.ServerError(
+            503, {'error': {'code': 503, 'message': 'Service unavailable'}}
+        )
+        self.assertTrue(is_transient_error(server_err_503))
+
+        server_err_504 = errors.ServerError(
+            504, {'error': {'code': 504, 'message': 'Gateway timeout'}}
+        )
+        self.assertTrue(is_transient_error(server_err_504))
+
+        # Network timeouts and drops
+        self.assertTrue(is_transient_error(httpx.TimeoutException('Timeout')))
+        self.assertTrue(
+            is_transient_error(httpx.ConnectError('Failed to connect'))
+        )
+        self.assertTrue(is_transient_error(TimeoutError('Request timed out')))
+        self.assertTrue(is_transient_error(ConnectionError('Connection reset')))
+        self.assertTrue(
+            is_transient_error(
+                json.JSONDecodeError('Expecting value', 'doc', 0)
+            )
+        )
+        self.assertTrue(
+            is_transient_error(
+                urllib.error.URLError(TimeoutError('Socket timeout'))
+            )
+        )
+
+    def test_is_transient_error_false_for_permanent_failures(self):
+        """Tests that non-retryable typed exceptions are identified as permanent."""
+        # 400 Bad Request / 404 Not Found from GenAI SDK
+        bad_request_err = errors.ClientError(
+            400, {'error': {'code': 400, 'message': 'Invalid parameter'}}
+        )
+        self.assertFalse(is_transient_error(bad_request_err))
+
+        not_found_err = errors.ClientError(
+            404, {'error': {'code': 404, 'message': 'Model not found'}}
+        )
+        self.assertFalse(is_transient_error(not_found_err))
+
+        self.assertFalse(
+            is_transient_error(ValueError('Invalid model argument'))
+        )
+        self.assertFalse(is_transient_error(KeyError('Missing required field')))
+        self.assertFalse(
+            is_transient_error(TypeError('Unsupported operand type'))
+        )
+
+    def test_get_error_source_and_message_mapping(self):
+        """Tests that typed exceptions map to user-friendly titles and descriptions."""
+        rate_limit_err = errors.ClientError(
+            429,
+            {
+                'error': {
+                    'code': 429,
+                    'message': 'Quota exceeded for Gemini 2.0',
+                }
+            },
+        )
+        source, msg = get_error_source_and_message(rate_limit_err)
+        self.assertEqual(source, 'Rate Limit Exceeded')
+        self.assertIn('quota exceeded', msg)
+
+        server_err = errors.ServerError(
+            503, {'error': {'code': 503, 'message': 'Service temporarily down'}}
+        )
+        source, msg = get_error_source_and_message(server_err)
+        self.assertEqual(source, 'Gemini API Unavailable')
+        self.assertIn('temporarily unavailable', msg)
+
+        generic_400_err = errors.ClientError(
+            400, {'error': {'code': 400, 'message': 'Field name too long'}}
+        )
+        source, msg = get_error_source_and_message(generic_400_err)
+        self.assertEqual(source, 'API Error')
+        self.assertEqual(msg, 'Field name too long')
+
+        source, msg = get_error_source_and_message(
+            httpx.TimeoutException('Socket read timed out')
+        )
+        self.assertEqual(source, 'Connection Timeout')
+        self.assertIn('timed out', msg)
+
+        source, msg = get_error_source_and_message(
+            httpx.ConnectError('DNS lookup failed')
+        )
+        self.assertEqual(source, 'Network Error')
+        self.assertIn('check network connectivity', msg)
+
+        source, msg = get_error_source_and_message(
+            json.JSONDecodeError('Unterminated string', '{"a": 1', 6)
+        )
+        self.assertEqual(source, 'JSON Parsing Error')
+        self.assertIn('Failed to parse LLM structured output', msg)
+
+        source, msg = get_error_source_and_message(
+            ValueError('Custom validation failure')
+        )
+        self.assertEqual(source, 'Generation Error')
+        self.assertEqual(msg, 'Custom validation failure')

--- a/framework/progress_reporter.py
+++ b/framework/progress_reporter.py
@@ -1,0 +1,150 @@
+# Copyright 2026 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Telemetry interfaces and progress reporters for AI generation pipelines."""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from google.cloud import ndb
+
+from internals.core_enums import (
+    AISummaryToolName,
+    ProgressStepId,
+    ProgressStepStatus,
+)
+from internals.core_models import FeatureSummaryProgressStep
+
+
+@dataclass(frozen=True)
+class SummaryResult:
+    """Structured result returned by the pure summary generator engine."""
+
+    suggested_summary: str
+    generation_rationale: str
+    suggested_doc_links: list[str] = field(default_factory=list)
+    error_message: str | None = None
+    raw_response: str | None = None
+
+
+@dataclass(frozen=True)
+class ProgressStepRecord:
+    """In-memory telemetry record for progress tracking and evaluations."""
+
+    step_id: str
+    status: str
+    tool_name: str | None = None
+    message: str = ''
+    start_timestamp: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    end_timestamp: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+
+class ProgressReporter(abc.ABC):
+    """Abstract telemetry reporter for observing agent execution steps."""
+
+    @abc.abstractmethod
+    def log_step(
+        self,
+        step_id: ProgressStepId | str,
+        status: ProgressStepStatus | str,
+        tool_name: AISummaryToolName | str | None = None,
+        message: str = '',
+        start_time: datetime | None = None,
+    ) -> None:
+        """Logs a single generator progress step."""
+        pass
+
+
+class ListProgressReporter(ProgressReporter):
+    """In-memory reporter collecting progress steps for unit tests and eval scripts."""
+
+    def __init__(self) -> None:
+        """Initializes empty in-memory step list."""
+        self.steps: list[ProgressStepRecord] = []
+
+    def log_step(
+        self,
+        step_id: ProgressStepId | str,
+        status: ProgressStepStatus | str,
+        tool_name: AISummaryToolName | str | None = None,
+        message: str = '',
+        start_time: datetime | None = None,
+    ) -> None:
+        """Records a progress step in memory."""
+        step_id_val = (
+            step_id.value if hasattr(step_id, 'value') else str(step_id)
+        )
+        status_val = status.value if hasattr(status, 'value') else str(status)
+        tool_val = (
+            tool_name.value
+            if (tool_name and hasattr(tool_name, 'value'))
+            else (str(tool_name) if tool_name else None)
+        )
+        now = datetime.now(timezone.utc)
+        self.steps.append(
+            ProgressStepRecord(
+                step_id=step_id_val,
+                status=status_val,
+                tool_name=tool_val,
+                message=message,
+                start_timestamp=start_time or now,
+                end_timestamp=now,
+            )
+        )
+
+
+class DatastoreProgressReporter(ProgressReporter):
+    """Persists progress steps under FeatureSummarySuggestion ancestor key in Datastore."""
+
+    def __init__(self, feature_id: int) -> None:
+        """Initializes reporter with target feature ID."""
+        self.feature_id = feature_id
+
+    def log_step(
+        self,
+        step_id: ProgressStepId | str,
+        status: ProgressStepStatus | str,
+        tool_name: AISummaryToolName | str | None = None,
+        message: str = '',
+        start_time: datetime | None = None,
+    ) -> None:
+        """Persists a progress step under the FeatureSummarySuggestion ancestor key."""
+        parent_key = ndb.Key('FeatureSummarySuggestion', self.feature_id)
+        step_id_val = (
+            step_id.value if hasattr(step_id, 'value') else str(step_id)
+        )
+        status_val = status.value if hasattr(status, 'value') else str(status)
+        tool_val = (
+            tool_name.value
+            if (tool_name and hasattr(tool_name, 'value'))
+            else (str(tool_name) if tool_name else None)
+        )
+        now = datetime.now(timezone.utc)
+        step = FeatureSummaryProgressStep(
+            parent=parent_key,
+            step_id=step_id_val,
+            status=status_val,
+            tool_name=tool_val,
+            message=message,
+            start_timestamp=start_time or now,
+            end_timestamp=now,
+        )
+        step.put()

--- a/framework/progress_reporter_test.py
+++ b/framework/progress_reporter_test.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for AI progress reporter implementations."""
+
+from __future__ import annotations
+
+import testing_config  # isort: skip  # Must be imported before other project modules.
+
+from google.cloud import ndb
+
+from framework.progress_reporter import (
+    DatastoreProgressReporter,
+    ListProgressReporter,
+    SummaryResult,
+)
+from internals.core_enums import (
+    AISummaryToolName,
+    ProgressStepId,
+    ProgressStepStatus,
+)
+from internals.core_models import (
+    FeatureSummaryProgressStep,
+    FeatureSummarySuggestion,
+)
+
+
+class ProgressReporterTest(testing_config.CustomTestCase):
+    """Tests in-memory ListProgressReporter and Cloud Datastore reporter persistence."""
+
+    def setUp(self):
+        """Initializes test feature and Datastore entities."""
+        self.feature_id = 10001
+        self.parent_key = ndb.Key('FeatureSummarySuggestion', self.feature_id)
+        self.suggestion = FeatureSummarySuggestion(
+            id=self.feature_id,
+            suggested_summary='Initial summary.',
+            source_fingerprint='abc123hash',
+        )
+        self.suggestion.put()
+
+    def tearDown(self):
+        """Cleans up Datastore entities after each test."""
+        steps = FeatureSummaryProgressStep.query(
+            ancestor=self.parent_key
+        ).fetch(keys_only=True)
+        ndb.delete_multi(steps)
+        self.suggestion.key.delete()
+
+    def test_summary_result_dataclass_properties(self):
+        """Tests that SummaryResult frozen dataclass stores structured fields."""
+        res = SummaryResult(
+            suggested_summary='Draft summary',
+            generation_rationale='Draft rationale',
+            suggested_doc_links=['https://developer.chrome.com/test'],
+        )
+        self.assertEqual(res.suggested_summary, 'Draft summary')
+        self.assertEqual(res.generation_rationale, 'Draft rationale')
+        self.assertEqual(
+            res.suggested_doc_links, ['https://developer.chrome.com/test']
+        )
+        self.assertIsNone(res.error_message)
+
+    def test_list_progress_reporter_records_steps(self):
+        """Tests that ListProgressReporter accumulates records in memory."""
+        reporter = ListProgressReporter()
+        reporter.log_step(
+            step_id=ProgressStepId.START,
+            status=ProgressStepStatus.SUCCESS,
+            message='Started generation',
+        )
+        reporter.log_step(
+            step_id=ProgressStepId.SEARCH_MDN,
+            status=ProgressStepStatus.IN_PROGRESS,
+            tool_name=AISummaryToolName.SEARCH_MDN,
+            message='Searching MDN',
+        )
+
+        self.assertEqual(len(reporter.steps), 2)
+        self.assertEqual(reporter.steps[0].step_id, ProgressStepId.START.value)
+        self.assertEqual(
+            reporter.steps[0].status, ProgressStepStatus.SUCCESS.value
+        )
+        self.assertEqual(
+            reporter.steps[1].step_id, ProgressStepId.SEARCH_MDN.value
+        )
+        self.assertEqual(
+            reporter.steps[1].tool_name, AISummaryToolName.SEARCH_MDN.value
+        )
+
+    def test_datastore_progress_reporter_persists_ancestor_entities(self):
+        """Tests that DatastoreProgressReporter writes FeatureSummaryProgressStep entities."""
+        reporter = DatastoreProgressReporter(feature_id=self.feature_id)
+        reporter.log_step(
+            step_id=ProgressStepId.START,
+            status=ProgressStepStatus.SUCCESS,
+            message='Pipeline started',
+        )
+        reporter.log_step(
+            step_id=ProgressStepId.VERIFY_DOC_LINK,
+            status=ProgressStepStatus.SUCCESS,
+            tool_name=AISummaryToolName.VERIFY_DOC_LINK,
+            message='Verified documentation link',
+        )
+
+        persisted_steps = (
+            FeatureSummaryProgressStep.query(ancestor=self.parent_key)
+            .order(FeatureSummaryProgressStep.start_timestamp)
+            .fetch()
+        )
+
+        self.assertEqual(len(persisted_steps), 2)
+        self.assertEqual(persisted_steps[0].step_id, ProgressStepId.START.value)
+        self.assertEqual(
+            persisted_steps[0].status, ProgressStepStatus.SUCCESS.value
+        )
+        self.assertEqual(persisted_steps[0].message, 'Pipeline started')
+        self.assertEqual(
+            persisted_steps[1].step_id, ProgressStepId.VERIFY_DOC_LINK.value
+        )
+        self.assertEqual(
+            persisted_steps[1].tool_name,
+            AISummaryToolName.VERIFY_DOC_LINK.value,
+        )


### PR DESCRIPTION
## Context
Autonomous developer release note generation requires clear error classification for background Cloud Task workers and frontend UI alerts, as well as a decoupled telemetry abstraction (`ProgressReporter`) that separates LLM generation from database mutations.

## Changes
- **Error Classification & Diagnostics (`framework/ai_errors.py`)**:
  - `is_transient_error()`: Identifies retryable exceptions (429 rate limits, 503 unavailable, timeouts, connection drops) to guide Cloud Task worker retry decisions.
  - `get_error_source_and_message()`: Maps exception payloads to user-friendly titles and actionable descriptions for frontend review components.
- **Telemetry & Data Contracts (`framework/progress_reporter.py`)**:
  - `SummaryResult`: Immutable data contract for generated summary text, rationale, and verified documentation links.
  - `ProgressStepRecord`: Telemetry record for progress tracking and offline evaluations.
  - `ProgressReporter`: Abstract telemetry interface for observing agent execution steps.
  - `ListProgressReporter`: In-memory step accumulator for unit tests, offline evaluations, and benchmark runners.
  - `DatastoreProgressReporter`: Persists `FeatureSummaryProgressStep` entities under `FeatureSummarySuggestion` ancestor keys in Cloud NDB.
- **Unit Tests**:
  - `framework/ai_errors_test.py`: Comprehensive tests for transient vs permanent error classification and error diagnostic mapping.
  - `framework/progress_reporter_test.py`: Unit tests for `SummaryResult`, `ListProgressReporter`, and `DatastoreProgressReporter`.

## Verification
- Unit Tests: 6/6 passed in 0.43s (`pytest -q framework/ai_errors_test.py framework/progress_reporter_test.py`).
- Linters: `ruff check`, `ruff format`, `make pylint` 100% clean.

TAG=agy
CONV=7dad7a60-89a0-4ab9-9f42-3300a3de7807
