### PR TITLE
[AI Curation] Add Summary Suggestions Client SDK and TaskProgressMonitor

### DIFF
--- a/client-src/js-src/cs-client.ts
+++ b/client-src/js-src/cs-client.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+import {
+  MessageResponse,
+  SummarySuggestionPatchRequest,
+  SummarySuggestionResponse,
+} from 'chromestatus-openapi';
+
 export interface FeatureLink {
   url: string;
   type: string;
@@ -924,5 +930,51 @@ export class ChromeStatusClient {
 
   async getSpecifiedChannels(start: number, end: number): Promise<unknown> {
     return this.doGet(`/channels?start=${start}&end=${end}`);
+  }
+
+  // Summary Suggestions API
+  /** Fetches current AI summary suggestion draft and execution progress timeline. */
+  async getSummarySuggestion(
+    featureId: number
+  ): Promise<SummarySuggestionResponse> {
+    if (!Number.isInteger(featureId) || featureId <= 0) {
+      throw new Error(
+        `Invalid featureId (${featureId}): must be a positive integer.`
+      );
+    }
+    return this.doGet(
+      `/summary-suggestions/${featureId}`
+    ) as Promise<SummarySuggestionResponse>;
+  }
+
+  /** Enqueues an asynchronous Cloud Task to generate AI summary and progress steps. */
+  async triggerSummaryGeneration(
+    featureId: number,
+    force = false
+  ): Promise<MessageResponse> {
+    if (!Number.isInteger(featureId) || featureId <= 0) {
+      throw new Error(
+        `Invalid featureId (${featureId}): must be a positive integer.`
+      );
+    }
+    return this.doPost(`/summary-suggestions/${featureId}`, {
+      force,
+    }) as Promise<MessageResponse>;
+  }
+
+  /** Applies review decision (APPLIED/REJECTED) or updates edited summary with OCC version token. */
+  async updateSummarySuggestion(
+    featureId: number,
+    patch: SummarySuggestionPatchRequest
+  ): Promise<SummarySuggestionResponse> {
+    if (!Number.isInteger(featureId) || featureId <= 0) {
+      throw new Error(
+        `Invalid featureId (${featureId}): must be a positive integer.`
+      );
+    }
+    return this.doPatch(
+      `/summary-suggestions/${featureId}`,
+      patch
+    ) as Promise<SummarySuggestionResponse>;
   }
 }

--- a/client-src/js-src/cs-client_test.ts
+++ b/client-src/js-src/cs-client_test.ts
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assert} from '@open-wc/testing';
+import sinon from 'sinon';
+import {ChromeStatusClient} from './cs-client.js';
+import {
+  SummarySuggestionPatchRequest,
+  SummarySuggestionPatchRequestStatusEnum,
+  SummarySuggestionResponse,
+} from 'chromestatus-openapi';
+
+describe('ChromeStatusClient - Summary Suggestions API', () => {
+  let sandbox: sinon.SinonSandbox;
+  let client: ChromeStatusClient;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    client = new ChromeStatusClient('test_token', 9999999999);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('getSummarySuggestion', () => {
+    it('calls doGet with the expected path', async () => {
+      const mockResponse: SummarySuggestionResponse = {
+        suggestion: {
+          feature_id: 123,
+          status: 'PENDING',
+          suggested_summary: 'Test summary',
+          suggested_doc_links: [],
+          version_token: 1,
+          created: new Date(),
+          updated: new Date(),
+        },
+        progress_steps: [],
+      };
+      const doGetStub = sandbox.stub(client, 'doGet').resolves(mockResponse);
+
+      const result = await client.getSummarySuggestion(123);
+
+      assert.deepEqual(result, mockResponse);
+      assert.isTrue(doGetStub.calledOnceWith('/summary-suggestions/123'));
+    });
+
+    it('rejects on invalid featureId with descriptive error context', async () => {
+      const invalidIds = [0, -1, -100, 1.5, NaN];
+      for (const id of invalidIds) {
+        try {
+          await client.getSummarySuggestion(id);
+          assert.fail(`Should have thrown for featureId: ${id}`);
+        } catch (err) {
+          const error = err as Error;
+          assert.include(error.message, 'Invalid featureId');
+          assert.include(error.message, String(id));
+        }
+      }
+    });
+  });
+
+  describe('triggerSummaryGeneration', () => {
+    it('calls doPost with expected path and payload', async () => {
+      const mockResponse = {message: 'Task enqueued'};
+      const doPostStub = sandbox.stub(client, 'doPost').resolves(mockResponse);
+
+      const result = await client.triggerSummaryGeneration(456, true);
+
+      assert.deepEqual(result, mockResponse);
+      assert.isTrue(
+        doPostStub.calledOnceWith('/summary-suggestions/456', {force: true})
+      );
+    });
+
+    it('defaults force parameter to false', async () => {
+      const mockResponse = {message: 'Task enqueued'};
+      const doPostStub = sandbox.stub(client, 'doPost').resolves(mockResponse);
+
+      await client.triggerSummaryGeneration(456);
+
+      assert.isTrue(
+        doPostStub.calledOnceWith('/summary-suggestions/456', {force: false})
+      );
+    });
+
+    it('rejects on invalid featureId with descriptive error context', async () => {
+      try {
+        await client.triggerSummaryGeneration(0);
+        assert.fail('Should have thrown for featureId 0');
+      } catch (err) {
+        const error = err as Error;
+        assert.include(error.message, 'Invalid featureId');
+        assert.include(error.message, '0');
+      }
+    });
+  });
+
+  describe('updateSummarySuggestion', () => {
+    it('calls doPatch with expected path and patch request payload', async () => {
+      const patchPayload: SummarySuggestionPatchRequest = {
+        status: SummarySuggestionPatchRequestStatusEnum.APPLIED,
+        suggested_summary: 'Edited summary text',
+        version_token: 42,
+      };
+      const mockResponse: SummarySuggestionResponse = {
+        suggestion: {
+          feature_id: 789,
+          status: 'APPLIED',
+          suggested_summary: 'Edited summary text',
+          suggested_doc_links: [],
+          version_token: 43,
+          created: new Date(),
+          updated: new Date(),
+        },
+        progress_steps: [],
+      };
+      const doPatchStub = sandbox
+        .stub(client, 'doPatch')
+        .resolves(mockResponse);
+
+      const result = await client.updateSummarySuggestion(789, patchPayload);
+
+      assert.deepEqual(result, mockResponse);
+      assert.isTrue(
+        doPatchStub.calledOnceWith('/summary-suggestions/789', patchPayload)
+      );
+    });
+
+    it('rejects on invalid featureId with descriptive error context', async () => {
+      try {
+        await client.updateSummarySuggestion(-5, {
+          status: SummarySuggestionPatchRequestStatusEnum.REJECTED,
+          version_token: 1,
+        });
+        assert.fail('Should have thrown for featureId -5');
+      } catch (err) {
+        const error = err as Error;
+        assert.include(error.message, 'Invalid featureId');
+        assert.include(error.message, '-5');
+      }
+    });
+  });
+});

--- a/client-src/js-src/task-progress-monitor.ts
+++ b/client-src/js-src/task-progress-monitor.ts
@@ -1,0 +1,190 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ChromeStatusHttpError} from './cs-client.js';
+
+export interface TaskProgressMonitorOptions<TData> {
+  fetcher: (signal?: AbortSignal) => Promise<TData>;
+  shouldContinue: (data: TData) => boolean;
+  onProgress?: (data: TData) => void;
+  pollIntervalMs?: number;
+  maxDurationMs?: number;
+  maxInitial404Retries?: number;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+const DEFAULT_MAX_DURATION_MS = 5 * 60 * 1000; // 5 minutes
+const DEFAULT_MAX_INITIAL_404_RETRIES = 5;
+
+/**
+ * Transport-agnostic asynchronous task progress monitor.
+ * Polls status updates until task completion, timeout, abort, or manual stop.
+ *
+ * @example
+ * ```typescript
+ * const monitor = new TaskProgressMonitor<MyTaskResponse>({
+ *   fetcher: (signal) => apiClient.fetchTaskStatus(taskId, {signal}),
+ *   shouldContinue: (resp) => resp.status === 'RUNNING',
+ *   onProgress: (resp) => {
+ *     console.log('Task progress:', resp.percent);
+ *   },
+ * });
+ * const finalResult = await monitor.run(abortController.signal);
+ * ```
+ */
+export class TaskProgressMonitor<TData> {
+  private readonly _fetcher: (signal?: AbortSignal) => Promise<TData>;
+  private readonly _shouldContinue: (data: TData) => boolean;
+  private readonly _onProgress?: (data: TData) => void;
+  private readonly _pollIntervalMs: number;
+  private readonly _maxDurationMs: number;
+  private readonly _maxInitial404Retries: number;
+
+  private _consecutive404Count = 0;
+  private _isRunning = false;
+  private _activeTimer: ReturnType<typeof setTimeout> | null = null;
+  private _activeReject: ((reason?: unknown) => void) | null = null;
+
+  constructor(options: TaskProgressMonitorOptions<TData>) {
+    this._fetcher = options.fetcher;
+    this._shouldContinue = options.shouldContinue;
+    this._onProgress = options.onProgress;
+    this._pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this._maxDurationMs = options.maxDurationMs ?? DEFAULT_MAX_DURATION_MS;
+    this._maxInitial404Retries =
+      options.maxInitial404Retries ?? DEFAULT_MAX_INITIAL_404_RETRIES;
+  }
+
+  get isRunning(): boolean {
+    return this._isRunning;
+  }
+
+  /**
+   * Runs the progress monitor until completion, timeout, abort signal, or stop.
+   */
+  async run(signal?: AbortSignal): Promise<TData> {
+    if (signal?.aborted) {
+      throw new DOMException('Task monitoring was aborted', 'AbortError');
+    }
+
+    this._isRunning = true;
+    this._consecutive404Count = 0;
+    const startTime = Date.now();
+
+    try {
+      while (this._isRunning) {
+        if (signal?.aborted) {
+          throw new DOMException('Task monitoring was aborted', 'AbortError');
+        }
+
+        // Hard timeout ceiling to prevent runaway polling if backend workers stall.
+        if (Date.now() - startTime > this._maxDurationMs) {
+          const timeoutSec = Math.round(this._maxDurationMs / 1000);
+          throw new Error(
+            `Task execution timed out after ${timeoutSec}s. Please retry.`
+          );
+        }
+
+        try {
+          const data = await this._fetcher(signal);
+          this._consecutive404Count = 0;
+
+          if (this._onProgress) {
+            this._onProgress(data);
+          }
+
+          if (!this._shouldContinue(data)) {
+            return data;
+          }
+        } catch (err) {
+          const is404 =
+            err instanceof ChromeStatusHttpError && err.status === 404;
+
+          if (is404) {
+            // Tolerates up to 5 consecutive 404s (10s window) to accommodate Cloud Task
+            // dispatch latency before the worker creates the initial Datastore entity.
+            this._consecutive404Count++;
+            if (this._consecutive404Count >= this._maxInitial404Retries) {
+              throw new Error('Task did not start or expired. Please retry.');
+            }
+          } else {
+            // Non-404 errors (e.g. 403, 500) fail fast immediately.
+            throw err instanceof Error ? err : new Error(String(err));
+          }
+        }
+
+        await this._delay(this._pollIntervalMs, signal);
+      }
+
+      throw new DOMException('Task monitoring stopped', 'AbortError');
+    } finally {
+      this._isRunning = false;
+      if (this._activeTimer !== null) {
+        globalThis.clearTimeout(this._activeTimer);
+        this._activeTimer = null;
+      }
+      this._activeReject = null;
+    }
+  }
+
+  stop(): void {
+    this._isRunning = false;
+    if (this._activeTimer !== null) {
+      globalThis.clearTimeout(this._activeTimer);
+      this._activeTimer = null;
+    }
+    if (this._activeReject) {
+      this._activeReject(
+        new DOMException('Task monitoring stopped', 'AbortError')
+      );
+      this._activeReject = null;
+    }
+  }
+
+  private _delay(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this._isRunning || signal?.aborted) {
+        return reject(
+          new DOMException('Task monitoring was aborted', 'AbortError')
+        );
+      }
+
+      this._activeReject = reject;
+      const timer = globalThis.setTimeout(() => {
+        this._activeTimer = null;
+        this._activeReject = null;
+        if (signal) {
+          signal.removeEventListener('abort', onAbort);
+        }
+        resolve();
+      }, ms);
+      this._activeTimer = timer;
+
+      const onAbort = () => {
+        if (this._activeTimer !== null) {
+          globalThis.clearTimeout(this._activeTimer);
+          this._activeTimer = null;
+        }
+        this._activeReject = null;
+        reject(new DOMException('Task monitoring was aborted', 'AbortError'));
+      };
+
+      if (signal) {
+        signal.addEventListener('abort', onAbort, {once: true});
+      }
+    });
+  }
+}

--- a/client-src/js-src/task-progress-monitor_test.ts
+++ b/client-src/js-src/task-progress-monitor_test.ts
@@ -1,0 +1,211 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assert} from '@open-wc/testing';
+import sinon from 'sinon';
+import {TaskProgressMonitor} from './task-progress-monitor.js';
+import {ChromeStatusHttpError} from './cs-client.js';
+
+interface TestProgressData {
+  status: string;
+  step?: number;
+}
+
+describe('TaskProgressMonitor', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('resolves when shouldContinue returns false', async () => {
+    const fetcherStub = sandbox
+      .stub()
+      .onFirstCall()
+      .resolves({status: 'IN_PROGRESS', step: 1})
+      .onSecondCall()
+      .resolves({status: 'COMPLETED', step: 2});
+
+    const progressUpdates: TestProgressData[] = [];
+
+    const monitor = new TaskProgressMonitor<TestProgressData>({
+      fetcher: fetcherStub,
+      shouldContinue: data => data.status === 'IN_PROGRESS',
+      onProgress: data => progressUpdates.push(data),
+      pollIntervalMs: 10,
+    });
+
+    const result = await monitor.run();
+    assert.deepEqual(result, {status: 'COMPLETED', step: 2});
+    assert.equal(progressUpdates.length, 2);
+    assert.equal(progressUpdates[0].step, 1);
+    assert.equal(progressUpdates[1].step, 2);
+    assert.isTrue(fetcherStub.calledTwice);
+  });
+
+  it('tolerates initial 404s and continues polling once available', async () => {
+    const fetcherStub = sandbox
+      .stub()
+      .onFirstCall()
+      .rejects(new ChromeStatusHttpError('Not Found', '/test', 'GET', 404))
+      .onSecondCall()
+      .resolves({status: 'COMPLETED'});
+
+    const monitor = new TaskProgressMonitor<TestProgressData>({
+      fetcher: fetcherStub,
+      shouldContinue: data => data.status === 'IN_PROGRESS',
+      pollIntervalMs: 10,
+      maxInitial404Retries: 3,
+    });
+
+    const result = await monitor.run();
+    assert.deepEqual(result, {status: 'COMPLETED'});
+    assert.isTrue(fetcherStub.calledTwice);
+  });
+
+  it('throws error when max initial 404 retries are exhausted', async () => {
+    const fetcherStub = sandbox
+      .stub()
+      .rejects(new ChromeStatusHttpError('Not Found', '/test', 'GET', 404));
+
+    const monitor = new TaskProgressMonitor<TestProgressData>({
+      fetcher: fetcherStub,
+      shouldContinue: () => true,
+      pollIntervalMs: 10,
+      maxInitial404Retries: 3,
+    });
+
+    try {
+      await monitor.run();
+      assert.fail('Should have thrown error');
+    } catch (err) {
+      const error = err as Error;
+      assert.include(error.message, 'did not start or expired');
+      assert.equal(fetcherStub.callCount, 3);
+    }
+  });
+
+  it('stops monitoring immediately when stop() is called during poll interval', async () => {
+    const fetcherStub = sandbox
+      .stub()
+      .resolves({status: 'IN_PROGRESS', step: 1});
+
+    const monitor = new TaskProgressMonitor<TestProgressData>({
+      fetcher: fetcherStub,
+      shouldContinue: () => true,
+      pollIntervalMs: 5000,
+    });
+
+    const runPromise = monitor.run();
+    assert.isTrue(monitor.isRunning);
+
+    // Wait for the first fetch to complete and enter the delay
+    await new Promise(r => setTimeout(r, 20));
+    assert.equal(fetcherStub.callCount, 1);
+
+    // Call stop() while delay is active
+    monitor.stop();
+    assert.isFalse(monitor.isRunning);
+
+    try {
+      await runPromise;
+      assert.fail('Should have rejected with AbortError on stop()');
+    } catch (err) {
+      const error = err as DOMException;
+      assert.equal(error.name, 'AbortError');
+      assert.include(error.message, 'Task monitoring stopped');
+    }
+
+    // Advance real time slightly to ensure no second fetch occurred
+    await new Promise(r => setTimeout(r, 50));
+    assert.equal(fetcherStub.callCount, 1);
+  });
+
+  it('aborts immediately when AbortSignal is triggered', async () => {
+    const abortController = new AbortController();
+    const fetcherStub = sandbox.stub().resolves({status: 'IN_PROGRESS'});
+
+    const monitor = new TaskProgressMonitor<TestProgressData>({
+      fetcher: fetcherStub,
+      shouldContinue: () => true,
+      pollIntervalMs: 50,
+    });
+
+    const runPromise = monitor.run(abortController.signal);
+    abortController.abort();
+
+    try {
+      await runPromise;
+      assert.fail('Should have thrown AbortError');
+    } catch (err) {
+      const error = err as DOMException;
+      assert.equal(error.name, 'AbortError');
+    }
+  });
+
+  it('throws error when maxDurationMs is exceeded', async () => {
+    const clock = sandbox.useFakeTimers();
+    try {
+      const fetcherStub = sandbox.stub().resolves({status: 'IN_PROGRESS'});
+
+      const monitor = new TaskProgressMonitor<TestProgressData>({
+        fetcher: fetcherStub,
+        shouldContinue: () => true,
+        pollIntervalMs: 1000,
+        maxDurationMs: 5000,
+      });
+
+      let errorThrown: Error | null = null;
+      const runPromise = monitor.run().catch((err: Error) => {
+        errorThrown = err;
+      });
+
+      // Advance clock past max duration
+      await clock.tickAsync(6000);
+      await runPromise;
+
+      assert.isNotNull(errorThrown);
+      assert.include((errorThrown as unknown as Error).message, 'timed out');
+    } finally {
+      clock.restore();
+    }
+  });
+
+  it('propagates non-404 errors immediately', async () => {
+    const fetcherStub = sandbox
+      .stub()
+      .rejects(new Error('Internal Server Error 500'));
+
+    const monitor = new TaskProgressMonitor<TestProgressData>({
+      fetcher: fetcherStub,
+      shouldContinue: () => true,
+      pollIntervalMs: 10,
+    });
+
+    try {
+      await monitor.run();
+      assert.fail('Should have thrown 500 error');
+    } catch (err) {
+      const error = err as Error;
+      assert.equal(error.message, 'Internal Server Error 500');
+      assert.isTrue(fetcherStub.calledOnce);
+    }
+  });
+});


### PR DESCRIPTION
Adds frontend client SDK methods for AI summary suggestions and a transport-agnostic `TaskProgressMonitor` utility.

### Key Changes
- **`ChromeStatusClient`**: Adds `getSummarySuggestion(featureId)` and `triggerSummaryGeneration(featureId, force)`.
- **`TaskProgressMonitor`**: Provides robust polling with initial 404 retries (for Cloud Tasks latency), hard timeout ceilings, `globalThis` environment-agnostic timers, and native `AbortSignal`/`stop()` support.

TAG=agy
CONV=7dad7a60-89a0-4ab9-9f42-3300a3de7807
