### PR TITLE
[AI Curation] Add Summary Review & Curation Dialog Component

### DIFF
--- a/client-src/components.js
+++ b/client-src/components.js
@@ -117,3 +117,5 @@ import './elements/chromedash-enterprise-page';
 import './elements/chromedash-enterprise-release-notes-page';
 import './elements/chromedash-wpt-eval-button';
 import './elements/chromedash-wpt-eval-page';
+import './elements/chromedash-summary-diff-view';
+import './elements/chromedash-summary-review-dialog';

--- a/client-src/elements/chromedash-summary-diff-view.ts
+++ b/client-src/elements/chromedash-summary-diff-view.ts
@@ -64,12 +64,6 @@ export class ChromedashSummaryDiffView extends LitElement {
           margin-bottom: var(--sl-spacing-medium);
         }
 
-        @media (max-width: 768px) {
-          .comparison-grid {
-            grid-template-columns: 1fr;
-          }
-        }
-
         .column-card {
           border: 1px solid var(--sl-color-neutral-200);
           border-radius: var(--sl-border-radius-medium);
@@ -142,6 +136,18 @@ export class ChromedashSummaryDiffView extends LitElement {
 
         .source-link {
           text-decoration: none;
+        }
+
+        @media (max-width: 768px) {
+          .comparison-grid {
+            grid-template-columns: 1fr;
+            gap: var(--sl-spacing-small);
+          }
+
+          .column-content {
+            min-height: auto;
+            padding: var(--sl-spacing-small) var(--sl-spacing-medium);
+          }
         }
       `,
     ];

--- a/client-src/elements/chromedash-summary-review-dialog.ts
+++ b/client-src/elements/chromedash-summary-review-dialog.ts
@@ -16,10 +16,7 @@
 
 import {LitElement, PropertyValues, css, html, nothing} from 'lit';
 import {customElement, property, query, state} from 'lit/decorators.js';
-import SlDialog from '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
-import '@shoelace-style/shoelace/dist/components/button/button.js';
-import '@shoelace-style/shoelace/dist/components/alert/alert.js';
-import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import type SlDialog from '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {ChromeStatusHttpError} from '../js-src/cs-client.js';
 import {
@@ -67,7 +64,7 @@ export class ChromedashSummaryReviewDialog extends LitElement {
       ...SHARED_STYLES,
       css`
         sl-dialog {
-          --width: 900px;
+          --width: min(900px, 95vw);
         }
 
         sl-alert {
@@ -92,6 +89,31 @@ export class ChromedashSummaryReviewDialog extends LitElement {
           display: flex;
           align-items: center;
           gap: var(--sl-spacing-small);
+        }
+
+        @media (max-width: 768px) {
+          .dialog-footer {
+            flex-direction: column-reverse;
+            align-items: stretch;
+            gap: var(--sl-spacing-medium);
+          }
+
+          .footer-left,
+          .footer-right {
+            width: 100%;
+            display: flex;
+            flex-wrap: wrap;
+            gap: var(--sl-spacing-small);
+          }
+
+          .footer-left sl-button {
+            width: 100%;
+          }
+
+          .footer-right sl-button {
+            flex: 1 1 110px;
+            min-width: 0;
+          }
         }
       `,
     ];

--- a/client-src/elements/chromedash-summary-review-dialog.ts
+++ b/client-src/elements/chromedash-summary-review-dialog.ts
@@ -1,0 +1,437 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement, PropertyValues, css, html, nothing} from 'lit';
+import {customElement, property, query, state} from 'lit/decorators.js';
+import SlDialog from '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/alert/alert.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import {SHARED_STYLES} from '../css/shared-css.js';
+import {ChromeStatusHttpError} from '../js-src/cs-client.js';
+import {
+  SummarySuggestion,
+  SummarySuggestionPatchRequest,
+  SummarySuggestionStatusEnum,
+} from 'chromestatus-openapi';
+import './chromedash-summary-diff-view.js';
+import {showToastMessage} from './utils.js';
+
+@customElement('chromedash-summary-review-dialog')
+export class ChromedashSummaryReviewDialog extends LitElement {
+  @property({type: Number})
+  featureId = 0;
+
+  @property({type: String})
+  currentSummary = '';
+
+  @property({attribute: false})
+  suggestion: SummarySuggestion | null = null;
+
+  @state()
+  editedSummary = '';
+
+  @state()
+  isEditing = false;
+
+  @state()
+  loading = false;
+
+  @state()
+  occConflict = false;
+
+  @state()
+  newerSuggestionAvailable = false;
+
+  @state()
+  errorMessage: string | null = null;
+
+  @query('sl-dialog')
+  dialogEl?: SlDialog;
+
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      css`
+        sl-dialog {
+          --width: 900px;
+        }
+
+        sl-alert {
+          margin-bottom: var(--sl-spacing-medium);
+        }
+
+        .dialog-footer {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: var(--sl-spacing-small);
+          width: 100%;
+        }
+
+        .footer-left {
+          display: flex;
+          align-items: center;
+          gap: var(--sl-spacing-x-small);
+        }
+
+        .footer-right {
+          display: flex;
+          align-items: center;
+          gap: var(--sl-spacing-small);
+        }
+      `,
+    ];
+  }
+
+  show() {
+    this.dialogEl?.show();
+  }
+
+  hide() {
+    this.dialogEl?.hide();
+  }
+
+  override willUpdate(changedProperties: PropertyValues) {
+    if (changedProperties.has('suggestion')) {
+      const newSuggested = this.suggestion?.suggested_summary || '';
+      if (this.isEditing && this.editedSummary !== newSuggested) {
+        // User has uncommitted edits in flight. Preserve them to avoid silent data loss,
+        // and notify the user that a newer server suggestion was received.
+        this.newerSuggestionAvailable = true;
+      } else {
+        this.editedSummary = newSuggested;
+        this.isEditing = false;
+        this.newerSuggestionAvailable = false;
+        this.occConflict = false;
+        this.errorMessage = null;
+      }
+    }
+  }
+
+  handleLoadNewestSuggestion() {
+    this.editedSummary = this.suggestion?.suggested_summary || '';
+    this.isEditing = false;
+    this.newerSuggestionAvailable = false;
+  }
+
+  handleDismissNewerSuggestion() {
+    this.newerSuggestionAvailable = false;
+  }
+
+  // Extracted API client delegates for modular testing and component extension
+  async applySuggestion(
+    featureId: number,
+    patch: SummarySuggestionPatchRequest
+  ) {
+    return window.csClient.updateSummarySuggestion(featureId, patch);
+  }
+
+  async rejectSuggestion(
+    featureId: number,
+    patch: SummarySuggestionPatchRequest
+  ) {
+    return window.csClient.updateSummarySuggestion(featureId, patch);
+  }
+
+  async fetchSuggestion(featureId: number) {
+    return window.csClient.getSummarySuggestion(featureId);
+  }
+
+  async triggerRegeneration(featureId: number, force: boolean) {
+    return window.csClient.triggerSummaryGeneration(featureId, force);
+  }
+
+  async handleAccept() {
+    if (
+      !this.featureId ||
+      typeof this.suggestion?.version_token !== 'number' ||
+      this.loading
+    ) {
+      return;
+    }
+
+    try {
+      this.loading = true;
+      this.errorMessage = null;
+      this.occConflict = false;
+
+      // OCC version_token guards against mid-air collision overwrites if another
+      // editor or background task modified the suggestion during review.
+      const patch: SummarySuggestionPatchRequest = {
+        status: SummarySuggestionStatusEnum.APPLIED,
+        suggested_summary: this.editedSummary,
+        version_token: this.suggestion.version_token,
+      };
+      const resp = await this.applySuggestion(this.featureId, patch);
+
+      this.dispatchEvent(
+        new CustomEvent('summary-suggestion-applied', {
+          bubbles: true,
+          composed: true,
+          detail: {
+            featureId: this.featureId,
+            summary: this.editedSummary,
+            response: resp,
+          },
+        })
+      );
+
+      showToastMessage('AI summary applied successfully.');
+      this.hide();
+    } catch (err) {
+      this._handleApiError(err);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  async handleReject() {
+    if (
+      !this.featureId ||
+      typeof this.suggestion?.version_token !== 'number' ||
+      this.loading
+    ) {
+      return;
+    }
+
+    try {
+      this.loading = true;
+      this.errorMessage = null;
+      this.occConflict = false;
+
+      const patch: SummarySuggestionPatchRequest = {
+        status: SummarySuggestionStatusEnum.REJECTED,
+        version_token: this.suggestion.version_token,
+      };
+      const resp = await this.rejectSuggestion(this.featureId, patch);
+
+      this.dispatchEvent(
+        new CustomEvent('summary-suggestion-rejected', {
+          bubbles: true,
+          composed: true,
+          detail: {
+            featureId: this.featureId,
+            response: resp,
+          },
+        })
+      );
+
+      showToastMessage('AI summary discarded.');
+      this.hide();
+    } catch (err) {
+      this._handleApiError(err);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  async handleRegenerate() {
+    if (!this.featureId || this.loading) return;
+
+    try {
+      this.loading = true;
+      this.errorMessage = null;
+      this.occConflict = false;
+
+      await this.triggerRegeneration(this.featureId, true);
+
+      this.dispatchEvent(
+        new CustomEvent('summary-generation-requested', {
+          bubbles: true,
+          composed: true,
+          detail: {featureId: this.featureId, force: true},
+        })
+      );
+
+      showToastMessage('Summary regeneration enqueued.');
+      this.hide();
+    } catch (err) {
+      this._handleApiError(err);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  async handleRefresh() {
+    if (!this.featureId || this.loading) return;
+
+    try {
+      this.loading = true;
+      this.errorMessage = null;
+      this.occConflict = false;
+      this.newerSuggestionAvailable = false;
+
+      const resp = await this.fetchSuggestion(this.featureId);
+      this.suggestion = resp.suggestion ?? null;
+      this.editedSummary = this.suggestion?.suggested_summary || '';
+      this.isEditing = false;
+    } catch (err) {
+      this._handleApiError(err);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private _handleApiError(err: unknown) {
+    if (err instanceof ChromeStatusHttpError && err.status === 409) {
+      this.occConflict = true;
+      this.errorMessage =
+        'This suggestion was modified in another session. Please refresh to view the latest version.';
+    } else {
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.errorMessage = error.message || 'An unexpected error occurred.';
+    }
+  }
+
+  private _renderAlertBanner() {
+    if (this.occConflict) {
+      return html`
+        <sl-alert variant="warning" open>
+          <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+          <span>${this.errorMessage}</span>
+          <sl-button
+            size="small"
+            variant="text"
+            @click=${this.handleRefresh}
+            ?disabled=${this.loading}
+          >
+            Refresh
+          </sl-button>
+        </sl-alert>
+      `;
+    }
+
+    if (this.newerSuggestionAvailable) {
+      return html`
+        <sl-alert variant="primary" open>
+          <sl-icon slot="icon" name="info-circle"></sl-icon>
+          <span>A newer suggestion is available on the server.</span>
+          <sl-button
+            size="small"
+            variant="text"
+            @click=${this.handleLoadNewestSuggestion}
+          >
+            Load Newest
+          </sl-button>
+          <sl-button
+            size="small"
+            variant="text"
+            @click=${this.handleDismissNewerSuggestion}
+          >
+            Keep My Edits
+          </sl-button>
+        </sl-alert>
+      `;
+    }
+
+    if (this.errorMessage) {
+      return html`
+        <sl-alert variant="danger" open>
+          <sl-icon slot="icon" name="exclamation-octagon"></sl-icon>
+          <span>${this.errorMessage}</span>
+        </sl-alert>
+      `;
+    }
+
+    return nothing;
+  }
+
+  private _renderFooter() {
+    const isAcceptDisabled =
+      this.loading ||
+      !this.suggestion ||
+      typeof this.suggestion.version_token !== 'number' ||
+      this.occConflict;
+
+    const isDiscardDisabled =
+      this.loading ||
+      !this.suggestion ||
+      typeof this.suggestion.version_token !== 'number';
+
+    return html`
+      <div slot="footer" class="dialog-footer">
+        <div class="footer-left">
+          <sl-button
+            variant="default"
+            size="small"
+            @click=${this.handleRegenerate}
+            ?loading=${this.loading}
+            ?disabled=${this.loading}
+          >
+            <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+            Regenerate
+          </sl-button>
+        </div>
+        <div class="footer-right">
+          <sl-button
+            variant="default"
+            size="small"
+            @click=${this.hide}
+            ?disabled=${this.loading}
+          >
+            Cancel
+          </sl-button>
+          <sl-button
+            variant="danger"
+            size="small"
+            @click=${this.handleReject}
+            ?loading=${this.loading}
+            ?disabled=${isDiscardDisabled}
+          >
+            Discard
+          </sl-button>
+          <sl-button
+            variant="primary"
+            size="small"
+            @click=${this.handleAccept}
+            ?loading=${this.loading}
+            ?disabled=${isAcceptDisabled}
+          >
+            Accept & Apply
+          </sl-button>
+        </div>
+      </div>
+    `;
+  }
+
+  render() {
+    return html`
+      <sl-dialog label="Review AI Summary Suggestion">
+        ${this._renderAlertBanner()}
+
+        <chromedash-summary-diff-view
+          .currentSummary=${this.currentSummary}
+          .suggestedSummary=${this.editedSummary}
+          .suggestedDocLinks=${this.suggestion?.suggested_doc_links ?? []}
+          .isEditing=${this.isEditing}
+          .disabled=${this.loading}
+          @summary-edit-toggle=${(
+            e: CustomEvent<{isEditing: boolean; value: string}>
+          ) => {
+            this.isEditing = e.detail.isEditing;
+            this.editedSummary = e.detail.value;
+          }}
+          @summary-value-change=${(e: CustomEvent<{value: string}>) => {
+            this.editedSummary = e.detail.value;
+          }}
+        ></chromedash-summary-diff-view>
+
+        ${this._renderFooter()}
+      </sl-dialog>
+    `;
+  }
+}

--- a/client-src/elements/chromedash-summary-review-dialog_test.ts
+++ b/client-src/elements/chromedash-summary-review-dialog_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {html, fixture, expect} from '@open-wc/testing';
+import {html, fixture, assert} from '@open-wc/testing';
 import sinon from 'sinon';
 import './chromedash-summary-review-dialog.js';
 import {ChromedashSummaryReviewDialog} from './chromedash-summary-review-dialog.js';
@@ -79,8 +79,8 @@ describe('chromedash-summary-review-dialog', () => {
     const diffView = el.shadowRoot!.querySelector(
       'chromedash-summary-diff-view'
     );
-    expect(diffView).to.exist;
-    expect(el.editedSummary).to.equal(mockSuggestion.suggested_summary);
+    assert.exists(diffView);
+    assert.equal(el.editedSummary, mockSuggestion.suggested_summary);
   });
 
   it('calls updateSummarySuggestion with APPLIED and dispatches event on Accept', async () => {
@@ -89,8 +89,9 @@ describe('chromedash-summary-review-dialog', () => {
       e: CustomEvent<{featureId: number; summary: string}>
     ) => {
       appliedFired = true;
-      expect(e.detail.featureId).to.equal(101);
-      expect(e.detail.summary).to.equal(
+      assert.equal(e.detail.featureId, 101);
+      assert.equal(
+        e.detail.summary,
         'AI generated summary for feature **101**.'
       );
     };
@@ -108,7 +109,7 @@ describe('chromedash-summary-review-dialog', () => {
     await el.handleAccept();
     await el.updateComplete;
 
-    expect(
+    assert.isTrue(
       (
         window.csClient.updateSummarySuggestion as sinon.SinonStub
       ).calledOnceWith(101, {
@@ -116,17 +117,17 @@ describe('chromedash-summary-review-dialog', () => {
         suggested_summary: 'AI generated summary for feature **101**.',
         version_token: 42,
       })
-    ).to.be.true;
+    );
 
-    expect(appliedFired).to.be.true;
-    expect(hideSpy.calledOnce).to.be.true;
+    assert.isTrue(appliedFired);
+    assert.isTrue(hideSpy.calledOnce);
   });
 
   it('calls updateSummarySuggestion with REJECTED and dispatches event on Discard', async () => {
     let rejectedFired = false;
     const onRejected = (e: CustomEvent<{featureId: number}>) => {
       rejectedFired = true;
-      expect(e.detail.featureId).to.equal(101);
+      assert.equal(e.detail.featureId, 101);
     };
 
     const el = await fixture<ChromedashSummaryReviewDialog>(
@@ -142,25 +143,25 @@ describe('chromedash-summary-review-dialog', () => {
     await el.handleReject();
     await el.updateComplete;
 
-    expect(
+    assert.isTrue(
       (
         window.csClient.updateSummarySuggestion as sinon.SinonStub
       ).calledOnceWith(101, {
         status: SummarySuggestionStatusEnum.REJECTED,
         version_token: 42,
       })
-    ).to.be.true;
+    );
 
-    expect(rejectedFired).to.be.true;
-    expect(hideSpy.calledOnce).to.be.true;
+    assert.isTrue(rejectedFired);
+    assert.isTrue(hideSpy.calledOnce);
   });
 
   it('calls triggerSummaryGeneration and dispatches event on Regenerate', async () => {
     let regenFired = false;
     const onRegen = (e: CustomEvent<{featureId: number; force: boolean}>) => {
       regenFired = true;
-      expect(e.detail.featureId).to.equal(101);
-      expect(e.detail.force).to.be.true;
+      assert.equal(e.detail.featureId, 101);
+      assert.isTrue(e.detail.force);
     };
 
     const el = await fixture<ChromedashSummaryReviewDialog>(
@@ -176,14 +177,14 @@ describe('chromedash-summary-review-dialog', () => {
     await el.handleRegenerate();
     await el.updateComplete;
 
-    expect(
+    assert.isTrue(
       (
         window.csClient.triggerSummaryGeneration as sinon.SinonStub
       ).calledOnceWith(101, true)
-    ).to.be.true;
+    );
 
-    expect(regenFired).to.be.true;
-    expect(hideSpy.calledOnce).to.be.true;
+    assert.isTrue(regenFired);
+    assert.isTrue(hideSpy.calledOnce);
   });
 
   it('handles OCC 409 conflict and refreshes latest data', async () => {
@@ -202,18 +203,21 @@ describe('chromedash-summary-review-dialog', () => {
     await el.handleAccept();
     await el.updateComplete;
 
-    expect(el.occConflict).to.be.true;
+    assert.isTrue(el.occConflict);
     const warningAlert = el.shadowRoot!.querySelector(
       'sl-alert[variant="warning"]'
     );
-    expect(warningAlert).to.exist;
-    expect(warningAlert!.textContent).to.contain('modified in another session');
+    assert.exists(warningAlert);
+    assert.include(
+      warningAlert!.textContent || '',
+      'modified in another session'
+    );
 
     // Accept button should be disabled during OCC conflict
     const acceptBtn = el.shadowRoot!.querySelector(
       'sl-button[variant="primary"]'
     ) as HTMLElement;
-    expect(acceptBtn.hasAttribute('disabled')).to.be.true;
+    assert.isTrue(acceptBtn.hasAttribute('disabled'));
 
     // Refresh updated version
     const updatedSuggestion: SummarySuggestion = {
@@ -229,9 +233,9 @@ describe('chromedash-summary-review-dialog', () => {
     await el.handleRefresh();
     await el.updateComplete;
 
-    expect(el.occConflict).to.be.false;
-    expect(el.suggestion?.version_token).to.equal(43);
-    expect(el.editedSummary).to.equal('Newer remote summary from token 43');
+    assert.isFalse(el.occConflict);
+    assert.equal(el.suggestion?.version_token, 43);
+    assert.equal(el.editedSummary, 'Newer remote summary from token 43');
   });
 
   it('renders danger alert on general API error', async () => {
@@ -250,12 +254,12 @@ describe('chromedash-summary-review-dialog', () => {
     await el.handleAccept();
     await el.updateComplete;
 
-    expect(el.occConflict).to.be.false;
+    assert.isFalse(el.occConflict);
     const dangerAlert = el.shadowRoot!.querySelector(
       'sl-alert[variant="danger"]'
     );
-    expect(dangerAlert).to.exist;
-    expect(dangerAlert!.textContent).to.contain('Permission denied');
+    assert.exists(dangerAlert);
+    assert.include(dangerAlert!.textContent || '', 'Permission denied');
   });
 
   it('preserves uncommitted edits and shows notification when suggestion changes while editing', async () => {
@@ -279,14 +283,16 @@ describe('chromedash-summary-review-dialog', () => {
     el.suggestion = newerSuggestion;
     await el.updateComplete;
 
-    expect(el.editedSummary).to.equal(
+    assert.equal(
+      el.editedSummary,
       'My customized draft that should not be lost.'
     );
-    expect(el.newerSuggestionAvailable).to.be.true;
+    assert.isTrue(el.newerSuggestionAvailable);
 
     const alert = el.shadowRoot!.querySelector('sl-alert[variant="primary"]');
-    expect(alert).to.exist;
-    expect(alert!.textContent).to.contain(
+    assert.exists(alert);
+    assert.include(
+      alert!.textContent || '',
       'A newer suggestion is available on the server.'
     );
   });
@@ -312,21 +318,21 @@ describe('chromedash-summary-review-dialog', () => {
     el.suggestion = newerSuggestion;
     await el.updateComplete;
 
-    expect(el.newerSuggestionAvailable).to.be.true;
+    assert.isTrue(el.newerSuggestionAvailable);
 
     // Test dismiss
     el.handleDismissNewerSuggestion();
     await el.updateComplete;
-    expect(el.newerSuggestionAvailable).to.be.false;
-    expect(el.editedSummary).to.equal('My custom edit.');
+    assert.isFalse(el.newerSuggestionAvailable);
+    assert.equal(el.editedSummary, 'My custom edit.');
 
     // Test load newest
     el.newerSuggestionAvailable = true;
     el.handleLoadNewestSuggestion();
     await el.updateComplete;
-    expect(el.newerSuggestionAvailable).to.be.false;
-    expect(el.editedSummary).to.equal('New remote summary.');
-    expect(el.isEditing).to.be.false;
+    assert.isFalse(el.newerSuggestionAvailable);
+    assert.equal(el.editedSummary, 'New remote summary.');
+    assert.isFalse(el.isEditing);
   });
 
   it('disables buttons when suggestion is null or missing version_token', async () => {
@@ -345,8 +351,8 @@ describe('chromedash-summary-review-dialog', () => {
       'sl-button[variant="danger"]'
     ) as HTMLElement;
 
-    expect(acceptBtn.hasAttribute('disabled')).to.be.true;
-    expect(discardBtn.hasAttribute('disabled')).to.be.true;
+    assert.isTrue(acceptBtn.hasAttribute('disabled'));
+    assert.isTrue(discardBtn.hasAttribute('disabled'));
   });
 
   it('delegates to extracted API methods which can be overridden or spyed', async () => {
@@ -362,6 +368,6 @@ describe('chromedash-summary-review-dialog', () => {
     await el.handleAccept();
     await el.updateComplete;
 
-    expect(applySpy.calledOnce).to.be.true;
+    assert.isTrue(applySpy.calledOnce);
   });
 });

--- a/client-src/elements/chromedash-summary-review-dialog_test.ts
+++ b/client-src/elements/chromedash-summary-review-dialog_test.ts
@@ -1,0 +1,367 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {html, fixture, expect} from '@open-wc/testing';
+import sinon from 'sinon';
+import './chromedash-summary-review-dialog.js';
+import {ChromedashSummaryReviewDialog} from './chromedash-summary-review-dialog.js';
+import {
+  ChromeStatusClient,
+  ChromeStatusHttpError,
+} from '../js-src/cs-client.js';
+import {
+  SummarySuggestion,
+  SummarySuggestionStatusEnum,
+} from 'chromestatus-openapi';
+
+describe('chromedash-summary-review-dialog', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  const mockSuggestion: SummarySuggestion = {
+    feature_id: 101,
+    status: SummarySuggestionStatusEnum.PENDING,
+    suggested_summary: 'AI generated summary for feature **101**.',
+    suggested_doc_links: [
+      'https://developer.mozilla.org/en-US/docs/Web/API/Test',
+    ],
+    version_token: 42,
+    created: new Date(),
+    updated: new Date(),
+  };
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    window.csClient = {
+      getSummarySuggestion: sandbox.stub().resolves({
+        suggestion: mockSuggestion,
+        progress_steps: [],
+      }),
+      updateSummarySuggestion: sandbox.stub().resolves({
+        suggestion: {
+          ...mockSuggestion,
+          status: SummarySuggestionStatusEnum.APPLIED,
+          version_token: 43,
+        },
+        progress_steps: [],
+      }),
+      triggerSummaryGeneration: sandbox.stub().resolves({
+        message: 'Task enqueued',
+      }),
+    } as Partial<ChromeStatusClient> as ChromeStatusClient;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('renders dialog and diff view child component', async () => {
+    const el = await fixture<ChromedashSummaryReviewDialog>(
+      html`<chromedash-summary-review-dialog
+        .featureId=${101}
+        .currentSummary=${'Manual author summary'}
+        .suggestion=${mockSuggestion}
+      ></chromedash-summary-review-dialog>`
+    );
+
+    const diffView = el.shadowRoot!.querySelector(
+      'chromedash-summary-diff-view'
+    );
+    expect(diffView).to.exist;
+    expect(el.editedSummary).to.equal(mockSuggestion.suggested_summary);
+  });
+
+  it('calls updateSummarySuggestion with APPLIED and dispatches event on Accept', async () => {
+    let appliedFired = false;
+    const onApplied = (
+      e: CustomEvent<{featureId: number; summary: string}>
+    ) => {
+      appliedFired = true;
+      expect(e.detail.featureId).to.equal(101);
+      expect(e.detail.summary).to.equal(
+        'AI generated summary for feature **101**.'
+      );
+    };
+
+    const el = await fixture<ChromedashSummaryReviewDialog>(
+      html`<chromedash-summary-review-dialog
+        .featureId=${101}
+        .currentSummary=${'Old summary'}
+        .suggestion=${mockSuggestion}
+        @summary-suggestion-applied=${onApplied}
+      ></chromedash-summary-review-dialog>`
+    );
+
+    const hideSpy = sandbox.spy(el, 'hide');
+    await el.handleAccept();
+    await el.updateComplete;
+
+    expect(
+      (
+        window.csClient.updateSummarySuggestion as sinon.SinonStub
+      ).calledOnceWith(101, {
+        status: SummarySuggestionStatusEnum.APPLIED,
+        suggested_summary: 'AI generated summary for feature **101**.',
+        version_token: 42,
+      })
+    ).to.be.true;
+
+    expect(appliedFired).to.be.true;
+    expect(hideSpy.calledOnce).to.be.true;
+  });
+
+  it('calls updateSummarySuggestion with REJECTED and dispatches event on Discard', async () => {
+    let rejectedFired = false;
+    const onRejected = (e: CustomEvent<{featureId: number}>) => {
+      rejectedFired = true;
+      expect(e.detail.featureId).to.equal(101);
+    };
+
+    const el = await fixture<ChromedashSummaryReviewDialog>(
+      html`<chromedash-summary-review-dialog
+        .featureId=${101}
+        .currentSummary=${'Old summary'}
+        .suggestion=${mockSuggestion}
+        @summary-suggestion-rejected=${onRejected}
+      ></chromedash-summary-review-dialog>`
+    );
+
+    const hideSpy = sandbox.spy(el, 'hide');
+    await el.handleReject();
+    await el.updateComplete;
+
+    expect(
+      (
+        window.csClient.updateSummarySuggestion as sinon.SinonStub
+      ).calledOnceWith(101, {
+        status: SummarySuggestionStatusEnum.REJECTED,
+        version_token: 42,
+      })
+    ).to.be.true;
+
+    expect(rejectedFired).to.be.true;
+    expect(hideSpy.calledOnce).to.be.true;
+  });
+
+  it('calls triggerSummaryGeneration and dispatches event on Regenerate', async () => {
+    let regenFired = false;
+    const onRegen = (e: CustomEvent<{featureId: number; force: boolean}>) => {
+      regenFired = true;
+      expect(e.detail.featureId).to.equal(101);
+      expect(e.detail.force).to.be.true;
+    };
+
+    const el = await fixture<ChromedashSummaryReviewDialog>(
+      html`<chromedash-summary-review-dialog
+        .featureId=${101}
+        .currentSummary=${'Old summary'}
+        .suggestion=${mockSuggestion}
+        @summary-generation-requested=${onRegen}
+      ></chromedash-summary-review-dialog>`
+    );
+
+    const hideSpy = sandbox.spy(el, 'hide');
+    await el.handleRegenerate();
+    await el.updateComplete;
+
+    expect(
+      (
+        window.csClient.triggerSummaryGeneration as sinon.SinonStub
+      ).calledOnceWith(101, true)
+    ).to.be.true;
+
+    expect(regenFired).to.be.true;
+    expect(hideSpy.calledOnce).to.be.true;
+  });
+
+  it('handles OCC 409 conflict and refreshes latest data', async () => {
+    (window.csClient.updateSummarySuggestion as sinon.SinonStub).rejects(
+      new ChromeStatusHttpError('Conflict', '/test', 'PATCH', 409)
+    );
+
+    const el = await fixture<ChromedashSummaryReviewDialog>(
+      html`<chromedash-summary-review-dialog
+        .featureId=${101}
+        .currentSummary=${'Old summary'}
+        .suggestion=${mockSuggestion}
+      ></chromedash-summary-review-dialog>`
+    );
+
+    await el.handleAccept();
+    await el.updateComplete;
+
+    expect(el.occConflict).to.be.true;
+    const warningAlert = el.shadowRoot!.querySelector(
+      'sl-alert[variant="warning"]'
+    );
+    expect(warningAlert).to.exist;
+    expect(warningAlert!.textContent).to.contain('modified in another session');
+
+    // Accept button should be disabled during OCC conflict
+    const acceptBtn = el.shadowRoot!.querySelector(
+      'sl-button[variant="primary"]'
+    ) as HTMLElement;
+    expect(acceptBtn.hasAttribute('disabled')).to.be.true;
+
+    // Refresh updated version
+    const updatedSuggestion: SummarySuggestion = {
+      ...mockSuggestion,
+      suggested_summary: 'Newer remote summary from token 43',
+      version_token: 43,
+    };
+    (window.csClient.getSummarySuggestion as sinon.SinonStub).resolves({
+      suggestion: updatedSuggestion,
+      progress_steps: [],
+    });
+
+    await el.handleRefresh();
+    await el.updateComplete;
+
+    expect(el.occConflict).to.be.false;
+    expect(el.suggestion?.version_token).to.equal(43);
+    expect(el.editedSummary).to.equal('Newer remote summary from token 43');
+  });
+
+  it('renders danger alert on general API error', async () => {
+    (window.csClient.updateSummarySuggestion as sinon.SinonStub).rejects(
+      new Error('Permission denied')
+    );
+
+    const el = await fixture<ChromedashSummaryReviewDialog>(
+      html`<chromedash-summary-review-dialog
+        .featureId=${101}
+        .currentSummary=${'Old summary'}
+        .suggestion=${mockSuggestion}
+      ></chromedash-summary-review-dialog>`
+    );
+
+    await el.handleAccept();
+    await el.updateComplete;
+
+    expect(el.occConflict).to.be.false;
+    const dangerAlert = el.shadowRoot!.querySelector(
+      'sl-alert[variant="danger"]'
+    );
+    expect(dangerAlert).to.exist;
+    expect(dangerAlert!.textContent).to.contain('Permission denied');
+  });
+
+  it('preserves uncommitted edits and shows notification when suggestion changes while editing', async () => {
+    const el = await fixture<ChromedashSummaryReviewDialog>(
+      html`<chromedash-summary-review-dialog
+        .featureId=${101}
+        .currentSummary=${'Old summary'}
+        .suggestion=${mockSuggestion}
+      ></chromedash-summary-review-dialog>`
+    );
+
+    el.isEditing = true;
+    el.editedSummary = 'My customized draft that should not be lost.';
+    await el.updateComplete;
+
+    const newerSuggestion: SummarySuggestion = {
+      ...mockSuggestion,
+      suggested_summary: 'New incoming summary from server.',
+      version_token: 45,
+    };
+    el.suggestion = newerSuggestion;
+    await el.updateComplete;
+
+    expect(el.editedSummary).to.equal(
+      'My customized draft that should not be lost.'
+    );
+    expect(el.newerSuggestionAvailable).to.be.true;
+
+    const alert = el.shadowRoot!.querySelector('sl-alert[variant="primary"]');
+    expect(alert).to.exist;
+    expect(alert!.textContent).to.contain(
+      'A newer suggestion is available on the server.'
+    );
+  });
+
+  it('allows user to load newest suggestion or keep edits', async () => {
+    const el = await fixture<ChromedashSummaryReviewDialog>(
+      html`<chromedash-summary-review-dialog
+        .featureId=${101}
+        .currentSummary=${'Old summary'}
+        .suggestion=${mockSuggestion}
+      ></chromedash-summary-review-dialog>`
+    );
+
+    el.isEditing = true;
+    el.editedSummary = 'My custom edit.';
+    await el.updateComplete;
+
+    const newerSuggestion: SummarySuggestion = {
+      ...mockSuggestion,
+      suggested_summary: 'New remote summary.',
+      version_token: 45,
+    };
+    el.suggestion = newerSuggestion;
+    await el.updateComplete;
+
+    expect(el.newerSuggestionAvailable).to.be.true;
+
+    // Test dismiss
+    el.handleDismissNewerSuggestion();
+    await el.updateComplete;
+    expect(el.newerSuggestionAvailable).to.be.false;
+    expect(el.editedSummary).to.equal('My custom edit.');
+
+    // Test load newest
+    el.newerSuggestionAvailable = true;
+    el.handleLoadNewestSuggestion();
+    await el.updateComplete;
+    expect(el.newerSuggestionAvailable).to.be.false;
+    expect(el.editedSummary).to.equal('New remote summary.');
+    expect(el.isEditing).to.be.false;
+  });
+
+  it('disables buttons when suggestion is null or missing version_token', async () => {
+    const el = await fixture<ChromedashSummaryReviewDialog>(
+      html`<chromedash-summary-review-dialog
+        .featureId=${101}
+        .currentSummary=${'Old summary'}
+        .suggestion=${null}
+      ></chromedash-summary-review-dialog>`
+    );
+
+    const acceptBtn = el.shadowRoot!.querySelector(
+      'sl-button[variant="primary"]'
+    ) as HTMLElement;
+    const discardBtn = el.shadowRoot!.querySelector(
+      'sl-button[variant="danger"]'
+    ) as HTMLElement;
+
+    expect(acceptBtn.hasAttribute('disabled')).to.be.true;
+    expect(discardBtn.hasAttribute('disabled')).to.be.true;
+  });
+
+  it('delegates to extracted API methods which can be overridden or spyed', async () => {
+    const el = await fixture<ChromedashSummaryReviewDialog>(
+      html`<chromedash-summary-review-dialog
+        .featureId=${101}
+        .currentSummary=${'Old summary'}
+        .suggestion=${mockSuggestion}
+      ></chromedash-summary-review-dialog>`
+    );
+
+    const applySpy = sandbox.spy(el, 'applySuggestion');
+    await el.handleAccept();
+    await el.updateComplete;
+
+    expect(applySpy.calledOnce).to.be.true;
+  });
+});


### PR DESCRIPTION
Adds `<chromedash-summary-review-dialog>` for reviewing, editing, regenerating, and accepting or rejecting AI-curated feature summaries.

### Key Changes
- **`<chromedash-summary-review-dialog>` Component**:
  - Embeds `<chromedash-summary-diff-view>` for side-by-side comparison and in-line editing of AI suggestions vs existing feature summaries.
  - Preserves in-flight user edits if newer suggestions arrive from the server, displaying a non-destructive notification banner with options to keep edits or reload newest.
  - Implements Optimistic Concurrency Control (OCC) using the monotonically increasing `version_token: number` payload from `SummarySuggestionPatchRequest` to prevent race-condition mid-air collisions.
  - Provides Accept & Apply, Discard, Regenerate (with force option), and Cancel/Dismiss actions.
  - Modularizes API delegates (`applySuggestion`, `rejectSuggestion`, `fetchSuggestion`, `triggerRegeneration`) for clear separation and decoupled testing.
  - Emits composed, bubbling events matching the OpenAPI lifecycle:
    - `summary-suggestion-applied`: fired upon successful acceptance/application.
    - `summary-suggestion-rejected`: fired upon discard/rejection.
    - `summary-generation-requested`: fired when user triggers background AI regeneration.
  - Includes comprehensive unit tests covering dialog lifecycle, review decision dispatches, OCC 409 conflict handling, edit preservation, and disabled button states.

TAG=agy
CONV=7dad7a60-89a0-4ab9-9f42-3300a3de7807