### PR TITLE
[Release Notes] Bump minimum SSR milestone threshold from M151 to M152

### DIFF
--- a/framework/seo_test.py
+++ b/framework/seo_test.py
@@ -26,16 +26,16 @@ class SEOMetadataTest(testing_config.CustomTestCase):
     def test_instantiation_defaults(self):
         """It applies default StrEnum values for og_type and schema_type."""
         metadata = seo.Metadata(
-            canonical_url='https://chromestatus.com/release-notes/151',
-            seo_title='Chrome 151 Release Notes',
+            canonical_url='https://chromestatus.com/release-notes/152',
+            seo_title='Chrome 152 Release Notes',
             seo_description='Release notes description.',
             site_logo_url='https://chromestatus.com/static/img/crstatus_192.png',
         )
 
         self.assertEqual(
-            'https://chromestatus.com/release-notes/151', metadata.canonical_url
+            'https://chromestatus.com/release-notes/152', metadata.canonical_url
         )
-        self.assertEqual('Chrome 151 Release Notes', metadata.seo_title)
+        self.assertEqual('Chrome 152 Release Notes', metadata.seo_title)
         self.assertEqual('Release notes description.', metadata.seo_description)
         self.assertEqual(
             'https://chromestatus.com/static/img/crstatus_192.png',
@@ -47,7 +47,7 @@ class SEOMetadataTest(testing_config.CustomTestCase):
     def test_strenum_custom_values(self):
         """It accepts explicit StrEnum members for og_type and schema_type."""
         metadata = seo.Metadata(
-            canonical_url='https://chromestatus.com/release-notes/151',
+            canonical_url='https://chromestatus.com/release-notes/152',
             og_type=seo.OpenGraphType.WEBSITE,
             schema_type=seo.SchemaType.ITEM_PAGE,
         )

--- a/internals/l10n_helpers_test.py
+++ b/internals/l10n_helpers_test.py
@@ -260,24 +260,24 @@ class L10nCoreFrameworkTest(unittest.TestCase):
     def test_format_localized_path(self):
         """It formats canonical URL paths with ?hl= for non-default languages only."""
         self.assertEqual(
-            l10n_helpers.format_localized_path('/release-notes/151', 'en'),
-            '/release-notes/151',
+            l10n_helpers.format_localized_path('/release-notes/152', 'en'),
+            '/release-notes/152',
         )
         self.assertEqual(
             l10n_helpers.format_localized_path(
-                '/release-notes/151', l10n_models.SupportedLanguage.EN
+                '/release-notes/152', l10n_models.SupportedLanguage.EN
             ),
-            '/release-notes/151',
+            '/release-notes/152',
         )
         self.assertEqual(
-            l10n_helpers.format_localized_path('/release-notes/151', 'ja'),
-            '/release-notes/151?hl=ja',
+            l10n_helpers.format_localized_path('/release-notes/152', 'ja'),
+            '/release-notes/152?hl=ja',
         )
         self.assertEqual(
             l10n_helpers.format_localized_path(
-                '/release-notes/151', l10n_models.SupportedLanguage.ES
+                '/release-notes/152', l10n_models.SupportedLanguage.ES
             ),
-            '/release-notes/151?hl=es',
+            '/release-notes/152?hl=es',
         )
         self.assertEqual(
             l10n_helpers.format_localized_path('/roadmap', 'unknown-lang'),

--- a/locales/release_notes/de.json
+++ b/locales/release_notes/de.json
@@ -5,7 +5,7 @@
   "jump_aria": "Zu Chrome-Meilenstein springen",
   "prev_milestone_aria": "Vorheriger Meilenstein: Chrome {milestone}",
   "next_milestone_aria": "Nächster Meilenstein: Chrome {milestone}",
-  "archival_banner": "Versionshinweise für Chrome 150 und früher sind auf developer.chrome.com archiviert.",
+  "archival_banner": "Versionshinweise für Chrome 151 und früher sind auf developer.chrome.com archiviert.",
   "browse_archive_btn": "Archiv durchsuchen",
   "origin_trials_heading": "Neue Origin Trials",
   "deprecations_heading": "Einstellungen und Entfernungen",

--- a/locales/release_notes/en.json
+++ b/locales/release_notes/en.json
@@ -5,7 +5,7 @@
   "jump_aria": "Jump to Chrome milestone",
   "prev_milestone_aria": "Previous milestone: Chrome {milestone}",
   "next_milestone_aria": "Next milestone: Chrome {milestone}",
-  "archival_banner": "Release notes for Chrome 150 and earlier are archived on developer.chrome.com.",
+  "archival_banner": "Release notes for Chrome 151 and earlier are archived on developer.chrome.com.",
   "browse_archive_btn": "Browse archive",
   "origin_trials_heading": "New origin trials",
   "deprecations_heading": "Deprecations and removals",

--- a/locales/release_notes/es.json
+++ b/locales/release_notes/es.json
@@ -5,7 +5,7 @@
   "jump_aria": "Ir al hito de Chrome",
   "prev_milestone_aria": "Hito anterior: Chrome {milestone}",
   "next_milestone_aria": "Hito siguiente: Chrome {milestone}",
-  "archival_banner": "Las notas de la versión de Chrome 150 y versiones anteriores están archivadas en developer.chrome.com.",
+  "archival_banner": "Las notas de la versión de Chrome 151 y versiones anteriores están archivadas en developer.chrome.com.",
   "browse_archive_btn": "Explorar archivo",
   "origin_trials_heading": "Nuevas pruebas de origen",
   "deprecations_heading": "Funciones obsoletas y eliminadas",

--- a/locales/release_notes/fr.json
+++ b/locales/release_notes/fr.json
@@ -5,7 +5,7 @@
   "jump_aria": "Aller au jalon Chrome",
   "prev_milestone_aria": "Jalon précédent : Chrome {milestone}",
   "next_milestone_aria": "Jalon suivant : Chrome {milestone}",
-  "archival_banner": "Les notes de version pour Chrome 150 et versions antérieures sont archivées sur developer.chrome.com.",
+  "archival_banner": "Les notes de version pour Chrome 151 et versions antérieures sont archivées sur developer.chrome.com.",
   "browse_archive_btn": "Parcourir les archives",
   "origin_trials_heading": "Nouveaux Origin Trials",
   "deprecations_heading": "Obsolescences et suppressions",

--- a/locales/release_notes/id.json
+++ b/locales/release_notes/id.json
@@ -5,7 +5,7 @@
   "jump_aria": "Beralih ke milestone Chrome",
   "prev_milestone_aria": "Milestone sebelumnya: Chrome {milestone}",
   "next_milestone_aria": "Milestone berikutnya: Chrome {milestone}",
-  "archival_banner": "Catatan rilis untuk Chrome 150 dan sebelumnya diarsipkan di developer.chrome.com.",
+  "archival_banner": "Catatan rilis untuk Chrome 151 dan sebelumnya diarsipkan di developer.chrome.com.",
   "browse_archive_btn": "Jelajahi arsip",
   "origin_trials_heading": "Origin trial baru",
   "deprecations_heading": "Penghentian dan penghapusan",

--- a/locales/release_notes/ja.json
+++ b/locales/release_notes/ja.json
@@ -5,7 +5,7 @@
   "jump_aria": "Chrome のマイルストーンにジャンプ",
   "prev_milestone_aria": "前のマイルストーン: Chrome {milestone}",
   "next_milestone_aria": "次のマイルストーン: Chrome {milestone}",
-  "archival_banner": "Chrome 150 以前のリリースノートは developer.chrome.com にアーカイブされています。",
+  "archival_banner": "Chrome 151 以前のリリースノートは developer.chrome.com にアーカイブされています。",
   "browse_archive_btn": "アーカイブを閲覧",
   "origin_trials_heading": "新しいオリジントライアル",
   "deprecations_heading": "非推奨および削除",

--- a/locales/release_notes/ko.json
+++ b/locales/release_notes/ko.json
@@ -5,7 +5,7 @@
   "jump_aria": "Chrome 마일스톤으로 이동",
   "prev_milestone_aria": "이전 마일스톤: Chrome {milestone}",
   "next_milestone_aria": "다음 마일스톤: Chrome {milestone}",
-  "archival_banner": "Chrome 150 이전의 릴리스 노트는 developer.chrome.com에 보관되어 있습니다.",
+  "archival_banner": "Chrome 151 이전의 릴리스 노트는 developer.chrome.com에 보관되어 있습니다.",
   "browse_archive_btn": "보관 문서 탐색",
   "origin_trials_heading": "새 오리진 트라이얼",
   "deprecations_heading": "지원 중단 및 삭제",

--- a/locales/release_notes/nl.json
+++ b/locales/release_notes/nl.json
@@ -5,7 +5,7 @@
   "jump_aria": "Naar Chrome-mijlpaal gaan",
   "prev_milestone_aria": "Vorige mijlpaal: Chrome {milestone}",
   "next_milestone_aria": "Volgende mijlpaal: Chrome {milestone}",
-  "archival_banner": "Releaseopmerkingen voor Chrome 150 en ouder zijn gearchiveerd op developer.chrome.com.",
+  "archival_banner": "Releaseopmerkingen voor Chrome 151 en ouder zijn gearchiveerd op developer.chrome.com.",
   "browse_archive_btn": "Archief bekijken",
   "origin_trials_heading": "Nieuwe origin trials",
   "deprecations_heading": "Buiten gebruik gesteld en verwijderd",

--- a/locales/release_notes/pt-br.json
+++ b/locales/release_notes/pt-br.json
@@ -5,7 +5,7 @@
   "jump_aria": "Ir para a versão do Chrome",
   "prev_milestone_aria": "Versão anterior: Chrome {milestone}",
   "next_milestone_aria": "Próxima versão: Chrome {milestone}",
-  "archival_banner": "As notas de versão do Chrome 150 e versões anteriores estão arquivadas no developer.chrome.com.",
+  "archival_banner": "As notas de versão do Chrome 151 e versões anteriores estão arquivadas no developer.chrome.com.",
   "browse_archive_btn": "Navegar no arquivo",
   "origin_trials_heading": "Novos testes de origem",
   "deprecations_heading": "Descontinuações e remoções",

--- a/locales/release_notes/zh-cn.json
+++ b/locales/release_notes/zh-cn.json
@@ -5,7 +5,7 @@
   "jump_aria": "跳转到 Chrome 里程碑",
   "prev_milestone_aria": "上一个里程碑: Chrome {milestone}",
   "next_milestone_aria": "下一个里程碑: Chrome {milestone}",
-  "archival_banner": "Chrome 150 及更早版本的发布说明已在 developer.chrome.com 上归档。",
+  "archival_banner": "Chrome 151 及更早版本的发布说明已在 developer.chrome.com 上归档。",
   "browse_archive_btn": "浏览归档",
   "origin_trials_heading": "新的源试用 (Origin Trials)",
   "deprecations_heading": "已弃用和已移除的功能",

--- a/packages/playwright/tests/chromedash-release-notes-ssr_pwtest.js
+++ b/packages/playwright/tests/chromedash-release-notes-ssr_pwtest.js
@@ -78,36 +78,36 @@ test.describe('Release Notes SSR Page', () => {
     page,
   }) => {
     await trackCumulativeLayoutShift(page);
-    await page.goto('/release-notes/151', {timeout: 30000});
+    await page.goto('/release-notes/152', {timeout: 30000});
 
     const pageHeading = page.getByRole('heading', {
-      name: 'Chrome 151 Release Notes',
+      name: 'Chrome 152 Release Notes',
     });
     await expect(pageHeading).toBeVisible();
 
     const prevStepper = page.getByRole('link', {
-      name: /Previous milestone: Chrome 150/i,
+      name: /Previous milestone: Chrome 151/i,
     });
     const nextStepper = page.getByRole('link', {
-      name: /Next milestone: Chrome 152/i,
+      name: /Next milestone: Chrome 153/i,
     });
 
     await expect(prevStepper).toBeVisible();
     await expect(nextStepper).toBeVisible();
 
-    await expect(prevStepper).toHaveAttribute('href', '/release-notes/150');
-    await expect(nextStepper).toHaveAttribute('href', '/release-notes/152');
+    await expect(prevStepper).toHaveAttribute('href', '/release-notes/151');
+    await expect(nextStepper).toHaveAttribute('href', '/release-notes/153');
 
     const jumpInput = page.getByLabel('Jump to Chrome milestone');
     await expect(jumpInput).toBeVisible();
     await expect(jumpInput).toHaveAttribute('list', 'milestones-datalist');
-    await expect(jumpInput).toHaveValue('Chrome 151');
+    await expect(jumpInput).toHaveValue('Chrome 152');
 
-    // Verify datalist option exists for milestone 151
-    const option151 = page
+    // Verify datalist option exists for milestone 152
+    const option152 = page
       .locator('#milestones-datalist')
-      .locator('option[value="Chrome 151"]');
-    await expect(option151).toBeAttached();
+      .locator('option[value="Chrome 152"]');
+    await expect(option152).toBeAttached();
 
     await expectZeroLayoutShift(page);
   });
@@ -115,33 +115,13 @@ test.describe('Release Notes SSR Page', () => {
   test('should navigate to another milestone when typing milestone number and pressing Enter', async ({
     page,
   }) => {
-    await page.goto('/release-notes/151', {timeout: 30000});
+    await page.goto('/release-notes/152', {timeout: 30000});
 
     const jumpInput = page.getByLabel('Jump to Chrome milestone');
     await expect(jumpInput).toBeVisible();
 
     // Type milestone number and press Enter
-    await jumpInput.fill('152');
-    await jumpInput.press('Enter');
-
-    await expect(page).toHaveURL(/\/release-notes\/152/);
-    const newHeading = page.getByRole('heading', {
-      name: 'Chrome 152 Release Notes',
-    });
-    await expect(newHeading).toBeVisible();
-    await expect(jumpInput).toHaveValue('Chrome 152');
-  });
-
-  test('should navigate to another milestone on jump box change event', async ({
-    page,
-  }) => {
-    await page.goto('/release-notes/151', {timeout: 30000});
-
-    const jumpInput = page.getByLabel('Jump to Chrome milestone');
-    await expect(jumpInput).toBeVisible();
-
-    // Select/fill formatted milestone string and press Enter to trigger change
-    await jumpInput.fill('Chrome 153');
+    await jumpInput.fill('153');
     await jumpInput.press('Enter');
 
     await expect(page).toHaveURL(/\/release-notes\/153/);
@@ -152,10 +132,30 @@ test.describe('Release Notes SSR Page', () => {
     await expect(jumpInput).toHaveValue('Chrome 153');
   });
 
+  test('should navigate to another milestone on jump box change event', async ({
+    page,
+  }) => {
+    await page.goto('/release-notes/152', {timeout: 30000});
+
+    const jumpInput = page.getByLabel('Jump to Chrome milestone');
+    await expect(jumpInput).toBeVisible();
+
+    // Select/fill formatted milestone string and press Enter to trigger change
+    await jumpInput.fill('Chrome 154');
+    await jumpInput.press('Enter');
+
+    await expect(page).toHaveURL(/\/release-notes\/154/);
+    const newHeading = page.getByRole('heading', {
+      name: 'Chrome 154 Release Notes',
+    });
+    await expect(newHeading).toBeVisible();
+    await expect(jumpInput).toHaveValue('Chrome 154');
+  });
+
   test('should not navigate when typing numbers below minimum milestone threshold (< 124)', async ({
     page,
   }) => {
-    await page.goto('/release-notes/151', {timeout: 30000});
+    await page.goto('/release-notes/152', {timeout: 30000});
 
     const jumpInput = page.getByLabel('Jump to Chrome milestone');
     await expect(jumpInput).toBeVisible();
@@ -163,37 +163,37 @@ test.describe('Release Notes SSR Page', () => {
     // Type single leading digit '1' and press Enter - should not navigate
     await jumpInput.fill('1');
     await jumpInput.press('Enter');
-    await expect(page).toHaveURL(/\/release-notes\/151/);
+    await expect(page).toHaveURL(/\/release-notes\/152/);
 
     // Type '12' and press Enter - should not navigate
     await jumpInput.fill('12');
     await jumpInput.press('Enter');
-    await expect(page).toHaveURL(/\/release-notes\/151/);
+    await expect(page).toHaveURL(/\/release-notes\/152/);
   });
 
   test('should navigate to next milestone when clicking the next stepper button', async ({
     page,
   }) => {
-    await page.goto('/release-notes/151', {timeout: 30000});
+    await page.goto('/release-notes/152', {timeout: 30000});
 
     const nextStepper = page.getByRole('link', {
-      name: /Next milestone: Chrome 152/i,
+      name: /Next milestone: Chrome 153/i,
     });
     await expect(nextStepper).toBeVisible();
 
     await nextStepper.click();
-    await expect(page).toHaveURL(/\/release-notes\/152/);
+    await expect(page).toHaveURL(/\/release-notes\/153/);
 
     const newHeading = page.getByRole('heading', {
-      name: 'Chrome 152 Release Notes',
+      name: 'Chrome 153 Release Notes',
     });
     await expect(newHeading).toBeVisible();
   });
 
-  test('should render archival notice banner on cutoff milestone 151', async ({
+  test('should render archival notice banner on cutoff milestone 152', async ({
     page,
   }) => {
-    await page.goto('/release-notes/151', {timeout: 30000});
+    await page.goto('/release-notes/152', {timeout: 30000});
 
     const archivalBanner = page.getByRole('note');
     await expect(archivalBanner).toBeVisible();
@@ -209,12 +209,12 @@ test.describe('Release Notes SSR Page', () => {
   test('should render populated release notes page with feature cards', async ({
     page,
   }) => {
-    await withShippedFeature(page, 151, async featureId => {
+    await withShippedFeature(page, 152, async featureId => {
       await trackCumulativeLayoutShift(page);
-      await page.goto('/release-notes/151', {timeout: 30000});
+      await page.goto('/release-notes/152', {timeout: 30000});
 
       const pageHeading = page.getByRole('heading', {
-        name: 'Chrome 151 Release Notes',
+        name: 'Chrome 152 Release Notes',
       });
       await expect(pageHeading).toBeVisible();
 
@@ -251,8 +251,8 @@ test.describe('Release Notes SSR Page', () => {
       }
     }
 
-    await withShippedFeature(page, 151, async featureId => {
-      await page.goto('/release-notes/151', {timeout: 30000});
+    await withShippedFeature(page, 152, async featureId => {
+      await page.goto('/release-notes/152', {timeout: 30000});
 
       const featureCard = page.locator(`#feature-${featureId}`);
       await expect(featureCard).toBeVisible({timeout: 20000});
@@ -278,7 +278,7 @@ test.describe('Release Notes SSR Page', () => {
   test('should render external links with target=_blank and rel=noopener', async ({
     page,
   }) => {
-    await page.goto('/release-notes/151', {timeout: 30000});
+    await page.goto('/release-notes/152', {timeout: 30000});
 
     const archiveLink = page.getByRole('link', {
       name: /archive/i,
@@ -302,10 +302,10 @@ test.describe('Release Notes SSR Page', () => {
   test('should render empty state with roadmap action buttons on unpopulated milestone', async ({
     page,
   }) => {
-    await page.goto('/release-notes/152', {timeout: 30000});
+    await page.goto('/release-notes/153', {timeout: 30000});
 
     const emptyHeading = page.getByRole('heading', {
-      name: /No release notes features available for Chrome 152/i,
+      name: /No release notes features available for Chrome 153/i,
     });
     await expect(emptyHeading).toBeVisible();
 
@@ -316,20 +316,20 @@ test.describe('Release Notes SSR Page', () => {
     await expect(roadmapLink).toHaveAttribute('href', '/roadmap');
   });
 
-  test('should perform HTTP 302 redirect for historical milestones prior to M151 cutoff', async ({
+  test('should perform HTTP 302 redirect for historical milestones prior to M152 cutoff', async ({
     page,
   }) => {
-    await page.goto('/release-notes/150', {timeout: 30000});
-    await expect(page).toHaveURL(/developer\.chrome\.com\/release-notes\/150/);
+    await page.goto('/release-notes/151', {timeout: 30000});
+    await expect(page).toHaveURL(/developer\.chrome\.com\/release-notes\/151/);
   });
 
   test('should pass automated WCAG 2.1 AA and Best Practice Axe audit on empty state', async ({
     page,
   }) => {
-    await page.goto('/release-notes/152', {timeout: 30000});
+    await page.goto('/release-notes/153', {timeout: 30000});
     await expect(
       page.getByRole('heading', {
-        name: /No release notes features available for Chrome 152/i,
+        name: /No release notes features available for Chrome 153/i,
       })
     ).toBeVisible();
 
@@ -352,10 +352,10 @@ test.describe('Release Notes SSR Page', () => {
   test('should pass automated WCAG 2.1 AA and Best Practice Axe audit on populated state', async ({
     page,
   }) => {
-    await withShippedFeature(page, 151, async featureId => {
-      await page.goto('/release-notes/151', {timeout: 30000});
+    await withShippedFeature(page, 152, async featureId => {
+      await page.goto('/release-notes/152', {timeout: 30000});
       await expect(
-        page.getByRole('heading', {name: 'Chrome 151 Release Notes'})
+        page.getByRole('heading', {name: 'Chrome 152 Release Notes'})
       ).toBeVisible();
       await expect(page.locator(`#feature-${featureId}`)).toBeVisible({
         timeout: 20000,
@@ -381,14 +381,14 @@ test.describe('Release Notes SSR Page', () => {
   test('should support keyboard navigation and valid tabindex order', async ({
     page,
   }) => {
-    await page.goto('/release-notes/151', {timeout: 30000});
+    await page.goto('/release-notes/152', {timeout: 30000});
 
     const prevStepper = page.getByRole('link', {
-      name: /Previous milestone: Chrome 150/i,
+      name: /Previous milestone: Chrome 151/i,
     });
     const milestoneInput = page.getByLabel('Jump to Chrome milestone');
     const nextStepper = page.getByRole('link', {
-      name: /Next milestone: Chrome 152/i,
+      name: /Next milestone: Chrome 153/i,
     });
 
     // Previous stepper button is focusable
@@ -412,14 +412,14 @@ test.describe('Release Notes SSR Page', () => {
   test('should pass automated a11y checks during interactive input typing and button focus states', async ({
     page,
   }) => {
-    await page.goto('/release-notes/151', {timeout: 30000});
+    await page.goto('/release-notes/152', {timeout: 30000});
 
     const milestoneInput = page.getByLabel('Jump to Chrome milestone');
     const prevStepper = page.getByRole('link', {
-      name: /Previous milestone: Chrome 150/i,
+      name: /Previous milestone: Chrome 151/i,
     });
     const nextStepper = page.getByRole('link', {
-      name: /Next milestone: Chrome 152/i,
+      name: /Next milestone: Chrome 153/i,
     });
 
     // 1. Check stepper button accessibility labels
@@ -450,10 +450,10 @@ test.describe('Release Notes SSR Page', () => {
     await nextStepper.focus();
     await expect(nextStepper).toBeFocused();
     await page.keyboard.press('Enter');
-    await expect(page).toHaveURL(/\/release-notes\/152/);
+    await expect(page).toHaveURL(/\/release-notes\/153/);
     await expect(
       page.getByRole('heading', {
-        name: 'Chrome 152 Release Notes',
+        name: 'Chrome 153 Release Notes',
       })
     ).toBeVisible();
   });
@@ -461,12 +461,12 @@ test.describe('Release Notes SSR Page', () => {
   test('should render localized Japanese release notes with ?hl=ja', async ({
     page,
   }) => {
-    await withShippedFeature(page, 151, async () => {
+    await withShippedFeature(page, 152, async () => {
       await trackCumulativeLayoutShift(page);
-      await page.goto('/release-notes/151?hl=ja', {timeout: 30000});
+      await page.goto('/release-notes/152?hl=ja', {timeout: 30000});
 
       const pageHeading = page.getByRole('heading', {
-        name: 'Chrome 151 リリースノート',
+        name: 'Chrome 152 リリースノート',
       });
       await expect(pageHeading).toBeVisible();
 
@@ -498,16 +498,16 @@ test.describe('Release Notes SSR Page', () => {
   test('should change language using language selector dropdown', async ({
     page,
   }) => {
-    await page.goto('/release-notes/151', {timeout: 30000});
+    await page.goto('/release-notes/152', {timeout: 30000});
 
     const langSelect = page.locator('#language-select');
     await expect(langSelect).toBeVisible();
 
     await langSelect.selectOption('es');
-    await expect(page).toHaveURL(/\/release-notes\/151\?hl=es/);
+    await expect(page).toHaveURL(/\/release-notes\/152\?hl=es/);
 
     const spanishHeading = page.getByRole('heading', {
-      name: 'Notas de la versión de Chrome 151',
+      name: 'Notas de la versión de Chrome 152',
     });
     await expect(spanishHeading).toBeVisible();
     await expect(page.locator('#release-notes-container')).toHaveAttribute(

--- a/pages/releasenotes.py
+++ b/pages/releasenotes.py
@@ -32,9 +32,9 @@ from internals import (
     translation_helpers,
 )
 
-# Milestones prior to M151 were published as standalone blog posts on developer.chrome.com.
-# ChromeStatus SSR release notes curation begins with Chrome 151.
-MIN_SSR_RELEASE_NOTES_MILESTONE: int = 151
+# Milestones prior to M152 were published as standalone blog posts on developer.chrome.com.
+# ChromeStatus SSR release notes curation begins with Chrome 152.
+MIN_SSR_RELEASE_NOTES_MILESTONE: int = 152
 
 # developer.chrome.com began publishing standalone release notes with Chrome 124.
 MIN_EXTERNAL_RELEASE_NOTES_MILESTONE: int = 124
@@ -108,7 +108,7 @@ class ReleaseNotesHandler(basehandlers.FlaskHandler):
         if milestone > max_allowed_milestone:
             self.abort(404, f'Milestone {milestone} is not available')
 
-        # Milestones prior to M151 redirect to developer.chrome.com
+        # Milestones prior to M152 redirect to developer.chrome.com
         if milestone < MIN_SSR_RELEASE_NOTES_MILESTONE:
             if milestone < MIN_EXTERNAL_RELEASE_NOTES_MILESTONE:
                 # Pre-124 milestones do not exist on d.c.c/release-notes/<m>; redirect to archive root.

--- a/pages/releasenotes_test.py
+++ b/pages/releasenotes_test.py
@@ -159,23 +159,31 @@ class ReleaseNotesHandlerTest(testing_config.CustomTestCase):
         )
 
     def test_get_template_data__specific_milestone(self):
-        """It returns template context data for a specific milestone >= 151."""
-        with test_app.test_request_context('/release-notes/151'):
-            data = self.handler.get_template_data(milestone=151)
-            self.assertEqual(151, data['milestone'])
-            self.assertEqual(150, data['prev_milestone'])
-            self.assertEqual(152, data['next_milestone'])
+        """It returns template context data for a specific milestone >= 152."""
+        with test_app.test_request_context('/release-notes/152'):
+            data = self.handler.get_template_data(milestone=152)
+            self.assertEqual(152, data['milestone'])
+            self.assertEqual(151, data['prev_milestone'])
+            self.assertEqual(153, data['next_milestone'])
             self.assertTrue(data['is_min_ssr_milestone'])
             self.assertIn('features_by_category', data)
             self.assertIn('milestones_list', data)
             self.assertEqual(124, data['milestones_list'][-1])
             self.assertIn('seo', data)
             self.assertEqual(
-                'Chrome 151 Release Notes', data['seo']['seo_title']
+                'Chrome 152 Release Notes', data['seo']['seo_title']
             )
 
-    def test_get_template_data__m124_to_m150_redirect(self):
-        """It returns an HTTP 302 redirect to developer.chrome.com/release-notes/<milestone> for 124 <= m < 151."""
+    def test_get_template_data__m124_to_m151_redirect(self):
+        """It returns an HTTP 302 redirect to developer.chrome.com/release-notes/<milestone> for 124 <= m < 152."""
+        with test_app.test_request_context('/release-notes/151'):
+            resp = self.handler.get_template_data(milestone=151)
+            self.assertEqual(302, resp.status_code)
+            self.assertEqual(
+                'https://developer.chrome.com/release-notes/151',
+                resp.headers['Location'],
+            )
+
         with test_app.test_request_context('/release-notes/150'):
             resp = self.handler.get_template_data(milestone=150)
             self.assertEqual(302, resp.status_code)
@@ -208,10 +216,10 @@ class ReleaseNotesHandlerTest(testing_config.CustomTestCase):
         with test_app.test_request_context('/release-notes'):
             with mock.patch(
                 'internals.fetchchannels.get_current_stable_milestone',
-                return_value=151,
+                return_value=152,
             ):
                 data = self.handler.get_template_data()
-                self.assertEqual(151, data['milestone'])
+                self.assertEqual(152, data['milestone'])
 
     def test_get_template_data__upstream_omaha_downtime_fallback(self):
         """It gracefully falls back to MIN_SSR_RELEASE_NOTES_MILESTONE if Omaha returns 0."""
@@ -221,16 +229,16 @@ class ReleaseNotesHandlerTest(testing_config.CustomTestCase):
                 return_value=0,
             ):
                 data = self.handler.get_template_data()
-                self.assertEqual(151, data['milestone'])
-                self.assertEqual(151, data['stable_milestone'])
-                self.assertEqual(153, data['milestones_list'][0])
+                self.assertEqual(152, data['milestone'])
+                self.assertEqual(152, data['stable_milestone'])
+                self.assertEqual(154, data['milestones_list'][0])
                 self.assertEqual(124, data['milestones_list'][-1])
 
     def test_get_template_data__string_milestone(self):
         """It accepts string milestone parameters and coerces them to int."""
-        with test_app.test_request_context('/release-notes/151'):
-            data = self.handler.get_template_data(milestone='151')
-            self.assertEqual(151, data['milestone'])
+        with test_app.test_request_context('/release-notes/152'):
+            data = self.handler.get_template_data(milestone='152')
+            self.assertEqual(152, data['milestone'])
 
     def test_get_template_data__invalid_milestone_400(self):
         """It aborts HTTP 400 for non-positive milestone values or invalid strings."""
@@ -245,7 +253,7 @@ class ReleaseNotesHandlerTest(testing_config.CustomTestCase):
         with test_app.test_request_context('/release-notes/9999'):
             with mock.patch(
                 'internals.fetchchannels.get_current_stable_milestone',
-                return_value=151,
+                return_value=152,
             ):
                 with self.assertRaises(werkzeug.exceptions.HTTPException) as cm:
                     self.handler.get_template_data(milestone=9999)
@@ -253,21 +261,21 @@ class ReleaseNotesHandlerTest(testing_config.CustomTestCase):
 
     def test_render_template_html_structure(self):
         """It asserts HTML elements, steppers, and jump box using built-in html.parser."""
-        with test_app.test_request_context('/release-notes/151'):
-            data = self.handler.get_template_data(milestone=151)
+        with test_app.test_request_context('/release-notes/152'):
+            data = self.handler.get_template_data(milestone=152)
             html_str = flask.render_template('release-notes.html', **data)
 
             parser = ReleaseNotesHTMLParser()
             parser.feed(html_str)
 
             # Verify subheader title (rendered as h1)
-            self.assertIn('Chrome 151 Release Notes', parser.headings)
+            self.assertIn('Chrome 152 Release Notes', parser.headings)
 
             # Verify previous and next stepper links
-            self.assertIn('/release-notes/150', parser.links)
-            self.assertIn('/release-notes/152', parser.links)
+            self.assertIn('/release-notes/151', parser.links)
+            self.assertIn('/release-notes/153', parser.links)
 
-            # Verify archival notice link on M151
+            # Verify archival notice link on M152
             self.assertIn(
                 'https://developer.chrome.com/release-notes', parser.links
             )
@@ -315,8 +323,8 @@ class ReleaseNotesHandlerTest(testing_config.CustomTestCase):
 
     def test_get_template_data__japanese_localizes_summaries(self):
         """It renders localized summary text and data-summary-lang='ja' when ?hl=ja is requested."""
-        with test_app.test_request_context('/release-notes/151?hl=ja'):
-            data = self.handler.get_template_data(milestone=151)
+        with test_app.test_request_context('/release-notes/152?hl=ja'):
+            data = self.handler.get_template_data(milestone=152)
             html_str = flask.render_template('release-notes.html', **data)
             self.assertEqual('ja', data['current_lang'])
             self.assertIn(


### PR DESCRIPTION
### Summary
This PR bumps the minimum milestone threshold for ChromeStatus SSR Release Notes curation from **Chrome 151** to **Chrome 152**.

### Changes
1. **Backend Minimum Milestone Threshold (`pages/releasenotes.py`)**:
   - Updated `MIN_SSR_RELEASE_NOTES_MILESTONE` from `151` to `152`.
   - Updated historical redirect logic so that Chrome 151 and earlier (`124 <= m < 152`) issue an HTTP 302 redirect to `https://developer.chrome.com/release-notes/<milestone>`.

2. **Localization Catalogs (`locales/release_notes/*.json`)**:
   - Updated `archival_banner` across all 10 language JSON catalogs (`en`, `de`, `es`, `fr`, `id`, `ja`, `ko`, `nl`, `pt-br`, `zh-cn`) from *"Chrome 150 and earlier"* to *"Chrome 151 and earlier"*.

3. **Backend Unit Tests (`pages/releasenotes_test.py`, `internals/l10n_helpers_test.py`, `framework/seo_test.py`)**:
   - Updated milestone assertions to target milestone 152 as the minimum loaded milestone (`prev_milestone = 151`, `next_milestone = 153`).
   - Verified HTTP 302 redirects for milestones 151, 150, and 124 to developer.chrome.com.
   - Updated Omaha downtime fallback default to 152.

4. **Playwright Integration Tests (`packages/playwright/tests/chromedash-release-notes-ssr_pwtest.js`)**:
   - Updated test feature fixture to seed milestone 152.
   - Updated empty state assertions to target milestone 153.
   - Updated archival banner assertions for milestone 152 cutoff.
   - Verified HTTP 302 redirect for historical milestone 151.

### Verification
- **Python Unit Tests**: 30/30 passed (`pytest internals/l10n_helpers_test.py pages/releasenotes_test.py framework/seo_test.py`).
- **Web Component Tests**: 49/49 test files passed (358 tests) across Chromium and Firefox (`make webtest`).
- **Linters & Types**: 0 problems across 133 files (`make lint-frontend`).