### PR TITLE
Fix UnboundLocalError when origin trials API requests fail

### DIFF
--- a/framework/origin_trials_client.py
+++ b/framework/origin_trials_client.py
@@ -176,6 +176,13 @@ def _get_ot_access_token() -> str:
     return credentials.token
 
 
+def _extract_error_text(e: requests.exceptions.RequestException) -> str:
+    """Extract error text from a RequestException or fallback to exception message."""
+    if e.response is not None and e.response.text:
+        return e.response.text
+    return str(e) or 'Unknown request error'
+
+
 def _send_create_trial_request(
     ot_stage: Stage, api_key: str, access_token: str
 ) -> tuple[int | None, str | None]:
@@ -252,11 +259,12 @@ def _send_create_trial_request(
         )
         logging.info(f'CreateTrial response text: {response.text}')
         response.raise_for_status()
-    except requests.exceptions.RequestException:
+    except requests.exceptions.RequestException as e:
+        error_text = _extract_error_text(e)
         logging.exception(
-            f'Failed to get response from origin trials API. {response.text}'
+            f'Failed to get response from origin trials API. {error_text}'
         )
-        return None, response.text
+        return None, error_text
     response_json = response.json()
     return response_json['trial']['id'], None
 
@@ -296,11 +304,12 @@ def _send_set_up_trial_request(
         )
         logging.info(f'SetUpTrial response text: {response.text}')
         response.raise_for_status()
-    except requests.exceptions.RequestException:
+    except requests.exceptions.RequestException as e:
+        error_text = _extract_error_text(e)
         logging.exception(
-            f'Failed to get response from origin trials API. {response.text}'
+            f'Failed to get response from origin trials API. {error_text}'
         )
-        return response.text
+        return error_text
     return None
 
 
@@ -388,8 +397,9 @@ def activate_origin_trial(origin_trial_id: str) -> None:
         logging.info(response.text)
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
+        error_text = _extract_error_text(e)
         logging.exception(
-            f'Failed to get response from origin trials API. {response.text}'
+            f'Failed to get response from origin trials API. {error_text}'
         )
         raise e
 
@@ -430,5 +440,8 @@ def extend_origin_trial(trial_id: str, end_milestone: int, intent_url: str):
         logging.info(response.text)
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
-        logging.exception('Failed to get response from origin trials API.')
+        error_text = _extract_error_text(e)
+        logging.exception(
+            f'Failed to get response from origin trials API. {error_text}'
+        )
         raise e

--- a/framework/origin_trials_client_test.py
+++ b/framework/origin_trials_client_test.py
@@ -21,9 +21,11 @@ trials, extending trials, and handling API key presence/absence.
 from unittest import mock
 
 import flask
+import requests
+
+import testing_config  # isort: split
 
 import settings
-import testing_config  # Must be imported before the module under test.
 from framework import origin_trials_client
 from internals.core_models import MilestoneSet, Stage
 
@@ -399,3 +401,188 @@ class OriginTrialsClientTest(testing_config.CustomTestCase):
             params={'key': 'api_key_value'},
             json={'trial_id': '-1234567890'},
         )
+
+    def test_extract_error_text(self):
+        """Should extract error text from response if available, else exception str."""
+        mock_response = mock.MagicMock(text='Error from API')
+        http_err = requests.exceptions.HTTPError(
+            '400 Client Error', response=mock_response
+        )
+        self.assertEqual(
+            origin_trials_client._extract_error_text(http_err), 'Error from API'
+        )
+
+        conn_err = requests.exceptions.ConnectionError('Connection refused')
+        self.assertEqual(
+            origin_trials_client._extract_error_text(conn_err),
+            'Connection refused',
+        )
+
+        empty_resp = mock.MagicMock(text='')
+        http_err_empty = requests.exceptions.HTTPError(
+            '502 Bad Gateway', response=empty_resp
+        )
+        self.assertEqual(
+            origin_trials_client._extract_error_text(http_err_empty),
+            '502 Bad Gateway',
+        )
+
+    @mock.patch('framework.origin_trials_client._get_ot_access_token')
+    @mock.patch('framework.origin_trials_client._get_trial_end_time')
+    @mock.patch('requests.post')
+    def test_create_origin_trial__create_connection_error(
+        self,
+        mock_requests_post,
+        mock_get_trial_end_time,
+        mock_get_ot_access_token,
+    ):
+        """If create trial request encounters network error, return error text without crashing."""
+        mock_requests_post.side_effect = requests.exceptions.ConnectionError(
+            'Failed to connect'
+        )
+        mock_get_trial_end_time.return_value = 111222333
+        mock_get_ot_access_token.return_value = 'access_token'
+        settings.OT_API_KEY = 'api_key_value'
+
+        ot_id, error_text = origin_trials_client.create_origin_trial(
+            self.ot_stage
+        )
+        self.assertIsNone(ot_id)
+        self.assertEqual('Failed to connect', error_text)
+
+    @mock.patch('framework.origin_trials_client._get_ot_access_token')
+    @mock.patch('framework.origin_trials_client._get_trial_end_time')
+    @mock.patch('requests.post')
+    def test_create_origin_trial__create_http_error(
+        self,
+        mock_requests_post,
+        mock_get_trial_end_time,
+        mock_get_ot_access_token,
+    ):
+        """If create trial request returns HTTP error, return response error text."""
+        mock_response = mock.MagicMock(
+            status_code=400,
+            text='{"error": "Invalid trial params"}',
+        )
+        mock_response.raise_for_status.side_effect = (
+            requests.exceptions.HTTPError(
+                '400 Client Error', response=mock_response
+            )
+        )
+        mock_requests_post.return_value = mock_response
+        mock_get_trial_end_time.return_value = 111222333
+        mock_get_ot_access_token.return_value = 'access_token'
+        settings.OT_API_KEY = 'api_key_value'
+
+        ot_id, error_text = origin_trials_client.create_origin_trial(
+            self.ot_stage
+        )
+        self.assertIsNone(ot_id)
+        self.assertEqual('{"error": "Invalid trial params"}', error_text)
+
+    @mock.patch('framework.secrets.get_ot_data_access_admin_group')
+    @mock.patch('framework.origin_trials_client._get_ot_access_token')
+    @mock.patch('framework.origin_trials_client._get_trial_end_time')
+    @mock.patch('requests.post')
+    def test_create_origin_trial__setup_connection_error(
+        self,
+        mock_requests_post,
+        mock_get_trial_end_time,
+        mock_get_ot_access_token,
+        mock_get_admin_group,
+    ):
+        """If setup request encounters network error, return trial ID and error text without crashing."""
+        create_response = mock.MagicMock(
+            status_code=200, json=lambda: ({'trial': {'id': -1234567890}})
+        )
+        create_response.raise_for_status.return_value = None
+        mock_requests_post.side_effect = [
+            create_response,
+            requests.exceptions.Timeout('Setup request timed out'),
+        ]
+        mock_get_trial_end_time.return_value = 111222333
+        mock_get_ot_access_token.return_value = 'access_token'
+        mock_get_admin_group.return_value = 'test-group-123'
+        settings.OT_API_KEY = 'api_key_value'
+
+        ot_id, error_text = origin_trials_client.create_origin_trial(
+            self.ot_stage
+        )
+        self.assertEqual(ot_id, '-1234567890')
+        self.assertEqual('Setup request timed out', error_text)
+
+    @mock.patch('framework.secrets.get_ot_data_access_admin_group')
+    @mock.patch('framework.origin_trials_client._get_ot_access_token')
+    @mock.patch('framework.origin_trials_client._get_trial_end_time')
+    @mock.patch('requests.post')
+    def test_create_origin_trial__setup_http_error(
+        self,
+        mock_requests_post,
+        mock_get_trial_end_time,
+        mock_get_ot_access_token,
+        mock_get_admin_group,
+    ):
+        """If setup request returns HTTP error, return trial ID and response error text."""
+        create_response = mock.MagicMock(
+            status_code=200, json=lambda: ({'trial': {'id': -1234567890}})
+        )
+        create_response.raise_for_status.return_value = None
+        setup_response = mock.MagicMock(
+            status_code=500,
+            text='{"error": "Internal setup failure"}',
+        )
+        setup_response.raise_for_status.side_effect = (
+            requests.exceptions.HTTPError(
+                '500 Server Error', response=setup_response
+            )
+        )
+        mock_requests_post.side_effect = [create_response, setup_response]
+        mock_get_trial_end_time.return_value = 111222333
+        mock_get_ot_access_token.return_value = 'access_token'
+        mock_get_admin_group.return_value = 'test-group-123'
+        settings.OT_API_KEY = 'api_key_value'
+
+        ot_id, error_text = origin_trials_client.create_origin_trial(
+            self.ot_stage
+        )
+        self.assertEqual(ot_id, '-1234567890')
+        self.assertEqual('{"error": "Internal setup failure"}', error_text)
+
+    @mock.patch('framework.origin_trials_client._get_ot_access_token')
+    @mock.patch('requests.post')
+    def test_activate_origin_trial__connection_error(
+        self,
+        mock_requests_post,
+        mock_get_ot_access_token,
+    ):
+        """If activation encounters network error, raise exception without UnboundLocalError."""
+        mock_requests_post.side_effect = requests.exceptions.ConnectionError(
+            'Network unreachable'
+        )
+        mock_get_ot_access_token.return_value = 'access_token'
+        settings.OT_API_KEY = 'api_key_value'
+
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            origin_trials_client.activate_origin_trial('-1234567890')
+
+    @mock.patch('framework.origin_trials_client._get_ot_access_token')
+    @mock.patch('framework.origin_trials_client._get_trial_end_time')
+    @mock.patch('requests.post')
+    def test_extend_origin_trial__connection_error(
+        self,
+        mock_requests_post,
+        mock_get_trial_end_time,
+        mock_get_ot_access_token,
+    ):
+        """If extension encounters network error, raise exception without error."""
+        mock_requests_post.side_effect = requests.exceptions.ConnectionError(
+            'Network unreachable'
+        )
+        mock_get_trial_end_time.return_value = 111222333
+        mock_get_ot_access_token.return_value = 'access_token'
+        settings.OT_API_KEY = 'api_key_value'
+
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            origin_trials_client.extend_origin_trial(
+                '1234567890', 123, 'https://example.com/intent'
+            )


### PR DESCRIPTION
## Overview
Prevents `UnboundLocalError` in `origin_trials_client` when HTTP requests to the Origin Trials API fail before a response object is returned (such as timeouts or connection errors).

## Root Cause / Motivation
When calls to `requests.post()` in `framework/origin_trials_client.py` raise an exception before returning (e.g. `ConnectionError`, `Timeout`, or DNS resolution issues), the local variable `response` is never assigned. The subsequent `except requests.exceptions.RequestException` blocks attempted to access `response.text` for logging or returning an error string, causing an unhandled `UnboundLocalError: cannot access local variable 'response' where it is not associated with a value`.

In automated cron jobs such as `CreateOriginTrials` (`internals/maintenance_scripts.py`), this unhandled exception crashed the cron execution and prevented the stage from properly transitioning to `OT_CREATION_FAILED` (leaving it stuck in `OT_CREATION_PROCESSING`).

## Detailed Changelog
* **`framework/origin_trials_client.py`**:
  * Added `_extract_error_text(e)` helper function to safely extract `e.response.text` when a response is present, falling back to `str(e)` or `'Unknown request error'`.
  * Updated `_send_create_trial_request`, `_send_set_up_trial_request`, `activate_origin_trial`, and `extend_origin_trial` to use `_extract_error_text(e)` instead of accessing `response.text`.
* **`framework/origin_trials_client_test.py`**:
  * Fixed test import ordering with `testing_config  # isort: split` so tests can run in isolation.
  * Added unit tests for `_extract_error_text` covering responses with text, empty responses, and errors without responses.
  * Added unit tests verifying connection/timeout errors and HTTP errors for trial creation, setup, activation, and extension without raising `UnboundLocalError`.
