### PR TITLE
[Infra] Upgrade ghapi==2.1.2 to support fastspec 0.2.1 and fasttransport

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ MarkupSafe==3.0.3
 Werkzeug==3.1.8
 click==8.4.2
 itsdangerous==2.2.0
-ghapi==2.0.5
+ghapi==2.1.2
 validators==0.35.0
 # Work-around for failure to deploy
 # https://stackoverflow.com/questions/69936420/google-cloud-platform-app-deploy-failure-due-to-pyparsing


### PR DESCRIPTION
## Problem
On PyPI, fast.ai released `fastspec 0.2.1` which split `fastspec.transport` into `fasttransport`. Because `requirements.txt` pinned `ghapi==2.0.5` without pinning `fastspec`, fresh CI runners resolving unpinned dependencies installed `fastspec 0.2.1`, crashing with `ModuleNotFoundError: No module named 'fastspec.transport'` and bouncing PRs out of the merge queue.

## Solution
Upgrade `ghapi==2.1.2` in `requirements.txt` to adopt `fastspec 0.2.1` and `fasttransport`.

TAG=agy
CONV=7dad7a60-89a0-4ab9-9f42-3300a3de7807