### PR TITLE
Remove the MWG checkbox on the Adoption gate for code-only entries.

### DIFF
--- a/api/converters.py
+++ b/api/converters.py
@@ -787,7 +787,10 @@ def vote_value_to_json_dict(vote: Vote) -> dict[str, Any]:
     }
 
 
-def gate_value_to_json_dict(gate: Gate) -> dict[str, Any]:
+def gate_value_to_json_dict(
+    gate: Gate,
+    feature: FeatureEntry | None = None,
+) -> dict[str, Any]:
     """Convert a Gate entity into a dict."""
     next_action = str(gate.next_action) if gate.next_action else None
     requested_on = str(gate.requested_on) if gate.requested_on else None
@@ -829,7 +832,7 @@ def gate_value_to_json_dict(gate: Gate) -> dict[str, Any]:
             ) + (gate.needs_work_elapsed or 0)
 
     self_certify_possible = self_certify.is_possible(gate)
-    self_certify_eligible = self_certify.is_eligible(gate)
+    self_certify_eligible = self_certify.is_eligible(gate, feature=feature)
     survey_answers = (
         to_dict(gate.survey_answers) if gate.survey_answers else None
     )

--- a/api/converters_test.py
+++ b/api/converters_test.py
@@ -684,6 +684,39 @@ class GateConvertersTest(testing_config.CustomTestCase):
         self.assertEqual(4, actual['slo_initial_response_took'])
         self.assertEqual(None, actual['slo_initial_response_remaining'])
 
+    def test_adoption_gate_code_change(self):
+        """Adoption gate is eligible for code change features even without MWG."""
+        gate = Gate(
+            feature_id=1,
+            stage_id=2,
+            gate_type=core_enums.GATE_ADOPTION_SHIP,
+            state=4,
+        )
+        gate.survey_answers = SurveyAnswers(
+            adoption_fields_up_to_date=True,
+            adoption_style_aligned=True,
+            adoption_lead_time=True,
+            adoption_mdn_drafted=True,
+            adoption_mwg_drafted=False,
+        )
+        gate.put()
+
+        actual = converters.gate_value_to_json_dict(
+            gate,
+            feature=FeatureEntry(
+                feature_type=core_enums.FEATURE_TYPE_CODE_CHANGE_ID
+            ),
+        )
+        self.assertTrue(actual['self_certify_eligible'])
+
+        actual_other = converters.gate_value_to_json_dict(
+            gate,
+            feature=FeatureEntry(
+                feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID
+            ),
+        )
+        self.assertFalse(actual_other['self_certify_eligible'])
+
 
 class AICurationConvertersTest(testing_config.CustomTestCase):
     """Tests for AI suggestion, progress step, and milestone curation converters."""

--- a/api/reviews_api.py
+++ b/api/reviews_api.py
@@ -132,7 +132,11 @@ class VotesAPI(basehandlers.APIHandler):
         if is_requesting_review and is_editor:
             return
 
-        if is_approving and is_editor and self_certify.is_eligible(gate):
+        if (
+            is_approving
+            and is_editor
+            and self_certify.is_eligible(gate, feature=feature)
+        ):
             return
 
         if is_approver:
@@ -167,7 +171,9 @@ class GatesAPI(basehandlers.APIHandler):
         feature_id = fe.key.integer_id()
         gates: list[Gate] = Gate.query(Gate.feature_id == feature_id).fetch()
 
-        dicts = [converters.gate_value_to_json_dict(g) for g in gates]
+        dicts = [
+            converters.gate_value_to_json_dict(g, feature=fe) for g in gates
+        ]
         for g in dicts:
             approvers = approval_defs.get_approvers(g['gate_type'])
             g['possible_assignee_emails'] = approvers

--- a/api/reviews_api_test.py
+++ b/api/reviews_api_test.py
@@ -397,6 +397,68 @@ class VotesAPITest(testing_config.CustomTestCase):
             Vote.NO_RESPONSE,
         )
 
+    @mock.patch('internals.notifier_helpers.notify_subscribers_of_vote_changes')
+    @mock.patch('internals.approval_defs.get_approvers')
+    def test_post__self_cert__adoption_code_change_eligible(
+        self, mock_get_approvers, mock_notifier
+    ):
+        """Feature owner can self-approve adoption gate for code change without mwg."""
+        mock_get_approvers.return_value = ['reviewer1@example.com']
+        testing_config.sign_in('owner1@example.com', 123567890)
+        self.feature_1.feature_type = core_enums.FEATURE_TYPE_CODE_CHANGE_ID
+        self.feature_1.put()
+        self.gate_1.gate_type = core_enums.GATE_ADOPTION_SHIP
+        self.gate_1.survey_answers = SurveyAnswers(
+            adoption_fields_up_to_date=True,
+            adoption_style_aligned=True,
+            adoption_lead_time=True,
+            adoption_mdn_drafted=True,
+            adoption_mwg_drafted=False,
+        )
+        self.gate_1.put()
+
+        params = {'state': Vote.NA_SELF}
+        with test_app.test_request_context(self.request_path, json=params):
+            actual = self.handler.do_post(
+                feature_id=self.feature_id, gate_id=self.gate_1_id
+            )
+
+        self.assertEqual(actual, {'message': 'Done'})
+        updated_votes = Vote.get_votes(feature_id=self.feature_id)
+        self.assertEqual(1, len(updated_votes))
+        vote = updated_votes[0]
+        self.assertEqual(vote.feature_id, self.feature_id)
+        self.assertEqual(vote.gate_id, 1)
+        self.assertEqual(vote.set_by, 'owner1@example.com')
+        self.assertEqual(vote.state, Vote.NA_SELF)
+
+    @mock.patch('internals.notifier_helpers.notify_subscribers_of_vote_changes')
+    @mock.patch('internals.approval_defs.get_approvers')
+    def test_post__self_cert__adoption_other_feature_type_ineligible(
+        self, mock_get_approvers, mock_notifier
+    ):
+        """Feature owner cannot self-approve adoption gate for incubate feature without mwg."""
+        mock_get_approvers.return_value = ['reviewer1@example.com']
+        testing_config.sign_in('owner1@example.com', 123567890)
+        self.feature_1.feature_type = core_enums.FEATURE_TYPE_INCUBATE_ID
+        self.feature_1.put()
+        self.gate_1.gate_type = core_enums.GATE_ADOPTION_SHIP
+        self.gate_1.survey_answers = SurveyAnswers(
+            adoption_fields_up_to_date=True,
+            adoption_style_aligned=True,
+            adoption_lead_time=True,
+            adoption_mdn_drafted=True,
+            adoption_mwg_drafted=False,
+        )
+        self.gate_1.put()
+
+        params = {'state': Vote.NA_SELF}
+        with test_app.test_request_context(self.request_path, json=params):
+            with self.assertRaises(werkzeug.exceptions.Forbidden):
+                self.handler.do_post(
+                    feature_id=self.feature_id, gate_id=self.gate_1_id
+                )
+
     def test_check_voting_rules__not_verification(self):
         """We allow anything that is not NA_VERIFIED."""
         self.handler.check_voting_rules(self.gate_1, Vote.NO_RESPONSE)
@@ -506,6 +568,28 @@ class GatesAPITest(testing_config.CustomTestCase):
             'gates': [],
         }
         self.assertEqual(actual, expected)
+
+    @mock.patch('internals.approval_defs.get_approvers')
+    def test_do_get__adoption_gate_code_change(self, mock_get_approvers):
+        """Adoption gate for code change feature is self-certify eligible without mwg."""
+        mock_get_approvers.return_value = ['reviewer1@example.com']
+        self.feature_1.feature_type = core_enums.FEATURE_TYPE_CODE_CHANGE_ID
+        self.feature_1.put()
+        self.gate_1.gate_type = core_enums.GATE_ADOPTION_SHIP
+        self.gate_1.survey_answers = SurveyAnswers(
+            adoption_fields_up_to_date=True,
+            adoption_style_aligned=True,
+            adoption_lead_time=True,
+            adoption_mdn_drafted=True,
+            adoption_mwg_drafted=False,
+        )
+        self.gate_1.put()
+
+        with test_app.test_request_context(self.request_path):
+            actual = self.handler.do_get(feature_id=self.feature_id)
+
+        self.assertEqual(1, len(actual['gates']))
+        self.assertTrue(actual['gates'][0]['self_certify_eligible'])
 
     def test_do_get__deleted(self):
         """If a feature is deleted, don't return any gates."""

--- a/client-src/elements/chromedash-survey-questions.ts
+++ b/client-src/elements/chromedash-survey-questions.ts
@@ -315,7 +315,8 @@ export class ChromedashSurveyQuestions extends LitElement {
   }
 
   renderAdoptionForm(): TemplateResult {
-    const mwg_needed = this.feature.feature_type_int !==
+    const mwg_needed =
+      this.feature.feature_type_int !==
       FEATURE_TYPES.FEATURE_TYPE_CODE_CHANGE_ID[0];
     return html`
       <div id="questionnaire">
@@ -364,24 +365,28 @@ export class ChromedashSurveyQuestions extends LitElement {
               this feature on
               <a href="https://github.com/mdn/content" target="_blank">MDN</a>.`
           )}
-          ${mwg_needed ? this.renderBooleanField(
-            'adoption_mwg_drafted',
-            html`<b>MWG work tracked</b>. You have
-              <a
-                href="https://github.com/GoogleChrome/modern-web-guidance-src/issues/new?template=new-feature.yml"
-                target="_blank"
-                >created an issue</a
-              >
-              in the
-              <a
-                href="https://github.com/GoogleChrome/modern-web-guidance-src"
-                target="_blank"
-                >Modern Web Guidance</a
-              >
-              tracker, providing information about how your feature impacts
-              guidance for LLMs, or you have left a comment here explaining why
-              there is no impact.`
-          ) : nothing}
+          ${
+            mwg_needed
+              ? this.renderBooleanField(
+                  'adoption_mwg_drafted',
+                  html`<b>MWG work tracked</b>. You have
+                    <a
+                      href="https://github.com/GoogleChrome/modern-web-guidance-src/issues/new?template=new-feature.yml"
+                      target="_blank"
+                      >created an issue</a
+                    >
+                    in the
+                    <a
+                      href="https://github.com/GoogleChrome/modern-web-guidance-src"
+                      target="_blank"
+                      >Modern Web Guidance</a
+                    >
+                    tracker, providing information about how your feature
+                    impacts guidance for LLMs, or you have left a comment here
+                    explaining why there is no impact.`
+                )
+              : nothing
+          }
         </ol>
       </div>
     `;

--- a/client-src/elements/chromedash-survey-questions.ts
+++ b/client-src/elements/chromedash-survey-questions.ts
@@ -20,7 +20,7 @@ import {SHARED_STYLES} from '../css/shared-css.js';
 import {SlChangeEvent, SlInput} from '@shoelace-style/shoelace';
 import {Feature, StageDict, User} from '../js-src/cs-client.js';
 import {GateDict} from './chromedash-gate-chip.js';
-import {GATE_TYPES} from './form-field-enums.js';
+import {FEATURE_TYPES, GATE_TYPES} from './form-field-enums.js';
 import {GATE_QUESTIONNAIRES} from './gate-details.js';
 import {autolink} from './utils.js';
 
@@ -315,6 +315,8 @@ export class ChromedashSurveyQuestions extends LitElement {
   }
 
   renderAdoptionForm(): TemplateResult {
+    const mwg_needed = this.feature.feature_type_int !==
+      FEATURE_TYPES.FEATURE_TYPE_CODE_CHANGE_ID[0];
     return html`
       <div id="questionnaire">
         Check the boxes below that are true for your feature, then use the
@@ -362,7 +364,7 @@ export class ChromedashSurveyQuestions extends LitElement {
               this feature on
               <a href="https://github.com/mdn/content" target="_blank">MDN</a>.`
           )}
-          ${this.renderBooleanField(
+          ${mwg_needed ? this.renderBooleanField(
             'adoption_mwg_drafted',
             html`<b>MWG work tracked</b>. You have
               <a
@@ -379,7 +381,7 @@ export class ChromedashSurveyQuestions extends LitElement {
               tracker, providing information about how your feature impacts
               guidance for LLMs, or you have left a comment here explaining why
               there is no impact.`
-          )}
+          ) : nothing}
         </ol>
       </div>
     `;

--- a/internals/self_certify.py
+++ b/internals/self_certify.py
@@ -17,6 +17,7 @@
 from chromestatus_openapi.models import SurveyAnswers as OASurveyAnswers
 
 from internals import core_enums
+from internals.core_models import FeatureEntry
 from internals.review_models import Gate, SurveyAnswers
 
 CERTIFIABLE_GATE_TYPES = [
@@ -92,18 +93,27 @@ def is_testing_eligible(answers: SurveyAnswers) -> bool:
     )
 
 
-def is_adoption_eligible(answers: SurveyAnswers) -> bool:
+def is_adoption_eligible(
+    answers: SurveyAnswers, feature: FeatureEntry | None = None
+) -> bool:
     """Return True if the answers allow self-certify for the Adoption gate."""
-    return (
+    mwg_needed = (
+        feature is None
+        or feature.feature_type != core_enums.FEATURE_TYPE_CODE_CHANGE_ID
+    )
+    return bool(
         answers.adoption_fields_up_to_date
         and answers.adoption_style_aligned
         and answers.adoption_lead_time
         and answers.adoption_mdn_drafted
-        and answers.adoption_mwg_drafted
+        and (not mwg_needed or answers.adoption_mwg_drafted)
     )
 
 
-def is_eligible(gate: Gate) -> bool:
+def is_eligible(
+    gate: Gate,
+    feature: FeatureEntry | None = None,
+) -> bool:
     """Return True if the feature owner can self-certify the gate now."""
     answers = gate.survey_answers
     if answers is None:
@@ -123,7 +133,9 @@ def is_eligible(gate: Gate) -> bool:
         core_enums.GATE_ADOPTION_PLAN,
         core_enums.GATE_ADOPTION_SHIP,
     ]:
-        return is_adoption_eligible(answers)
+        if feature is None and gate.feature_id:
+            feature = FeatureEntry.get_by_id(gate.feature_id)
+        return is_adoption_eligible(answers, feature=feature)
 
     return False
 

--- a/internals/self_certify_test.py
+++ b/internals/self_certify_test.py
@@ -16,9 +16,12 @@
 
 import testing_config  # isort: split
 
+from unittest import mock
+
 from chromestatus_openapi.models import SurveyAnswers as OASurveyAnswers
 
 from internals import core_enums, self_certify
+from internals.core_models import FeatureEntry
 from internals.review_models import Gate, SurveyAnswers
 
 
@@ -136,22 +139,76 @@ class SelfCertifyFunctionTest(testing_config.CustomTestCase):
         )
 
     def test_is_adoption_eligible(self):
-        """Adoption is eligible if all of the booleans is True."""
+        """Adoption is eligible if required booleans are True."""
         self.assertFalse(self_certify.is_adoption_eligible(SurveyAnswers()))
         self.assertFalse(
             self_certify.is_adoption_eligible(
                 SurveyAnswers(adoption_style_aligned=False)
             )
         )
+        all_five = SurveyAnswers(
+            adoption_fields_up_to_date=True,
+            adoption_style_aligned=True,
+            adoption_lead_time=True,
+            adoption_mdn_drafted=True,
+            adoption_mwg_drafted=True,
+        )
+        first_four_only = SurveyAnswers(
+            adoption_fields_up_to_date=True,
+            adoption_style_aligned=True,
+            adoption_lead_time=True,
+            adoption_mdn_drafted=True,
+            adoption_mwg_drafted=False,
+        )
+        # Without feature (or None), all 5 are required.
+        self.assertTrue(self_certify.is_adoption_eligible(all_five))
+        self.assertFalse(self_certify.is_adoption_eligible(first_four_only))
+
+        feature_incubate = FeatureEntry(
+            feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID
+        )
+        feature_code_change = FeatureEntry(
+            feature_type=core_enums.FEATURE_TYPE_CODE_CHANGE_ID
+        )
+
+        # For normal feature types, MWG is required.
         self.assertTrue(
             self_certify.is_adoption_eligible(
+                all_five,
+                feature=feature_incubate,
+            )
+        )
+        self.assertFalse(
+            self_certify.is_adoption_eligible(
+                first_four_only,
+                feature=feature_incubate,
+            )
+        )
+
+        # For code change features, MWG is NOT required.
+        self.assertTrue(
+            self_certify.is_adoption_eligible(
+                first_four_only,
+                feature=feature_code_change,
+            )
+        )
+        self.assertTrue(
+            self_certify.is_adoption_eligible(
+                all_five,
+                feature=feature_code_change,
+            )
+        )
+        # But other 4 fields are still required for code change features.
+        self.assertFalse(
+            self_certify.is_adoption_eligible(
                 SurveyAnswers(
-                    adoption_fields_up_to_date=True,
+                    adoption_fields_up_to_date=False,
                     adoption_style_aligned=True,
                     adoption_lead_time=True,
                     adoption_mdn_drafted=True,
-                    adoption_mwg_drafted=True,
-                )
+                    adoption_mwg_drafted=False,
+                ),
+                feature=feature_code_change,
             )
         )
 
@@ -191,6 +248,85 @@ class SelfCertifyFunctionTest(testing_config.CustomTestCase):
                 )
             )
         )
+
+        feature_code_change = FeatureEntry(
+            feature_type=core_enums.FEATURE_TYPE_CODE_CHANGE_ID
+        )
+        feature_incubate = FeatureEntry(
+            feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID
+        )
+
+        # Code change features allow self-certifying adoption gate without mwg drafted.
+        adoption_gate = Gate(
+            gate_type=core_enums.GATE_ADOPTION_SHIP,
+            survey_answers=SurveyAnswers(
+                adoption_fields_up_to_date=True,
+                adoption_style_aligned=True,
+                adoption_lead_time=True,
+                adoption_mdn_drafted=True,
+                adoption_mwg_drafted=False,
+            ),
+        )
+        self.assertTrue(
+            self_certify.is_eligible(
+                adoption_gate,
+                feature=feature_code_change,
+            )
+        )
+        self.assertFalse(
+            self_certify.is_eligible(
+                adoption_gate,
+                feature=feature_incubate,
+            )
+        )
+
+        # Also works for GATE_ADOPTION_PLAN.
+        adoption_plan_gate = Gate(
+            gate_type=core_enums.GATE_ADOPTION_PLAN,
+            survey_answers=SurveyAnswers(
+                adoption_fields_up_to_date=True,
+                adoption_style_aligned=True,
+                adoption_lead_time=True,
+                adoption_mdn_drafted=True,
+                adoption_mwg_drafted=False,
+            ),
+        )
+        self.assertTrue(
+            self_certify.is_eligible(
+                adoption_plan_gate,
+                feature=feature_code_change,
+            )
+        )
+
+        # If gate has feature_id and neither feature nor feature_type is passed,
+        # it fetches the FeatureEntry by id.
+        gate_with_fid = Gate(
+            feature_id=123,
+            gate_type=core_enums.GATE_ADOPTION_SHIP,
+            survey_answers=SurveyAnswers(
+                adoption_fields_up_to_date=True,
+                adoption_style_aligned=True,
+                adoption_lead_time=True,
+                adoption_mdn_drafted=True,
+                adoption_mwg_drafted=False,
+            ),
+        )
+        with mock.patch(
+            'internals.core_models.FeatureEntry.get_by_id'
+        ) as mock_get_by_id:
+            mock_get_by_id.return_value = FeatureEntry(
+                feature_type=core_enums.FEATURE_TYPE_CODE_CHANGE_ID
+            )
+            self.assertTrue(self_certify.is_eligible(gate_with_fid))
+            mock_get_by_id.assert_called_once_with(123)
+
+        with mock.patch(
+            'internals.core_models.FeatureEntry.get_by_id'
+        ) as mock_get_by_id:
+            mock_get_by_id.return_value = FeatureEntry(
+                feature_type=core_enums.FEATURE_TYPE_INCUBATE_ID
+            )
+            self.assertFalse(self_certify.is_eligible(gate_with_fid))
 
         self.assertFalse(
             self_certify.is_eligible(


### PR DESCRIPTION
Resolves #6703.

Code-change only feature entries usually cannot affect MWG because they do not change any APIs.  So, this PR removes the MWG checkbox for such entries and does not require it to self-certify the gate.