### PR TITLE
fix: fix deployment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -87,6 +87,7 @@
 			// Only pick LTS versions from
 			// https://www.oracle.com/java/technologies/java-se-support-roadmap.html
 			// Match the version on Cloudtops
+			"jdkDistro": "tem",
 			"version": "25"
 		},
 		"ghcr.io/devcontainers/features/node:1": {


### PR DESCRIPTION
Currently, when installing java in the devcontainer during the deployment, it fails due to https://github.com/devcontainers/features/issues/1712

This fixes it by using the same fix used in webstatus.dev: https://github.com/GoogleChrome/webstatus.dev/commit/12cd4ce16a28e515ef2dc5740bec65a72302ea6f#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R54-R55

More details can be found [here](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/bbbbf056-2175-4b83-bec6-3eea9868838e;step=0?project=interop-tooling-ops).