### PR TITLE
[AI Curation] Add View-Only Release Feature Card Component

### DIFF
--- a/client-src/components.js
+++ b/client-src/components.js
@@ -119,3 +119,4 @@ import './elements/chromedash-wpt-eval-button';
 import './elements/chromedash-wpt-eval-page';
 import './elements/chromedash-summary-diff-view';
 import './elements/chromedash-summary-review-dialog';
+import './elements/chromedash-release-feature-card';

--- a/client-src/elements/chromedash-release-feature-card.ts
+++ b/client-src/elements/chromedash-release-feature-card.ts
@@ -16,21 +16,36 @@
 
 import {LitElement, css, html, nothing, TemplateResult} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
-import '@shoelace-style/shoelace/dist/components/badge/badge.js';
-import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {autolink} from './utils.js';
 import {FEATURE_CATEGORIES} from './form-field-enums.js';
-import {ReleaseNoteFeatureSummarySourceEnum} from 'chromestatus-openapi';
+import {
+  ReleaseNoteFeature,
+  ReleaseNoteLink,
+  ReleaseNoteLinkTypeEnum,
+  ReleaseNoteFeatureSummarySourceEnum,
+} from 'chromestatus-openapi';
 
-export type FeatureCardItem = {
+export const LINK_TYPE_TITLES: Record<ReleaseNoteLinkTypeEnum, string> = {
+  [ReleaseNoteLinkTypeEnum.BUG]: 'Tracking bug',
+  [ReleaseNoteLinkTypeEnum.CHROMESTATUS]: 'ChromeStatus',
+  [ReleaseNoteLinkTypeEnum.SPEC]: 'Spec',
+  [ReleaseNoteLinkTypeEnum.ORIGIN_TRIAL]: 'Origin trial',
+  [ReleaseNoteLinkTypeEnum.DOC]: 'Docs',
+  [ReleaseNoteLinkTypeEnum.EXPLAINER]: 'Explainer',
+  [ReleaseNoteLinkTypeEnum.DEMO]: 'Demo',
+  [ReleaseNoteLinkTypeEnum.OTHER]: 'Resource',
+};
+
+export type FeatureCardItem = Partial<ReleaseNoteFeature> & {
   id: number;
   name: string;
   summary: string;
   category?: string | number;
   category_name?: string;
   feature_type?: string | number;
-  summary_source?: string;
+  summary_source?: ReleaseNoteFeatureSummarySourceEnum | string;
+  links?: ReleaseNoteLink[];
   doc_links?: string[];
   spec_link?: string;
   explainer_links?: string[];
@@ -204,12 +219,25 @@ export class ChromedashReleaseFeatureCard extends LitElement {
           text-underline-offset: 2px;
         }
 
-        .feature-links-section {
+        .feature-links-bar {
           display: flex;
-          flex-direction: column;
-          gap: var(--content-padding-quarter);
+          flex-wrap: wrap;
+          align-items: center;
+          gap: var(--content-padding-quarter) var(--content-padding-half);
           border-top: var(--default-border);
           padding-top: var(--content-padding-half);
+          margin-top: auto;
+          font-size: var(--button-font-size, 0.875rem);
+        }
+
+        .feature-links-bar a {
+          text-decoration: underline;
+          text-underline-offset: 2px;
+        }
+
+        .link-separator {
+          color: var(--card-border, #e0e0e0);
+          user-select: none;
         }
 
         .feature-link-item {
@@ -219,13 +247,17 @@ export class ChromedashReleaseFeatureCard extends LitElement {
           max-width: 100%;
           text-decoration: underline;
           text-underline-offset: 2px;
-          font-size: var(--button-small-font-size, 0.875rem);
         }
 
-        .link-text {
+        .doc-link-text {
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
+        }
+
+        .external-icon {
+          font-size: var(--button-font-size, 0.875rem);
+          line-height: 1;
         }
       `,
     ];
@@ -260,8 +292,9 @@ export class ChromedashReleaseFeatureCard extends LitElement {
     if (!categoryName && typeof this.feature.category === 'string') {
       categoryName = this.feature.category;
     } else if (!categoryName && typeof this.feature.category === 'number') {
+      const targetCat = this.feature.category;
       const entry = Object.values(FEATURE_CATEGORIES).find(
-        ([val]) => val === this.feature!.category
+        tuple => tuple[0] === targetCat
       );
       categoryName = entry ? entry[1] : '';
     }
@@ -286,40 +319,77 @@ export class ChromedashReleaseFeatureCard extends LitElement {
   renderDocLinks(): TemplateResult | typeof nothing {
     if (!this.feature) return nothing;
 
-    const links: string[] = [];
+    let normalizedLinks: ReleaseNoteLink[] = [];
 
-    if (Array.isArray(this.feature.doc_links)) {
-      links.push(...this.feature.doc_links);
-    }
-    if (this.feature.spec_link && !links.includes(this.feature.spec_link)) {
-      links.push(this.feature.spec_link);
-    }
-    if (Array.isArray(this.feature.explainer_links)) {
-      for (const link of this.feature.explainer_links) {
-        if (!links.includes(link)) {
-          links.push(link);
+    if (Array.isArray(this.feature.links) && this.feature.links.length > 0) {
+      normalizedLinks = this.feature.links;
+    } else {
+      if (Array.isArray(this.feature.doc_links)) {
+        for (const url of this.feature.doc_links) {
+          normalizedLinks.push({
+            url,
+            type: ReleaseNoteLinkTypeEnum.DOC,
+          });
+        }
+      }
+      if (
+        this.feature.spec_link &&
+        !normalizedLinks.some(l => l.url === this.feature!.spec_link)
+      ) {
+        normalizedLinks.push({
+          url: this.feature.spec_link,
+          type: ReleaseNoteLinkTypeEnum.SPEC,
+        });
+      }
+      if (Array.isArray(this.feature.explainer_links)) {
+        for (const url of this.feature.explainer_links) {
+          if (!normalizedLinks.some(l => l.url === url)) {
+            normalizedLinks.push({
+              url,
+              type: ReleaseNoteLinkTypeEnum.EXPLAINER,
+            });
+          }
         }
       }
     }
 
-    if (links.length === 0) return nothing;
+    if (normalizedLinks.length === 0) return nothing;
 
     return html`
-      <div class="feature-links-section" aria-label="Documentation links">
-        ${links.map(
-          link => html`
+      <div
+        class="feature-links-bar"
+        aria-label="Feature metadata and resources"
+      >
+        ${normalizedLinks.map((link, idx) => {
+          const isExternal =
+            !link.url.startsWith('/') && !link.url.startsWith('#');
+          const displayLabel =
+            link.title ||
+            LINK_TYPE_TITLES[link.type as ReleaseNoteLinkTypeEnum] ||
+            link.url;
+          return html`
+            ${
+              idx > 0
+                ? html`<span class="link-separator" aria-hidden="true">|</span>`
+                : nothing
+            }
             <a
               class="feature-link-item"
-              href=${link}
-              target="_blank"
-              rel="noopener noreferrer"
-              title=${link}
+              href=${link.url}
+              target=${isExternal ? '_blank' : '_self'}
+              rel=${isExternal ? 'noopener noreferrer' : ''}
+              title=${link.url}
             >
-              <span class="link-text">${link}</span>
-              <sl-icon name="box-arrow-up-right"></sl-icon>
+              <span class="doc-link-text">${displayLabel}</span>
+              ${
+                isExternal
+                  ? html`<span aria-hidden="true" class="external-icon">↗</span
+                      ><span class="sr-only">(opens in new window)</span>`
+                  : nothing
+              }
             </a>
-          `
-        )}
+          `;
+        })}
       </div>
     `;
   }

--- a/client-src/elements/chromedash-release-feature-card.ts
+++ b/client-src/elements/chromedash-release-feature-card.ts
@@ -22,6 +22,7 @@ import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {autolink} from './utils.js';
+import {FEATURE_CATEGORIES} from './form-field-enums.js';
 import {
   SummarySuggestion,
   SummarySuggestionStatusEnum,
@@ -58,6 +59,15 @@ export class ChromedashReleaseFeatureCard extends LitElement {
 
   @state()
   isCopied = false;
+
+  private _copiedTimeout?: ReturnType<typeof setTimeout>;
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._copiedTimeout) {
+      clearTimeout(this._copiedTimeout);
+    }
+  }
 
   static get styles() {
     return [
@@ -266,8 +276,11 @@ export class ChromedashReleaseFeatureCard extends LitElement {
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {
         await navigator.clipboard.writeText(fullUrl);
+        if (this._copiedTimeout) {
+          clearTimeout(this._copiedTimeout);
+        }
         this.isCopied = true;
-        setTimeout(() => {
+        this._copiedTimeout = setTimeout(() => {
           this.isCopied = false;
         }, 2000);
       }
@@ -305,9 +318,15 @@ export class ChromedashReleaseFeatureCard extends LitElement {
 
   renderCategoryBadge(): TemplateResult | typeof nothing {
     if (!this.feature) return nothing;
-    const categoryName =
-      this.feature.category_name ||
-      (typeof this.feature.category === 'string' ? this.feature.category : '');
+    let categoryName = this.feature.category_name;
+    if (!categoryName && typeof this.feature.category === 'string') {
+      categoryName = this.feature.category;
+    } else if (!categoryName && typeof this.feature.category === 'number') {
+      const entry = Object.values(FEATURE_CATEGORIES).find(
+        ([val]) => val === this.feature!.category
+      );
+      categoryName = entry ? entry[1] : '';
+    }
     if (!categoryName) return nothing;
 
     return html`<sl-badge variant="neutral" pill>${categoryName}</sl-badge>`;
@@ -434,7 +453,11 @@ export class ChromedashReleaseFeatureCard extends LitElement {
             ? html`
                 <div class="suggestion-meta">
                   <sl-tooltip content=${this.suggestion.reasoning}>
-                    <sl-icon name="info-circle"></sl-icon>
+                    <sl-icon
+                      tabindex="0"
+                      name="info-circle"
+                      aria-label="Summary reasoning details"
+                    ></sl-icon>
                   </sl-tooltip>
                   <span>Grounding available</span>
                 </div>
@@ -450,15 +473,15 @@ export class ChromedashReleaseFeatureCard extends LitElement {
       return nothing;
     }
 
-    const isMarkdown =
-      (this.feature.markdown_fields || []).includes('summary') || true;
+    const isMarkdown = Boolean(
+      this.feature.markdown_fields?.includes('summary')
+    );
     const formattedSummary = autolink(this.feature.summary, [], isMarkdown);
 
     return html`
       <article
         class="feature-card"
         id="feature-${this.feature.id}"
-        role="article"
         aria-labelledby="feature-title-${this.feature.id}"
       >
         <header class="card-header">

--- a/client-src/elements/chromedash-release-feature-card.ts
+++ b/client-src/elements/chromedash-release-feature-card.ts
@@ -16,17 +16,12 @@
 
 import {LitElement, css, html, nothing, TemplateResult} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
-import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
-import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {autolink} from './utils.js';
 import {FEATURE_CATEGORIES} from './form-field-enums.js';
-import {
-  SummarySuggestion,
-  SummarySuggestionStatusEnum,
-} from 'chromestatus-openapi';
+import {ReleaseNoteFeatureSummarySourceEnum} from 'chromestatus-openapi';
 
 export type FeatureCardItem = {
   id: number;
@@ -47,12 +42,6 @@ export type FeatureCardItem = {
 export class ChromedashReleaseFeatureCard extends LitElement {
   @property({attribute: false})
   feature: FeatureCardItem | null = null;
-
-  @property({attribute: false})
-  suggestion: SummarySuggestion | null = null;
-
-  @property({type: Boolean})
-  reviewMode = false;
 
   @property({type: Number})
   milestone?: number;
@@ -238,30 +227,6 @@ export class ChromedashReleaseFeatureCard extends LitElement {
           text-overflow: ellipsis;
           white-space: nowrap;
         }
-
-        .card-actions {
-          display: flex;
-          align-items: center;
-          justify-content: space-between;
-          flex-wrap: wrap;
-          gap: var(--sl-spacing-small);
-          border-top: var(--default-border);
-          padding-top: var(--content-padding-half);
-        }
-
-        .action-buttons {
-          display: flex;
-          align-items: center;
-          gap: var(--sl-spacing-small);
-        }
-
-        .suggestion-meta {
-          display: flex;
-          align-items: center;
-          gap: var(--sl-spacing-x-small);
-          font-size: var(--button-small-font-size, 0.875rem);
-          color: var(--unimportant-text-color);
-        }
       `,
     ];
   }
@@ -289,33 +254,6 @@ export class ChromedashReleaseFeatureCard extends LitElement {
     }
   }
 
-  handleReviewClick() {
-    this.dispatchEvent(
-      new CustomEvent('review-click', {
-        detail: {
-          feature: this.feature,
-          suggestion: this.suggestion,
-          featureId: this.feature?.id,
-        },
-        bubbles: true,
-        composed: true,
-      })
-    );
-  }
-
-  handleGenerateClick() {
-    this.dispatchEvent(
-      new CustomEvent('generate-click', {
-        detail: {
-          feature: this.feature,
-          featureId: this.feature?.id,
-        },
-        bubbles: true,
-        composed: true,
-      })
-    );
-  }
-
   renderCategoryBadge(): TemplateResult | typeof nothing {
     if (!this.feature) return nothing;
     let categoryName = this.feature.category_name;
@@ -336,15 +274,9 @@ export class ChromedashReleaseFeatureCard extends LitElement {
     if (!this.feature) return nothing;
 
     if (
-      this.suggestion &&
-      this.suggestion.status === SummarySuggestionStatusEnum.PENDING
+      this.feature.summary_source ===
+      ReleaseNoteFeatureSummarySourceEnum.AI_APPLIED
     ) {
-      return html`<sl-badge variant="warning" pill
-        >AI Review Pending</sl-badge
-      >`;
-    }
-
-    if (this.feature.summary_source === 'AI_APPLIED') {
       return html`<sl-badge variant="success" pill>AI Applied</sl-badge>`;
     }
 
@@ -369,16 +301,6 @@ export class ChromedashReleaseFeatureCard extends LitElement {
         }
       }
     }
-    if (
-      this.suggestion?.suggested_doc_links &&
-      Array.isArray(this.suggestion.suggested_doc_links)
-    ) {
-      for (const link of this.suggestion.suggested_doc_links) {
-        if (!links.includes(link)) {
-          links.push(link);
-        }
-      }
-    }
 
     if (links.length === 0) return nothing;
 
@@ -398,72 +320,6 @@ export class ChromedashReleaseFeatureCard extends LitElement {
             </a>
           `
         )}
-      </div>
-    `;
-  }
-
-  renderReviewActions(): TemplateResult | typeof nothing {
-    if (!this.reviewMode || !this.feature) return nothing;
-
-    const hasPendingSuggestion =
-      this.suggestion &&
-      this.suggestion.status === SummarySuggestionStatusEnum.PENDING;
-
-    return html`
-      <div class="card-actions">
-        <div class="action-buttons">
-          ${
-            hasPendingSuggestion
-              ? html`
-                  <sl-button
-                    size="small"
-                    variant="primary"
-                    class="review-button"
-                    @click=${this.handleReviewClick}
-                  >
-                    <sl-icon slot="prefix" name="pencil"></sl-icon>
-                    Review Suggestion
-                  </sl-button>
-                `
-              : html`
-                  <sl-button
-                    size="small"
-                    variant="default"
-                    class="review-button"
-                    @click=${this.handleReviewClick}
-                  >
-                    <sl-icon slot="prefix" name="eye"></sl-icon>
-                    Inspect / Edit
-                  </sl-button>
-                `
-          }
-          <sl-button
-            size="small"
-            variant="default"
-            class="generate-button"
-            @click=${this.handleGenerateClick}
-          >
-            <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
-            ${hasPendingSuggestion ? 'Regenerate' : 'Generate AI Summary'}
-          </sl-button>
-        </div>
-
-        ${
-          this.suggestion?.reasoning
-            ? html`
-                <div class="suggestion-meta">
-                  <sl-tooltip content=${this.suggestion.reasoning}>
-                    <sl-icon
-                      tabindex="0"
-                      name="info-circle"
-                      aria-label="Summary reasoning details"
-                    ></sl-icon>
-                  </sl-tooltip>
-                  <span>Grounding available</span>
-                </div>
-              `
-            : nothing
-        }
       </div>
     `;
   }
@@ -522,7 +378,6 @@ export class ChromedashReleaseFeatureCard extends LitElement {
         </header>
 
         ${this.renderFeatureSummary()} ${this.renderDocLinks()}
-        ${this.renderReviewActions()}
       </article>
     `;
   }

--- a/client-src/elements/chromedash-release-feature-card.ts
+++ b/client-src/elements/chromedash-release-feature-card.ts
@@ -41,16 +41,10 @@ export type FeatureCardItem = Partial<ReleaseNoteFeature> & {
   id: number;
   name: string;
   summary: string;
-  category?: string | number;
-  category_name?: string;
-  feature_type?: string | number;
-  summary_source?: ReleaseNoteFeatureSummarySourceEnum | string;
-  links?: ReleaseNoteLink[];
   doc_links?: string[];
   spec_link?: string;
   explainer_links?: string[];
   markdown_fields?: string[];
-  [key: string]: unknown;
 };
 
 @customElement('chromedash-release-feature-card')
@@ -66,10 +60,11 @@ export class ChromedashReleaseFeatureCard extends LitElement {
 
   private _copiedTimeout?: ReturnType<typeof setTimeout>;
 
-  disconnectedCallback() {
+  disconnectedCallback(): void {
     super.disconnectedCallback();
     if (this._copiedTimeout) {
       clearTimeout(this._copiedTimeout);
+      this._copiedTimeout = undefined;
     }
   }
 
@@ -97,7 +92,7 @@ export class ChromedashReleaseFeatureCard extends LitElement {
         }
 
         .feature-card:hover {
-          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+          box-shadow: var(--sl-shadow-medium, 0 4px 12px rgba(0, 0, 0, 0.08));
         }
 
         .card-header {
@@ -116,10 +111,11 @@ export class ChromedashReleaseFeatureCard extends LitElement {
         }
 
         .feature-title {
-          font-size: var(--h3-font-size, 1.25rem);
+          font-size: var(--sl-font-size-large, 1.25rem);
           font-weight: 600;
           margin: 0;
           line-height: 1.3;
+          overflow-wrap: break-word;
         }
 
         .feature-name {
@@ -153,12 +149,24 @@ export class ChromedashReleaseFeatureCard extends LitElement {
           opacity: 1;
         }
 
-        .heading-anchor-link:hover,
+        .heading-anchor-link:hover {
+          background-color: var(--light-accent-color);
+          color: var(--default-color);
+        }
+
         .heading-anchor-link:focus-visible {
           background-color: var(--light-accent-color);
           color: var(--default-color);
           outline: 2px solid var(--primary-button-background);
           outline-offset: 2px;
+        }
+
+        @media (hover: none) {
+          .heading-anchor-link {
+            opacity: 0.6;
+            min-width: 2rem;
+            min-height: 2rem;
+          }
         }
 
         .anchor-tooltip {
@@ -236,7 +244,7 @@ export class ChromedashReleaseFeatureCard extends LitElement {
         }
 
         .link-separator {
-          color: var(--card-border, #e0e0e0);
+          color: var(--sl-color-neutral-400);
           user-select: none;
         }
 
@@ -247,12 +255,26 @@ export class ChromedashReleaseFeatureCard extends LitElement {
           max-width: 100%;
           text-decoration: underline;
           text-underline-offset: 2px;
+          min-width: 0;
         }
 
         .doc-link-text {
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
+          min-width: 0;
+        }
+
+        .sr-only {
+          position: absolute;
+          width: 1px;
+          height: 1px;
+          padding: 0;
+          margin: -1px;
+          overflow: hidden;
+          clip: rect(0, 0, 0, 0);
+          white-space: nowrap;
+          border: 0;
         }
 
         .external-icon {
@@ -263,15 +285,16 @@ export class ChromedashReleaseFeatureCard extends LitElement {
     ];
   }
 
-  async handleAnchorCopy(e: Event) {
-    e.preventDefault();
-    if (!this.feature) return;
+  async handleAnchorCopy(e: Event): Promise<void> {
+    const feature = this.feature;
+    if (!feature) return;
 
-    const anchor = `#feature-${this.feature.id}`;
+    const anchor = `#feature-${feature.id}`;
     const fullUrl = new URL(anchor, window.location.href).href;
 
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      e.preventDefault();
+      try {
         await navigator.clipboard.writeText(fullUrl);
         if (this._copiedTimeout) {
           clearTimeout(this._copiedTimeout);
@@ -279,24 +302,26 @@ export class ChromedashReleaseFeatureCard extends LitElement {
         this.isCopied = true;
         this._copiedTimeout = setTimeout(() => {
           this.isCopied = false;
+          this._copiedTimeout = undefined;
         }, 2000);
+      } catch (err) {
+        console.warn('Could not copy anchor link to clipboard:', err);
+        window.location.hash = anchor;
       }
-    } catch (err) {
-      console.warn('Could not copy anchor link to clipboard:', err);
     }
   }
 
   renderCategoryBadge(): TemplateResult | typeof nothing {
-    if (!this.feature) return nothing;
-    let categoryName = this.feature.category_name;
-    if (!categoryName && typeof this.feature.category === 'string') {
-      categoryName = this.feature.category;
-    } else if (!categoryName && typeof this.feature.category === 'number') {
-      const targetCat = this.feature.category;
+    const feature = this.feature;
+    if (!feature) return nothing;
+
+    let categoryName = feature.category_name?.trim();
+    if (!categoryName && typeof feature.category === 'number') {
+      const targetCat = feature.category;
       const entry = Object.values(FEATURE_CATEGORIES).find(
         tuple => tuple[0] === targetCat
       );
-      categoryName = entry ? entry[1] : '';
+      categoryName = entry ? entry[1] : undefined;
     }
     if (!categoryName) return nothing;
 
@@ -304,11 +329,11 @@ export class ChromedashReleaseFeatureCard extends LitElement {
   }
 
   renderProvenanceBadge(): TemplateResult | typeof nothing {
-    if (!this.feature) return nothing;
+    const feature = this.feature;
+    if (!feature) return nothing;
 
     if (
-      this.feature.summary_source ===
-      ReleaseNoteFeatureSummarySourceEnum.AI_APPLIED
+      feature.summary_source === ReleaseNoteFeatureSummarySourceEnum.AI_APPLIED
     ) {
       return html`<sl-badge variant="success" pill>AI Applied</sl-badge>`;
     }
@@ -317,33 +342,36 @@ export class ChromedashReleaseFeatureCard extends LitElement {
   }
 
   renderDocLinks(): TemplateResult | typeof nothing {
-    if (!this.feature) return nothing;
+    const feature = this.feature;
+    if (!feature) return nothing;
 
     let normalizedLinks: ReleaseNoteLink[] = [];
 
-    if (Array.isArray(this.feature.links) && this.feature.links.length > 0) {
-      normalizedLinks = this.feature.links;
+    if (Array.isArray(feature.links) && feature.links.length > 0) {
+      normalizedLinks = feature.links;
     } else {
-      if (Array.isArray(this.feature.doc_links)) {
-        for (const url of this.feature.doc_links) {
-          normalizedLinks.push({
-            url,
-            type: ReleaseNoteLinkTypeEnum.DOC,
-          });
+      if (Array.isArray(feature.doc_links)) {
+        for (const url of feature.doc_links) {
+          if (url && !normalizedLinks.some(l => l.url === url)) {
+            normalizedLinks.push({
+              url,
+              type: ReleaseNoteLinkTypeEnum.DOC,
+            });
+          }
         }
       }
       if (
-        this.feature.spec_link &&
-        !normalizedLinks.some(l => l.url === this.feature!.spec_link)
+        feature.spec_link &&
+        !normalizedLinks.some(l => l.url === feature.spec_link)
       ) {
         normalizedLinks.push({
-          url: this.feature.spec_link,
+          url: feature.spec_link,
           type: ReleaseNoteLinkTypeEnum.SPEC,
         });
       }
-      if (Array.isArray(this.feature.explainer_links)) {
-        for (const url of this.feature.explainer_links) {
-          if (!normalizedLinks.some(l => l.url === url)) {
+      if (Array.isArray(feature.explainer_links)) {
+        for (const url of feature.explainer_links) {
+          if (url && !normalizedLinks.some(l => l.url === url)) {
             normalizedLinks.push({
               url,
               type: ReleaseNoteLinkTypeEnum.EXPLAINER,
@@ -353,6 +381,7 @@ export class ChromedashReleaseFeatureCard extends LitElement {
       }
     }
 
+    normalizedLinks = normalizedLinks.filter(l => Boolean(l?.url?.trim()));
     if (normalizedLinks.length === 0) return nothing;
 
     return html`
@@ -361,12 +390,12 @@ export class ChromedashReleaseFeatureCard extends LitElement {
         aria-label="Feature metadata and resources"
       >
         ${normalizedLinks.map((link, idx) => {
-          const isExternal =
-            !link.url.startsWith('/') && !link.url.startsWith('#');
-          const displayLabel =
-            link.title ||
-            LINK_TYPE_TITLES[link.type as ReleaseNoteLinkTypeEnum] ||
-            link.url;
+          const isInternal =
+            (link.url.startsWith('/') && !link.url.startsWith('//')) ||
+            link.url.startsWith('#');
+          const isExternal = !isInternal;
+          const title = link.title?.trim();
+          const displayLabel = title || LINK_TYPE_TITLES[link.type] || link.url;
           return html`
             ${
               idx > 0
@@ -395,12 +424,11 @@ export class ChromedashReleaseFeatureCard extends LitElement {
   }
 
   renderFeatureSummary(): TemplateResult | typeof nothing {
-    if (!this.feature) return nothing;
+    const feature = this.feature;
+    if (!feature || !feature.summary?.trim()) return nothing;
 
-    const isMarkdown = Boolean(
-      this.feature.markdown_fields?.includes('summary')
-    );
-    const formattedSummary = autolink(this.feature.summary, [], isMarkdown);
+    const isMarkdown = Boolean(feature.markdown_fields?.includes('summary'));
+    const formattedSummary = autolink(feature.summary, [], isMarkdown);
 
     return html`
       <div class="feature-summary ${isMarkdown ? '' : 'preformatted'}">
@@ -409,30 +437,35 @@ export class ChromedashReleaseFeatureCard extends LitElement {
     `;
   }
 
-  render() {
-    if (!this.feature) {
+  render(): TemplateResult | typeof nothing {
+    const feature = this.feature;
+    if (!feature) {
       return nothing;
     }
 
     return html`
       <article
         class="feature-card"
-        id="feature-${this.feature.id}"
-        aria-labelledby="feature-title-${this.feature.id}"
+        id="feature-${feature.id}"
+        aria-labelledby="feature-title-${feature.id}"
       >
         <header class="card-header">
           <div class="title-wrapper">
-            <h3 class="feature-title" id="feature-title-${this.feature.id}">
-              <a class="feature-name" href="/feature/${this.feature.id}">
-                ${this.feature.name}
+            <h3 class="feature-title" id="feature-title-${feature.id}">
+              <a class="feature-name" href="/feature/${feature.id}">
+                ${feature.name}
               </a>
             </h3>
             <a
               class="heading-anchor-link ${this.isCopied ? 'copied' : ''}"
-              href="#feature-${this.feature.id}"
-              aria-label="Copy link to ${this.feature.name}"
+              href="#feature-${feature.id}"
+              aria-label=${
+                this.isCopied
+                  ? `Link to ${feature.name} copied to clipboard`
+                  : `Copy link to ${feature.name}`
+              }
               title="Copy link to feature"
-              data-anchor="#feature-${this.feature.id}"
+              data-anchor="#feature-${feature.id}"
               @click=${this.handleAnchorCopy}
             >
               <span aria-hidden="true">#</span>

--- a/client-src/elements/chromedash-release-feature-card.ts
+++ b/client-src/elements/chromedash-release-feature-card.ts
@@ -468,15 +468,25 @@ export class ChromedashReleaseFeatureCard extends LitElement {
     `;
   }
 
-  render() {
-    if (!this.feature) {
-      return nothing;
-    }
+  renderFeatureSummary(): TemplateResult | typeof nothing {
+    if (!this.feature) return nothing;
 
     const isMarkdown = Boolean(
       this.feature.markdown_fields?.includes('summary')
     );
     const formattedSummary = autolink(this.feature.summary, [], isMarkdown);
+
+    return html`
+      <div class="feature-summary ${isMarkdown ? '' : 'preformatted'}">
+        ${formattedSummary}
+      </div>
+    `;
+  }
+
+  render() {
+    if (!this.feature) {
+      return nothing;
+    }
 
     return html`
       <article
@@ -511,9 +521,8 @@ export class ChromedashReleaseFeatureCard extends LitElement {
           </div>
         </header>
 
-        <div class="feature-summary">${formattedSummary}</div>
-
-        ${this.renderDocLinks()} ${this.renderReviewActions()}
+        ${this.renderFeatureSummary()} ${this.renderDocLinks()}
+        ${this.renderReviewActions()}
       </article>
     `;
   }

--- a/client-src/elements/chromedash-release-feature-card.ts
+++ b/client-src/elements/chromedash-release-feature-card.ts
@@ -1,0 +1,497 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement, css, html, nothing, TemplateResult} from 'lit';
+import {customElement, property, state} from 'lit/decorators.js';
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/badge/badge.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
+import {SHARED_STYLES} from '../css/shared-css.js';
+import {autolink} from './utils.js';
+import {
+  SummarySuggestion,
+  SummarySuggestionStatusEnum,
+} from 'chromestatus-openapi';
+
+export type FeatureCardItem = {
+  id: number;
+  name: string;
+  summary: string;
+  category?: string | number;
+  category_name?: string;
+  feature_type?: string | number;
+  summary_source?: string;
+  doc_links?: string[];
+  spec_link?: string;
+  explainer_links?: string[];
+  markdown_fields?: string[];
+  [key: string]: unknown;
+};
+
+@customElement('chromedash-release-feature-card')
+export class ChromedashReleaseFeatureCard extends LitElement {
+  @property({attribute: false})
+  feature: FeatureCardItem | null = null;
+
+  @property({attribute: false})
+  suggestion: SummarySuggestion | null = null;
+
+  @property({type: Boolean})
+  reviewMode = false;
+
+  @property({type: Number})
+  milestone?: number;
+
+  @state()
+  isCopied = false;
+
+  static get styles() {
+    return [
+      ...SHARED_STYLES,
+      css`
+        :host {
+          display: block;
+        }
+
+        .feature-card {
+          border: var(--card-border);
+          border-radius: var(--border-radius);
+          box-shadow: var(--card-box-shadow);
+          padding: var(--content-padding);
+          background-color: var(--card-background);
+          display: flex;
+          flex-direction: column;
+          gap: var(--content-padding-half);
+          scroll-margin-top: 5rem;
+          transition:
+            box-shadow 0.15s ease,
+            border-color 0.15s ease;
+        }
+
+        .feature-card:hover {
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        }
+
+        .card-header {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          flex-wrap: wrap;
+          gap: var(--content-padding-half);
+        }
+
+        .title-wrapper {
+          display: flex;
+          align-items: center;
+          gap: var(--content-padding-quarter);
+          flex-wrap: wrap;
+        }
+
+        .feature-title {
+          font-size: var(--h3-font-size, 1.25rem);
+          font-weight: 600;
+          margin: 0;
+          line-height: 1.3;
+        }
+
+        .feature-name {
+          color: var(--link-color, #1a73e8);
+          text-decoration: none;
+        }
+
+        .feature-name:hover {
+          text-decoration: underline;
+        }
+
+        .heading-anchor-link {
+          opacity: 0;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          min-width: 1.5rem;
+          min-height: 1.5rem;
+          padding: 2px;
+          border-radius: var(--border-radius);
+          color: var(--unimportant-text-color);
+          text-decoration: none;
+          position: relative;
+          transition:
+            opacity 0.15s ease,
+            background-color 0.15s ease;
+        }
+
+        .feature-card:hover .heading-anchor-link,
+        .heading-anchor-link:focus-visible {
+          opacity: 1;
+        }
+
+        .heading-anchor-link:hover,
+        .heading-anchor-link:focus-visible {
+          background-color: var(--light-accent-color);
+          color: var(--default-color);
+          outline: 2px solid var(--primary-button-background);
+          outline-offset: 2px;
+        }
+
+        .anchor-tooltip {
+          position: absolute;
+          bottom: calc(100% + var(--content-padding-quarter));
+          left: 50%;
+          transform: translateX(-50%);
+          background-color: var(--toast-background, #323232);
+          color: var(--toast-color, #fff);
+          font-size: var(--button-small-font-size, 0.75rem);
+          padding: 4px 8px;
+          border-radius: var(--border-radius);
+          white-space: nowrap;
+          pointer-events: none;
+          opacity: 0;
+          transition:
+            opacity 0.2s ease,
+            transform 0.2s ease;
+          z-index: 10;
+        }
+
+        .heading-anchor-link.copied .anchor-tooltip {
+          opacity: 1;
+          transform: translateX(-50%) translateY(-2px);
+        }
+
+        .badges-wrapper {
+          display: flex;
+          align-items: center;
+          gap: var(--sl-spacing-2x-small);
+          flex-wrap: wrap;
+        }
+
+        .feature-summary {
+          line-height: 1.5;
+          color: var(--default-color);
+          overflow-wrap: break-word;
+        }
+
+        .feature-summary p {
+          margin: 0 0 var(--content-padding-half) 0;
+        }
+
+        .feature-summary p:last-child {
+          margin-bottom: 0;
+        }
+
+        .feature-summary code {
+          font-family: monospace;
+          background-color: var(--light-accent-color);
+          padding: 2px 4px;
+          border-radius: var(--border-radius);
+          border: var(--default-border);
+        }
+
+        .feature-summary a {
+          text-decoration: underline;
+          text-underline-offset: 2px;
+        }
+
+        .feature-links-section {
+          display: flex;
+          flex-direction: column;
+          gap: var(--content-padding-quarter);
+          border-top: var(--default-border);
+          padding-top: var(--content-padding-half);
+        }
+
+        .feature-link-item {
+          display: inline-flex;
+          align-items: center;
+          gap: var(--content-padding-quarter);
+          max-width: 100%;
+          text-decoration: underline;
+          text-underline-offset: 2px;
+          font-size: var(--button-small-font-size, 0.875rem);
+        }
+
+        .link-text {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .card-actions {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          flex-wrap: wrap;
+          gap: var(--sl-spacing-small);
+          border-top: var(--default-border);
+          padding-top: var(--content-padding-half);
+        }
+
+        .action-buttons {
+          display: flex;
+          align-items: center;
+          gap: var(--sl-spacing-small);
+        }
+
+        .suggestion-meta {
+          display: flex;
+          align-items: center;
+          gap: var(--sl-spacing-x-small);
+          font-size: var(--button-small-font-size, 0.875rem);
+          color: var(--unimportant-text-color);
+        }
+      `,
+    ];
+  }
+
+  async handleAnchorCopy(e: Event) {
+    e.preventDefault();
+    if (!this.feature) return;
+
+    const anchor = `#feature-${this.feature.id}`;
+    const fullUrl = new URL(anchor, window.location.href).href;
+
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(fullUrl);
+        this.isCopied = true;
+        setTimeout(() => {
+          this.isCopied = false;
+        }, 2000);
+      }
+    } catch (err) {
+      console.warn('Could not copy anchor link to clipboard:', err);
+    }
+  }
+
+  handleReviewClick() {
+    this.dispatchEvent(
+      new CustomEvent('review-click', {
+        detail: {
+          feature: this.feature,
+          suggestion: this.suggestion,
+          featureId: this.feature?.id,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  handleGenerateClick() {
+    this.dispatchEvent(
+      new CustomEvent('generate-click', {
+        detail: {
+          feature: this.feature,
+          featureId: this.feature?.id,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  renderCategoryBadge(): TemplateResult | typeof nothing {
+    if (!this.feature) return nothing;
+    const categoryName =
+      this.feature.category_name ||
+      (typeof this.feature.category === 'string' ? this.feature.category : '');
+    if (!categoryName) return nothing;
+
+    return html`<sl-badge variant="neutral" pill>${categoryName}</sl-badge>`;
+  }
+
+  renderProvenanceBadge(): TemplateResult | typeof nothing {
+    if (!this.feature) return nothing;
+
+    if (
+      this.suggestion &&
+      this.suggestion.status === SummarySuggestionStatusEnum.PENDING
+    ) {
+      return html`<sl-badge variant="warning" pill
+        >AI Review Pending</sl-badge
+      >`;
+    }
+
+    if (this.feature.summary_source === 'AI_APPLIED') {
+      return html`<sl-badge variant="success" pill>AI Applied</sl-badge>`;
+    }
+
+    return html`<sl-badge variant="neutral" pill>Human Authored</sl-badge>`;
+  }
+
+  renderDocLinks(): TemplateResult | typeof nothing {
+    if (!this.feature) return nothing;
+
+    const links: string[] = [];
+
+    if (Array.isArray(this.feature.doc_links)) {
+      links.push(...this.feature.doc_links);
+    }
+    if (this.feature.spec_link && !links.includes(this.feature.spec_link)) {
+      links.push(this.feature.spec_link);
+    }
+    if (Array.isArray(this.feature.explainer_links)) {
+      for (const link of this.feature.explainer_links) {
+        if (!links.includes(link)) {
+          links.push(link);
+        }
+      }
+    }
+    if (
+      this.suggestion?.suggested_doc_links &&
+      Array.isArray(this.suggestion.suggested_doc_links)
+    ) {
+      for (const link of this.suggestion.suggested_doc_links) {
+        if (!links.includes(link)) {
+          links.push(link);
+        }
+      }
+    }
+
+    if (links.length === 0) return nothing;
+
+    return html`
+      <div class="feature-links-section" aria-label="Documentation links">
+        ${links.map(
+          link => html`
+            <a
+              class="feature-link-item"
+              href=${link}
+              target="_blank"
+              rel="noopener noreferrer"
+              title=${link}
+            >
+              <span class="link-text">${link}</span>
+              <sl-icon name="box-arrow-up-right"></sl-icon>
+            </a>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  renderReviewActions(): TemplateResult | typeof nothing {
+    if (!this.reviewMode || !this.feature) return nothing;
+
+    const hasPendingSuggestion =
+      this.suggestion &&
+      this.suggestion.status === SummarySuggestionStatusEnum.PENDING;
+
+    return html`
+      <div class="card-actions">
+        <div class="action-buttons">
+          ${
+            hasPendingSuggestion
+              ? html`
+                  <sl-button
+                    size="small"
+                    variant="primary"
+                    class="review-button"
+                    @click=${this.handleReviewClick}
+                  >
+                    <sl-icon slot="prefix" name="pencil"></sl-icon>
+                    Review Suggestion
+                  </sl-button>
+                `
+              : html`
+                  <sl-button
+                    size="small"
+                    variant="default"
+                    class="review-button"
+                    @click=${this.handleReviewClick}
+                  >
+                    <sl-icon slot="prefix" name="eye"></sl-icon>
+                    Inspect / Edit
+                  </sl-button>
+                `
+          }
+          <sl-button
+            size="small"
+            variant="default"
+            class="generate-button"
+            @click=${this.handleGenerateClick}
+          >
+            <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+            ${hasPendingSuggestion ? 'Regenerate' : 'Generate AI Summary'}
+          </sl-button>
+        </div>
+
+        ${
+          this.suggestion?.reasoning
+            ? html`
+                <div class="suggestion-meta">
+                  <sl-tooltip content=${this.suggestion.reasoning}>
+                    <sl-icon name="info-circle"></sl-icon>
+                  </sl-tooltip>
+                  <span>Grounding available</span>
+                </div>
+              `
+            : nothing
+        }
+      </div>
+    `;
+  }
+
+  render() {
+    if (!this.feature) {
+      return nothing;
+    }
+
+    const isMarkdown =
+      (this.feature.markdown_fields || []).includes('summary') || true;
+    const formattedSummary = autolink(this.feature.summary, [], isMarkdown);
+
+    return html`
+      <article
+        class="feature-card"
+        id="feature-${this.feature.id}"
+        role="article"
+        aria-labelledby="feature-title-${this.feature.id}"
+      >
+        <header class="card-header">
+          <div class="title-wrapper">
+            <h3 class="feature-title" id="feature-title-${this.feature.id}">
+              <a class="feature-name" href="/feature/${this.feature.id}">
+                ${this.feature.name}
+              </a>
+            </h3>
+            <a
+              class="heading-anchor-link ${this.isCopied ? 'copied' : ''}"
+              href="#feature-${this.feature.id}"
+              aria-label="Copy link to ${this.feature.name}"
+              title="Copy link to feature"
+              data-anchor="#feature-${this.feature.id}"
+              @click=${this.handleAnchorCopy}
+            >
+              <span aria-hidden="true">#</span>
+              <span class="anchor-tooltip" role="status" aria-live="polite">
+                ${this.isCopied ? 'Link copied!' : 'Copy link'}
+              </span>
+            </a>
+          </div>
+
+          <div class="badges-wrapper">
+            ${this.renderCategoryBadge()} ${this.renderProvenanceBadge()}
+          </div>
+        </header>
+
+        <div class="feature-summary">${formattedSummary}</div>
+
+        ${this.renderDocLinks()} ${this.renderReviewActions()}
+      </article>
+    `;
+  }
+}

--- a/client-src/elements/chromedash-release-feature-card_test.ts
+++ b/client-src/elements/chromedash-release-feature-card_test.ts
@@ -20,7 +20,10 @@ import {
   ChromedashReleaseFeatureCard,
   FeatureCardItem,
 } from './chromedash-release-feature-card.js';
-import {ReleaseNoteFeatureSummarySourceEnum} from 'chromestatus-openapi';
+import {
+  ReleaseNoteFeatureSummarySourceEnum,
+  ReleaseNoteLinkTypeEnum,
+} from 'chromestatus-openapi';
 import sinon from 'sinon';
 
 describe('chromedash-release-feature-card', () => {
@@ -29,15 +32,25 @@ describe('chromedash-release-feature-card', () => {
     name: 'CSS Subgrid',
     summary:
       'Enables grid items to inherit and share the **grid definition** of their parent.',
-    category: 'CSS',
+    category: 15,
     category_name: 'CSS',
     feature_type: 1,
     summary_source: ReleaseNoteFeatureSummarySourceEnum.HUMAN,
-    doc_links: [
-      'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid',
+    links: [
+      {
+        url: 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid',
+        type: ReleaseNoteLinkTypeEnum.DOC,
+        title: 'MDN Subgrid Guide',
+      },
+      {
+        url: 'https://www.w3.org/TR/css-grid-2/',
+        type: ReleaseNoteLinkTypeEnum.SPEC,
+      },
+      {
+        url: 'https://github.com/w3c/csswg-drafts/issues/1234',
+        type: ReleaseNoteLinkTypeEnum.EXPLAINER,
+      },
     ],
-    spec_link: 'https://www.w3.org/TR/css-grid-2/',
-    explainer_links: ['https://github.com/w3c/csswg-drafts/issues/1234'],
   };
 
   it('renders standard feature card with name, summary, category, and links', async () => {
@@ -66,9 +79,58 @@ describe('chromedash-release-feature-card', () => {
     assert.equal(categoryBadge?.textContent?.trim(), 'CSS');
 
     const links = el.shadowRoot!.querySelectorAll(
-      '.feature-links-section .feature-link-item'
+      '.feature-links-bar .feature-link-item'
     );
     assert.equal(links.length, 3);
+    assert.equal(
+      links[0].querySelector('.doc-link-text')?.textContent?.trim(),
+      'MDN Subgrid Guide'
+    );
+    assert.equal(
+      links[1].querySelector('.doc-link-text')?.textContent?.trim(),
+      'Spec'
+    );
+    assert.equal(
+      links[2].querySelector('.doc-link-text')?.textContent?.trim(),
+      'Explainer'
+    );
+  });
+
+  it('renders links from legacy flat fields when links array is missing', async () => {
+    const legacyFeature: FeatureCardItem = {
+      id: 67890,
+      name: 'Legacy Links Feature',
+      summary: 'Summary text.',
+      category: 5,
+      category_name: 'DOM',
+      feature_type: 1,
+      doc_links: ['https://example.com/doc'],
+      spec_link: 'https://example.com/spec',
+      explainer_links: ['https://example.com/explainer'],
+    };
+
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${legacyFeature}
+      ></chromedash-release-feature-card>`
+    );
+
+    const links = el.shadowRoot!.querySelectorAll(
+      '.feature-links-bar .feature-link-item'
+    );
+    assert.equal(links.length, 3);
+    assert.equal(
+      links[0].querySelector('.doc-link-text')?.textContent?.trim(),
+      'Docs'
+    );
+    assert.equal(
+      links[1].querySelector('.doc-link-text')?.textContent?.trim(),
+      'Spec'
+    );
+    assert.equal(
+      links[2].querySelector('.doc-link-text')?.textContent?.trim(),
+      'Explainer'
+    );
   });
 
   it('renders plain-text summary with preformatted class', async () => {
@@ -193,6 +255,7 @@ describe('chromedash-release-feature-card', () => {
   it('renders no doc links section when no links are present', async () => {
     const featureNoLinks: FeatureCardItem = {
       ...mockFeature,
+      links: [],
       doc_links: [],
       spec_link: undefined,
       explainer_links: [],
@@ -202,12 +265,13 @@ describe('chromedash-release-feature-card', () => {
         .feature=${featureNoLinks}
       ></chromedash-release-feature-card>`
     );
-    assert.isNull(el.shadowRoot!.querySelector('.feature-links-section'));
+    assert.isNull(el.shadowRoot!.querySelector('.feature-links-bar'));
   });
 
   it('deduplicates links across doc_links, spec_link, and explainer_links', async () => {
     const duplicateFeature: FeatureCardItem = {
       ...mockFeature,
+      links: undefined,
       doc_links: ['https://example.com/same-link'],
       spec_link: 'https://example.com/same-link',
       explainer_links: ['https://example.com/same-link'],
@@ -218,7 +282,7 @@ describe('chromedash-release-feature-card', () => {
       ></chromedash-release-feature-card>`
     );
     const links = el.shadowRoot!.querySelectorAll(
-      '.feature-links-section .feature-link-item'
+      '.feature-links-bar .feature-link-item'
     );
     assert.equal(links.length, 1);
     assert.equal(

--- a/client-src/elements/chromedash-release-feature-card_test.ts
+++ b/client-src/elements/chromedash-release-feature-card_test.ts
@@ -203,4 +203,52 @@ describe('chromedash-release-feature-card', () => {
 
     clipboardStub.restore();
   });
+
+  it('renders nothing when feature is null', async () => {
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card></chromedash-release-feature-card>`
+    );
+    assert.isNull(el.shadowRoot!.querySelector('.feature-card'));
+  });
+
+  it('does not render card actions when reviewMode is false', async () => {
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+        .reviewMode=${false}
+      ></chromedash-release-feature-card>`
+    );
+    assert.isNull(el.shadowRoot!.querySelector('.card-actions'));
+  });
+
+  it('renders inspect button when reviewMode is true without pending suggestion', async () => {
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+        ?reviewMode=${true}
+      ></chromedash-release-feature-card>`
+    );
+    const reviewBtn = el.shadowRoot!.querySelector('.review-button');
+    assert.include(reviewBtn?.textContent || '', 'Inspect / Edit');
+    const generateBtn = el.shadowRoot!.querySelector('.generate-button');
+    assert.include(generateBtn?.textContent || '', 'Generate AI Summary');
+  });
+
+  it('renders category badge from numeric category ID', async () => {
+    const featureWithNumCategory: FeatureCardItem = {
+      ...mockFeature,
+      category: 15,
+      category_name: undefined,
+    };
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${featureWithNumCategory}
+      ></chromedash-release-feature-card>`
+    );
+    const badges = el.shadowRoot!.querySelectorAll('sl-badge');
+    const categoryBadge = Array.from(badges).find(
+      b => b.textContent?.trim() === 'CSS'
+    );
+    assert.isDefined(categoryBadge);
+  });
 });

--- a/client-src/elements/chromedash-release-feature-card_test.ts
+++ b/client-src/elements/chromedash-release-feature-card_test.ts
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-import {html, fixture, assert, oneEvent} from '@open-wc/testing';
+import {html, fixture, assert} from '@open-wc/testing';
 import './chromedash-release-feature-card.js';
 import {
   ChromedashReleaseFeatureCard,
   FeatureCardItem,
 } from './chromedash-release-feature-card.js';
-import {
-  SummarySuggestion,
-  SummarySuggestionStatusEnum,
-} from 'chromestatus-openapi';
+import {ReleaseNoteFeatureSummarySourceEnum} from 'chromestatus-openapi';
 import sinon from 'sinon';
 
 describe('chromedash-release-feature-card', () => {
@@ -35,26 +32,12 @@ describe('chromedash-release-feature-card', () => {
     category: 'CSS',
     category_name: 'CSS',
     feature_type: 1,
-    summary_source: 'HUMAN',
+    summary_source: ReleaseNoteFeatureSummarySourceEnum.HUMAN,
     doc_links: [
       'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid',
     ],
     spec_link: 'https://www.w3.org/TR/css-grid-2/',
     explainer_links: ['https://github.com/w3c/csswg-drafts/issues/1234'],
-  };
-
-  const mockSuggestion: SummarySuggestion = {
-    feature_id: 12345,
-    suggested_summary: 'AI-generated summary for CSS Subgrid.',
-    original_summary: 'Enables grid items to inherit grid definition.',
-    status: SummarySuggestionStatusEnum.PENDING,
-    reasoning: 'Extracted from W3C spec and MDN documentation.',
-    suggested_doc_links: [
-      'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid',
-    ],
-    version_token: 1,
-    created: new Date('2026-08-20T10:00:00Z'),
-    updated: new Date('2026-08-20T10:00:00Z'),
   };
 
   it('renders standard feature card with name, summary, category, and links', async () => {
@@ -133,7 +116,7 @@ describe('chromedash-release-feature-card', () => {
   it('renders AI Applied badge when summary_source is AI_APPLIED', async () => {
     const aiFeature: FeatureCardItem = {
       ...mockFeature,
-      summary_source: 'AI_APPLIED',
+      summary_source: ReleaseNoteFeatureSummarySourceEnum.AI_APPLIED,
     };
 
     const el = await fixture<ChromedashReleaseFeatureCard>(
@@ -147,80 +130,16 @@ describe('chromedash-release-feature-card', () => {
     assert.include(badgeTexts, 'AI Applied');
   });
 
-  it('renders AI Review Pending badge when pending suggestion exists', async () => {
+  it('renders Human Authored badge when summary_source is HUMAN or unset', async () => {
     const el = await fixture<ChromedashReleaseFeatureCard>(
       html`<chromedash-release-feature-card
         .feature=${mockFeature}
-        .suggestion=${mockSuggestion}
       ></chromedash-release-feature-card>`
     );
 
     const badges = el.shadowRoot!.querySelectorAll('.badges-wrapper sl-badge');
     const badgeTexts = Array.from(badges).map(b => b.textContent?.trim());
-    assert.include(badgeTexts, 'AI Review Pending');
-  });
-
-  it('renders review actions when reviewMode is true', async () => {
-    const el = await fixture<ChromedashReleaseFeatureCard>(
-      html`<chromedash-release-feature-card
-        .feature=${mockFeature}
-        .suggestion=${mockSuggestion}
-        ?reviewMode=${true}
-      ></chromedash-release-feature-card>`
-    );
-
-    const actions = el.shadowRoot!.querySelector('.card-actions');
-    assert.isNotNull(actions);
-
-    const reviewBtn = el.shadowRoot!.querySelector('.review-button');
-    assert.isNotNull(reviewBtn);
-    assert.include(reviewBtn?.textContent || '', 'Review Suggestion');
-
-    const generateBtn = el.shadowRoot!.querySelector('.generate-button');
-    assert.isNotNull(generateBtn);
-    assert.include(generateBtn?.textContent || '', 'Regenerate');
-
-    const groundingMeta = el.shadowRoot!.querySelector('.suggestion-meta');
-    assert.isNotNull(groundingMeta);
-    assert.include(groundingMeta?.textContent || '', 'Grounding available');
-  });
-
-  it('dispatches review-click event when review button is clicked', async () => {
-    const el = await fixture<ChromedashReleaseFeatureCard>(
-      html`<chromedash-release-feature-card
-        .feature=${mockFeature}
-        .suggestion=${mockSuggestion}
-        ?reviewMode=${true}
-      ></chromedash-release-feature-card>`
-    );
-
-    const reviewBtn =
-      el.shadowRoot!.querySelector<HTMLElement>('.review-button');
-    const eventPromise = oneEvent(el, 'review-click');
-    reviewBtn?.click();
-
-    const event = (await eventPromise) as CustomEvent;
-    assert.isNotNull(event);
-    assert.equal(event.detail.featureId, 12345);
-    assert.deepEqual(event.detail.suggestion, mockSuggestion);
-  });
-
-  it('dispatches generate-click event when generate button is clicked', async () => {
-    const el = await fixture<ChromedashReleaseFeatureCard>(
-      html`<chromedash-release-feature-card
-        .feature=${mockFeature}
-        ?reviewMode=${true}
-      ></chromedash-release-feature-card>`
-    );
-
-    const generateBtn =
-      el.shadowRoot!.querySelector<HTMLElement>('.generate-button');
-    const eventPromise = oneEvent(el, 'generate-click');
-    generateBtn?.click();
-
-    const event = (await eventPromise) as CustomEvent;
-    assert.isNotNull(event);
-    assert.equal(event.detail.featureId, 12345);
+    assert.include(badgeTexts, 'Human Authored');
   });
 
   it('copies anchor link when heading anchor link is clicked', async () => {
@@ -251,29 +170,6 @@ describe('chromedash-release-feature-card', () => {
       html`<chromedash-release-feature-card></chromedash-release-feature-card>`
     );
     assert.isNull(el.shadowRoot!.querySelector('.feature-card'));
-  });
-
-  it('does not render card actions when reviewMode is false', async () => {
-    const el = await fixture<ChromedashReleaseFeatureCard>(
-      html`<chromedash-release-feature-card
-        .feature=${mockFeature}
-        .reviewMode=${false}
-      ></chromedash-release-feature-card>`
-    );
-    assert.isNull(el.shadowRoot!.querySelector('.card-actions'));
-  });
-
-  it('renders inspect button when reviewMode is true without pending suggestion', async () => {
-    const el = await fixture<ChromedashReleaseFeatureCard>(
-      html`<chromedash-release-feature-card
-        .feature=${mockFeature}
-        ?reviewMode=${true}
-      ></chromedash-release-feature-card>`
-    );
-    const reviewBtn = el.shadowRoot!.querySelector('.review-button');
-    assert.include(reviewBtn?.textContent || '', 'Inspect / Edit');
-    const generateBtn = el.shadowRoot!.querySelector('.generate-button');
-    assert.include(generateBtn?.textContent || '', 'Generate AI Summary');
   });
 
   it('renders category badge from numeric category ID', async () => {
@@ -309,21 +205,16 @@ describe('chromedash-release-feature-card', () => {
     assert.isNull(el.shadowRoot!.querySelector('.feature-links-section'));
   });
 
-  it('deduplicates links across doc_links, spec_link, explainer_links, and suggested_doc_links', async () => {
+  it('deduplicates links across doc_links, spec_link, and explainer_links', async () => {
     const duplicateFeature: FeatureCardItem = {
       ...mockFeature,
       doc_links: ['https://example.com/same-link'],
       spec_link: 'https://example.com/same-link',
       explainer_links: ['https://example.com/same-link'],
     };
-    const suggestionWithSameLink: SummarySuggestion = {
-      ...mockSuggestion,
-      suggested_doc_links: ['https://example.com/same-link'],
-    };
     const el = await fixture<ChromedashReleaseFeatureCard>(
       html`<chromedash-release-feature-card
         .feature=${duplicateFeature}
-        .suggestion=${suggestionWithSameLink}
       ></chromedash-release-feature-card>`
     );
     const links = el.shadowRoot!.querySelectorAll(
@@ -352,7 +243,6 @@ describe('chromedash-release-feature-card', () => {
     );
     anchorLink?.click();
 
-    // Should not throw or mark isCopied
     assert.isFalse(el.isCopied);
 
     clipboardStub.restore();
@@ -377,7 +267,6 @@ describe('chromedash-release-feature-card', () => {
     await el.handleAnchorCopy(clickEvent);
     assert.isTrue(el.isCopied);
 
-    // Trigger disconnectedCallback
     el.disconnectedCallback();
     assert.isTrue(clearTimeoutSpy.called);
 

--- a/client-src/elements/chromedash-release-feature-card_test.ts
+++ b/client-src/elements/chromedash-release-feature-card_test.ts
@@ -251,4 +251,95 @@ describe('chromedash-release-feature-card', () => {
     );
     assert.isDefined(categoryBadge);
   });
+
+  it('renders no doc links section when no links are present', async () => {
+    const featureNoLinks: FeatureCardItem = {
+      ...mockFeature,
+      doc_links: [],
+      spec_link: undefined,
+      explainer_links: [],
+    };
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${featureNoLinks}
+      ></chromedash-release-feature-card>`
+    );
+    assert.isNull(el.shadowRoot!.querySelector('.feature-links-section'));
+  });
+
+  it('deduplicates links across doc_links, spec_link, explainer_links, and suggested_doc_links', async () => {
+    const duplicateFeature: FeatureCardItem = {
+      ...mockFeature,
+      doc_links: ['https://example.com/same-link'],
+      spec_link: 'https://example.com/same-link',
+      explainer_links: ['https://example.com/same-link'],
+    };
+    const suggestionWithSameLink: SummarySuggestion = {
+      ...mockSuggestion,
+      suggested_doc_links: ['https://example.com/same-link'],
+    };
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${duplicateFeature}
+        .suggestion=${suggestionWithSameLink}
+      ></chromedash-release-feature-card>`
+    );
+    const links = el.shadowRoot!.querySelectorAll(
+      '.feature-links-section .feature-link-item'
+    );
+    assert.equal(links.length, 1);
+    assert.equal(
+      links[0].getAttribute('href'),
+      'https://example.com/same-link'
+    );
+  });
+
+  it('handles clipboard failure gracefully without throwing', async () => {
+    const clipboardStub = sinon
+      .stub(navigator.clipboard, 'writeText')
+      .rejects(new Error('Clipboard permission denied'));
+
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+      ></chromedash-release-feature-card>`
+    );
+
+    const anchorLink = el.shadowRoot!.querySelector<HTMLElement>(
+      '.heading-anchor-link'
+    );
+    anchorLink?.click();
+
+    // Should not throw or mark isCopied
+    assert.isFalse(el.isCopied);
+
+    clipboardStub.restore();
+  });
+
+  it('clears copied timeout on disconnectedCallback', async () => {
+    const clearTimeoutSpy = sinon.spy(window, 'clearTimeout');
+    const clipboardStub = sinon
+      .stub(navigator.clipboard, 'writeText')
+      .resolves();
+
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+      ></chromedash-release-feature-card>`
+    );
+
+    const clickEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    await el.handleAnchorCopy(clickEvent);
+    assert.isTrue(el.isCopied);
+
+    // Trigger disconnectedCallback
+    el.disconnectedCallback();
+    assert.isTrue(clearTimeoutSpy.called);
+
+    clipboardStub.restore();
+    clearTimeoutSpy.restore();
+  });
 });

--- a/client-src/elements/chromedash-release-feature-card_test.ts
+++ b/client-src/elements/chromedash-release-feature-card_test.ts
@@ -88,6 +88,48 @@ describe('chromedash-release-feature-card', () => {
     assert.equal(links.length, 3);
   });
 
+  it('renders plain-text summary with preformatted class', async () => {
+    const plainFeature: FeatureCardItem = {
+      ...mockFeature,
+      summary: 'Line 1\nLine 2',
+      markdown_fields: [],
+    };
+
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${plainFeature}
+      ></chromedash-release-feature-card>`
+    );
+
+    const summaryEl = el.shadowRoot!.querySelector('.feature-summary');
+    assert.isNotNull(summaryEl);
+    assert.isTrue(summaryEl?.classList.contains('preformatted'));
+    assert.include(summaryEl?.textContent || '', 'Line 1\nLine 2');
+  });
+
+  it('renders markdown summary without preformatted class', async () => {
+    const mdFeature: FeatureCardItem = {
+      ...mockFeature,
+      summary: '**Bold summary** with [link](https://example.com)',
+      markdown_fields: ['summary'],
+    };
+
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mdFeature}
+      ></chromedash-release-feature-card>`
+    );
+
+    const summaryEl = el.shadowRoot!.querySelector('.feature-summary');
+    assert.isNotNull(summaryEl);
+    assert.isFalse(summaryEl?.classList.contains('preformatted'));
+    assert.isNotNull(summaryEl?.querySelector('strong'));
+    assert.equal(
+      summaryEl?.querySelector('strong')?.textContent,
+      'Bold summary'
+    );
+  });
+
   it('renders AI Applied badge when summary_source is AI_APPLIED', async () => {
     const aiFeature: FeatureCardItem = {
       ...mockFeature,

--- a/client-src/elements/chromedash-release-feature-card_test.ts
+++ b/client-src/elements/chromedash-release-feature-card_test.ts
@@ -27,6 +27,16 @@ import {
 import sinon from 'sinon';
 
 describe('chromedash-release-feature-card', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   const mockFeature: FeatureCardItem = {
     id: 12345,
     name: 'CSS Subgrid',
@@ -60,40 +70,90 @@ describe('chromedash-release-feature-card', () => {
       ></chromedash-release-feature-card>`
     );
 
-    const titleEl = el.shadowRoot!.querySelector('.feature-title a');
-    assert.isNotNull(titleEl);
-    assert.equal(titleEl?.textContent?.trim(), 'CSS Subgrid');
-    assert.equal(titleEl?.getAttribute('href'), '/feature/12345');
-
-    const summaryEl = el.shadowRoot!.querySelector('.feature-summary');
-    assert.isNotNull(summaryEl);
-    assert.include(
-      summaryEl?.textContent || '',
-      'Enables grid items to inherit'
+    const titleEl = el.shadowRoot!.querySelector<HTMLAnchorElement>(
+      '.feature-title .feature-name'
     );
+    assert.isNotNull(titleEl);
+    assert.strictEqual(titleEl!.textContent?.trim(), 'CSS Subgrid');
+    assert.strictEqual(titleEl!.getAttribute('href'), '/feature/12345');
 
-    const categoryBadge = el.shadowRoot!.querySelector(
+    const summaryEl =
+      el.shadowRoot!.querySelector<HTMLElement>('.feature-summary');
+    assert.isNotNull(summaryEl);
+    assert.include(summaryEl!.textContent!, 'Enables grid items to inherit');
+
+    const categoryBadge = el.shadowRoot!.querySelector<HTMLElement>(
       '.badges-wrapper sl-badge'
     );
     assert.isNotNull(categoryBadge);
-    assert.equal(categoryBadge?.textContent?.trim(), 'CSS');
+    assert.strictEqual(categoryBadge!.textContent?.trim(), 'CSS');
 
-    const links = el.shadowRoot!.querySelectorAll(
+    const links = el.shadowRoot!.querySelectorAll<HTMLElement>(
       '.feature-links-bar .feature-link-item'
     );
-    assert.equal(links.length, 3);
-    assert.equal(
-      links[0].querySelector('.doc-link-text')?.textContent?.trim(),
-      'MDN Subgrid Guide'
+    assert.strictEqual(links.length, 3);
+
+    const docText0 = links[0].querySelector('.doc-link-text');
+    assert.isNotNull(docText0);
+    assert.strictEqual(docText0!.textContent?.trim(), 'MDN Subgrid Guide');
+
+    const docText1 = links[1].querySelector('.doc-link-text');
+    assert.isNotNull(docText1);
+    assert.strictEqual(docText1!.textContent?.trim(), 'Spec');
+
+    const docText2 = links[2].querySelector('.doc-link-text');
+    assert.isNotNull(docText2);
+    assert.strictEqual(docText2!.textContent?.trim(), 'Explainer');
+  });
+
+  it('sets target="_blank" and rel="noopener noreferrer" on external links, and target="_self" on internal links', async () => {
+    const featureWithMixedLinks: FeatureCardItem = {
+      ...mockFeature,
+      links: [
+        {
+          url: 'https://external.example.com',
+          type: ReleaseNoteLinkTypeEnum.DOC,
+          title: 'External Doc',
+        },
+        {
+          url: '/feature/12345',
+          type: ReleaseNoteLinkTypeEnum.CHROMESTATUS,
+          title: 'Internal Feature',
+        },
+        {
+          url: '//attacker.com/test',
+          type: ReleaseNoteLinkTypeEnum.OTHER,
+          title: 'Protocol Relative',
+        },
+      ],
+    };
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${featureWithMixedLinks}
+      ></chromedash-release-feature-card>`
     );
-    assert.equal(
-      links[1].querySelector('.doc-link-text')?.textContent?.trim(),
-      'Spec'
+    const links = el.shadowRoot!.querySelectorAll<HTMLAnchorElement>(
+      '.feature-links-bar a'
     );
-    assert.equal(
-      links[2].querySelector('.doc-link-text')?.textContent?.trim(),
-      'Explainer'
+    assert.strictEqual(links.length, 3);
+
+    // External link
+    assert.strictEqual(links[0].getAttribute('target'), '_blank');
+    assert.strictEqual(links[0].getAttribute('rel'), 'noopener noreferrer');
+    assert.isNotNull(links[0].querySelector('.external-icon'));
+    assert.strictEqual(
+      links[0].querySelector('.sr-only')?.textContent?.trim(),
+      '(opens in new window)'
     );
+
+    // Internal link
+    assert.strictEqual(links[1].getAttribute('target'), '_self');
+    assert.strictEqual(links[1].getAttribute('rel'), '');
+    assert.isNull(links[1].querySelector('.external-icon'));
+
+    // Protocol relative treated as external
+    assert.strictEqual(links[2].getAttribute('target'), '_blank');
+    assert.strictEqual(links[2].getAttribute('rel'), 'noopener noreferrer');
   });
 
   it('renders links from legacy flat fields when links array is missing', async () => {
@@ -115,19 +175,19 @@ describe('chromedash-release-feature-card', () => {
       ></chromedash-release-feature-card>`
     );
 
-    const links = el.shadowRoot!.querySelectorAll(
+    const links = el.shadowRoot!.querySelectorAll<HTMLElement>(
       '.feature-links-bar .feature-link-item'
     );
-    assert.equal(links.length, 3);
-    assert.equal(
+    assert.strictEqual(links.length, 3);
+    assert.strictEqual(
       links[0].querySelector('.doc-link-text')?.textContent?.trim(),
       'Docs'
     );
-    assert.equal(
+    assert.strictEqual(
       links[1].querySelector('.doc-link-text')?.textContent?.trim(),
       'Spec'
     );
-    assert.equal(
+    assert.strictEqual(
       links[2].querySelector('.doc-link-text')?.textContent?.trim(),
       'Explainer'
     );
@@ -146,10 +206,11 @@ describe('chromedash-release-feature-card', () => {
       ></chromedash-release-feature-card>`
     );
 
-    const summaryEl = el.shadowRoot!.querySelector('.feature-summary');
+    const summaryEl =
+      el.shadowRoot!.querySelector<HTMLElement>('.feature-summary');
     assert.isNotNull(summaryEl);
-    assert.isTrue(summaryEl?.classList.contains('preformatted'));
-    assert.include(summaryEl?.textContent || '', 'Line 1\nLine 2');
+    assert.isTrue(summaryEl!.classList.contains('preformatted'));
+    assert.include(summaryEl!.textContent!, 'Line 1\nLine 2');
   });
 
   it('renders markdown summary without preformatted class', async () => {
@@ -165,14 +226,26 @@ describe('chromedash-release-feature-card', () => {
       ></chromedash-release-feature-card>`
     );
 
-    const summaryEl = el.shadowRoot!.querySelector('.feature-summary');
+    const summaryEl =
+      el.shadowRoot!.querySelector<HTMLElement>('.feature-summary');
     assert.isNotNull(summaryEl);
-    assert.isFalse(summaryEl?.classList.contains('preformatted'));
-    assert.isNotNull(summaryEl?.querySelector('strong'));
-    assert.equal(
-      summaryEl?.querySelector('strong')?.textContent,
-      'Bold summary'
+    assert.isFalse(summaryEl!.classList.contains('preformatted'));
+    const strongEl = summaryEl!.querySelector('strong');
+    assert.isNotNull(strongEl);
+    assert.strictEqual(strongEl!.textContent, 'Bold summary');
+  });
+
+  it('renders nothing for feature summary when summary is missing or whitespace', async () => {
+    const emptySummaryFeature: FeatureCardItem = {
+      ...mockFeature,
+      summary: '   ',
+    };
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${emptySummaryFeature}
+      ></chromedash-release-feature-card>`
     );
+    assert.isNull(el.shadowRoot!.querySelector('.feature-summary'));
   });
 
   it('renders AI Applied badge when summary_source is AI_APPLIED', async () => {
@@ -193,19 +266,35 @@ describe('chromedash-release-feature-card', () => {
   });
 
   it('renders Human Authored badge when summary_source is HUMAN or unset', async () => {
-    const el = await fixture<ChromedashReleaseFeatureCard>(
+    const humanEl = await fixture<ChromedashReleaseFeatureCard>(
       html`<chromedash-release-feature-card
         .feature=${mockFeature}
       ></chromedash-release-feature-card>`
     );
+    const humanBadges = humanEl.shadowRoot!.querySelectorAll(
+      '.badges-wrapper sl-badge'
+    );
+    const humanTexts = Array.from(humanBadges).map(b => b.textContent?.trim());
+    assert.include(humanTexts, 'Human Authored');
 
-    const badges = el.shadowRoot!.querySelectorAll('.badges-wrapper sl-badge');
-    const badgeTexts = Array.from(badges).map(b => b.textContent?.trim());
-    assert.include(badgeTexts, 'Human Authored');
+    const unsetFeature: FeatureCardItem = {
+      ...mockFeature,
+      summary_source: undefined,
+    };
+    const unsetEl = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${unsetFeature}
+      ></chromedash-release-feature-card>`
+    );
+    const unsetBadges = unsetEl.shadowRoot!.querySelectorAll(
+      '.badges-wrapper sl-badge'
+    );
+    const unsetTexts = Array.from(unsetBadges).map(b => b.textContent?.trim());
+    assert.include(unsetTexts, 'Human Authored');
   });
 
   it('copies anchor link when heading anchor link is clicked', async () => {
-    const clipboardStub = sinon
+    const clipboardStub = sandbox
       .stub(navigator.clipboard, 'writeText')
       .resolves();
 
@@ -215,16 +304,15 @@ describe('chromedash-release-feature-card', () => {
       ></chromedash-release-feature-card>`
     );
 
-    const anchorLink = el.shadowRoot!.querySelector<HTMLElement>(
-      '.heading-anchor-link'
-    );
-    assert.isNotNull(anchorLink);
-    anchorLink?.click();
+    const clickEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    await el.handleAnchorCopy(clickEvent);
 
     assert.isTrue(clipboardStub.calledOnce);
     assert.include(clipboardStub.firstCall.args[0], '#feature-12345');
-
-    clipboardStub.restore();
+    assert.isTrue(el.isCopied);
   });
 
   it('renders nothing when feature is null', async () => {
@@ -252,6 +340,22 @@ describe('chromedash-release-feature-card', () => {
     assert.isDefined(categoryBadge);
   });
 
+  it('renders nothing for category badge when numeric category ID is unknown', async () => {
+    const featureWithUnknownCategory: FeatureCardItem = {
+      ...mockFeature,
+      category: 99999,
+      category_name: undefined,
+    };
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${featureWithUnknownCategory}
+      ></chromedash-release-feature-card>`
+    );
+    const badges = el.shadowRoot!.querySelectorAll('sl-badge');
+    assert.strictEqual(badges.length, 1);
+    assert.strictEqual(badges[0].textContent?.trim(), 'Human Authored');
+  });
+
   it('renders no doc links section when no links are present', async () => {
     const featureNoLinks: FeatureCardItem = {
       ...mockFeature,
@@ -268,11 +372,40 @@ describe('chromedash-release-feature-card', () => {
     assert.isNull(el.shadowRoot!.querySelector('.feature-links-bar'));
   });
 
+  it('filters out empty and whitespace URLs from links array', async () => {
+    const emptyLinksFeature: FeatureCardItem = {
+      ...mockFeature,
+      links: [
+        {url: '', type: ReleaseNoteLinkTypeEnum.DOC},
+        {url: '   ', type: ReleaseNoteLinkTypeEnum.SPEC},
+        {
+          url: 'https://valid.example.com',
+          type: ReleaseNoteLinkTypeEnum.DOC,
+          title: 'Valid Link',
+        },
+      ],
+    };
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${emptyLinksFeature}
+      ></chromedash-release-feature-card>`
+    );
+    const links = el.shadowRoot!.querySelectorAll('.feature-links-bar a');
+    assert.strictEqual(links.length, 1);
+    assert.strictEqual(
+      links[0].getAttribute('href'),
+      'https://valid.example.com'
+    );
+  });
+
   it('deduplicates links across doc_links, spec_link, and explainer_links', async () => {
     const duplicateFeature: FeatureCardItem = {
       ...mockFeature,
       links: undefined,
-      doc_links: ['https://example.com/same-link'],
+      doc_links: [
+        'https://example.com/same-link',
+        'https://example.com/same-link',
+      ],
       spec_link: 'https://example.com/same-link',
       explainer_links: ['https://example.com/same-link'],
     };
@@ -284,17 +417,18 @@ describe('chromedash-release-feature-card', () => {
     const links = el.shadowRoot!.querySelectorAll(
       '.feature-links-bar .feature-link-item'
     );
-    assert.equal(links.length, 1);
-    assert.equal(
+    assert.strictEqual(links.length, 1);
+    assert.strictEqual(
       links[0].getAttribute('href'),
       'https://example.com/same-link'
     );
   });
 
   it('handles clipboard failure gracefully without throwing', async () => {
-    const clipboardStub = sinon
+    sandbox
       .stub(navigator.clipboard, 'writeText')
       .rejects(new Error('Clipboard permission denied'));
+    const warnStub = sandbox.stub(console, 'warn');
 
     const el = await fixture<ChromedashReleaseFeatureCard>(
       html`<chromedash-release-feature-card
@@ -302,21 +436,19 @@ describe('chromedash-release-feature-card', () => {
       ></chromedash-release-feature-card>`
     );
 
-    const anchorLink = el.shadowRoot!.querySelector<HTMLElement>(
-      '.heading-anchor-link'
-    );
-    anchorLink?.click();
+    const clickEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    await el.handleAnchorCopy(clickEvent);
 
     assert.isFalse(el.isCopied);
-
-    clipboardStub.restore();
+    assert.isTrue(warnStub.calledOnce);
   });
 
   it('clears copied timeout on disconnectedCallback', async () => {
-    const clearTimeoutSpy = sinon.spy(window, 'clearTimeout');
-    const clipboardStub = sinon
-      .stub(navigator.clipboard, 'writeText')
-      .resolves();
+    const clearTimeoutSpy = sandbox.spy(window, 'clearTimeout');
+    sandbox.stub(navigator.clipboard, 'writeText').resolves();
 
     const el = await fixture<ChromedashReleaseFeatureCard>(
       html`<chromedash-release-feature-card
@@ -333,8 +465,5 @@ describe('chromedash-release-feature-card', () => {
 
     el.disconnectedCallback();
     assert.isTrue(clearTimeoutSpy.called);
-
-    clipboardStub.restore();
-    clearTimeoutSpy.restore();
   });
 });

--- a/client-src/elements/chromedash-release-feature-card_test.ts
+++ b/client-src/elements/chromedash-release-feature-card_test.ts
@@ -1,0 +1,206 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {html, fixture, assert, oneEvent} from '@open-wc/testing';
+import './chromedash-release-feature-card.js';
+import {
+  ChromedashReleaseFeatureCard,
+  FeatureCardItem,
+} from './chromedash-release-feature-card.js';
+import {
+  SummarySuggestion,
+  SummarySuggestionStatusEnum,
+} from 'chromestatus-openapi';
+import sinon from 'sinon';
+
+describe('chromedash-release-feature-card', () => {
+  const mockFeature: FeatureCardItem = {
+    id: 12345,
+    name: 'CSS Subgrid',
+    summary:
+      'Enables grid items to inherit and share the **grid definition** of their parent.',
+    category: 'CSS',
+    category_name: 'CSS',
+    feature_type: 1,
+    summary_source: 'HUMAN',
+    doc_links: [
+      'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid',
+    ],
+    spec_link: 'https://www.w3.org/TR/css-grid-2/',
+    explainer_links: ['https://github.com/w3c/csswg-drafts/issues/1234'],
+  };
+
+  const mockSuggestion: SummarySuggestion = {
+    feature_id: 12345,
+    suggested_summary: 'AI-generated summary for CSS Subgrid.',
+    original_summary: 'Enables grid items to inherit grid definition.',
+    status: SummarySuggestionStatusEnum.PENDING,
+    reasoning: 'Extracted from W3C spec and MDN documentation.',
+    suggested_doc_links: [
+      'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid',
+    ],
+    version_token: 1,
+    created: new Date('2026-08-20T10:00:00Z'),
+    updated: new Date('2026-08-20T10:00:00Z'),
+  };
+
+  it('renders standard feature card with name, summary, category, and links', async () => {
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+      ></chromedash-release-feature-card>`
+    );
+
+    const titleEl = el.shadowRoot!.querySelector('.feature-title a');
+    assert.isNotNull(titleEl);
+    assert.equal(titleEl?.textContent?.trim(), 'CSS Subgrid');
+    assert.equal(titleEl?.getAttribute('href'), '/feature/12345');
+
+    const summaryEl = el.shadowRoot!.querySelector('.feature-summary');
+    assert.isNotNull(summaryEl);
+    assert.include(
+      summaryEl?.textContent || '',
+      'Enables grid items to inherit'
+    );
+
+    const categoryBadge = el.shadowRoot!.querySelector(
+      '.badges-wrapper sl-badge'
+    );
+    assert.isNotNull(categoryBadge);
+    assert.equal(categoryBadge?.textContent?.trim(), 'CSS');
+
+    const links = el.shadowRoot!.querySelectorAll(
+      '.feature-links-section .feature-link-item'
+    );
+    assert.equal(links.length, 3);
+  });
+
+  it('renders AI Applied badge when summary_source is AI_APPLIED', async () => {
+    const aiFeature: FeatureCardItem = {
+      ...mockFeature,
+      summary_source: 'AI_APPLIED',
+    };
+
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${aiFeature}
+      ></chromedash-release-feature-card>`
+    );
+
+    const badges = el.shadowRoot!.querySelectorAll('.badges-wrapper sl-badge');
+    const badgeTexts = Array.from(badges).map(b => b.textContent?.trim());
+    assert.include(badgeTexts, 'AI Applied');
+  });
+
+  it('renders AI Review Pending badge when pending suggestion exists', async () => {
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+        .suggestion=${mockSuggestion}
+      ></chromedash-release-feature-card>`
+    );
+
+    const badges = el.shadowRoot!.querySelectorAll('.badges-wrapper sl-badge');
+    const badgeTexts = Array.from(badges).map(b => b.textContent?.trim());
+    assert.include(badgeTexts, 'AI Review Pending');
+  });
+
+  it('renders review actions when reviewMode is true', async () => {
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+        .suggestion=${mockSuggestion}
+        ?reviewMode=${true}
+      ></chromedash-release-feature-card>`
+    );
+
+    const actions = el.shadowRoot!.querySelector('.card-actions');
+    assert.isNotNull(actions);
+
+    const reviewBtn = el.shadowRoot!.querySelector('.review-button');
+    assert.isNotNull(reviewBtn);
+    assert.include(reviewBtn?.textContent || '', 'Review Suggestion');
+
+    const generateBtn = el.shadowRoot!.querySelector('.generate-button');
+    assert.isNotNull(generateBtn);
+    assert.include(generateBtn?.textContent || '', 'Regenerate');
+
+    const groundingMeta = el.shadowRoot!.querySelector('.suggestion-meta');
+    assert.isNotNull(groundingMeta);
+    assert.include(groundingMeta?.textContent || '', 'Grounding available');
+  });
+
+  it('dispatches review-click event when review button is clicked', async () => {
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+        .suggestion=${mockSuggestion}
+        ?reviewMode=${true}
+      ></chromedash-release-feature-card>`
+    );
+
+    const reviewBtn =
+      el.shadowRoot!.querySelector<HTMLElement>('.review-button');
+    const eventPromise = oneEvent(el, 'review-click');
+    reviewBtn?.click();
+
+    const event = (await eventPromise) as CustomEvent;
+    assert.isNotNull(event);
+    assert.equal(event.detail.featureId, 12345);
+    assert.deepEqual(event.detail.suggestion, mockSuggestion);
+  });
+
+  it('dispatches generate-click event when generate button is clicked', async () => {
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+        ?reviewMode=${true}
+      ></chromedash-release-feature-card>`
+    );
+
+    const generateBtn =
+      el.shadowRoot!.querySelector<HTMLElement>('.generate-button');
+    const eventPromise = oneEvent(el, 'generate-click');
+    generateBtn?.click();
+
+    const event = (await eventPromise) as CustomEvent;
+    assert.isNotNull(event);
+    assert.equal(event.detail.featureId, 12345);
+  });
+
+  it('copies anchor link when heading anchor link is clicked', async () => {
+    const clipboardStub = sinon
+      .stub(navigator.clipboard, 'writeText')
+      .resolves();
+
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+      ></chromedash-release-feature-card>`
+    );
+
+    const anchorLink = el.shadowRoot!.querySelector<HTMLElement>(
+      '.heading-anchor-link'
+    );
+    assert.isNotNull(anchorLink);
+    anchorLink?.click();
+
+    assert.isTrue(clipboardStub.calledOnce);
+    assert.include(clipboardStub.firstCall.args[0], '#feature-12345');
+
+    clipboardStub.restore();
+  });
+});


### PR DESCRIPTION
## Overview
Adds `<chromedash-release-feature-card>`, a Lit web component for rendering feature release cards in Chrome release notes pages. This PR implements the view-only presentation layer, with editorial review actions deferred to #6786.

## Changes
- **Feature Card (`client-src/elements/chromedash-release-feature-card.ts`)**:
  - Renders feature title linking to `/feature/<id>`.
  - Implements deep-link anchor copying (`#feature-<id>`) with hover/focus state and clipboard copy.
  - Renders category and provenance badges (`AI Applied` vs `Human Authored`).
  - Renders Markdown and plain-text summaries using `autolink()`.
  - Renders structured `ReleaseNoteLink` items (`ReleaseNoteLinkTypeEnum`) with external link icons (`↗`), falling back to flat link fields if unset.
  - Registered in `client-src/components.js`.
- **Unit Tests (`client-src/elements/chromedash-release-feature-card_test.ts`)**:
  - 16 unit tests validating rendering, link formats, markdown/plain-text formatting, badges, external link security, and anchor copying.

## Verification
- Unit tests: 16/16 passing in `@web/test-runner`.
- Linters: `make lint-frontend` clean (0 errors).

TAG=agy
CONV=7dad7a60-89a0-4ab9-9f42-3300a3de7807
