### PR TITLE
[AI Curation] Add Editorial Review Mode to Release Feature Card Component

### DIFF
--- a/client-src/elements/chromedash-release-feature-card.ts
+++ b/client-src/elements/chromedash-release-feature-card.ts
@@ -24,6 +24,8 @@ import {
   ReleaseNoteLink,
   ReleaseNoteLinkTypeEnum,
   ReleaseNoteFeatureSummarySourceEnum,
+  SummarySuggestion,
+  SummarySuggestionStatusEnum,
 } from 'chromestatus-openapi';
 
 export const LINK_TYPE_TITLES: Record<ReleaseNoteLinkTypeEnum, string> = {
@@ -47,10 +49,66 @@ export type FeatureCardItem = Partial<ReleaseNoteFeature> & {
   markdown_fields?: string[];
 };
 
+/**
+ * Aggregates and deduplicates resource and documentation links for a feature.
+ */
+export function aggregateFeatureLinks(
+  feature: FeatureCardItem,
+  suggestion?: SummarySuggestion | null
+): ReleaseNoteLink[] {
+  const normalizedLinks: ReleaseNoteLink[] = [];
+  const seenUrls = new Set<string>();
+
+  function addLink(
+    url?: string,
+    type: ReleaseNoteLinkTypeEnum = ReleaseNoteLinkTypeEnum.DOC,
+    title?: string
+  ): void {
+    const trimmed = url?.trim();
+    if (!trimmed || seenUrls.has(trimmed)) return;
+    seenUrls.add(trimmed);
+    normalizedLinks.push({url: trimmed, type, title: title?.trim()});
+  }
+
+  if (Array.isArray(feature.links) && feature.links.length > 0) {
+    for (const link of feature.links) {
+      addLink(link.url, link.type, link.title);
+    }
+  } else {
+    if (Array.isArray(feature.doc_links)) {
+      for (const url of feature.doc_links) {
+        addLink(url, ReleaseNoteLinkTypeEnum.DOC);
+      }
+    }
+    if (feature.spec_link) {
+      addLink(feature.spec_link, ReleaseNoteLinkTypeEnum.SPEC);
+    }
+    if (Array.isArray(feature.explainer_links)) {
+      for (const url of feature.explainer_links) {
+        addLink(url, ReleaseNoteLinkTypeEnum.EXPLAINER);
+      }
+    }
+  }
+
+  if (Array.isArray(suggestion?.suggested_doc_links)) {
+    for (const url of suggestion.suggested_doc_links) {
+      addLink(url, ReleaseNoteLinkTypeEnum.DOC);
+    }
+  }
+
+  return normalizedLinks;
+}
+
 @customElement('chromedash-release-feature-card')
 export class ChromedashReleaseFeatureCard extends LitElement {
   @property({attribute: false})
   feature: FeatureCardItem | null = null;
+
+  @property({attribute: false})
+  suggestion: SummarySuggestion | null = null;
+
+  @property({type: Boolean})
+  reviewMode = false;
 
   @property({type: Number})
   milestone?: number;
@@ -281,6 +339,30 @@ export class ChromedashReleaseFeatureCard extends LitElement {
           font-size: var(--button-font-size, 0.875rem);
           line-height: 1;
         }
+
+        .card-actions {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          flex-wrap: wrap;
+          gap: var(--sl-spacing-small);
+          border-top: var(--default-border);
+          padding-top: var(--content-padding-half);
+        }
+
+        .action-buttons {
+          display: flex;
+          align-items: center;
+          gap: var(--sl-spacing-small);
+        }
+
+        .suggestion-meta {
+          display: flex;
+          align-items: center;
+          gap: var(--sl-spacing-x-small);
+          font-size: var(--button-small-font-size, 0.875rem);
+          color: var(--unimportant-text-color);
+        }
       `,
     ];
   }
@@ -309,6 +391,44 @@ export class ChromedashReleaseFeatureCard extends LitElement {
         window.location.hash = anchor;
       }
     }
+  }
+
+  /**
+   * Dispatched when the user clicks the "Review Suggestion" or "Inspect / Edit" button.
+   * Event name: `review-click`
+   * Detail payload: { feature: FeatureCardItem | null, featureId: number | undefined, suggestion: SummarySuggestion | null }
+   */
+  handleReviewClick(): void {
+    this.dispatchEvent(
+      new CustomEvent('review-click', {
+        detail: {
+          feature: this.feature,
+          featureId: this.feature?.id,
+          suggestion: this.suggestion ?? null,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  /**
+   * Dispatched when the user clicks the "Generate AI Summary" or "Regenerate" button.
+   * Event name: `generate-click`
+   * Detail payload: { feature: FeatureCardItem | null, featureId: number | undefined, suggestion: SummarySuggestion | null }
+   */
+  handleGenerateClick(): void {
+    this.dispatchEvent(
+      new CustomEvent('generate-click', {
+        detail: {
+          feature: this.feature,
+          featureId: this.feature?.id,
+          suggestion: this.suggestion ?? null,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
   }
 
   renderCategoryBadge(): TemplateResult | typeof nothing {
@@ -341,47 +461,23 @@ export class ChromedashReleaseFeatureCard extends LitElement {
     return html`<sl-badge variant="neutral" pill>Human Authored</sl-badge>`;
   }
 
+  renderReviewBadge(): TemplateResult | typeof nothing {
+    if (
+      this.suggestion &&
+      this.suggestion.status === SummarySuggestionStatusEnum.PENDING
+    ) {
+      return html`<sl-badge variant="warning" pill
+        >AI Review Pending</sl-badge
+      >`;
+    }
+    return nothing;
+  }
+
   renderDocLinks(): TemplateResult | typeof nothing {
     const feature = this.feature;
     if (!feature) return nothing;
 
-    let normalizedLinks: ReleaseNoteLink[] = [];
-
-    if (Array.isArray(feature.links) && feature.links.length > 0) {
-      normalizedLinks = feature.links;
-    } else {
-      if (Array.isArray(feature.doc_links)) {
-        for (const url of feature.doc_links) {
-          if (url && !normalizedLinks.some(l => l.url === url)) {
-            normalizedLinks.push({
-              url,
-              type: ReleaseNoteLinkTypeEnum.DOC,
-            });
-          }
-        }
-      }
-      if (
-        feature.spec_link &&
-        !normalizedLinks.some(l => l.url === feature.spec_link)
-      ) {
-        normalizedLinks.push({
-          url: feature.spec_link,
-          type: ReleaseNoteLinkTypeEnum.SPEC,
-        });
-      }
-      if (Array.isArray(feature.explainer_links)) {
-        for (const url of feature.explainer_links) {
-          if (url && !normalizedLinks.some(l => l.url === url)) {
-            normalizedLinks.push({
-              url,
-              type: ReleaseNoteLinkTypeEnum.EXPLAINER,
-            });
-          }
-        }
-      }
-    }
-
-    normalizedLinks = normalizedLinks.filter(l => Boolean(l?.url?.trim()));
+    const normalizedLinks = aggregateFeatureLinks(feature, this.suggestion);
     if (normalizedLinks.length === 0) return nothing;
 
     return html`
@@ -419,6 +515,84 @@ export class ChromedashReleaseFeatureCard extends LitElement {
             </a>
           `;
         })}
+      </div>
+    `;
+  }
+
+  renderPrimaryReviewButton(hasPendingSuggestion: boolean): TemplateResult {
+    if (hasPendingSuggestion) {
+      return html`
+        <sl-button
+          size="small"
+          variant="primary"
+          class="review-button"
+          @click=${this.handleReviewClick}
+        >
+          <sl-icon slot="prefix" name="pencil"></sl-icon>
+          Review Suggestion
+        </sl-button>
+      `;
+    }
+
+    return html`
+      <sl-button
+        size="small"
+        variant="default"
+        class="review-button"
+        @click=${this.handleReviewClick}
+      >
+        <sl-icon slot="prefix" name="eye"></sl-icon>
+        Inspect / Edit
+      </sl-button>
+    `;
+  }
+
+  renderGenerateButton(hasPendingSuggestion: boolean): TemplateResult {
+    const label = hasPendingSuggestion ? 'Regenerate' : 'Generate AI Summary';
+    return html`
+      <sl-button
+        size="small"
+        variant="default"
+        class="generate-button"
+        @click=${this.handleGenerateClick}
+      >
+        <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+        ${label}
+      </sl-button>
+    `;
+  }
+
+  renderReasoningMeta(): TemplateResult | typeof nothing {
+    const reasoning = this.suggestion?.reasoning?.trim();
+    if (!reasoning) return nothing;
+
+    return html`
+      <div class="suggestion-meta">
+        <sl-tooltip content=${reasoning}>
+          <sl-icon
+            tabindex="0"
+            name="info-circle"
+            aria-label="Summary reasoning details"
+          ></sl-icon>
+        </sl-tooltip>
+        <span>Grounding available</span>
+      </div>
+    `;
+  }
+
+  renderReviewActions(): TemplateResult | typeof nothing {
+    if (!this.reviewMode || !this.feature) return nothing;
+
+    const hasPendingSuggestion =
+      this.suggestion?.status === SummarySuggestionStatusEnum.PENDING;
+
+    return html`
+      <div class="card-actions">
+        <div class="action-buttons">
+          ${this.renderPrimaryReviewButton(hasPendingSuggestion)}
+          ${this.renderGenerateButton(hasPendingSuggestion)}
+        </div>
+        ${this.renderReasoningMeta()}
       </div>
     `;
   }
@@ -477,10 +651,12 @@ export class ChromedashReleaseFeatureCard extends LitElement {
 
           <div class="badges-wrapper">
             ${this.renderCategoryBadge()} ${this.renderProvenanceBadge()}
+            ${this.renderReviewBadge()}
           </div>
         </header>
 
         ${this.renderFeatureSummary()} ${this.renderDocLinks()}
+        ${this.renderReviewActions()}
       </article>
     `;
   }

--- a/client-src/elements/chromedash-release-feature-card_test.ts
+++ b/client-src/elements/chromedash-release-feature-card_test.ts
@@ -14,15 +14,18 @@
  * limitations under the License.
  */
 
-import {html, fixture, assert} from '@open-wc/testing';
+import {html, fixture, assert, oneEvent} from '@open-wc/testing';
 import './chromedash-release-feature-card.js';
 import {
   ChromedashReleaseFeatureCard,
   FeatureCardItem,
+  aggregateFeatureLinks,
 } from './chromedash-release-feature-card.js';
 import {
   ReleaseNoteFeatureSummarySourceEnum,
   ReleaseNoteLinkTypeEnum,
+  SummarySuggestion,
+  SummarySuggestionStatusEnum,
 } from 'chromestatus-openapi';
 import sinon from 'sinon';
 
@@ -61,6 +64,20 @@ describe('chromedash-release-feature-card', () => {
         type: ReleaseNoteLinkTypeEnum.EXPLAINER,
       },
     ],
+  };
+
+  const mockSuggestion: SummarySuggestion = {
+    feature_id: 12345,
+    suggested_summary: 'AI-generated summary for CSS Subgrid.',
+    original_summary: 'Enables grid items to inherit grid definition.',
+    status: SummarySuggestionStatusEnum.PENDING,
+    reasoning: 'Extracted from W3C spec and MDN documentation.',
+    suggested_doc_links: [
+      'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid',
+    ],
+    version_token: 1,
+    created: new Date('2026-08-20T10:00:00Z'),
+    updated: new Date('2026-08-20T10:00:00Z'),
   };
 
   it('renders standard feature card with name, summary, category, and links', async () => {
@@ -293,6 +310,85 @@ describe('chromedash-release-feature-card', () => {
     assert.include(unsetTexts, 'Human Authored');
   });
 
+  it('renders AI Review Pending badge alongside provenance badge when pending suggestion exists', async () => {
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+        .suggestion=${mockSuggestion}
+      ></chromedash-release-feature-card>`
+    );
+    const badges = el.shadowRoot!.querySelectorAll('.badges-wrapper sl-badge');
+    const badgeTexts = Array.from(badges).map(b => b.textContent?.trim());
+    assert.include(badgeTexts, 'CSS');
+    assert.include(badgeTexts, 'Human Authored');
+    assert.include(badgeTexts, 'AI Review Pending');
+  });
+
+  it('renders review actions when reviewMode is true', async () => {
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+        .suggestion=${mockSuggestion}
+        ?reviewMode=${true}
+      ></chromedash-release-feature-card>`
+    );
+
+    const actions = el.shadowRoot!.querySelector('.card-actions');
+    assert.isNotNull(actions);
+
+    const reviewBtn = el.shadowRoot!.querySelector('.review-button');
+    assert.isNotNull(reviewBtn);
+    assert.include(reviewBtn?.textContent || '', 'Review Suggestion');
+
+    const generateBtn = el.shadowRoot!.querySelector('.generate-button');
+    assert.isNotNull(generateBtn);
+    assert.include(generateBtn?.textContent || '', 'Regenerate');
+
+    const groundingMeta = el.shadowRoot!.querySelector('.suggestion-meta');
+    assert.isNotNull(groundingMeta);
+    assert.include(groundingMeta?.textContent || '', 'Grounding available');
+  });
+
+  it('dispatches review-click event when review button is clicked', async () => {
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+        .suggestion=${mockSuggestion}
+        ?reviewMode=${true}
+      ></chromedash-release-feature-card>`
+    );
+
+    const reviewBtn =
+      el.shadowRoot!.querySelector<HTMLElement>('.review-button');
+    const eventPromise = oneEvent(el, 'review-click');
+    reviewBtn?.click();
+
+    const event = (await eventPromise) as CustomEvent;
+    assert.isNotNull(event);
+    assert.strictEqual(event.detail.featureId, 12345);
+    assert.deepEqual(event.detail.suggestion, mockSuggestion);
+  });
+
+  it('dispatches generate-click event when generate button is clicked', async () => {
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+        .suggestion=${mockSuggestion}
+        ?reviewMode=${true}
+      ></chromedash-release-feature-card>`
+    );
+
+    const generateBtn =
+      el.shadowRoot!.querySelector<HTMLElement>('.generate-button');
+    const eventPromise = oneEvent(el, 'generate-click');
+    generateBtn?.click();
+
+    const event = (await eventPromise) as CustomEvent;
+    assert.isNotNull(event);
+    assert.strictEqual(event.detail.featureId, 12345);
+    assert.deepEqual(event.detail.suggestion, mockSuggestion);
+  });
+
   it('copies anchor link when heading anchor link is clicked', async () => {
     const clipboardStub = sandbox
       .stub(navigator.clipboard, 'writeText')
@@ -320,6 +416,29 @@ describe('chromedash-release-feature-card', () => {
       html`<chromedash-release-feature-card></chromedash-release-feature-card>`
     );
     assert.isNull(el.shadowRoot!.querySelector('.feature-card'));
+  });
+
+  it('does not render card actions when reviewMode is false', async () => {
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+        .reviewMode=${false}
+      ></chromedash-release-feature-card>`
+    );
+    assert.isNull(el.shadowRoot!.querySelector('.card-actions'));
+  });
+
+  it('renders inspect button when reviewMode is true without pending suggestion', async () => {
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${mockFeature}
+        ?reviewMode=${true}
+      ></chromedash-release-feature-card>`
+    );
+    const reviewBtn = el.shadowRoot!.querySelector('.review-button');
+    assert.include(reviewBtn?.textContent || '', 'Inspect / Edit');
+    const generateBtn = el.shadowRoot!.querySelector('.generate-button');
+    assert.include(generateBtn?.textContent || '', 'Generate AI Summary');
   });
 
   it('renders category badge from numeric category ID', async () => {
@@ -398,7 +517,7 @@ describe('chromedash-release-feature-card', () => {
     );
   });
 
-  it('deduplicates links across doc_links, spec_link, and explainer_links', async () => {
+  it('deduplicates links across doc_links, spec_link, explainer_links, and suggested_doc_links', async () => {
     const duplicateFeature: FeatureCardItem = {
       ...mockFeature,
       links: undefined,
@@ -409,9 +528,14 @@ describe('chromedash-release-feature-card', () => {
       spec_link: 'https://example.com/same-link',
       explainer_links: ['https://example.com/same-link'],
     };
+    const suggestionWithSameLink: SummarySuggestion = {
+      ...mockSuggestion,
+      suggested_doc_links: ['https://example.com/same-link'],
+    };
     const el = await fixture<ChromedashReleaseFeatureCard>(
       html`<chromedash-release-feature-card
         .feature=${duplicateFeature}
+        .suggestion=${suggestionWithSameLink}
       ></chromedash-release-feature-card>`
     );
     const links = el.shadowRoot!.querySelectorAll(
@@ -421,6 +545,34 @@ describe('chromedash-release-feature-card', () => {
     assert.strictEqual(
       links[0].getAttribute('href'),
       'https://example.com/same-link'
+    );
+  });
+
+  it('deduplicates duplicate links across feature fields and suggestions via Set and trimming', async () => {
+    const featureWithWhitespaceLink: FeatureCardItem = {
+      ...mockFeature,
+      links: undefined,
+      doc_links: ['  https://example.com/docs/guide  '],
+      spec_link: undefined,
+      explainer_links: [],
+    };
+    const suggestionWithSameLink: SummarySuggestion = {
+      ...mockSuggestion,
+      suggested_doc_links: ['https://example.com/docs/guide'],
+    };
+    const el = await fixture<ChromedashReleaseFeatureCard>(
+      html`<chromedash-release-feature-card
+        .feature=${featureWithWhitespaceLink}
+        .suggestion=${suggestionWithSameLink}
+      ></chromedash-release-feature-card>`
+    );
+    const links = el.shadowRoot!.querySelectorAll(
+      '.feature-links-bar .feature-link-item'
+    );
+    assert.strictEqual(links.length, 1);
+    assert.strictEqual(
+      links[0].getAttribute('href'),
+      'https://example.com/docs/guide'
     );
   });
 
@@ -442,6 +594,7 @@ describe('chromedash-release-feature-card', () => {
     });
     await el.handleAnchorCopy(clickEvent);
 
+    // Should not throw or mark isCopied
     assert.isFalse(el.isCopied);
     assert.isTrue(warnStub.calledOnce);
   });
@@ -463,7 +616,49 @@ describe('chromedash-release-feature-card', () => {
     await el.handleAnchorCopy(clickEvent);
     assert.isTrue(el.isCopied);
 
+    // Trigger disconnectedCallback
     el.disconnectedCallback();
     assert.isTrue(clearTimeoutSpy.called);
+  });
+
+  describe('aggregateFeatureLinks', () => {
+    it('aggregates structured feature links directly', () => {
+      const links = aggregateFeatureLinks(mockFeature);
+      assert.strictEqual(links.length, 3);
+      assert.strictEqual(
+        links[0].url,
+        'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid'
+      );
+      assert.strictEqual(links[0].title, 'MDN Subgrid Guide');
+    });
+
+    it('aggregates legacy fields and suggested doc links with Set deduplication', () => {
+      const legacy: FeatureCardItem = {
+        id: 999,
+        name: 'Legacy Feature',
+        summary: 'Summary',
+        doc_links: ['https://example.com/doc', 'https://example.com/doc'],
+        spec_link: 'https://example.com/spec',
+        explainer_links: ['https://example.com/explainer'],
+      };
+      const suggestion: SummarySuggestion = {
+        ...mockSuggestion,
+        suggested_doc_links: [
+          'https://example.com/doc',
+          'https://example.com/new-doc',
+        ],
+      };
+      const links = aggregateFeatureLinks(legacy, suggestion);
+      assert.strictEqual(links.length, 4);
+      assert.deepStrictEqual(
+        links.map(l => l.url),
+        [
+          'https://example.com/doc',
+          'https://example.com/spec',
+          'https://example.com/explainer',
+          'https://example.com/new-doc',
+        ]
+      );
+    });
   });
 });


### PR DESCRIPTION
## Overview
Adds editorial review mode and AI curation actions to `<chromedash-release-feature-card>`, building on the view-only card in #6785.

## Changes
- **Editorial Review Mode (`client-src/elements/chromedash-release-feature-card.ts`)**:
  - Adds `reviewMode` boolean property to toggle curation controls.
  - Adds `suggestion` property accepting OpenAPI `SummarySuggestion`.
  - Displays `AI Review Pending` provenance badge when a suggestion is pending review.
  - Merges `suggested_doc_links` from suggestions into the feature link bar.
  - Adds action button bar (`Review Suggestion` / `Inspect / Edit`, `Generate AI Summary`, reasoning tooltip).
  - Dispatches `review-click` and `generate-click` events for parent containers to handle.
- **Unit Tests (`client-src/elements/chromedash-release-feature-card_test.ts`)**:
  - 26 unit tests validating review mode toggle, badge coexistence, event dispatches, and `aggregateFeatureLinks` pure function deduplication.

## Verification
- Unit tests: 26/26 passing in `@web/test-runner`.
- Linters: `make lint-frontend` clean (0 errors).

TAG=agy
CONV=7dad7a60-89a0-4ab9-9f42-3300a3de7807