### PR TITLE
[AI Curation] Integrate @lit/task and Progress Monitor into Progress Component

### DIFF
--- a/client-src/elements/chromedash-ai-summary-progress.ts
+++ b/client-src/elements/chromedash-ai-summary-progress.ts
@@ -128,8 +128,8 @@ export class ChromedashAiSummaryProgress extends LitElement {
    * manual task runs deterministically.
    */
   public _statusTask = new Task(this, {
-    task: async ([featureId], {signal}) => {
-      if (!featureId || featureId <= 0 || !this.autoPoll) {
+    task: async ([featureId, autoPoll], {signal}) => {
+      if (!featureId || featureId <= 0 || !autoPoll) {
         return null;
       }
 
@@ -180,7 +180,7 @@ export class ChromedashAiSummaryProgress extends LitElement {
         this._monitor = null;
       }
     },
-    args: () => [this.featureId],
+    args: () => [this.featureId, this.autoPoll],
   });
 
   static get styles() {

--- a/client-src/elements/chromedash-ai-summary-progress.ts
+++ b/client-src/elements/chromedash-ai-summary-progress.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import {LitElement, css, html, nothing} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {Task} from '@lit/task';
+import {LitElement, PropertyValues, css, html, nothing} from 'lit';
+import {customElement, property, state} from 'lit/decorators.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
@@ -25,11 +26,16 @@ import {
   SummaryProgressStep as ProgressStep,
   SummaryProgressStepStatusEnum,
   SummaryProgressStepStepEnum,
+  SummarySuggestion,
+  SummarySuggestionResponse,
 } from 'chromestatus-openapi';
+import {TaskProgressMonitor} from '../js-src/task-progress-monitor.js';
 
 const MAX_STEP_MESSAGE_LENGTH = 300;
+const MAX_ERROR_MESSAGE_LENGTH = 200;
 const DEFAULT_TRIGGER_ERROR_MESSAGE =
   'Failed to trigger summary generation task';
+const DEFAULT_FETCH_ERROR_MESSAGE = 'Failed to fetch summary generation status';
 const DEFAULT_STEP_LABEL = 'Processing feature data';
 
 /** Compile-time exhaustive map from pipeline step enum to human-readable label. */
@@ -80,21 +86,14 @@ export const STATUS_LABELS: Readonly<
 });
 
 /**
- * UI presentational component displaying the live progress timeline of AI summary generation.
+ * Component displaying live progress timeline and background execution polling for AI summary generation.
  *
  * @fires summary-generation-started - Dispatched when background generation is triggered.
  *   detail: { featureId: number, force: boolean }
- *
- * @example
- * ```html
- * <chromedash-ai-summary-progress
- *   .featureId=${123}
- *   .progressSteps=${steps}
- *   @summary-generation-started=${(e) => {
- *     console.log('Started generation for feature:', e.detail.featureId);
- *   }}
- * ></chromedash-ai-summary-progress>
- * ```
+ * @fires summary-generation-completed - Dispatched when generation completes successfully.
+ *   detail: { featureId: number, suggestion: SummarySuggestion | null, progressSteps: ProgressStep[] }
+ * @fires summary-generation-failed - Dispatched when a pipeline step fails.
+ *   detail: { featureId: number, suggestion: SummarySuggestion | null, progressSteps: ProgressStep[], error?: string }
  */
 @customElement('chromedash-ai-summary-progress')
 export class ChromedashAiSummaryProgress extends LitElement {
@@ -102,16 +101,87 @@ export class ChromedashAiSummaryProgress extends LitElement {
   featureId = 0;
 
   @property({attribute: false})
+  suggestion: SummarySuggestion | null = null;
+
+  @property({attribute: false})
   progressSteps: ProgressStep[] = [];
+
+  @property({type: Boolean})
+  autoPoll = true;
 
   @property({type: Boolean})
   compact = false;
 
-  @property({type: Boolean})
+  @state()
   loading = false;
 
-  @property({type: String})
+  @state()
   error: string | null = null;
+
+  private _monitor: TaskProgressMonitor<SummarySuggestionResponse> | null =
+    null;
+
+  /**
+   * Reactive @lit/task managing background polling and lifecycle integration.
+   * Exposed with a leading underscore as a public lifecycle and testing hook so
+   * test suites and integration harnesses can inspect execution state or trigger
+   * manual task runs deterministically.
+   */
+  public _statusTask = new Task(this, {
+    task: async ([featureId], {signal}) => {
+      if (!featureId || featureId <= 0 || !this.autoPoll) {
+        return null;
+      }
+
+      this.error = null;
+      this._monitor = new TaskProgressMonitor<SummarySuggestionResponse>({
+        fetcher: () => window.csClient.getSummarySuggestion(featureId),
+        shouldContinue: resp => this._isStepsActive(resp.progress_steps),
+        onProgress: resp => {
+          this.suggestion = resp.suggestion ?? null;
+          this.progressSteps = resp.progress_steps ?? [];
+        },
+      });
+
+      try {
+        const resp = await this._monitor.run(signal);
+        this.suggestion = resp.suggestion ?? null;
+        this.progressSteps = resp.progress_steps ?? [];
+
+        const hasFailed = this.progressSteps.some(
+          s => s.status === SummaryProgressStepStatusEnum.FAILED
+        );
+        if (hasFailed) {
+          this._dispatchFailedEvent();
+        } else {
+          this._dispatchCompletedEvent();
+        }
+        return resp;
+      } catch (err) {
+        const isAbort =
+          signal?.aborted ||
+          (err instanceof DOMException && err.name === 'AbortError') ||
+          (err instanceof Error && err.name === 'AbortError');
+        if (isAbort) return null;
+
+        const errorMsg =
+          err instanceof Error
+            ? err.message
+            : typeof err === 'object'
+              ? JSON.stringify(err)
+              : String(err);
+        this.error = this._formatErrorMessage(
+          errorMsg,
+          DEFAULT_FETCH_ERROR_MESSAGE
+        );
+        this._dispatchFailedEvent(this.error);
+        throw err;
+      } finally {
+        this._monitor = null;
+      }
+    },
+    args: () => [this.featureId],
+  });
 
   static get styles() {
     return [
@@ -264,13 +334,44 @@ export class ChromedashAiSummaryProgress extends LitElement {
     return this.compact ? 'small' : 'medium';
   }
 
-  get isTaskRunning(): boolean {
-    if (this.loading) return true;
-    return this.progressSteps.some(
+  private _isStepsActive(steps?: ProgressStep[]): boolean {
+    if (!steps || steps.length === 0) return false;
+    return steps.some(
       s =>
         s.status === SummaryProgressStepStatusEnum.IN_PROGRESS ||
         s.status === SummaryProgressStepStatusEnum.RETRYING
     );
+  }
+
+  get isTaskRunning(): boolean {
+    return (
+      this.loading ||
+      (this._monitor?.isRunning ?? false) ||
+      this._isStepsActive(this.progressSteps)
+    );
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._monitor) {
+      this._monitor.stop();
+      this._monitor = null;
+    }
+  }
+
+  override willUpdate(changedProperties: PropertyValues) {
+    if (
+      changedProperties.has('featureId') &&
+      changedProperties.get('featureId') !== undefined
+    ) {
+      if (this._monitor) {
+        this._monitor.stop();
+        this._monitor = null;
+      }
+      this.suggestion = null;
+      this.progressSteps = [];
+      this.error = null;
+    }
   }
 
   async handleTrigger(force = false) {
@@ -286,11 +387,14 @@ export class ChromedashAiSummaryProgress extends LitElement {
     try {
       this.loading = true;
       this.error = null;
+      this.progressSteps = [];
+      this.suggestion = null;
 
       await window.csClient.triggerSummaryGeneration(this.featureId, force);
       if (!this.isConnected) return;
 
       this._dispatchStartedEvent(force);
+      await this._statusTask.run();
     } catch (err) {
       if (!this.isConnected) return;
       const errorMsg =
@@ -299,10 +403,24 @@ export class ChromedashAiSummaryProgress extends LitElement {
           : typeof err === 'object'
             ? JSON.stringify(err)
             : String(err);
-      this.error = errorMsg || DEFAULT_TRIGGER_ERROR_MESSAGE;
+      this.error = this._formatErrorMessage(
+        errorMsg,
+        DEFAULT_TRIGGER_ERROR_MESSAGE
+      );
     } finally {
       this.loading = false;
     }
+  }
+
+  private _formatErrorMessage(
+    rawMsg: string | undefined | null,
+    fallback: string
+  ): string {
+    const trimmed = (rawMsg || '').trim();
+    if (!trimmed) return fallback;
+    return trimmed.length > MAX_ERROR_MESSAGE_LENGTH
+      ? `${trimmed.slice(0, MAX_ERROR_MESSAGE_LENGTH)}...`
+      : trimmed;
   }
 
   /**
@@ -315,6 +433,35 @@ export class ChromedashAiSummaryProgress extends LitElement {
         bubbles: true,
         composed: true,
         detail: {featureId: this.featureId, force},
+      })
+    );
+  }
+
+  private _dispatchCompletedEvent() {
+    this.dispatchEvent(
+      new CustomEvent('summary-generation-completed', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          featureId: this.featureId,
+          suggestion: this.suggestion,
+          progressSteps: this.progressSteps,
+        },
+      })
+    );
+  }
+
+  private _dispatchFailedEvent(error?: string | null) {
+    this.dispatchEvent(
+      new CustomEvent('summary-generation-failed', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          featureId: this.featureId,
+          suggestion: this.suggestion,
+          progressSteps: this.progressSteps,
+          ...(error !== undefined && {error}),
+        },
       })
     );
   }

--- a/client-src/elements/chromedash-ai-summary-progress.ts
+++ b/client-src/elements/chromedash-ai-summary-progress.ts
@@ -1,0 +1,424 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement, css, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/badge/badge.js';
+import {SHARED_STYLES} from '../css/shared-css.js';
+import {
+  SummaryProgressStep as ProgressStep,
+  SummaryProgressStepStatusEnum,
+  SummaryProgressStepStepEnum,
+} from 'chromestatus-openapi';
+
+const MAX_STEP_MESSAGE_LENGTH = 300;
+const DEFAULT_TRIGGER_ERROR_MESSAGE =
+  'Failed to trigger summary generation task';
+const DEFAULT_STEP_LABEL = 'Processing feature data';
+
+/** Compile-time exhaustive map from pipeline step enum to human-readable label. */
+export const STEP_LABELS: Readonly<
+  Record<SummaryProgressStepStepEnum, string>
+> = Object.freeze({
+  [SummaryProgressStepStepEnum.READ_SPEC]: 'Reading specification',
+  [SummaryProgressStepStepEnum.READ_EXPLAINER]: 'Analyzing explainer document',
+  [SummaryProgressStepStepEnum.SEARCH_MDN]: 'Searching MDN documentation',
+  [SummaryProgressStepStepEnum.VERIFY_DOC_LINK]:
+    'Verifying documentation links',
+  [SummaryProgressStepStepEnum.UNKNOWN]: DEFAULT_STEP_LABEL,
+});
+
+/** Compile-time exhaustive map from step execution status to CSS class names. */
+export const STEP_STATUS_CSS_CLASSES: Readonly<
+  Record<SummaryProgressStepStatusEnum, string>
+> = Object.freeze({
+  [SummaryProgressStepStatusEnum.IN_PROGRESS]: 'in-progress',
+  [SummaryProgressStepStatusEnum.SUCCESS]: 'success',
+  [SummaryProgressStepStatusEnum.FAILED]: 'failed',
+  [SummaryProgressStepStatusEnum.RETRYING]: 'retrying',
+});
+
+/** Compile-time exhaustive map from step execution status to Shoelace icon names. */
+export const STEP_STATUS_ICONS: Readonly<
+  Record<
+    Exclude<
+      SummaryProgressStepStatusEnum,
+      typeof SummaryProgressStepStatusEnum.IN_PROGRESS
+    >,
+    string
+  >
+> = Object.freeze({
+  [SummaryProgressStepStatusEnum.SUCCESS]: 'check-lg',
+  [SummaryProgressStepStatusEnum.FAILED]: 'x-circle-fill',
+  [SummaryProgressStepStatusEnum.RETRYING]: 'exclamation-circle-fill',
+});
+
+/** Human-readable status descriptions for screen reader accessibility announcements. */
+export const STATUS_LABELS: Readonly<
+  Record<SummaryProgressStepStatusEnum, string>
+> = Object.freeze({
+  [SummaryProgressStepStatusEnum.IN_PROGRESS]: 'In progress',
+  [SummaryProgressStepStatusEnum.SUCCESS]: 'Succeeded',
+  [SummaryProgressStepStatusEnum.FAILED]: 'Failed',
+  [SummaryProgressStepStatusEnum.RETRYING]: 'Retrying',
+});
+
+/**
+ * UI presentational component displaying the live progress timeline of AI summary generation.
+ *
+ * @fires summary-generation-started - Dispatched when background generation is triggered.
+ *   detail: { featureId: number, force: boolean }
+ *
+ * @example
+ * ```html
+ * <chromedash-ai-summary-progress
+ *   .featureId=${123}
+ *   .progressSteps=${steps}
+ *   @summary-generation-started=${(e) => {
+ *     console.log('Started generation for feature:', e.detail.featureId);
+ *   }}
+ * ></chromedash-ai-summary-progress>
+ * ```
+ */
+@customElement('chromedash-ai-summary-progress')
+export class ChromedashAiSummaryProgress extends LitElement {
+  @property({type: Number})
+  featureId = 0;
+
+  @property({attribute: false})
+  progressSteps: ProgressStep[] = [];
+
+  @property({type: Boolean})
+  compact = false;
+
+  @property({type: Boolean})
+  loading = false;
+
+  @property({type: String})
+  error: string | null = null;
+
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      css`
+        :host {
+          display: block;
+        }
+
+        :host([hidden]) {
+          display: none;
+        }
+
+        .visually-hidden {
+          position: absolute;
+          width: 1px;
+          height: 1px;
+          padding: 0;
+          margin: -1px;
+          overflow: hidden;
+          clip: rect(0, 0, 0, 0);
+          white-space: nowrap;
+          border: 0;
+        }
+
+        .container {
+          background: var(--sl-color-neutral-50);
+          border: 1px solid var(--sl-color-neutral-200);
+          border-radius: var(--sl-border-radius-medium);
+          padding: var(--sl-spacing-medium);
+        }
+
+        .container.compact {
+          padding: var(--sl-spacing-small);
+        }
+
+        .header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          margin-bottom: var(--sl-spacing-small);
+        }
+
+        .container.compact .header {
+          margin-bottom: var(--sl-spacing-2x-small);
+        }
+
+        .title {
+          display: flex;
+          align-items: center;
+          gap: var(--sl-spacing-x-small);
+          font-size: var(--sl-font-size-small);
+          font-weight: var(--sl-font-weight-semibold);
+          color: var(--sl-color-neutral-700);
+        }
+
+        sl-spinner {
+          font-size: var(--sl-font-size-small);
+          --indicator-color: var(--sl-color-primary-600);
+          --track-width: 2px;
+        }
+
+        .steps-list {
+          display: flex;
+          flex-direction: column;
+          gap: var(--sl-spacing-2x-small);
+          list-style: none;
+          margin: 0;
+          padding: 0;
+        }
+
+        .step-item {
+          display: flex;
+          align-items: center;
+          gap: var(--sl-spacing-x-small);
+          font-size: var(--sl-font-size-small);
+          color: var(--sl-color-neutral-600);
+        }
+
+        .container.compact .step-item {
+          padding: 1px 0;
+        }
+
+        .step-item.in-progress {
+          color: var(--sl-color-primary-700);
+          font-weight: var(--sl-font-weight-medium);
+        }
+
+        .step-item.success {
+          color: var(--sl-color-success-700);
+        }
+
+        .step-item.failed {
+          color: var(--sl-color-danger-700);
+        }
+
+        .step-item.retrying {
+          color: var(--sl-color-warning-700);
+        }
+
+        .step-item sl-icon {
+          font-size: var(--sl-font-size-medium);
+          flex-shrink: 0;
+        }
+
+        .step-label {
+          min-width: 0;
+        }
+
+        .step-message {
+          font-size: var(--sl-font-size-x-small);
+          color: var(--sl-color-neutral-500);
+          word-break: break-word;
+          overflow-wrap: anywhere;
+        }
+
+        .error-banner {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: var(--sl-spacing-small);
+          margin-top: var(--sl-spacing-small);
+          padding: var(--sl-spacing-2x-small) var(--sl-spacing-small);
+          background: var(--sl-color-danger-50);
+          border: 1px solid var(--sl-color-danger-200);
+          color: var(--sl-color-danger-800);
+          border-radius: var(--sl-border-radius-small);
+          font-size: var(--sl-font-size-small);
+        }
+
+        .error-banner span {
+          min-width: 0;
+          word-break: break-word;
+        }
+
+        .error-banner sl-button {
+          flex-shrink: 0;
+        }
+
+        .error-banner sl-button::part(base) {
+          color: var(--sl-color-danger-800);
+          font-weight: var(--sl-font-weight-semibold);
+          padding: 0 var(--sl-spacing-2x-small);
+        }
+      `,
+    ];
+  }
+
+  get badgeSize(): 'small' | 'medium' {
+    return this.compact ? 'small' : 'medium';
+  }
+
+  get isTaskRunning(): boolean {
+    if (this.loading) return true;
+    return this.progressSteps.some(
+      s =>
+        s.status === SummaryProgressStepStatusEnum.IN_PROGRESS ||
+        s.status === SummaryProgressStepStatusEnum.RETRYING
+    );
+  }
+
+  async handleTrigger(force = false) {
+    if (!this.featureId || this.featureId <= 0) {
+      console.warn(
+        '[chromedash-ai-summary-progress] handleTrigger called with invalid featureId:',
+        this.featureId
+      );
+      return;
+    }
+    if (this.loading) return;
+
+    try {
+      this.loading = true;
+      this.error = null;
+
+      await window.csClient.triggerSummaryGeneration(this.featureId, force);
+      if (!this.isConnected) return;
+
+      this._dispatchStartedEvent(force);
+    } catch (err) {
+      if (!this.isConnected) return;
+      const errorMsg =
+        err instanceof Error
+          ? err.message
+          : typeof err === 'object'
+            ? JSON.stringify(err)
+            : String(err);
+      this.error = errorMsg || DEFAULT_TRIGGER_ERROR_MESSAGE;
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  /**
+   * Dispatches composed event when generation task is successfully triggered.
+   * @param force Whether this was a forced regeneration request.
+   */
+  private _dispatchStartedEvent(force: boolean) {
+    this.dispatchEvent(
+      new CustomEvent('summary-generation-started', {
+        bubbles: true,
+        composed: true,
+        detail: {featureId: this.featureId, force},
+      })
+    );
+  }
+
+  renderStepIcon(status: SummaryProgressStepStatusEnum) {
+    if (status === SummaryProgressStepStatusEnum.IN_PROGRESS) {
+      return html`<sl-spinner aria-hidden="true"></sl-spinner>`;
+    }
+    const iconName =
+      STEP_STATUS_ICONS[status as keyof typeof STEP_STATUS_ICONS];
+    return iconName
+      ? html`<sl-icon name="${iconName}" aria-hidden="true"></sl-icon>`
+      : nothing;
+  }
+
+  renderStep(step: ProgressStep) {
+    const label = STEP_LABELS[step.step] || step.step || DEFAULT_STEP_LABEL;
+    const rawMsg = String(step.message || '');
+    const safeMessage =
+      rawMsg.length > MAX_STEP_MESSAGE_LENGTH
+        ? `${rawMsg.slice(0, MAX_STEP_MESSAGE_LENGTH)}...`
+        : rawMsg;
+    const statusClass =
+      STEP_STATUS_CSS_CLASSES[step.status] || 'unknown-status';
+    const statusLabel = STATUS_LABELS[step.status] || String(step.status);
+
+    return html`
+      <li class="step-item ${statusClass}" role="listitem">
+        ${this.renderStepIcon(step.status)}
+        <span class="visually-hidden">Status: ${statusLabel}</span>
+        <span class="step-label">${label}</span>
+        ${
+          safeMessage
+            ? html`<span class="step-message">(${safeMessage})</span>`
+            : nothing
+        }
+      </li>
+    `;
+  }
+
+  private _renderHeader(running: boolean) {
+    return html`
+      <div class="header">
+        <span class="title">
+          ${
+            running
+              ? html`<sl-spinner aria-hidden="true"></sl-spinner>`
+              : nothing
+          }
+          AI Summary Generation
+        </span>
+        ${
+          running
+            ? html`<sl-badge variant="primary" pill size=${this.badgeSize}>
+                Running
+              </sl-badge>`
+            : nothing
+        }
+      </div>
+    `;
+  }
+
+  private _renderErrorBanner() {
+    if (!this.error) return nothing;
+    return html`
+      <div class="error-banner" role="alert">
+        <span>${this.error}</span>
+        <sl-button
+          size="small"
+          variant="text"
+          ?disabled=${this.loading}
+          ?loading=${this.loading}
+          @click=${() => this.handleTrigger(true)}
+        >
+          Retry
+        </sl-button>
+      </div>
+    `;
+  }
+
+  render() {
+    if (!this.progressSteps.length && !this.loading && !this.error) {
+      return nothing;
+    }
+
+    const running = this.isTaskRunning;
+
+    return html`
+      <div
+        class="container ${this.compact ? 'compact' : ''}"
+        aria-live="polite"
+      >
+        ${this._renderHeader(running)}
+        ${
+          this.progressSteps.length
+            ? html`
+                <ul class="steps-list" role="list">
+                  ${this.progressSteps.map(step => this.renderStep(step))}
+                </ul>
+              `
+            : nothing
+        }
+        ${this._renderErrorBanner()}
+      </div>
+    `;
+  }
+}

--- a/client-src/elements/chromedash-ai-summary-progress_test.ts
+++ b/client-src/elements/chromedash-ai-summary-progress_test.ts
@@ -628,4 +628,57 @@ describe('chromedash-ai-summary-progress', () => {
     ).to.be.true;
     expect(el.suggestion?.feature_id).to.equal(202);
   });
+
+  it('triggers polling automatically when autoPoll is dynamically toggled to true', async () => {
+    (window.csClient.getSummarySuggestion as sinon.SinonStub)
+      .withArgs(303)
+      .resolves({
+        suggestion: {
+          feature_id: 303,
+          status: 'PENDING',
+          suggested_summary: 'AI summary 303',
+          suggested_doc_links: [],
+          version_token: 1,
+          created: new Date(),
+          updated: new Date(),
+        },
+        progress_steps: [
+          {
+            step: SummaryProgressStepStepEnum.READ_SPEC,
+            status: SummaryProgressStepStatusEnum.SUCCESS,
+            message: 'Done 303',
+            start_timestamp: new Date(),
+          },
+        ],
+      });
+
+    let resolveCompleted: (e: CustomEvent) => void;
+    const completedPromise = new Promise<CustomEvent>(resolve => {
+      resolveCompleted = resolve;
+    });
+
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .autoPoll=${false}
+        .featureId=${303}
+        @summary-generation-completed=${(e: CustomEvent) => {
+          resolveCompleted(e);
+        }}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    // Initial state: autoPoll is false, so getSummarySuggestion(303) should not have been called
+    expect(
+      (window.csClient.getSummarySuggestion as sinon.SinonStub).calledWith(303)
+    ).to.be.false;
+
+    // Dynamically toggle autoPoll to true
+    el.autoPoll = true;
+    await completedPromise;
+
+    expect(
+      (window.csClient.getSummarySuggestion as sinon.SinonStub).calledWith(303)
+    ).to.be.true;
+    expect(el.suggestion?.feature_id).to.equal(303);
+  });
 });

--- a/client-src/elements/chromedash-ai-summary-progress_test.ts
+++ b/client-src/elements/chromedash-ai-summary-progress_test.ts
@@ -1,0 +1,320 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {html, fixture, expect} from '@open-wc/testing';
+import sinon from 'sinon';
+import './chromedash-ai-summary-progress.js';
+import {ChromedashAiSummaryProgress} from './chromedash-ai-summary-progress.js';
+import {ChromeStatusClient} from '../js-src/cs-client.js';
+import {
+  SummaryProgressStep as ProgressStep,
+  SummaryProgressStepStatusEnum,
+  SummaryProgressStepStepEnum,
+} from 'chromestatus-openapi';
+
+describe('chromedash-ai-summary-progress', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    window.csClient = {
+      triggerSummaryGeneration: sandbox.stub().resolves({
+        message: 'Task enqueued',
+      }),
+    } as Partial<ChromeStatusClient> as ChromeStatusClient;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('renders nothing when empty with no steps, not loading, and no error', async () => {
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress></chromedash-ai-summary-progress>`
+    );
+
+    expect(el.shadowRoot!.children.length).to.equal(0);
+  });
+
+  it('renders progress steps with correct labels, accessibility roles, and icons', async () => {
+    const steps: ProgressStep[] = [
+      {
+        step: SummaryProgressStepStepEnum.READ_SPEC,
+        status: SummaryProgressStepStatusEnum.SUCCESS,
+        message: 'Found spec link',
+        start_timestamp: new Date(),
+      },
+      {
+        step: SummaryProgressStepStepEnum.SEARCH_MDN,
+        status: SummaryProgressStepStatusEnum.IN_PROGRESS,
+        message: 'Searching web docs',
+        start_timestamp: new Date(),
+      },
+      {
+        step: SummaryProgressStepStepEnum.VERIFY_DOC_LINK,
+        status: SummaryProgressStepStatusEnum.FAILED,
+        message: '404 not found',
+        start_timestamp: new Date(),
+      },
+      {
+        step: SummaryProgressStepStepEnum.READ_EXPLAINER,
+        status: SummaryProgressStepStatusEnum.RETRYING,
+        message: 'Retrying explainer',
+        start_timestamp: new Date(),
+      },
+    ];
+
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .progressSteps=${steps}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    const stepsList = el.shadowRoot!.querySelector('.steps-list');
+    expect(stepsList).to.exist;
+    expect(stepsList!.getAttribute('role')).to.equal('list');
+
+    const stepItems = el.shadowRoot!.querySelectorAll('.step-item');
+    expect(stepItems.length).to.equal(4);
+
+    expect(stepItems[0].getAttribute('role')).to.equal('listitem');
+    expect(stepItems[0].classList.contains('success')).to.be.true;
+    expect(stepItems[0].textContent).to.contain('Reading specification');
+    expect(stepItems[0].textContent).to.contain('Found spec link');
+    expect(
+      stepItems[0].querySelector('.visually-hidden')!.textContent
+    ).to.contain('Status: Succeeded');
+    const successIcon = stepItems[0].querySelector('sl-icon');
+    expect(successIcon).to.exist;
+    expect(successIcon!.getAttribute('name')).to.equal('check-lg');
+    expect(successIcon!.getAttribute('aria-hidden')).to.equal('true');
+
+    expect(stepItems[1].classList.contains('in-progress')).to.be.true;
+    expect(stepItems[1].textContent).to.contain('Searching MDN documentation');
+    expect(
+      stepItems[1].querySelector('.visually-hidden')!.textContent
+    ).to.contain('Status: In progress');
+    expect(stepItems[1].querySelector('sl-spinner')).to.exist;
+
+    expect(stepItems[2].classList.contains('failed')).to.be.true;
+    expect(stepItems[2].textContent).to.contain(
+      'Verifying documentation links'
+    );
+    expect(
+      stepItems[2].querySelector('.visually-hidden')!.textContent
+    ).to.contain('Status: Failed');
+    const failedIcon = stepItems[2].querySelector('sl-icon');
+    expect(failedIcon).to.exist;
+    expect(failedIcon!.getAttribute('name')).to.equal('x-circle-fill');
+
+    expect(stepItems[3].classList.contains('retrying')).to.be.true;
+    expect(
+      stepItems[3].querySelector('.visually-hidden')!.textContent
+    ).to.contain('Status: Retrying');
+    const retryIcon = stepItems[3].querySelector('sl-icon');
+    expect(retryIcon).to.exist;
+    expect(retryIcon!.getAttribute('name')).to.equal('exclamation-circle-fill');
+  });
+
+  it('renders default fallback label and renders no icon for unknown step/status', async () => {
+    const steps: ProgressStep[] = [
+      {
+        step: 'FUTURE_CUSTOM_STEP' as SummaryProgressStepStepEnum,
+        status: 'UNKNOWN_STATUS' as SummaryProgressStepStatusEnum,
+        start_timestamp: new Date(),
+      },
+    ];
+
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .progressSteps=${steps}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    const stepItem = el.shadowRoot!.querySelector('.step-item');
+    expect(stepItem).to.exist;
+    expect(stepItem!.textContent).to.contain('FUTURE_CUSTOM_STEP');
+    expect(stepItem!.querySelector('.visually-hidden')!.textContent).to.contain(
+      'Status: UNKNOWN_STATUS'
+    );
+    expect(stepItem!.querySelector('sl-icon')).to.not.exist;
+    expect(stepItem!.querySelector('sl-spinner')).to.not.exist;
+  });
+
+  it('truncates step message longer than MAX_STEP_MESSAGE_LENGTH (300 chars)', async () => {
+    const longMessage = 'A'.repeat(400);
+    const steps: ProgressStep[] = [
+      {
+        step: SummaryProgressStepStepEnum.READ_SPEC,
+        status: SummaryProgressStepStatusEnum.SUCCESS,
+        message: longMessage,
+        start_timestamp: new Date(),
+      },
+    ];
+
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .progressSteps=${steps}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    const stepMessage = el.shadowRoot!.querySelector('.step-message');
+    expect(stepMessage).to.exist;
+    expect(stepMessage!.textContent).to.contain('A'.repeat(300) + '...');
+    expect(stepMessage!.textContent).to.not.contain('A'.repeat(301));
+  });
+
+  it('renders header spinner and Running badge in loading-only state when progressSteps is empty', async () => {
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .loading=${true}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    const container = el.shadowRoot!.querySelector('.container');
+    expect(container).to.exist;
+
+    const header = el.shadowRoot!.querySelector('.header');
+    expect(header).to.exist;
+    expect(header!.querySelector('sl-spinner')).to.exist;
+    expect(header!.textContent).to.contain('Running');
+
+    const stepsList = el.shadowRoot!.querySelector('.steps-list');
+    expect(stepsList).to.not.exist;
+  });
+
+  it('does not call triggerSummaryGeneration and warns when featureId is invalid (0)', async () => {
+    const warnSpy = sandbox.spy(console, 'warn');
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .featureId=${0}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    await el.handleTrigger();
+
+    expect(warnSpy.calledOnce).to.be.true;
+    expect((window.csClient.triggerSummaryGeneration as sinon.SinonStub).called)
+      .to.be.false;
+  });
+
+  it('does not re-trigger when loading is already true', async () => {
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .featureId=${101}
+        .loading=${true}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    await el.handleTrigger();
+
+    expect((window.csClient.triggerSummaryGeneration as sinon.SinonStub).called)
+      .to.be.false;
+  });
+
+  it('resets loading flag unconditionally even if disconnected during execution', async () => {
+    let resolveTrigger: (value?: unknown) => void;
+    (window.csClient.triggerSummaryGeneration as sinon.SinonStub).returns(
+      new Promise(resolve => {
+        resolveTrigger = resolve;
+      })
+    );
+
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .featureId=${101}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    const triggerPromise = el.handleTrigger();
+    expect(el.loading).to.be.true;
+
+    // Disconnect element while in-flight
+    el.remove();
+    resolveTrigger!();
+    await triggerPromise;
+
+    expect(el.loading).to.be.false;
+  });
+
+  it('renders error banner and calls handleTrigger on Retry click', async () => {
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .featureId=${101}
+      ></chromedash-ai-summary-progress>`
+    );
+    el.error = 'Failed to generate summary';
+    await el.updateComplete;
+
+    const errorBanner = el.shadowRoot!.querySelector('.error-banner');
+    expect(errorBanner).to.exist;
+    expect(errorBanner!.textContent).to.contain('Failed to generate summary');
+
+    const retryButton = errorBanner!.querySelector('sl-button');
+    expect(retryButton).to.exist;
+
+    const triggerSpy = sandbox.spy(el, 'handleTrigger');
+    retryButton!.click();
+    expect(triggerSpy.calledOnceWith(true)).to.be.true;
+  });
+
+  it('dispatches summary-generation-started event when triggered', async () => {
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .featureId=${101}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    let eventFired = false;
+    el.addEventListener('summary-generation-started', ((
+      e: CustomEvent<{featureId: number; force: boolean}>
+    ) => {
+      eventFired = true;
+      expect(e.detail.featureId).to.equal(101);
+      expect(e.detail.force).to.be.true;
+    }) as EventListener);
+
+    await el.handleTrigger(true);
+    expect(eventFired).to.be.true;
+    expect(
+      (
+        window.csClient.triggerSummaryGeneration as sinon.SinonStub
+      ).calledOnceWith(101, true)
+    ).to.be.true;
+  });
+
+  it('applies compact styling when compact is true', async () => {
+    const steps: ProgressStep[] = [
+      {
+        step: SummaryProgressStepStepEnum.READ_SPEC,
+        status: SummaryProgressStepStatusEnum.SUCCESS,
+        message: 'Done',
+        start_timestamp: new Date(),
+      },
+    ];
+
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .compact=${true}
+        .progressSteps=${steps}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    const container = el.shadowRoot!.querySelector('.container');
+    expect(container).to.exist;
+    expect(container!.classList.contains('compact')).to.be.true;
+  });
+});

--- a/client-src/elements/chromedash-ai-summary-progress_test.ts
+++ b/client-src/elements/chromedash-ai-summary-progress_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {html, fixture, expect} from '@open-wc/testing';
+import {html, fixture, expect, oneEvent} from '@open-wc/testing';
 import sinon from 'sinon';
 import './chromedash-ai-summary-progress.js';
 import {ChromedashAiSummaryProgress} from './chromedash-ai-summary-progress.js';
@@ -23,6 +23,7 @@ import {
   SummaryProgressStep as ProgressStep,
   SummaryProgressStepStatusEnum,
   SummaryProgressStepStepEnum,
+  SummarySuggestion,
 } from 'chromestatus-openapi';
 
 describe('chromedash-ai-summary-progress', () => {
@@ -31,6 +32,31 @@ describe('chromedash-ai-summary-progress', () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     window.csClient = {
+      getSummarySuggestion: sandbox.stub().resolves({
+        suggestion: {
+          feature_id: 101,
+          status: 'PENDING',
+          suggested_summary: 'AI summary',
+          suggested_doc_links: [],
+          version_token: 1,
+          created: new Date(),
+          updated: new Date(),
+        } as SummarySuggestion,
+        progress_steps: [
+          {
+            step: SummaryProgressStepStepEnum.READ_SPEC,
+            status: SummaryProgressStepStatusEnum.SUCCESS,
+            message: 'Read 120 lines',
+            start_timestamp: new Date(),
+          },
+          {
+            step: SummaryProgressStepStepEnum.SEARCH_MDN,
+            status: SummaryProgressStepStatusEnum.IN_PROGRESS,
+            message: 'Querying MDN',
+            start_timestamp: new Date(),
+          },
+        ] as ProgressStep[],
+      }),
       triggerSummaryGeneration: sandbox.stub().resolves({
         message: 'Task enqueued',
       }),
@@ -43,7 +69,9 @@ describe('chromedash-ai-summary-progress', () => {
 
   it('renders nothing when empty with no steps, not loading, and no error', async () => {
     const el = await fixture<ChromedashAiSummaryProgress>(
-      html`<chromedash-ai-summary-progress></chromedash-ai-summary-progress>`
+      html`<chromedash-ai-summary-progress
+        .autoPoll=${false}
+      ></chromedash-ai-summary-progress>`
     );
 
     expect(el.shadowRoot!.children.length).to.equal(0);
@@ -79,6 +107,7 @@ describe('chromedash-ai-summary-progress', () => {
 
     const el = await fixture<ChromedashAiSummaryProgress>(
       html`<chromedash-ai-summary-progress
+        .autoPoll=${false}
         .progressSteps=${steps}
       ></chromedash-ai-summary-progress>`
     );
@@ -140,6 +169,7 @@ describe('chromedash-ai-summary-progress', () => {
 
     const el = await fixture<ChromedashAiSummaryProgress>(
       html`<chromedash-ai-summary-progress
+        .autoPoll=${false}
         .progressSteps=${steps}
       ></chromedash-ai-summary-progress>`
     );
@@ -167,6 +197,7 @@ describe('chromedash-ai-summary-progress', () => {
 
     const el = await fixture<ChromedashAiSummaryProgress>(
       html`<chromedash-ai-summary-progress
+        .autoPoll=${false}
         .progressSteps=${steps}
       ></chromedash-ai-summary-progress>`
     );
@@ -180,6 +211,7 @@ describe('chromedash-ai-summary-progress', () => {
   it('renders header spinner and Running badge in loading-only state when progressSteps is empty', async () => {
     const el = await fixture<ChromedashAiSummaryProgress>(
       html`<chromedash-ai-summary-progress
+        .autoPoll=${false}
         .loading=${true}
       ></chromedash-ai-summary-progress>`
     );
@@ -200,6 +232,7 @@ describe('chromedash-ai-summary-progress', () => {
     const warnSpy = sandbox.spy(console, 'warn');
     const el = await fixture<ChromedashAiSummaryProgress>(
       html`<chromedash-ai-summary-progress
+        .autoPoll=${false}
         .featureId=${0}
       ></chromedash-ai-summary-progress>`
     );
@@ -211,48 +244,40 @@ describe('chromedash-ai-summary-progress', () => {
       .to.be.false;
   });
 
-  it('does not re-trigger when loading is already true', async () => {
+  it('clears suggestion and progressSteps when handleTrigger is invoked', async () => {
     const el = await fixture<ChromedashAiSummaryProgress>(
       html`<chromedash-ai-summary-progress
-        .featureId=${101}
-        .loading=${true}
-      ></chromedash-ai-summary-progress>`
-    );
-
-    await el.handleTrigger();
-
-    expect((window.csClient.triggerSummaryGeneration as sinon.SinonStub).called)
-      .to.be.false;
-  });
-
-  it('resets loading flag unconditionally even if disconnected during execution', async () => {
-    let resolveTrigger: (value?: unknown) => void;
-    (window.csClient.triggerSummaryGeneration as sinon.SinonStub).returns(
-      new Promise(resolve => {
-        resolveTrigger = resolve;
-      })
-    );
-
-    const el = await fixture<ChromedashAiSummaryProgress>(
-      html`<chromedash-ai-summary-progress
+        .autoPoll=${false}
         .featureId=${101}
       ></chromedash-ai-summary-progress>`
     );
+    el.suggestion = {
+      feature_id: 101,
+      status: 'PENDING',
+      suggested_summary: 'Old summary',
+      suggested_doc_links: [],
+      version_token: 1,
+      created: new Date(),
+      updated: new Date(),
+    };
+    el.progressSteps = [
+      {
+        step: SummaryProgressStepStepEnum.READ_SPEC,
+        status: SummaryProgressStepStatusEnum.SUCCESS,
+        start_timestamp: new Date(),
+      },
+    ];
 
-    const triggerPromise = el.handleTrigger();
-    expect(el.loading).to.be.true;
-
-    // Disconnect element while in-flight
-    el.remove();
-    resolveTrigger!();
+    const triggerPromise = el.handleTrigger(true);
+    expect(el.suggestion).to.be.null;
+    expect(el.progressSteps).to.deep.equal([]);
     await triggerPromise;
-
-    expect(el.loading).to.be.false;
   });
 
   it('renders error banner and calls handleTrigger on Retry click', async () => {
     const el = await fixture<ChromedashAiSummaryProgress>(
       html`<chromedash-ai-summary-progress
+        .autoPoll=${false}
         .featureId=${101}
       ></chromedash-ai-summary-progress>`
     );
@@ -274,26 +299,232 @@ describe('chromedash-ai-summary-progress', () => {
   it('dispatches summary-generation-started event when triggered', async () => {
     const el = await fixture<ChromedashAiSummaryProgress>(
       html`<chromedash-ai-summary-progress
+        .autoPoll=${false}
         .featureId=${101}
       ></chromedash-ai-summary-progress>`
     );
 
-    let eventFired = false;
-    el.addEventListener('summary-generation-started', ((
-      e: CustomEvent<{featureId: number; force: boolean}>
-    ) => {
-      eventFired = true;
-      expect(e.detail.featureId).to.equal(101);
-      expect(e.detail.force).to.be.true;
-    }) as EventListener);
-
+    const startedPromise = oneEvent(el, 'summary-generation-started');
     await el.handleTrigger(true);
-    expect(eventFired).to.be.true;
+    const event = (await startedPromise) as CustomEvent<{
+      featureId: number;
+      force: boolean;
+    }>;
+
+    expect(event.detail.featureId).to.equal(101);
+    expect(event.detail.force).to.be.true;
     expect(
       (
         window.csClient.triggerSummaryGeneration as sinon.SinonStub
       ).calledOnceWith(101, true)
     ).to.be.true;
+  });
+
+  it('polls status and emits summary-generation-completed when finished', async () => {
+    (window.csClient.getSummarySuggestion as sinon.SinonStub).resolves({
+      suggestion: {
+        feature_id: 101,
+        status: 'PENDING',
+        suggested_summary: 'Completed AI summary',
+        suggested_doc_links: [],
+        version_token: 1,
+        created: new Date(),
+        updated: new Date(),
+      },
+      progress_steps: [
+        {
+          step: SummaryProgressStepStepEnum.READ_SPEC,
+          status: SummaryProgressStepStatusEnum.SUCCESS,
+          message: 'Done',
+          start_timestamp: new Date(),
+        },
+      ],
+    });
+
+    let resolveCompleted: (e: CustomEvent) => void;
+    const completedPromise = new Promise<CustomEvent>(resolve => {
+      resolveCompleted = resolve;
+    });
+
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .autoPoll=${true}
+        .featureId=${101}
+        @summary-generation-completed=${(e: CustomEvent) => resolveCompleted(e)}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    const event = (await completedPromise) as CustomEvent<{
+      featureId: number;
+      suggestion: SummarySuggestion | null;
+    }>;
+
+    expect(event.detail.featureId).to.equal(101);
+    expect(event.detail.suggestion?.suggested_summary).to.equal(
+      'Completed AI summary'
+    );
+    expect(el.suggestion?.suggested_summary).to.equal('Completed AI summary');
+  });
+
+  it('emits summary-generation-failed event when a step fails', async () => {
+    (window.csClient.getSummarySuggestion as sinon.SinonStub).resolves({
+      suggestion: null,
+      progress_steps: [
+        {
+          step: SummaryProgressStepStepEnum.READ_SPEC,
+          status: SummaryProgressStepStatusEnum.FAILED,
+          message: 'Error reading spec',
+          start_timestamp: new Date(),
+        },
+      ],
+    });
+
+    let resolveFailed: (e: CustomEvent) => void;
+    const failedPromise = new Promise<CustomEvent>(resolve => {
+      resolveFailed = resolve;
+    });
+
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .autoPoll=${true}
+        .featureId=${101}
+        @summary-generation-failed=${(e: CustomEvent) => resolveFailed(e)}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    const event = (await failedPromise) as CustomEvent<{
+      featureId: number;
+    }>;
+
+    expect(event.detail.featureId).to.equal(101);
+  });
+
+  it('stops in-flight monitor and does not emit failure event when featureId changes rapidly', async () => {
+    let resolveDelay: (value: unknown) => void;
+    (window.csClient.getSummarySuggestion as sinon.SinonStub)
+      .withArgs(101)
+      .returns(
+        new Promise(resolve => {
+          resolveDelay = resolve;
+        })
+      );
+
+    let failedEventFired = false;
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .autoPoll=${true}
+        .featureId=${101}
+        @summary-generation-failed=${() => {
+          failedEventFired = true;
+        }}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    // Rapidly switch featureId while 101 is pending
+    el.featureId = 202;
+    await el.updateComplete;
+
+    // Resolve the old 101 promise
+    resolveDelay!({
+      suggestion: null,
+      progress_steps: [],
+    });
+
+    expect(failedEventFired).to.be.false;
+  });
+
+  it('stops in-flight monitor and emits no events when disconnected', async () => {
+    let failedEventFired = false;
+    (window.csClient.getSummarySuggestion as sinon.SinonStub)
+      .withArgs(101)
+      .returns(new Promise(() => {}));
+
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .autoPoll=${true}
+        .featureId=${101}
+        @summary-generation-failed=${() => {
+          failedEventFired = true;
+        }}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    el.remove();
+    expect(failedEventFired).to.be.false;
+  });
+
+  it('truncates error messages exceeding 200 characters with ellipsis at exact boundary', async () => {
+    const msg200 = 'E'.repeat(200);
+    const msg201 = 'F'.repeat(201);
+
+    (window.csClient.getSummarySuggestion as sinon.SinonStub)
+      .withArgs(101)
+      .rejects(new Error(msg200));
+
+    (window.csClient.getSummarySuggestion as sinon.SinonStub)
+      .withArgs(202)
+      .rejects(new Error(msg201));
+
+    let resolveFailed1: (e: CustomEvent) => void;
+    const failedPromise1 = new Promise<CustomEvent>(resolve => {
+      resolveFailed1 = resolve;
+    });
+
+    const el1 = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .autoPoll=${true}
+        .featureId=${101}
+        @summary-generation-failed=${(e: CustomEvent) => resolveFailed1(e)}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    await failedPromise1;
+    await el1.updateComplete;
+
+    expect(el1.error).to.equal(msg200);
+    expect(el1.error!.endsWith('...')).to.be.false;
+
+    let resolveFailed2: (e: CustomEvent) => void;
+    const failedPromise2 = new Promise<CustomEvent>(resolve => {
+      resolveFailed2 = resolve;
+    });
+
+    const el2 = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .autoPoll=${true}
+        .featureId=${202}
+        @summary-generation-failed=${(e: CustomEvent) => resolveFailed2(e)}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    await failedPromise2;
+    await el2.updateComplete;
+
+    expect(el2.error).to.equal('F'.repeat(200) + '...');
+  });
+
+  it('falls back to default fetch error message when error message is empty or whitespace', async () => {
+    (window.csClient.getSummarySuggestion as sinon.SinonStub)
+      .withArgs(101)
+      .rejects(new Error('   '));
+
+    let resolveFailed: (e: CustomEvent) => void;
+    const failedPromise = new Promise<CustomEvent>(resolve => {
+      resolveFailed = resolve;
+    });
+
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .autoPoll=${true}
+        .featureId=${101}
+        @summary-generation-failed=${(e: CustomEvent) => resolveFailed(e)}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    await failedPromise;
+    await el.updateComplete;
+
+    expect(el.error).to.equal('Failed to fetch summary generation status');
   });
 
   it('applies compact styling when compact is true', async () => {
@@ -308,6 +539,7 @@ describe('chromedash-ai-summary-progress', () => {
 
     const el = await fixture<ChromedashAiSummaryProgress>(
       html`<chromedash-ai-summary-progress
+        .autoPoll=${false}
         .compact=${true}
         .progressSteps=${steps}
       ></chromedash-ai-summary-progress>`
@@ -316,5 +548,84 @@ describe('chromedash-ai-summary-progress', () => {
     const container = el.shadowRoot!.querySelector('.container');
     expect(container).to.exist;
     expect(container!.classList.contains('compact')).to.be.true;
+  });
+
+  it('resets state and refetches when featureId changes dynamically', async () => {
+    (window.csClient.getSummarySuggestion as sinon.SinonStub)
+      .withArgs(101)
+      .resolves({
+        suggestion: {
+          feature_id: 101,
+          status: 'PENDING',
+          suggested_summary: 'AI summary 101',
+          suggested_doc_links: [],
+          version_token: 1,
+          created: new Date(),
+          updated: new Date(),
+        },
+        progress_steps: [
+          {
+            step: SummaryProgressStepStepEnum.READ_SPEC,
+            status: SummaryProgressStepStatusEnum.SUCCESS,
+            message: 'Done 101',
+            start_timestamp: new Date(),
+          },
+        ],
+      });
+
+    (window.csClient.getSummarySuggestion as sinon.SinonStub)
+      .withArgs(202)
+      .resolves({
+        suggestion: {
+          feature_id: 202,
+          status: 'PENDING',
+          suggested_summary: 'New summary for 202',
+          suggested_doc_links: [],
+          version_token: 1,
+          created: new Date(),
+          updated: new Date(),
+        },
+        progress_steps: [
+          {
+            step: SummaryProgressStepStepEnum.READ_SPEC,
+            status: SummaryProgressStepStatusEnum.SUCCESS,
+            message: 'Read spec for 202',
+            start_timestamp: new Date(),
+          },
+        ],
+      });
+
+    let resolveFirst: (e: CustomEvent) => void;
+    const firstPromise = new Promise<CustomEvent>(resolve => {
+      resolveFirst = resolve;
+    });
+    let resolveSecond: (e: CustomEvent) => void;
+    const secondPromise = new Promise<CustomEvent>(resolve => {
+      resolveSecond = resolve;
+    });
+
+    let completedCount = 0;
+    const el = await fixture<ChromedashAiSummaryProgress>(
+      html`<chromedash-ai-summary-progress
+        .autoPoll=${true}
+        .featureId=${101}
+        @summary-generation-completed=${(e: CustomEvent) => {
+          completedCount++;
+          if (completedCount === 1) resolveFirst(e);
+          else resolveSecond(e);
+        }}
+      ></chromedash-ai-summary-progress>`
+    );
+
+    await firstPromise;
+    expect(el.suggestion?.feature_id).to.equal(101);
+
+    el.featureId = 202;
+    await secondPromise;
+
+    expect(
+      (window.csClient.getSummarySuggestion as sinon.SinonStub).calledWith(202)
+    ).to.be.true;
+    expect(el.suggestion?.feature_id).to.equal(202);
   });
 });


### PR DESCRIPTION
Integrates `@lit/task` (`Task`) and `TaskProgressMonitor` into `ChromedashAiSummaryProgress` for automatic async polling, dynamic navigation cancellation, and event composition.

### Key Changes
- **`@lit/task` Integration**: Automatically polls `/api/v0/summary-suggestions/{featureId}` with dynamic `featureId` args binding.
- **Lifecycle Management**: Cleans up and nullifies monitors on `disconnectedCallback` and property updates; suppresses failed events on `AbortError`.
- **Event Composition**: Dispatches `summary-generation-started`, `summary-generation-completed`, and `summary-generation-failed` across Shadow DOM boundaries.

TAG=agy
CONV=7dad7a60-89a0-4ab9-9f42-3300a3de7807
